### PR TITLE
Fix bugs in patient search form

### DIFF
--- a/src/main/java/org/openelisglobal/common/rest/provider/PatientSearchRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/PatientSearchRestController.java
@@ -69,18 +69,19 @@ public class PatientSearchRestController {
             if (!GenericValidator.isBlankOrNull(labNumber)) {
                 Patient patient = getPatientForLabNumber(labNumber);
                 if (patient == null || GenericValidator.isBlankOrNull(patient.getId())) {
+                    form.setPatientSearchResults(results);
                     return form;
                 } else {
                     PatientSearchResults searchResult = getSearchResultsForPatient(patient, null);
                     searchResult.setDataSourceName(MessageUtil.getMessage("patient.local.source"));
                     results.add(searchResult);
-
                 }
             } else {
                 if (GenericValidator.isBlankOrNull(lastName) && GenericValidator.isBlankOrNull(firstName)
                         && GenericValidator.isBlankOrNull(STNumber) && GenericValidator.isBlankOrNull(subjectNumber)
                         && GenericValidator.isBlankOrNull(nationalID) && GenericValidator.isBlankOrNull(guid) && GenericValidator.isBlankOrNull(dateOfBirth)
                         && GenericValidator.isBlankOrNull(gender)) {
+                    form.setPatientSearchResults(results);
                     return form;
                 }
                 results = searchResultsService.getSearchResults(lastName, firstName, STNumber,


### PR DESCRIPTION
This PR addresses couple of bugs in [patient search form](https://openelis28.openelis-global.org/PatientManagement)

1. When all the fields are left empty and the form is submitted, it gets stuck in loading screen.
2. When the form is submitted with an invalid Previous Lab Number, the form gets stuck in loading screen.