### PR TITLE
Add required field indicator to site name in Add Order page

### DIFF
--- a/frontend/src/components/addOrder/AddOrder.js
+++ b/frontend/src/components/addOrder/AddOrder.js
@@ -526,7 +526,12 @@ const AddOrder = (props) => {
               }
               onChange={handleSiteName}
               onSelect={handleAutoCompleteSiteName}
-              label={intl.formatMessage({ id: "order.search.site.name" })}
+              label={
+                <>
+                  <FormattedMessage id="order.search.site.name" />{" "}
+                  <span className="requiredlabel">*</span>
+                </>
+              }
               class="inputText"
               style={{ width: "!important 100%" }}
               suggestions={siteNames.length > 0 ? siteNames : []}


### PR DESCRIPTION
The `Search Site Name` is a required field in the Add Order page as mentioned in https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/592 but lacks a required field indicator(red asterisk). This PR aims to implement the necessary changes.