### PR TITLE
Add bread crumbs and common bread crumbs page

### DIFF
--- a/frontend/src/components/common/HomeBreadCrumb.js
+++ b/frontend/src/components/common/HomeBreadCrumb.js
@@ -1,0 +1,20 @@
+import React from "react";
+import {Grid, Column, Breadcrumb, BreadcrumbItem} from "@carbon/react";
+import { useIntl } from "react-intl";
+
+export default function HomeBreadCrumb()  {
+    const intl = useIntl();
+    return(
+    <>
+      <Grid fullWidth={true}>
+        <Column lg={16}>
+        <Breadcrumb>
+          <BreadcrumbItem href="/">
+            {intl.formatMessage({id:"home.label"})}
+          </BreadcrumbItem>
+        </Breadcrumb>
+        </Column>
+      </Grid>
+    </>
+    );
+}

--- a/frontend/src/components/immunohistochemistry/ImmunohistochemistryDashboard.js
+++ b/frontend/src/components/immunohistochemistry/ImmunohistochemistryDashboard.js
@@ -31,6 +31,7 @@ import { AlertDialog } from "../common/CustomNotification";
 import { FormattedMessage, useIntl } from "react-intl";
 import "./../pathology/PathologyDashboard.css";
 import UserSessionDetailsContext from "../../UserSessionDetailsContext";
+import HomeBreadCrumb from "../common/HomeBreadCrumb";
 
 function ImmunohistochemistryDashboard() {
   const componentMounted = useRef(false);
@@ -284,6 +285,7 @@ function ImmunohistochemistryDashboard() {
     <>
       {notificationVisible === true ? <AlertDialog /> : ""}
       {loading && <Loading description="Loading Dasboard..." />}
+      <HomeBreadCrumb/>
       <Grid fullWidth={true}>
         <Column lg={16}>
           <Section>

--- a/frontend/src/components/pathology/PathologyDashboard.js
+++ b/frontend/src/components/pathology/PathologyDashboard.js
@@ -281,14 +281,14 @@ function PathologyDashboard() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       {loading && <Loading description="Loading Dasboard..." />}
       <Grid fullWidth={true}>
-      <Column lg={16}>
+        <Column lg={16}>
         <Breadcrumb>
           <BreadcrumbItem href="/">
             {intl.formatMessage({id:"home.label"})}
           </BreadcrumbItem>
         </Breadcrumb>
-      </Column>
-    </Grid>
+        </Column>
+      </Grid>
       <Grid fullWidth={true}>
         <Column lg={16}>
           <Section>

--- a/frontend/src/components/pathology/PathologyDashboard.js
+++ b/frontend/src/components/pathology/PathologyDashboard.js
@@ -19,6 +19,8 @@ import {
   Tile,
   Loading,
   Pagination,
+  Breadcrumb,
+  BreadcrumbItem
 } from "@carbon/react";
 import UserSessionDetailsContext from "../../UserSessionDetailsContext";
 import { Search } from "@carbon/react";
@@ -278,7 +280,15 @@ function PathologyDashboard() {
     <>
       {notificationVisible === true ? <AlertDialog /> : ""}
       {loading && <Loading description="Loading Dasboard..." />}
-
+      <Grid fullWidth={true}>
+      <Column lg={16}>
+        <Breadcrumb>
+          <BreadcrumbItem href="/">
+            {intl.formatMessage({id:"home.label"})}
+          </BreadcrumbItem>
+        </Breadcrumb>
+      </Column>
+    </Grid>
       <Grid fullWidth={true}>
         <Column lg={16}>
           <Section>

--- a/frontend/src/components/workplan/Workplan.js
+++ b/frontend/src/components/workplan/Workplan.js
@@ -12,6 +12,8 @@ import {
   TableHeader,
   TableRow,
   Pagination,
+  Breadcrumb,
+  BreadcrumbItem
 } from "@carbon/react";
 import React, { useState, useContext, useEffect } from "react";
 import "../Style.css";
@@ -172,6 +174,15 @@ export default function Workplan(props) {
   let currentAccessionNumber = "";
   return (
     <>
+      <Grid fullWidth={true}>
+      <Column lg={16}>
+        <Breadcrumb>
+          <BreadcrumbItem href="/">
+            {intl.formatMessage({id:"home.label"})}
+          </BreadcrumbItem>
+        </Breadcrumb>
+      </Column>
+    </Grid>
       <Grid fullWidth={true}>
         {notificationVisible === true ? <AlertDialog /> : ""}
         <Column lg={16}>


### PR DESCRIPTION
Hi @mozzy11  adding breadcrumb to 3 other pages. workplan, Pathology and ImmunohistochemistryDashboard pages

I have also added a resuable HomeBreadCrumb component, we can refactor alll the code, to avoid verbosity.

It has worked first with ImmunohistochemistryDashboard page

![Screenshot from 2024-02-02 08-06-52](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/16301386/2c5a9466-e492-4844-87fd-e854d278130d)
![Screenshot from 2024-02-02 08-07-10](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/16301386/329695a8-960b-4e0a-b233-63799c530e01)
![Screenshot from 2024-02-02 08-44-13](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/16301386/a8b4fb47-b86d-4468-babe-fc279bbf6a9e)
