### PR TITLE
Fixed Auto label Merge Conflict Workflow

### DIFF
--- a/.github/workflows/label-merge-conflict.yml
+++ b/.github/workflows/label-merge-conflict.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   auto-label:
-    if: github.repository == 'I-TECH-UW/OpenELIS-Global-2/'
+    if: github.repository == 'I-TECH-UW/OpenELIS-Global-2'
     runs-on: ubuntu-latest
     steps:
       - uses: prince-chrismc/label-merge-conflicts-action@v2


### PR DESCRIPTION
This pull request removes an unnecessary slash in the GitHub repository name, which is causing the workflow to auto-label merge conflicts  skipping and prevents it from running.

Expected Behaviour:
![image](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/101407963/7fddce1b-fe8b-499f-93c7-b605f244b704)


But now:
![image](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/101407963/ffbc7abf-e558-407a-86e2-581240407e46)
