### PR TITLE
fixed average turn around time tile returning NaN

### DIFF
--- a/src/main/java/org/openelisglobal/common/rest/provider/PatientDashBoardProvider.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/PatientDashBoardProvider.java
@@ -96,7 +96,7 @@ public class PatientDashBoardProvider {
             }
             
         }
-        return (double) sum / hours.size();
+        return hours.isEmpty() ? 0.0 : (double) sum / hours.size();
     }
     
     private double calculateAverageReceptionToResultTime() {
@@ -122,7 +122,7 @@ public class PatientDashBoardProvider {
             }
             
         }
-        return (double) sum / hours.size();
+        return hours.isEmpty() ? 0.0 : (double) sum / hours.size();
     }
     
     private double calculateAverageResultToValidationTime() {
@@ -146,7 +146,7 @@ public class PatientDashBoardProvider {
             }
             
         }
-        return (double) sum / hours.size();
+        return hours.isEmpty() ? 0.0 : (double) sum / hours.size();
     }
     
     private List<Analysis> analysesWithDelayedTurnAroundTime() {


### PR DESCRIPTION
Fixes #767 

## Fix Summary
**Issue:** The `calculateAverageReceptionToValidationTime`, `calculateAverageReceptionToResultTime`, `calculateAverageResultToValidationTime` method was returning NaN due to division by zero when the hours list was empty.

**Fix:** Added a check to ensure that the hours list is not empty before performing the division. If the hours list is empty, the method now returns 0.0 instead.

## Screenshots

### Before

<br/>
<img src="https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/38161296/d8b8b07c-4de0-4e0e-9ac2-c06dbae72e20" width="100%" height="300" style="margin-bottom: 4rem">
<hr/>
<br/>

<img src="https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/38161296/618f155a-6c96-40e1-99ee-cb0238cf5a75" width="100%" height="300" style="margin-bottom: 4rem">
<hr/>

<br/>

### After

<br/>

<img src="https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/38161296/5891356d-d124-4338-aac4-8d8d698024d5" width="80%" height="400" style="margin-bottom: 4rem">
<hr/>

<br/>

<img src="https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/38161296/95c06d14-ee9f-49a2-89ad-ae1157add212" width="80%" height="400" style="margin-bottom: 4rem">
<hr/>

cc @mozzy11 