### PR TITLE
Fix Distorted Responsiveness on Print Barcode Page

### DIFF
--- a/frontend/src/components/printBarcode/ExistingOrder.js
+++ b/frontend/src/components/printBarcode/ExistingOrder.js
@@ -100,12 +100,12 @@ const ExistingOrder = () => {
       <div className="orderLegendBody">
         <Form onSubmit={handleSearch}>
           <Grid>
-            <Column lg={16}>
+            <Column lg={16} md={8} sm={4}>
               <h4>
                 <FormattedMessage id="sample.entry.search.barcode" />
               </h4>
             </Column>
-            <Column lg={4}>
+            <Column lg={8} md={8} sm={4}>
               <CustomLabNumberInput
                 placeholder={"Enter Lab No"}
                 id="labNumber"
@@ -118,11 +118,13 @@ const ExistingOrder = () => {
                 labelText={<FormattedMessage id="search.label.accession" />}
               />
             </Column>
-            <Column lg={2}>
-              <Button type="submit">
+            <div className="tabsLayout">
+            <Column lg={16} md={8} sm={4}>
+              <Button type="submit" className="btn">
                 <FormattedMessage id="label.button.submit" />
               </Button>
             </Column>
+            </div>
           </Grid>
         </Form>
         {patientSearchResults !== null && orderResults !== null && (
@@ -161,19 +163,21 @@ const ExistingOrder = () => {
       {patientSearchResults !== null && orderResults !== null && (
         <div className="orderLegendBody">
           <Grid>
-            <Column lg={16}>
+            <Column lg={16} md={8} sm={4}>
               <h4>
                 <FormattedMessage id="barcode.print.section.set" />
               </h4>
             </Column>
-            <Column lg={6}>
+            <Column lg={16} md={8} sm={4}>
               <FormattedMessage id="barcode.print.set.instruction" />
             </Column>
+            <div className="tabsLayout">
             <Column>
               <Button onClick={printLabelSets}>
                 <FormattedMessage id="barcode.print.set.button" />
               </Button>
             </Column>
+            </div>
           </Grid>
         </div>
       )}
@@ -262,7 +266,7 @@ const ExistingOrder = () => {
       {renderBarcode && (
         <div className="orderLegendBody">
           <Grid>
-            <Column lg={16}>
+            <Column lg={16} md={8} sm={4}>
               <h4>
                 <FormattedMessage id="barcode.header" />
               </h4>

--- a/frontend/src/components/printBarcode/Index.js
+++ b/frontend/src/components/printBarcode/Index.js
@@ -8,7 +8,7 @@ const PrintBarcode = () => {
   return (
     <div>
       <Grid fullWidth={true}>
-        <Column lg={12}>
+        <Column lg={16} md={8} sm={4}>
           <Section>
             <Section>
               <Heading>

--- a/frontend/src/components/printBarcode/PrePrint.js
+++ b/frontend/src/components/printBarcode/PrePrint.js
@@ -12,6 +12,7 @@ import {
 } from "@carbon/react";
 import { getFromOpenElisServer } from "../utils/Utils";
 import { sampleTypeTestsStructure } from "../data/SampleEntryTestsForTypeProvider";
+import "../Style.css"
 
 const PrePrint = () => {
   const intl = useIntl();
@@ -168,12 +169,12 @@ const PrePrint = () => {
     <>
       <div className="orderLegendBody">
         <Grid>
-          <Column lg={16}>
+          <Column lg={8} md={8} sm={4}>
             <h4>
               <FormattedMessage id="barcode.print.preprint" />
             </h4>
           </Column>
-          <Column lg={16}>
+          <Column lg={8} md={8} sm={4}>
             <NumberInput
               min={1}
               max={100}
@@ -184,7 +185,7 @@ const PrePrint = () => {
               className="inputText"
             />
           </Column>
-          <Column lg={8}>
+          <Column lg={8} md={8} sm={4}>
             <NumberInput
               min={1}
               max={100}
@@ -195,7 +196,7 @@ const PrePrint = () => {
               className="inputText"
             />
           </Column>
-          <Column lg={8}>
+          <Column lg={8} md={8} sm={4}>
             <NumberInput
               min={1}
               max={100}
@@ -206,7 +207,7 @@ const PrePrint = () => {
               className="inputText"
             />
           </Column>
-          <Column lg={8}>
+          <Column lg={8} md={8} sm={4}>
             <NumberInput
               readOnly
               value={labelSets * (orderLabelsPerSet + specimenLabelsPerSet)}
@@ -215,7 +216,7 @@ const PrePrint = () => {
               className="inputText"
             />
           </Column>
-          <Column lg={8}>
+          <Column lg={8} md={8} sm={4}>
             <TextInput
               id="facilityId"
               onChange={(e) => setFacilityId(e.target.value)}
@@ -226,12 +227,12 @@ const PrePrint = () => {
       </div>
       <div className="orderLegendBody">
         <Grid>
-          <Column lg={16}>
+          <Column lg={16} md={8} sm={4}>
             <h4>
               <FormattedMessage id="label.button.sample" />
             </h4>
           </Column>
-          <Column lg={16}>
+          <Column lg={16} md={8} sm={4}>
             <Select
               id="selectSampleType"
               className="selectSampleType"
@@ -255,7 +256,7 @@ const PrePrint = () => {
               ))}
             </Select>
           </Column>
-          <Column lg={4}>
+          <Column lg={16} md={8} sm={4}>
             {selectedSampleTypeId && (
               <h4>
                 <FormattedMessage id="sample.entry.panels" />
@@ -279,7 +280,7 @@ const PrePrint = () => {
                 );
               })}
           </Column>
-          <Column lg={4}>
+          <Column lg={16} md={8} sm={4}>
             {selectedSampleTypeId && (
               <h4>
                 <FormattedMessage id="sample.entry.available.tests" />
@@ -303,20 +304,22 @@ const PrePrint = () => {
                 );
               })}
           </Column>
-          <Column lg={16}>
+          <Column lg={16} md={8} sm={4}>
             <FormattedMessage id="barcode.print.preprint.note" />
           </Column>
-          <Column lg={16}>
+          <div className="tabsLayout">
+          <Column lg={8} md={8} sm={4}>
             <Button disabled={!selectedSampleTypeId} onClick={prePrintLabels}>
               <FormattedMessage id="barcode.print.preprint.button" />
             </Button>
           </Column>
+          </div>
         </Grid>
       </div>
       {renderBarcode && (
         <div className="orderLegendBody">
           <Grid>
-            <Column lg={16}>
+            <Column lg={16} md={8} sm={4}>
               <h4>
                 <FormattedMessage id="barcode.header" />
               </h4>


### PR DESCRIPTION
This pull request addresses the responsiveness issue identified in the GitHub issue #811 . The print barcode page's layout becomes distorted and cluttered when the viewport width is less than 1056 pixels, impacting user readability and usability. To resolve this issue, the following changes have been implemented:

Improved responsiveness of the print barcode page, ensuring that elements are correctly displayed and spaced for viewport widths less than 1086 pixels.
Enhanced readability, usability, and overall user satisfaction with the feature.

Before:
    
![Screen Shot 2024-03-15 at 20 34 40](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/b4a7b4c4-2180-4fb4-aefa-87a46ced94e4)

After:
![Screen Shot 2024-03-15 at 20 34 25](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/f744527e-9e4c-474f-a806-25bbcd71ee10)

@mozzy11 This PR is ready to review.
Thank You
