### PR TITLE
Fixed Responsiveness of Patient History and Add/Edit Patient Page

### DIFF
--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -489,3 +489,8 @@ button {
     font-size: 1.5vw;
   }
 }
+@media screen and (max-width: 400px) {
+  .inlineDiv {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
### Description
Previously, the input fields on the Patient History and Add/Edit Patient pages were overflowing because two fields were arranged in a single row, leading to responsiveness issues on mobile view. To address this, each page now accommodates one input field per row for mobile view, ensuring responsiveness .

### Before
Mobile View
![Screenshot from 2024-03-19 12-57-54](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/0880a456-c1b6-491a-9eb7-f08362c2e21f)
![Screenshot from 2024-03-19 12-58-07](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/3ad581f9-d684-41fd-a32f-9f29bee9ee12)

Desktop View
![Screenshot from 2024-03-19 12-57-32](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/a51d666e-6a05-41ac-8c5a-e47cfe578407)
![Screenshot from 2024-03-19 12-57-44](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/aceba953-fbba-4b00-9652-4d29ce916b6c)


### After
Mobile View
![Screenshot from 2024-03-19 12-54-46](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/b0bf827e-6fa1-4946-ae0d-ba67a9b3e75d)
![Screenshot from 2024-03-19 12-55-25](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/f8a35e84-98a1-4ae0-b2b7-d92756271100)
Desktop View
![Screenshot from 2024-03-19 12-55-41](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/bb8c3ba9-0337-4e41-9c54-0ee17ce5a8bd)
![Screenshot from 2024-03-19 12-55-57](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/ef7e57b5-5eee-4e70-87ef-7f1a76ad2b4e)
