### PR TITLE
Fixed underflow of adminPageContent under Side Navbar

### DIFF
--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -496,3 +496,8 @@ button {
     flex-direction: column;
   }
 }
+@media screen and (max-width:500px) {
+  .adminPageContent{
+    margin-left: 17%;
+  }
+}


### PR DESCRIPTION
### Description
This PR resolves the issue of underflow of admin Page content under side Navbar on Program Entry Page of Admin section in mobile view.

### Before
![Screenshot from 2024-03-20 23-58-25](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/1cb01da8-e92f-4461-ac95-e49530e61a55)
![Screenshot from 2024-03-20 23-55-11](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/72422848-0859-49f9-b6b4-081a8c573199)


### After
![Screenshot from 2024-03-20 23-54-58](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/31718efa-6fee-4596-ab31-297210f296ed)
![Screenshot from 2024-03-20 23-55-11](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/72422848-0859-49f9-b6b4-081a8c573199)

