### PR TITLE
Embedded Breadcrumbs to Lab Number Management and Program Entry Pages

### DIFF
--- a/frontend/src/components/admin/labNumber/LabNumberManagement.js
+++ b/frontend/src/components/admin/labNumber/LabNumberManagement.js
@@ -26,7 +26,9 @@ import {
 } from "../../common/CustomNotification";
 import { FormattedMessage, useIntl } from "react-intl";
 import { ConfigurationContext } from "../../layout/Layout";
+import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
+let breadcrumbs = [{ label: "home.label", link: "/" }];
 function LabNumberManagement() {
   const intl = useIntl();
 
@@ -156,6 +158,7 @@ function LabNumberManagement() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       {loading && <Loading />}
       <div className="adminPageContent">
+      <PageBreadCrumb breadcrumbs={breadcrumbs} />
         <Grid>
           <Column lg={16}>
             <Section>

--- a/frontend/src/components/admin/program/ProgramManagement.js
+++ b/frontend/src/components/admin/program/ProgramManagement.js
@@ -25,7 +25,9 @@ import {
   NotificationKinds,
 } from "../../common/CustomNotification";
 import { FormattedMessage, useIntl } from "react-intl";
+import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
+let breadcrumbs = [{ label: "home.label", link: "/" }];
 function ProgramManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -169,6 +171,7 @@ function ProgramManagement() {
     <>
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
+      <PageBreadCrumb breadcrumbs={breadcrumbs} />
         <Grid>
           <Column lg={16}>
             <Section>


### PR DESCRIPTION
### Description
Previously, the  Lab Number Management and Program Entry pages did not feature breadcrumbs. This pull request addresses this by adding breadcrumbs, thus improving user navigation.

### Before
![Screenshot from 2024-03-21 07-34-28](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/c72641fc-5f6d-41eb-8a0c-62c30d148690)
![Screenshot from 2024-03-21 07-34-34](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/0428edd3-0694-43b2-b3bd-37ae1c25dcba)

### After
![Screenshot from 2024-03-21 08-09-39](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/b85149ab-b9fd-4747-8153-3499d9ecf64d)
![Screenshot from 2024-03-21 08-09-50](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/07e50a1c-f1d5-4455-805c-bedf4e10d3df)


