### PR TITLE
Included Breadcrumbs to Non-Conformity Menu Management, Patient Menu Management and Study Menu Management pages

### DIFF
--- a/frontend/src/components/admin/menu/NonConformityMenuManagement.js
+++ b/frontend/src/components/admin/menu/NonConformityMenuManagement.js
@@ -20,7 +20,9 @@ import {
   NotificationKinds,
 } from "../../common/CustomNotification";
 import { FormattedMessage, useIntl } from "react-intl";
+import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
+let breadcrumbs = [{ label: "home.label", link: "/" }];
 function NonConformityMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -83,6 +85,7 @@ function NonConformityMenuManagement() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       {loading && <Loading />}
       <div className="adminPageContent">
+      <PageBreadCrumb breadcrumbs={breadcrumbs} />
         <Grid>
           <Column lg={16}>
             <Section>

--- a/frontend/src/components/admin/menu/PatientMenuManagement.js
+++ b/frontend/src/components/admin/menu/PatientMenuManagement.js
@@ -21,7 +21,9 @@ import {
   NotificationKinds,
 } from "../../common/CustomNotification";
 import { FormattedMessage, useIntl } from "react-intl";
+import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
+let breadcrumbs = [{ label: "home.label", link: "/" }];
 function PatientMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -82,6 +84,7 @@ function PatientMenuManagement() {
     <>
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
+      <PageBreadCrumb breadcrumbs={breadcrumbs} />
         <Grid>
           <Column lg={16}>
             <Section>

--- a/frontend/src/components/admin/menu/StudyMenuManagement.js
+++ b/frontend/src/components/admin/menu/StudyMenuManagement.js
@@ -20,6 +20,9 @@ import {
   NotificationKinds,
 } from "../../common/CustomNotification";
 import { FormattedMessage, useIntl } from "react-intl";
+import PageBreadCrumb from "../../common/PageBreadCrumb.js";
+
+let breadcrumbs = [{ label: "home.label", link: "/" }];
 
 function StudyMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
@@ -192,6 +195,7 @@ function StudyMenuManagement() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       {loading && <Loading />}
       <div className="adminPageContent">
+      <PageBreadCrumb breadcrumbs={breadcrumbs} />
         <Grid>
           <Column lg={16}>
             <Section>


### PR DESCRIPTION
### Description
Previously, the Non-Conformity Menu Management, Patient Menu Management and Study Menu Management pages did not feature breadcrumbs. This pull request addresses this by adding breadcrumbs, thus improving user navigation.

### Before
![Screenshot from 2024-03-21 07-35-44](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/961f4fde-b7f0-4b3f-8762-1348c95d8623)
![Screenshot from 2024-03-21 07-35-49](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/a15ab882-9ce9-40d4-ba76-6f4eb5a9f121)
![Screenshot from 2024-03-21 07-35-54](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/493b21d9-81ec-41ab-968b-e14feb017c3f)

### After
![Screenshot from 2024-03-21 08-17-50](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/4cbd774c-8dd4-4e6c-9836-fa511b46f8d4)
![Screenshot from 2024-03-21 08-17-41](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/af6347a2-60f3-4c6e-8346-97d7bf25004e)
![Screenshot from 2024-03-21 08-17-46](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/b5eb16cd-d248-46d7-862a-c3597d043c69)
