### PR TITLE
Fixing HeaderPanel Alignment and Screen Coverage Issue

### DIFF
--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -23,6 +23,8 @@
 
 .userDetails {
   padding: 5%;
+  display: flex;
+  align-items: center;
 }
 
 li.userDetails {
@@ -508,5 +510,11 @@ button {
 @media screen and (max-width:500px) {
   .adminPageContent{
     margin-left: 17%;
+  }
+}
+
+@media screen and (max-width:375px) {
+  .headerPanel {
+    width: 14rem !important;
   }
 }

--- a/frontend/src/components/layout/Header.js
+++ b/frontend/src/components/layout/Header.js
@@ -384,7 +384,7 @@ function OEHeader(props) {
                     {userSessionDetails.authenticated && (
                       <>
                         <li className="userDetails">
-                          <UserAvatarFilledAlt size={18} />{" "}
+                          <UserAvatarFilledAlt size={18} style={{marginRight: '4px'}}/>
                           {userSessionDetails.firstName}{" "}
                           {userSessionDetails.lastName}
                         </li>
@@ -392,7 +392,7 @@ function OEHeader(props) {
                           className="userDetails clickableUserDetails"
                           onClick={logout}
                         >
-                          <Logout id="sign-out" />
+                          <Logout id="sign-out" style={{marginRight: '3px'}}/>
                           <FormattedMessage id="header.label.logout" />
                         </li>
                       </>


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and design documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary
This PR makes sure that the "Open ELIS" and "Logout" texts in the HeaderPanel line up correctly with the icons on the left. It also improves interface usability by adjusting the HeaderPanel width to prevent it from covering most of the screen on smaller devices.

## Related Issue
This PR fixes the issue https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/871

## Screen Recordings
### Before: 

https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/146843890/73e77704-c860-4fe8-b28d-4aedff70eb1e


### After: 

https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/146843890/b5360801-c9e5-4193-8451-9ad37902411c

