### PR TITLE
Adding API pagination to the Dashboard Order Lists #681

### DIFF
--- a/frontend/src/components/home/Dashboard.tsx
+++ b/frontend/src/components/home/Dashboard.tsx
@@ -155,7 +155,7 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
 
     // Sets next and previous page numbers based on the total pages and current page number.
     if (res && res.paging) {
-      let { totalPages, currentPage } = res.paging;
+      var { totalPages, currentPage } = res.paging;
       if (totalPages > 1) {
         setPagination(true);
         if (parseInt(currentPage) < parseInt(totalPages)) {

--- a/frontend/src/components/home/Dashboard.tsx
+++ b/frontend/src/components/home/Dashboard.tsx
@@ -155,7 +155,7 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
 
     // Sets next and previous page numbers based on the total pages and current page number.
     if (res && res.paging) {
-      var { totalPages, currentPage } = res.paging;
+      const { totalPages, currentPage } = res.paging;
       if (totalPages > 1) {
         setPagination(true);
         if (parseInt(currentPage) < parseInt(totalPages)) {

--- a/src/main/java/org/openelisglobal/common/provider/query/PatientDashBoardForm.java
+++ b/src/main/java/org/openelisglobal/common/provider/query/PatientDashBoardForm.java
@@ -1,0 +1,36 @@
+package org.openelisglobal.common.provider.query;
+
+import org.openelisglobal.common.form.IPagingForm;
+import org.openelisglobal.common.paging.PagingBean;
+import org.openelisglobal.common.rest.provider.bean.homedashboard.OrderDisplayBean;
+
+import java.util.List;
+
+/**
+ * To be returned as a response to a request for a patient dashboard form.
+ * It contains display iteams of a page and paging information.
+ */
+public class PatientDashBoardForm implements IPagingForm {
+
+    private PagingBean paging;
+
+    private List<OrderDisplayBean> displayItems;
+
+    public void setOrderDisplayBeans(List<OrderDisplayBean> displayItems) {
+        this.displayItems = displayItems;
+    }
+
+    public List<OrderDisplayBean> getDisplayItems() {
+        return displayItems;
+    }
+
+    @Override
+    public void setPaging(PagingBean paging) {
+        this.paging = paging;
+    }
+
+    @Override
+    public PagingBean getPaging() {
+        return paging;
+    }
+}  

--- a/src/main/java/org/openelisglobal/common/rest/util/PatientDashBoardPaging.java
+++ b/src/main/java/org/openelisglobal/common/rest/util/PatientDashBoardPaging.java
@@ -1,0 +1,157 @@
+package org.openelisglobal.common.rest.util;
+
+/**
+* The contents of this file are subject to the Mozilla Public License
+* Version 1.1 (the "License"); you may not use this file except in
+* compliance with the License. You may obtain a copy of the License at
+* http://www.mozilla.org/MPL/
+*
+* Software distributed under the License is distributed on an "AS IS"
+* basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+* License for the specific language governing rights and limitations under
+* the License.
+*
+* The Original Code is OpenELIS code.
+*
+* Copyright (C) CIRG, University of Washington, Seattle WA.  All Rights Reserved.
+*
+*/
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.common.paging.IPageDivider;
+import org.openelisglobal.common.paging.IPageFlattener;
+import org.openelisglobal.common.paging.IPageUpdater;
+import org.openelisglobal.common.paging.PagingProperties;
+import org.openelisglobal.common.paging.PagingUtility;
+import org.openelisglobal.common.provider.query.PatientDashBoardForm;
+import org.openelisglobal.common.rest.provider.bean.homedashboard.OrderDisplayBean;
+import org.openelisglobal.common.util.IdValuePair;
+
+import org.openelisglobal.spring.util.SpringContext;
+
+/**
+ * Responsible for building a page by accepting all display and paging information.
+ * Based on the page size and the page number, it will return the appropriate page.
+ */
+public class PatientDashBoardPaging {
+
+    private final PagingUtility<List<OrderDisplayBean>> paging = new PagingUtility<>(); // Adjust type based on your data
+    private static final PatientDashboardPageHelper pagingHelper = new PatientDashboardPageHelper(); // Implement helper class
+
+    public void setDatabaseResults(HttpServletRequest request, PatientDashBoardForm form, List<OrderDisplayBean> orders)
+            throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+
+        paging.setDatabaseResults(request.getSession(), orders, pagingHelper);
+
+        List<OrderDisplayBean> resultPage = paging.getPage(1, request.getSession());
+        if (resultPage != null) {
+            form.setOrderDisplayBeans(resultPage);
+            form.setPaging(paging.getPagingBeanWithSearchMapping(1, request.getSession()));
+        }
+    }
+
+    public void page(HttpServletRequest request, PatientDashBoardForm form, int newPage)
+            throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+
+        request.getSession().setAttribute(IActionConstants.SAVE_DISABLED, IActionConstants.FALSE);
+
+        if (newPage < 0) {
+            newPage = 0;
+        }
+        List<OrderDisplayBean> resultPage = paging.getPage(newPage, request.getSession());
+        if (resultPage != null) {
+            form.setOrderDisplayBeans(resultPage);
+            //form.setTestSectionId("0");
+            form.setPaging(paging.getPagingBeanWithSearchMapping(newPage, request.getSession()));
+        }
+
+    }
+
+
+    public List<OrderDisplayBean> getResults(HttpServletRequest request) {
+        return paging.getAllResults(request.getSession(), pagingHelper);
+    }
+
+    private static class PatientDashboardPageHelper implements IPageDivider<List<OrderDisplayBean>>, 
+                        IPageUpdater<List<OrderDisplayBean>>, IPageFlattener<List<OrderDisplayBean>> {            
+
+        @Override
+        public void createPages(List<OrderDisplayBean> orders, List<List<OrderDisplayBean>> pagedResults) {
+            List<OrderDisplayBean> page = new ArrayList<>();
+
+            Boolean createNewPage = false;
+            int resultCount = 0;
+
+            for (OrderDisplayBean item : orders) { 
+               if (createNewPage) {
+                    resultCount = 0;
+                    createNewPage = false;
+                    pagedResults.add(page);
+                    page = new ArrayList<>();
+                }
+                if (resultCount >= SpringContext.getBean(PagingProperties.class).getResultsPageSize()) {
+                    createNewPage = true;
+                }
+
+                page.add(item);
+                resultCount++;
+            }
+
+            if (!page.isEmpty() || pagedResults.isEmpty()) {
+                pagedResults.add(page);
+            }
+        }
+
+        @Override
+        public void updateCache(List<OrderDisplayBean> cacheItems, List<OrderDisplayBean> clientItems) {
+            for (int i = 0; i < clientItems.size(); i++) {
+                cacheItems.set(i, clientItems.get(i));
+            }
+
+        }
+
+        @Override
+        public List<OrderDisplayBean> flattenPages(List<List<OrderDisplayBean>> pages) {
+
+            List<OrderDisplayBean> allResults = new ArrayList<>();
+
+            for (List<OrderDisplayBean> page : pages) {
+                for (OrderDisplayBean item : page) {
+                    allResults.add(item);
+                }
+            }
+
+            return allResults;
+
+        }
+
+        @Override
+        public List<IdValuePair> createSearchToPageMapping(List<List<OrderDisplayBean>> allPages) {
+            List<IdValuePair> mappingList = new ArrayList<>();
+
+            int page = 0;
+            for (List<OrderDisplayBean> resultList : allPages) {
+                page++;
+                String pageString = String.valueOf(page);
+
+                String orderID = null;
+
+                for (OrderDisplayBean resultItem : resultList) {
+                    if (!resultItem.getId().equals(orderID)) {
+                        orderID = resultItem.getId();
+                        mappingList.add(new IdValuePair(orderID, pageString));
+                    }
+                }
+
+            }
+
+            return mappingList;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and design documentation.
- [ ] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary
Added API pagination logic into Orders controller & Integrated Home Dashboard with API pagination functionality.
Before, all the data would go to the Frontend and would be paginated there only, now the data gets paginated by the API(100 results per bundle) and is sent in chunks/bundles to the Frontend for further pagination by the Frontend(i.e into 10, 20, 30, 50 or 100 results per page).

## Video

**Before**

https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96483874/5908a08e-a072-495e-8add-eac823122928

**After**
To test the pagination, property `org.openelisglobal.paging.results.pageSize:2` was set to 2(i.e. 3 results per page), this test is shown below along with enabled/disabled Next and Previous Bundle buttons.

https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96483874/70e8678d-2403-474e-ba55-a76f9f706290

## Related Issue

Issue - #681 

https://github.com/orgs/I-TECH-UW/projects/6/views/1?pane=issue&itemId=49773666

