### PR TITLE
Adding Placeholder Text in Workplan Dropdowns (On Workplan by Panel, Priority & Unit Pages)

### DIFF
--- a/frontend/src/components/workplan/PanelSelectForm.js
+++ b/frontend/src/components/workplan/PanelSelectForm.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Column, Grid, Select, SelectItem } from "@carbon/react";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import "../Style.css";
 import { getFromOpenElisServer } from "../utils/Utils";
 
@@ -20,13 +20,15 @@ function PanelSelectForm(props) {
     }
   };
 
+  const intl = useIntl();
+
   useEffect(() => {
     mounted.current = true;
     let panelId = new URLSearchParams(window.location.search).get("panelId");
     panelId = panelId ? panelId : "";
     getFromOpenElisServer("/rest/panels", (fetchedPanels) => {
       let panel = fetchedPanels.find((panel) => panel.id === panelId);
-      let panelLabel = panel ? panel.value : "";
+      let panelLabel = panel ? panel.value : intl.formatMessage({id:"input.placeholder.selectPanel"});
       setDefaultPanelId(panelId);
       setDefaultPanelLabel(panelLabel);
       props.value(panelId, panelLabel);

--- a/frontend/src/components/workplan/PrioritySelectForm.js
+++ b/frontend/src/components/workplan/PrioritySelectForm.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Column, Grid, Select, SelectItem } from "@carbon/react";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import "../Style.css";
 import { getFromOpenElisServer } from "../utils/Utils";
 
@@ -20,6 +20,8 @@ function PanelSelectForm(props) {
     }
   };
 
+  const intl = useIntl();
+
   useEffect(() => {
     mounted.current = true;
     let priorityId = new URLSearchParams(window.location.search).get(
@@ -30,7 +32,7 @@ function PanelSelectForm(props) {
       let priority = fetchedPriorities.find(
         (priority) => priority.id === priorityId,
       );
-      let priorityLabel = priority ? priority.value : "";
+      let priorityLabel = priority ? priority.value : intl.formatMessage({id:"input.placeholder.selectPriority"});
       setDefaultPriorityId(priorityId);
       setDefaultPriorityLabel(priorityLabel);
       props.value(priorityId, priorityLabel);

--- a/frontend/src/components/workplan/TestSectionSelectForm.js
+++ b/frontend/src/components/workplan/TestSectionSelectForm.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Column, Grid, Select, SelectItem } from "@carbon/react";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import "../Style.css";
 import { getFromOpenElisServer } from "../utils/Utils";
 
@@ -20,6 +20,8 @@ function TestSectionSelectForm(props) {
     }
   };
 
+  const intl = useIntl();
+
   useEffect(() => {
     mounted.current = true;
     let testSectionId = new URLSearchParams(window.location.search).get(
@@ -30,7 +32,7 @@ function TestSectionSelectForm(props) {
       let testSection = fetchedTestSections.find(
         (testSection) => testSection.id === testSectionId,
       );
-      let testSectionLabel = testSection ? testSection.value : "";
+      let testSectionLabel = testSection ? testSection.value : intl.formatMessage({id:"input.placeholder.selectTestSection"});
       setDefaultTestSectionId(testSectionId);
       setDefaultTestSectionLabel(testSectionLabel);
       props.value(testSectionId, testSectionLabel);

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -765,5 +765,8 @@
   "input.placeholder.providerWorkPhone":"Enter Requester's Phone Number",
   "input.placeholder.providerFax":"Enter Requester's Fax Number",
   "input.placeholder.providerEmail":"Enter Requester's Email",
-  "input.placeholder.selectTest":"Select Test Type"
+  "input.placeholder.selectTest":"Select Test Type",
+  "input.placeholder.selectPanel":"Select Panel Type",
+  "input.placeholder.selectPriority":"Select Priority",
+  "input.placeholder.selectTestSection":"Select Unit Type"
 }

--- a/frontend/src/languages/fr.json
+++ b/frontend/src/languages/fr.json
@@ -706,5 +706,8 @@
   "input.placeholder.providerWorkPhone":"Saisir le numéro de téléphone du demandeur",
   "input.placeholder.providerFax":"Saisir le numéro de fax du demandeur",
   "input.placeholder.providerEmail":"Saisir l'adresse e-mail du demandeur",
-  "input.placeholder.selectTest":"Sélectionnez le type de test"
+  "input.placeholder.selectTest":"Sélectionnez le type de test",
+  "input.placeholder.selectPanel":"Sélectionnez le type de panneau",
+  "input.placeholder.selectPriority":"Sélectionnez la priorité",
+  "input.placeholder.selectTestSection":"Sélectionnez le type d'unité"
 }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and design documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary

Previously, there was a select box on the workplan pages. The first option in this select box on all these pages was set to 'null' instead of displaying helpful placeholder text. This PR improves the user experience by adding placeholder text in the work plan dropdowns. For instance, phrases like 'Select Panel Type,' 'Select Unit Type,' and 'Select Priority' have been added on the Workplan by Panel page, Workplan by Unit page, and Workplan by Priority page respectively.

## Related Issue

This PR fixes the issue https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/874

## Before:

https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/146843890/2a21b2d4-60f8-4a52-a22c-1cc5eb8f4e11


## After:

https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/146843890/547f083b-17b4-4e96-8ada-fa6d209f7265

And, I also implemented support for **French language**, ensuring the placeholder text is available in both **English** and **French** for enhanced user experience.