### PR TITLE
Adding Integration Test for OrganizationContact

### DIFF
--- a/src/test/java/org/openelisglobal/organizationContact/OrganizationContactIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/organizationContact/OrganizationContactIntegrationTest.java
@@ -1,0 +1,46 @@
+package org.openelisglobal.organizationContact;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+
+
+import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.organization.valueholder.OrganizationContact;
+import  org.openelisglobal.person.valueholder.Person;
+
+
+
+
+public class OrganizationContactIntegrationTest {
+    private Person person;
+    private Organization organization;
+
+    @Before
+    public void setUp() {
+        // Initialize Person
+        person = new Person();
+        person.setFirstName("John");
+        person.setLastName("Doe");
+
+        // Initialize Organization
+        organization = new Organization();
+        organization.setId("123");
+    }
+
+    @Test
+    public void testOrganizationContactIntegration() {
+        // Create an instance of OrganizationContact and associate it with both Person and Organization
+        OrganizationContact organizationContact = new OrganizationContact();
+        organizationContact.setPerson(person);
+        organizationContact.setOrganizationId(organization.getId());
+
+        // Validate that OrganizationContact is associated with the correct Person and Organization
+        assertEquals("John", organizationContact.getPerson().getFirstName());
+        assertEquals("Doe", organizationContact.getPerson().getLastName());
+        assertEquals(person, organizationContact.getPerson());
+        assertEquals("123", organizationContact.getOrganizationId());
+        
+    }
+}


### PR DESCRIPTION
This pull request implements an integration test for the `OrganizationContact `class by verifying its association with the `Person` and `Organization` classes. The test ensures that the `OrganizationContact `correctly stores and retrieves information about the associated Person and Organization.

![Screenshot from 2024-03-24 15-30-07](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/103145317/dfd4d7d2-1651-4d5d-9a6f-89045fea8191)
