### PR TITLE
Fixed home-dashboard responsiveness

### DIFF
--- a/frontend/src/components/home/Dashboard.css
+++ b/frontend/src/components/home/Dashboard.css
@@ -62,13 +62,21 @@
   font-size: 1.9rem;
   font-weight: bold;
 }
-@media (max-width: 425px) {
+
+@media (max-width: 925px) {
   .home-dashboard-container {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     gap: 22px;
     padding: 22px;
   }
 }
+
+@media (max-width: 500px) {
+  .home-dashboard-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 @media (max-width: 846px) {
   .dashboard-view {
     padding: 0;


### PR DESCRIPTION
This PR addresses the issue #887 
Subsequently, this PR addresses the responsiveness of overflow of home dashboard tiles for all screen width devices

Before: iPad view
![Screenshot from 2024-03-25 16-44-06](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/46bddb70-3e11-4ffa-a893-9b7677bd376e)
After: iPad View
![Screenshot from 2024-03-25 16-44-18](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/5a7d794b-62bd-4f8b-af0f-5ccccaa7bd09)
