### PR TITLE
Fixed responsiveness for patient header

### DIFF
--- a/frontend/src/components/common/PatientHeader.js
+++ b/frontend/src/components/common/PatientHeader.js
@@ -26,13 +26,13 @@ const PatientHeader = (props) => {
   const patternUrl = GeoPattern.generate(id).toDataUri();
   return (
     <Grid fullWidth={true}>
-      <Column lg={16}>
+      <Column lg={16} md={8} sm={4}>
         <Section>
           <Section>
             {id ? (
               <div className={className}>
                 <Grid>
-                  <Column lg={4}>
+                  <Column lg={4} md={2} sm={2}>
                     <div
                       className={
                         referringFacility ? "patientAvatar2" : "patientAvatar"
@@ -55,7 +55,7 @@ const PatientHeader = (props) => {
                       />
                     </div>
                   </Column>
-                  <Column lg={10}>
+                  <Column lg={10} md={5} sm={2}>
                     <div className="patient-name">
                       {patientName ? patientName : lastName + " " + firstName}
                     </div>

--- a/frontend/src/components/pathology/PathologyCaseView.js
+++ b/frontend/src/components/pathology/PathologyCaseView.js
@@ -263,7 +263,7 @@ function PathologyCaseView() {
       <PageBreadCrumb breadcrumbs={breadcrumbs} />
 
       <Grid fullWidth={true}>
-        <Column lg={16}>
+        <Column lg={16} md={8} sm={4}>
           <Section>
             <Section>
               <Heading>
@@ -274,7 +274,7 @@ function PathologyCaseView() {
         </Column>
       </Grid>
       <Grid fullWidth={true}>
-        <Column lg={16}>
+        <Column lg={16} md={8} sm={4}>
           <Section>
             <Section>
               <PatientHeader


### PR DESCRIPTION
## Summary
This PR fixes the issue #892 . Subsequently it addresses the patient header responsiveness to all the components where it has been reused like in following components:

->Pathology dashboard
->Immunohistochemistry Dashboard
->Cytology dashboard
 ->Modify order components

## Screenshots

Before -->Pathology dashboard:iPad view
![Screen Shot 2024-03-25 at 22 08 40](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/d2cf0e8d-cb06-4a3a-a64a-ddc2a26b9506)

After:iPad view

![Screen Shot 2024-03-25 at 22 08 14](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/f9d2c6cb-30c9-4d0c-81fe-50195db458fe)

Before:Modify order component: iPad view
![Screen Shot 2024-03-25 at 22 16 30](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/4ae054ad-535d-4937-926d-4072930ca996)

After:Modify order component: iPad view
![Screen Shot 2024-03-25 at 22 16 38](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/1ab5f536-8d0c-4a4b-ac7b-d4013e29a4b7)


@mozzy11 This PR is ready to review, and would like for your valuable feedback on this PR.
Thank you

