### PR TITLE
Fixed Header panel Component Popup Behavior

### DIFF
--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -529,6 +529,6 @@ button {
 
 @media screen and (max-width:375px) {
   .headerPanel {
-    width: 14rem !important;
+    width: 14rem;
    }
  }


### PR DESCRIPTION
## Summary
This pull request addresses the issue #900  where the header panel component pops up automatically at a maximum width of 375px without user interaction. Additionally, it resolves the problem where clicking on the cancel (X) button fails to close the panel as expected.
## Screen Casts
Before:
[Screencast from 26-03-24 11:15:13 AM IST.webm](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/ab3313d8-df23-4fc9-90de-5d3a10ca283f)

After:
[After.webm](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/2ddcf14d-937e-44f2-94d4-b459b56230f3)

@mozzy11 This PR is ready for review. Please review the changes and provide your valuable feedback.
Thank you
