### PR TITLE
Fixed Responsiveness of Tiles on Home Dashboard

### DIFF
--- a/frontend/src/components/home/Dashboard.css
+++ b/frontend/src/components/home/Dashboard.css
@@ -34,8 +34,8 @@
 
 .tile-icon {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 0.1rem;
+  right: 0.1rem;
 }
 
 .icon-wrapper {


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and design documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary
Earlier, the Tile title and tile icon were overlapping on home dashboard for screen size 375px. This PR will fix the overlapping issue.

## Screenshots
### Before
![6_b](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/f80b0745-38d7-4920-9e47-a1ca8236c98b)
### After
![6_a](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/96368921/19e9cd65-af95-4470-83f2-bba7b206f85d)

## Related Issue

Resolves Issue #903

