### PR TITLE
Fixed patient header in Cytology and Immunohistochemistry dashboard

### DIFF
--- a/frontend/src/components/cytology/CytologyCaseView.js
+++ b/frontend/src/components/cytology/CytologyCaseView.js
@@ -361,7 +361,7 @@ function CytologyCaseView() {
       <PageBreadCrumb breadcrumbs={breadcrumbs} />
 
       <Grid fullWidth={true}>
-        <Column lg={16}>
+        <Column lg={16} md={8} sm={4}>
           <Section>
             <Section>
               <Heading>
@@ -372,7 +372,7 @@ function CytologyCaseView() {
         </Column>
       </Grid>
       <Grid fullWidth={true}>
-        <Column lg={16}>
+        <Column lg={16} md={8} sm={4}>
           <Section>
             <Section>
               <PatientHeader

--- a/frontend/src/components/immunohistochemistry/ImmunohistochemistryCaseView.js
+++ b/frontend/src/components/immunohistochemistry/ImmunohistochemistryCaseView.js
@@ -794,7 +794,7 @@ function ImmunohistochemistryCaseView() {
       <PageBreadCrumb breadcrumbs={breadcrumbs} />
 
       <Grid fullWidth={true}>
-        <Column lg={16}>
+        <Column lg={16} md={8} sm={4}>
           <Section>
             <Section>
               <Heading>
@@ -805,7 +805,7 @@ function ImmunohistochemistryCaseView() {
         </Column>
       </Grid>
       <Grid fullWidth={true}>
-        <Column lg={16}>
+        <Column lg={16} md={8} sm={4}>
           <Section>
             <Section>
               <PatientHeader


### PR DESCRIPTION
## Description
This PR fixes the issue #910 . Subsequently it addresses the specimen details responsiveness to the components below the patient header in Immunohistochemistry dashboard

## Screenshots
Before:iPad view(width:810 px)
![Screen Shot 2024-03-26 at 21 11 35](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/a8f92e74-f892-4194-b732-aadd634a6dd0)
After:
![Screen Shot 2024-03-26 at 21 11 08](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/3023b8cf-79ac-49e5-b853-6f72ef54008d)
@mozzy11 Sir, This PR is ready to review
Thank you