### PR TITLE
Fixed pathology dashboard selectors alignment

### DIFF
--- a/frontend/src/components/pathology/PathologyCaseView.js
+++ b/frontend/src/components/pathology/PathologyCaseView.js
@@ -17,7 +17,7 @@ import {
   Tag,
   TextArea,
   Loading,
-  InlineLoading,
+  InlineLoading
 } from "@carbon/react";
 import { Launch, Subtract } from "@carbon/react/icons";
 import {
@@ -347,8 +347,7 @@ function PathologyCaseView() {
             })}
           </Select>
         </Column>
-        <Column lg={2} md={1} sm={2}></Column>
-        <Column lg={2} md={1} sm={2}>
+        <Column lg={4} md={2} sm={2}>
           <Select
             id="assignedTechnician"
             name="assignedTechnician"
@@ -371,7 +370,7 @@ function PathologyCaseView() {
             })}
           </Select>
         </Column>
-        <Column lg={2} md={4} sm={2} />
+        
         <Column lg={4} md={2} sm={2}>
           <Select
             id="assignedPathologist"
@@ -414,7 +413,7 @@ function PathologyCaseView() {
               pathologySampleInfo.reports.map((report, index) => {
                 return (
                   <>
-                    <Column lg={2} md={8} sm={4}>
+                    <Column lg={2} md={4} sm={4}>
                       <IconButton
                         label={intl.formatMessage({
                           id: "label.button.remove.report",
@@ -431,8 +430,7 @@ function PathologyCaseView() {
                         <FormattedMessage id="immunohistochemistry.label.report" />
                       </IconButton>
                     </Column>
-
-                    <Column lg={3} md={1} sm={2}>
+                    <Column lg={2} md={4} sm={4}>
                       <FileUploader
                         style={{ marginTop: "-20px" }}
                         buttonLabel={
@@ -889,9 +887,9 @@ function PathologyCaseView() {
         <Column lg={16} md={8} sm={4}></Column>
         {hasRole(userSessionDetails, "Pathologist") && (
           <>
-            <Column lg={16} md={4} sm={2}>
+            <Column lg={16} md={8} sm={4}>
               <Grid fullWidth={true} className="gridBoundary">
-                <Column lg={4} md={4} sm={2}>
+                <Column lg={4} md={8} sm={4}>
                   {initialMount && (
                     <FilterableMultiSelect
                       id="techniques"
@@ -911,7 +909,7 @@ function PathologyCaseView() {
                     />
                   )}
                 </Column>
-                <Column lg={12} md={4} sm={2}>
+                <Column lg={16} md={8} sm={4}>
                   {pathologySampleInfo.techniques &&
                     pathologySampleInfo.techniques.map((technique, index) => (
                       <Tag
@@ -929,9 +927,9 @@ function PathologyCaseView() {
                 </Column>
               </Grid>
             </Column>
-            <Column lg={16} md={4} sm={2}>
+            <Column lg={16} md={8} sm={4}>
               <Grid fullWidth={true} className="gridBoundary">
-                <Column lg={4} md={4} sm={2}>
+                <Column lg={4} md={8} sm={4}>
                   {initialMount && (
                     <FilterableMultiSelect
                       id="requests"
@@ -971,7 +969,7 @@ function PathologyCaseView() {
                           {request.value}
                         </Tag>
                       </Column>
-                      <Column lg={2} md={4} sm={2}>
+                      <Column lg={2} md={8} sm={4}>
                         <Select
                           id={"requeststatus" + index}
                           name="requeststatus"
@@ -1008,7 +1006,7 @@ function PathologyCaseView() {
                   ))}
               </Grid>
             </Column>
-            <Column lg={16} md={4} sm={2}>
+            <Column lg={16} md={8} sm={4}>
               <Grid fullWidth={true} className="gridBoundary">
                 <Column lg={16} md={8} sm={4}>
                   <TextArea
@@ -1040,9 +1038,9 @@ function PathologyCaseView() {
                 </Column>
               </Grid>
             </Column>
-            <Column lg={16} md={4} sm={2}>
+            <Column lg={16} md={8} sm={4}>
               <Grid fullWidth={true} className="gridBoundary">
-                <Column lg={4} md={4} sm={2}>
+                <Column lg={4} md={8} sm={4}>
                   {initialMount && (
                     <FilterableMultiSelect
                       id="conclusion"
@@ -1062,7 +1060,7 @@ function PathologyCaseView() {
                     />
                   )}
                 </Column>
-                <Column lg={12} md={4} sm={2}>
+                <Column lg={12} md={8} sm={4}>
                   {pathologySampleInfo.conclusions &&
                     pathologySampleInfo.conclusions.map((conclusion, index) => (
                       <Tag
@@ -1080,8 +1078,7 @@ function PathologyCaseView() {
                 </Column>
               </Grid>
             </Column>
-
-            <Column lg={16} md={4} sm={2}>
+            <Column lg={16} md={8} sm={4}>
               <Grid fullWidth={true} className="gridBoundary">
                 <Column lg={16} md={8} sm={4}>
                   <TextArea
@@ -1101,9 +1098,9 @@ function PathologyCaseView() {
             </Column>
           </>
         )}
-        <Column lg={16} md={4} sm={2}>
+        <Column lg={16} md={8} sm={4}>
           <Grid fullWidth={true} className="gridBoundary">
-            <Column lg={4}>
+            <Column lg={4} md={4} sm={2}>
               <Checkbox
                 labelText={intl.formatMessage({ id: "pathology.label.refer" })}
                 id="referToImmunoHistoChemistry"
@@ -1118,7 +1115,7 @@ function PathologyCaseView() {
             </Column>
             {pathologySampleInfo.referToImmunoHistoChemistry && (
               <>
-                <Column lg={4}>
+                <Column lg={4} md={4} sm={2}>
                   <FilterableMultiSelect
                     id="ihctests"
                     titleText={
@@ -1162,7 +1159,7 @@ function PathologyCaseView() {
         </Column>
         {pathologySampleInfo.assignedPathologistId &&
           pathologySampleInfo.assignedTechnicianId && (
-            <Column lg={16}>
+            <Column lg={16} md={8} sm={4}>
               <Checkbox
                 labelText={intl.formatMessage({
                   id: "pathology.label.release",


### PR DESCRIPTION
## Description:
This PR addresses the issue #914 

## Summary:
1. Aligned various selectors in the pathology‬‭ dashboard adequately‬ for smaller screens.‬
Before: iPad view (width:810 px)
![Screenshot from 2024-03-27 09-17-14](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/76a8df7b-b605-43aa-a5b2-9c3151cde33d)

After:
![Screenshot from 2024-03-27 09-26-44](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/8e2fee66-f30f-4696-98f4-2aafa5f095aa)


2. Align, the checkbox "Refer to Immunohistochemistry" selectors appropriately.

Before:
![Screenshot from 2024-03-27 09-19-37](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/4b5cbeaf-ac08-49ed-ba88-6e812f4c873f)

After:
![Screenshot from 2024-03-27 09-28-56](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/1a9ea9dc-7d4b-47a0-9350-70bcfa395f21)

3. Aligned various Textarea input boxes‬:
Before:

![Screenshot from 2024-03-27 09-21-20](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/e7ea73cd-be60-4880-9d60-678f84d83c05)

After:
![Screen Shot 2024-03-27 at 09 29 52](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/d7cb3a7c-3e76-43ad-9eb7-007e4e438ec4)

@mozzy11 Sir, This PR is ready to review, I would appreciate for your valuable feedback.
Thank you.