### PR TITLE
Fixed home dashboard tabs responsiveness

### DIFF
--- a/frontend/src/components/home/Dashboard.tsx
+++ b/frontend/src/components/home/Dashboard.tsx
@@ -510,7 +510,7 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
                     )}
                     {tilesWithTabs.includes(selectedTile.type) && (
                       <Grid>
-                      <Column lg={16}>
+                      <Column lg={16} md={8} sm={4}>
                       {testSections.length > 0 ?( 
                       <Tabs>
                         <TabList aria-label="List of tabs" contained>


### PR DESCRIPTION
## Description
This PR addresses the issue #940 
## Screenshots
Before: iPad view
![bi](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/b3060fb3-1a23-4bb4-a32d-d065c18e2374)

After:
![ai](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/be6970ef-1eb8-4b81-aac9-a2f168f05d9c)

Before: Phone view
![bp](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/18bbe9c8-5d0b-42c0-a5c2-b1870352b9d9)

After:
![af](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/106299466/a977c498-541b-4ab6-9cab-18e925f264b6)

@mozzy11 Sir, This PR is ready to review.
Thank you!