### PR TITLE
Fix the browser console style errors due to bad syntax

### DIFF
--- a/frontend/src/components/layout/Header.js
+++ b/frontend/src/components/layout/Header.js
@@ -213,7 +213,7 @@ function OEHeader(props) {
     return (
       <button
         className={"custom-sidenav-button"}
-        style={{ "margin-left": marginValue }}
+        style={{ marginLeft: marginValue }}
         onClick={() => {
           if (menuItem.menu.openInNewWindow) {
             window.open(menuItem.menu.actionURL);
@@ -232,7 +232,7 @@ function OEHeader(props) {
     return (
       <button
         className={"custom-sidenav-button"}
-        style={{ "margin-left": marginValue }}
+        style={{ marginLeft: marginValue }}
         onClick={(e) => {
           onClickSideNavItem(e, menuItem, path);
         }}
@@ -253,7 +253,7 @@ function OEHeader(props) {
               ? "custom-sidenav-button"
               : "custom-sidenav-button-unclickable"
           }
-          style={{ "margin-left": marginValue }}
+          style={{ marginLeft: marginValue }}
           onClick={() => {
             if (menuItem.menu.openInNewWindow) {
               window.open(menuItem.menu.actionURL);
@@ -298,7 +298,7 @@ function OEHeader(props) {
   const renderSideNavMenuItemLabel = (menuItem, level) => {
     const fontPercent = 100 - 5 * (level - 1) + "%";
     return (
-      <span style={{ "font-size": fontPercent }}>
+      <span style={{ fontSize: fontPercent }}>
         <FormattedMessage id={menuItem.menu.displayKey} />
       </span>
     );


### PR DESCRIPTION
# Pull Requests Requirements
These have been persistent in the browser console and i felt we should fix that

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and design documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary

## Screenshots
![Screenshot from 2024-06-07 18-38-28](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/47120265/85dc12dd-2e2c-43a4-a957-52ffdc71c230)
![Screenshot from 2024-06-07 18-38-45](https://github.com/I-TECH-UW/OpenELIS-Global-2/assets/47120265/f40cb96a-c7dc-40f7-a835-4391fa017472)


[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
