### PR TITLE
Add mapping for indexing Patient and Person entities

### DIFF
--- a/src/main/java/org/openelisglobal/hibernate/search/analysis/CustomLuceneAnalysisConfigurer.java
+++ b/src/main/java/org/openelisglobal/hibernate/search/analysis/CustomLuceneAnalysisConfigurer.java
@@ -1,0 +1,13 @@
+package org.openelisglobal.hibernate.search.analysis;
+
+import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurationContext;
+import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer;
+
+public class CustomLuceneAnalysisConfigurer implements LuceneAnalysisConfigurer {
+    @Override
+    public void configure(LuceneAnalysisConfigurationContext context) {
+        context.normalizer("lowercase").custom()
+                .tokenFilter("lowercase")
+                .tokenFilter("asciifolding");
+    }
+}

--- a/src/main/java/org/openelisglobal/hibernate/search/analysis/CustomLuceneAnalysisConfigurer.java
+++ b/src/main/java/org/openelisglobal/hibernate/search/analysis/CustomLuceneAnalysisConfigurer.java
@@ -4,10 +4,8 @@ import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurationC
 import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer;
 
 public class CustomLuceneAnalysisConfigurer implements LuceneAnalysisConfigurer {
-    @Override
-    public void configure(LuceneAnalysisConfigurationContext context) {
-        context.normalizer("lowercase").custom()
-                .tokenFilter("lowercase")
-                .tokenFilter("asciifolding");
-    }
+  @Override
+  public void configure(LuceneAnalysisConfigurationContext context) {
+    context.normalizer("lowercase").custom().tokenFilter("lowercase").tokenFilter("asciifolding");
+  }
 }

--- a/src/main/java/org/openelisglobal/patient/valueholder/Patient.java
+++ b/src/main/java/org/openelisglobal/patient/valueholder/Patient.java
@@ -16,7 +16,6 @@ package org.openelisglobal.patient.valueholder;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.UUID;
-
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
@@ -33,18 +32,15 @@ public class Patient extends BaseObject<String> {
 
   private static final long serialVersionUID = 1L;
 
-  @GenericField
-  private String id;
+  @GenericField private String id;
 
   private String race;
 
-  @GenericField
-  private String gender;
+  @GenericField private String gender;
 
   private Timestamp birthDate;
 
-  @GenericField
-  private String birthDateForDisplay;
+  @GenericField private String birthDateForDisplay;
 
   private String epiFirstName;
 

--- a/src/main/java/org/openelisglobal/patient/valueholder/Patient.java
+++ b/src/main/java/org/openelisglobal/patient/valueholder/Patient.java
@@ -16,24 +16,34 @@ package org.openelisglobal.patient.valueholder;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.UUID;
+
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.valueholder.BaseObject;
 import org.openelisglobal.common.valueholder.ValueHolder;
 import org.openelisglobal.common.valueholder.ValueHolderInterface;
 import org.openelisglobal.person.valueholder.Person;
 
+@Indexed
 public class Patient extends BaseObject<String> {
 
   private static final long serialVersionUID = 1L;
 
+  @GenericField
   private String id;
 
   private String race;
 
+  @GenericField
   private String gender;
 
   private Timestamp birthDate;
 
+  @GenericField
   private String birthDateForDisplay;
 
   private String epiFirstName;
@@ -50,6 +60,7 @@ public class Patient extends BaseObject<String> {
 
   private String deathDateForDisplay;
 
+  @KeywordField(normalizer = "lowercase")
   private String nationalId;
 
   private String ethnicity;
@@ -62,8 +73,10 @@ public class Patient extends BaseObject<String> {
 
   private String birthPlace;
 
+  @IndexedEmbedded(structure = ObjectStructure.NESTED)
   private ValueHolderInterface person;
 
+  @KeywordField(normalizer = "lowercase")
   private String externalId;
 
   private String upidCode;

--- a/src/main/java/org/openelisglobal/person/valueholder/Person.java
+++ b/src/main/java/org/openelisglobal/person/valueholder/Person.java
@@ -17,6 +17,11 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
 import org.openelisglobal.common.validator.ValidationHelper;
 import org.openelisglobal.common.valueholder.BaseObject;
 import org.openelisglobal.patient.valueholder.Patient;
@@ -29,9 +34,11 @@ public class Person extends BaseObject<String> {
   private String id;
 
   @ValidName(nameType = NameType.LAST_NAME)
+  @KeywordField(normalizer = "lowercase")
   private String lastName;
 
   @ValidName(nameType = NameType.FIRST_NAME)
+  @KeywordField(normalizer = "lowercase")
   private String firstName;
 
   private String middleName;
@@ -63,6 +70,7 @@ public class Person extends BaseObject<String> {
   private String fax;
   @Email private String email;
 
+  @AssociationInverseSide(inversePath = @ObjectPath(@PropertyValue(propertyName = "person")))
   private Set<Patient> patients = new HashSet<>(0);
 
   public Person() {

--- a/src/main/java/org/openelisglobal/person/valueholder/Person.java
+++ b/src/main/java/org/openelisglobal/person/valueholder/Person.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
-
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;

--- a/src/main/resources/persistence/persistence.xml
+++ b/src/main/resources/persistence/persistence.xml
@@ -32,6 +32,7 @@
                 value="classpath:hibernate/hibernate.cfg.xml" />
             <property name="hibernate.search.backend.directory.type" value="local-filesystem" />
             <property name="hibernate.search.backend.directory.root" value="/var/lib/lucene_index" />
+            <property name="hibernate.search.backend.analysis.configurer" value="class:org.openelisglobal.hibernate.search.analysis.CustomLuceneAnalysisConfigurer"/>
         </properties>
 
     </persistence-unit>

--- a/src/test/resources/persistence/test-persistence.xml
+++ b/src/test/resources/persistence/test-persistence.xml
@@ -30,6 +30,7 @@
         <properties>
             <property name="hibernate.ejb.cfgfile"
                 value="hibernate/test-hibernate.cfg.xml" />
+            <property name="hibernate.search.backend.analysis.configurer" value="class:org.openelisglobal.hibernate.search.analysis.CustomLuceneAnalysisConfigurer"/>
         </properties>
 
     </persistence-unit>


### PR DESCRIPTION
Issue - https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1049

### Summary

- We will use `@Indexed` and `@*Field` (such as `@KeywordField`) annotations to map _Patient_ and _Person_ entities and their fields to Lucene indexes.
- We will create a custom _normalizer_ that includes _lowercase_ and _ascii-folding_ filters for the _Keyword_ fields. These filters will convert every character to lowercase and replace characters with diacritics ("é", "à", …​) with their ASCII equivalent ("e", "a", …​).