### PR TITLE
Change index directory type to local heap in testing configuration

### DIFF
--- a/src/test/resources/persistence/test-persistence.xml
+++ b/src/test/resources/persistence/test-persistence.xml
@@ -30,6 +30,7 @@
         <properties>
             <property name="hibernate.ejb.cfgfile"
                 value="hibernate/test-hibernate.cfg.xml" />
+            <property name="hibernate.search.backend.directory.type" value="local-heap" />
             <property name="hibernate.search.backend.analysis.configurer" value="class:org.openelisglobal.hibernate.search.analysis.CustomLuceneAnalysisConfigurer"/>
         </properties>
 


### PR DESCRIPTION
Issue - https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1049

 ### Summary
- We will use `local-heap` directory type in the testing configuration to store indexes in the local JVM’s heap instead of the default `local-filesystem`.
- This will be different from the main configuration where we use `local-filesystem` directory type to [implement persistent Lucene indexing with Docker volumes](https://github.com/I-TECH-UW/OpenELIS-Global-2/pull/1064).
- [Reference documentation](https://docs.jboss.org/hibernate/search/6.1/reference/en-US/html_single/#backend-lucene-configuration-directory-local-heap)

CC: @mozzy11 