### PR TITLE
remove unnecessary ResponseBody annotation

### DIFF
--- a/src/main/java/org/openelisglobal/image/controller/DBImageController.java
+++ b/src/main/java/org/openelisglobal/image/controller/DBImageController.java
@@ -8,7 +8,6 @@ import org.openelisglobal.image.valueholder.Image;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,7 +17,6 @@ public class DBImageController {
     private ImageService imageService;
 
     @GetMapping(value = "/dbImage/siteInformation/{imageName}")
-    @ResponseBody
     public IdValuePair getImage(@PathVariable String imageName) {
         Optional<Image> image = imageService.getImageBySiteInfoName(imageName);
         if (image.isEmpty()) {


### PR DESCRIPTION
Fix: Remove unnecessary @ResponseBody annotation from DBImageController

Fixes #1196

This pull request removes the redundant @ResponseBody annotation from the getImage method in the DBImageController class. The @RestController annotation already includes @ResponseBody functionality, making the explicit use of @ResponseBody unnecessary.

