### PR TITLE
Added left-over pages routes of admin menuConfigs

### DIFF
--- a/frontend/src/components/admin/Admin.js
+++ b/frontend/src/components/admin/Admin.js
@@ -148,6 +148,12 @@ function Admin() {
             title={intl.formatMessage({ id: "admin.formEntryConfig" })}
             renderIcon={ListDropdown}
           >
+            <SideNavMenuItem href="#NonConformityConfigurationMenu">
+              <FormattedMessage id="sidenav.label.admin.formEntry.nonconformityconfig" />
+            </SideNavMenuItem>
+            <SideNavMenuItem href="#MenuStatementConfigMenu">
+              <FormattedMessage id="sidenav.label.admin.formEntry.menustatementconfig" />
+            </SideNavMenuItem>
             <SideNavMenuItem href="#WorkPlanConfigurationMenu">
               <FormattedMessage id="sidenav.label.admin.formEntry.Workplanconfig" />
             </SideNavMenuItem>
@@ -257,6 +263,18 @@ function Admin() {
         <CommonProperties />
       </PathRoute>
 
+      <PathRoute path="#NonConformityConfigurationMenu">
+        <ConfigMenuDisplay
+          menuType="NonConformityConfigurationMenu"
+          id="sidenav.label.admin.formEntry.nonconformityconfig"
+        />
+      </PathRoute>
+      <PathRoute path="#MenuStatementConfigMenu">
+        <ConfigMenuDisplay
+          menuType="MenuStatementConfigMenu"
+          id="sidenav.label.admin.formEntry.menustatementconfig"
+        />
+      </PathRoute>
       <PathRoute path="#ValidationConfigurationMenu">
         <ConfigMenuDisplay
           menuType="ValidationConfigurationMenu"

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -284,6 +284,8 @@
   "sidenav.label.admin.usermgt": "User Management",
   "sidenav.label.admin.labNumber": "Lab Number Management",
   "sidenav.label.admin.commonproperties": "Application Properties",
+  "sidenav.label.admin.formEntry.nonconformityconfig": "NonConformity Configuration",
+  "sidenav.label.admin.formEntry.menustatementconfig": "MenuStatement Configuration",
   "sidenav.label.admin.formEntry.validationconfig": "Validation Configuration",
   "sidenav.label.admin.formEntry.sampleEntryconfig": "Order Entry Configuration",
   "sidenav.label.admin.formEntry.Workplanconfig": "WorkPlan Configuration",

--- a/frontend/src/languages/fr.json
+++ b/frontend/src/languages/fr.json
@@ -263,6 +263,8 @@
   "sidenav.label.admin.usermgt": "Gestion des Utilisateurs",
   "sidenav.label.admin.labNumber": "Gestion des Numéro de Laboratoire",
   "sidenav.label.admin.commonproperties": "Propriétés de l'application",
+  "sidenav.label.admin.formEntry.nonconformityconfig": "Configuration de Non-Conformité",
+  "sidenav.label.admin.formEntry.menustatementconfig": "Configuration de MenuStatement",
   "sidenav.label.admin.formEntry.validationconfig": "Configuration de validation",
   "sidenav.label.admin.formEntry.sampleEntryconfig": "Configuration de saisie de commande",
   "sidenav.label.admin.formEntry.Workplanconfig": "Configuration du plan de travail",


### PR DESCRIPTION
- referencing #1051 

## fixed some left over pages and its routes in the configuration menu

### Old Pages
![image](https://github.com/user-attachments/assets/28e5e7d4-a85a-4980-b4b8-ca86e7a68bc7)
![image](https://github.com/user-attachments/assets/1606cebc-15fc-4c87-a651-db1752af3982)

### Link
- https://localhost/api/OpenELIS-Global/NonConformityConfigurationMenu
- https://localhost/api/OpenELIS-Global/MenuStatementConfigMenu

### New Pages
![image](https://github.com/user-attachments/assets/c0f3fe49-0250-4fb6-b709-894680318423)
![image](https://github.com/user-attachments/assets/9d550714-d1ad-463b-8077-377b8252da81)

### WorkFlow 
![leftOverPageWorkFlow](https://github.com/user-attachments/assets/38e3f05c-d5e9-4931-b7d8-2646f34179b3)


If any changes required please let me know : )

Thank You