### PR TITLE
Make LuceneSearchResultsServiceImpl the primary implementation for SearchResultsService interface

### DIFF
--- a/src/main/java/org/openelisglobal/sample/daoimpl/DBSearchResultsDAOImpl.java
+++ b/src/main/java/org/openelisglobal/sample/daoimpl/DBSearchResultsDAOImpl.java
@@ -27,12 +27,10 @@ import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.provider.query.PatientSearchResults;
 import org.openelisglobal.patientidentitytype.util.PatientIdentityTypeMap;
 import org.openelisglobal.sample.dao.SearchResultsDAO;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@Primary
 public class DBSearchResultsDAOImpl implements SearchResultsDAO {
 
     @PersistenceContext

--- a/src/main/java/org/openelisglobal/sample/daoimpl/LuceneSearchResultsDAOImpl.java
+++ b/src/main/java/org/openelisglobal/sample/daoimpl/LuceneSearchResultsDAOImpl.java
@@ -17,9 +17,11 @@ import org.openelisglobal.common.provider.query.PatientSearchResults;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.patientidentitytype.util.PatientIdentityTypeMap;
 import org.openelisglobal.sample.dao.SearchResultsDAO;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
+@Primary
 public class LuceneSearchResultsDAOImpl implements SearchResultsDAO {
 
     @PersistenceContext

--- a/src/main/java/org/openelisglobal/search/service/DBSearchResultsServiceImpl.java
+++ b/src/main/java/org/openelisglobal/search/service/DBSearchResultsServiceImpl.java
@@ -4,15 +4,15 @@ import java.util.List;
 import org.openelisglobal.common.provider.query.PatientSearchResults;
 import org.openelisglobal.sample.dao.SearchResultsDAO;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Primary;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Primary
 public class DBSearchResultsServiceImpl implements SearchResultsService {
 
     @Autowired
+    @Qualifier("DBSearchResultsDAOImpl")
     SearchResultsDAO searchResultsDAO;
 
     @Override

--- a/src/main/java/org/openelisglobal/search/service/LuceneSearchResultsServiceImpl.java
+++ b/src/main/java/org/openelisglobal/search/service/LuceneSearchResultsServiceImpl.java
@@ -6,9 +6,11 @@ import org.openelisglobal.common.provider.query.PatientSearchResults;
 import org.openelisglobal.sample.dao.SearchResultsDAO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 @Service
+@Primary
 public class LuceneSearchResultsServiceImpl implements SearchResultsService {
 
     @Autowired

--- a/src/test/java/org/openelisglobal/search/SearchResultsServiceTest.java
+++ b/src/test/java/org/openelisglobal/search/SearchResultsServiceTest.java
@@ -29,6 +29,7 @@ public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
     PersonService personService;
 
     @Autowired
+    @Qualifier("DBSearchResultsServiceImpl")
     SearchResultsService DBSearchResultsServiceImpl;
 
     @Autowired


### PR DESCRIPTION
Issue - https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1049

### Summary
- This PR aims to make `LuceneSearchResultsServiceImpl` the primary implementation for `SearchResultsService` interface and `LuceneSearchResultsDAOImpl` the primary implementation for `SearchResultsDAO` interface.
- I have also added `Qualifier` annotations to make it more readable about which specific implementation is being used.
