### PR TITLE
Fix admin management pages to use the fullwidth grid

### DIFF
--- a/frontend/src/components/admin/Admin.js
+++ b/frontend/src/components/admin/Admin.js
@@ -285,54 +285,63 @@ function Admin() {
       <PathRoute path="#NonConformityConfigurationMenu">
         <ConfigMenuDisplay
           menuType="NonConformityConfigurationMenu"
+          label="Non Conformity Configuration Menu"
           id="sidenav.label.admin.formEntry.nonconformityconfig"
         />
       </PathRoute>
       <PathRoute path="#MenuStatementConfigMenu">
         <ConfigMenuDisplay
           menuType="MenuStatementConfigMenu"
+          label="Menu Statement Configuration Menu"
           id="sidenav.label.admin.formEntry.menustatementconfig"
         />
       </PathRoute>
       <PathRoute path="#ValidationConfigurationMenu">
         <ConfigMenuDisplay
           menuType="ValidationConfigurationMenu"
+          label="Validation Configuration Menu"
           id="sidenav.label.admin.formEntry.validationconfig"
         />
       </PathRoute>
       <PathRoute path="#SampleEntryConfigurationMenu">
         <ConfigMenuDisplay
           menuType="SampleEntryConfigMenu"
+          label="Sample Entry Configuration Menu"
           id="sidenav.label.admin.formEntry.sampleEntryconfig"
         />
       </PathRoute>
       <PathRoute path="#WorkPlanConfigurationMenu">
         <ConfigMenuDisplay
           menuType="WorkplanConfigurationMenu"
+          label="WorkPlan Configuration Menu"
           id="sidenav.label.admin.formEntry.Workplanconfig"
         />
       </PathRoute>
       <PathRoute path="#SiteInformationMenu">
         <ConfigMenuDisplay
           menuType="SiteInformationMenu"
+          label="Site Information Menu"
           id="sidenav.label.admin.formEntry.siteInfoconfig"
         />
       </PathRoute>
       <PathRoute path="#ResultConfigurationMenu">
         <ConfigMenuDisplay
           menuType="ResultConfigurationMenu"
+          label="Result Configuration Menu"
           id="sidenav.label.admin.formEntry.resultConfig"
         />
       </PathRoute>
       <PathRoute path="#PatientConfigurationMenu">
         <ConfigMenuDisplay
           menuType="PatientConfigurationMenu"
+          label="Patient Configuration Menu"
           id="sidenav.label.admin.formEntry.patientconfig"
         />
       </PathRoute>
       <PathRoute path="#PrintedReportsConfigurationMenu">
         <ConfigMenuDisplay
           menuType="PrintedReportsConfigurationMenu"
+          label="PrintedReports Configuration Menu"
           id="sidenav.label.admin.formEntry.PrintedReportsconfig"
         />
       </PathRoute>

--- a/frontend/src/components/admin/BatchTestReassignmentAndCancellation/BatchTestReassignmentAndCancelation.js
+++ b/frontend/src/components/admin/BatchTestReassignmentAndCancellation/BatchTestReassignmentAndCancelation.js
@@ -407,7 +407,7 @@ function BatchTestReassignmentAndCancelation() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16} md={8} sm={4}>
             <Section>
               <Section>

--- a/frontend/src/components/admin/barcodeConfiguration/BarcodeConfiguration.js
+++ b/frontend/src/components/admin/barcodeConfiguration/BarcodeConfiguration.js
@@ -29,6 +29,10 @@ import BarcodeConfigurationFormValues from "../../formModel/innitialValues/Barco
 let breadcrumbs = [
   { label: "home.label", link: "/" },
   { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "sidenav.label.admin.barcodeconfiguration",
+    link: "/MasterListsPage#barcodeConfiguration",
+  },
 ];
 function BarcodeConfiguration() {
   const { notificationVisible, setNotificationVisible, addNotification } =

--- a/frontend/src/components/admin/calculatedValue/CalculatedValueForm.tsx
+++ b/frontend/src/components/admin/calculatedValue/CalculatedValueForm.tsx
@@ -38,7 +38,14 @@ import {
 } from "../../common/CustomNotification";
 import PageBreadCrumb from "../../common/PageBreadCrumb";
 
-const breadcrumbs = [{ label: "home.label", link: "/" }];
+const breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "sidenav.label.admin.testmgt.calculated",
+    link: "/MasterListsPage#calculatedValue",
+  },
+];
 interface CalculatedValueProps {}
 
 type TestListField = "TEST_RESULT" | "FINAL_RESULT";

--- a/frontend/src/components/admin/calculatedValue/CalculatedValueForm.tsx
+++ b/frontend/src/components/admin/calculatedValue/CalculatedValueForm.tsx
@@ -623,7 +623,7 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
   return (
     <div className="adminPageContent">
       <PageBreadCrumb breadcrumbs={breadcrumbs} />
-      <Grid>
+      <Grid fullWidth={true}>
         <Column lg={16}>
           <Section>
             <Heading>

--- a/frontend/src/components/admin/generalConfig/common/ConfigMenuDisplay.js
+++ b/frontend/src/components/admin/generalConfig/common/ConfigMenuDisplay.js
@@ -35,7 +35,6 @@ import { FormattedMessage, useIntl } from "react-intl";
 import PageBreadCrumb from "../../../common/PageBreadCrumb.js";
 import GenericConfigEdit from "../../generalConfig/common/GenericConfigEdit.js";
 
-let breadcrumbs = [{ label: "home.label", link: "/" }];
 function ConfigMenuDisplay(props) {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -53,6 +52,12 @@ function ConfigMenuDisplay(props) {
     useState([]);
 
   const [ConfigEdit, setConfigEdit] = useState(false);
+
+  let breadcrumbs = [
+    { label: "home.label", link: "/" },
+    { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+    { label: `${props.label}`, link: `/MasterListsPage#${props.menuType}` },
+  ];
 
   function handleModify(event) {
     event.preventDefault();
@@ -185,7 +190,7 @@ function ConfigMenuDisplay(props) {
           {notificationVisible === true ? <AlertDialog /> : ""}
           <div className="adminPageContent">
             <PageBreadCrumb breadcrumbs={breadcrumbs} />
-            <Grid>
+            <Grid fullWidth={true}>
               <Column lg={16} md={8} sm={4}>
                 <Section>
                   <Heading>

--- a/frontend/src/components/admin/labNumber/LabNumberManagement.js
+++ b/frontend/src/components/admin/labNumber/LabNumberManagement.js
@@ -28,7 +28,14 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { ConfigurationContext } from "../../layout/Layout";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
-let breadcrumbs = [{ label: "home.label", link: "/" }];
+let breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "sidenav.label.admin.labNumber",
+    link: "/MasterListsPage#labNumber",
+  },
+];
 function LabNumberManagement() {
   const intl = useIntl();
 

--- a/frontend/src/components/admin/labNumber/LabNumberManagement.js
+++ b/frontend/src/components/admin/labNumber/LabNumberManagement.js
@@ -159,7 +159,7 @@ function LabNumberManagement() {
       {loading && <Loading />}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16}>
             <Section>
               <Heading>
@@ -169,7 +169,7 @@ function LabNumberManagement() {
           </Column>
         </Grid>
         <Form onSubmit={handleSubmit}>
-          <Grid>
+          <Grid fullWidth={true}>
             <Column lg={8}>
               <Select
                 id="lab_number_type"

--- a/frontend/src/components/admin/menu/BillingMenuManagement.js
+++ b/frontend/src/components/admin/menu/BillingMenuManagement.js
@@ -25,6 +25,10 @@ import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 let breadcrumbs = [
   { label: "home.label", link: "/" },
   { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "Billing Menu Management",
+    link: "/MasterListsPage#billingMenuManagement",
+  },
 ];
 function BillingMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =

--- a/frontend/src/components/admin/menu/BillingMenuManagement.js
+++ b/frontend/src/components/admin/menu/BillingMenuManagement.js
@@ -22,7 +22,10 @@ import {
 import { FormattedMessage, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
-let breadcrumbs = [{ label: "home.label", link: "/" }];
+let breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+];
 function BillingMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -87,13 +90,14 @@ function BillingMenuManagement() {
       {loading && <Loading />}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16} md={8} sm={4}>
             <Section>
               <Heading>
                 <FormattedMessage id="menu.billing.title" />
               </Heading>
             </Section>
+            <br />
             <Section>
               <Form onSubmit={handleSubmit}>
                 <div className="formInlineDiv">

--- a/frontend/src/components/admin/menu/CommonProperties.js
+++ b/frontend/src/components/admin/menu/CommonProperties.js
@@ -64,7 +64,16 @@ export const CommonProperties = () => {
     <>
       <div className="adminPageContent">
         {notificationVisible === true ? <AlertDialog /> : ""}
-        <PageBreadCrumb breadcrumbs={[{ label: "home.label", link: "/" }]} />
+        <PageBreadCrumb
+          breadcrumbs={[
+            { label: "home.label", link: "/" },
+            { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+            {
+              label: "common properties",
+              link: "/MasterListsPage#commonproperties",
+            },
+          ]}
+        />
         <Grid fullWidth={true}>
           <Column lg={16} md={8} sm={4}>
             <Section>

--- a/frontend/src/components/admin/menu/DictionaryManagement.js
+++ b/frontend/src/components/admin/menu/DictionaryManagement.js
@@ -402,7 +402,11 @@ function DictionaryManagement() {
       <PageBreadCrumb
         breadcrumbs={[
           { label: "home.label", link: "/" },
-          { label: "dictionary.label.modify", link: "/DictionaryManagement" },
+          { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+          {
+            label: "dictionary.label.modify",
+            link: "/MasterListsPage#DictionaryManagement",
+          },
         ]}
       />
       <Grid fullWidth={true}>

--- a/frontend/src/components/admin/menu/GlobalMenuManagement.js
+++ b/frontend/src/components/admin/menu/GlobalMenuManagement.js
@@ -22,7 +22,10 @@ import {
 import { FormattedMessage, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
-let breadcrumbs = [{ label: "home.label", link: "/" }];
+let breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+];
 function GlobalMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -103,7 +106,7 @@ function GlobalMenuManagement() {
       {loading && <Loading />}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16}>
             <Section>
               <Heading>

--- a/frontend/src/components/admin/menu/GlobalMenuManagement.js
+++ b/frontend/src/components/admin/menu/GlobalMenuManagement.js
@@ -25,6 +25,10 @@ import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 let breadcrumbs = [
   { label: "home.label", link: "/" },
   { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "Global Menu Management",
+    link: "/MasterListsPage#globalMenuManagement",
+  },
 ];
 function GlobalMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =

--- a/frontend/src/components/admin/menu/NonConformityMenuManagement.js
+++ b/frontend/src/components/admin/menu/NonConformityMenuManagement.js
@@ -22,7 +22,10 @@ import {
 import { FormattedMessage, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
-let breadcrumbs = [{ label: "home.label", link: "/" }];
+let breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+];
 function NonConformityMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -86,7 +89,7 @@ function NonConformityMenuManagement() {
       {loading && <Loading />}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16}>
             <Section>
               <Heading>

--- a/frontend/src/components/admin/menu/NonConformityMenuManagement.js
+++ b/frontend/src/components/admin/menu/NonConformityMenuManagement.js
@@ -25,6 +25,10 @@ import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 let breadcrumbs = [
   { label: "home.label", link: "/" },
   { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "Non Conformity Menu Management",
+    link: "/MasterListsPage#nonConformityMenuManagement",
+  },
 ];
 function NonConformityMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =

--- a/frontend/src/components/admin/menu/PatientMenuManagement.js
+++ b/frontend/src/components/admin/menu/PatientMenuManagement.js
@@ -26,6 +26,10 @@ import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 let breadcrumbs = [
   { label: "home.label", link: "/" },
   { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "sidenav.label.admin.menu.patient",
+    link: "/MasterListsPage#patientMenuManagement",
+  },
 ];
 function PatientMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =

--- a/frontend/src/components/admin/menu/PatientMenuManagement.js
+++ b/frontend/src/components/admin/menu/PatientMenuManagement.js
@@ -23,7 +23,10 @@ import {
 import { FormattedMessage, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
-let breadcrumbs = [{ label: "home.label", link: "/" }];
+let breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+];
 function PatientMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -85,7 +88,7 @@ function PatientMenuManagement() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16}>
             <Section>
               <Heading>

--- a/frontend/src/components/admin/menu/StudyMenuManagement.js
+++ b/frontend/src/components/admin/menu/StudyMenuManagement.js
@@ -22,7 +22,10 @@ import {
 import { FormattedMessage, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
-let breadcrumbs = [{ label: "home.label", link: "/" }];
+let breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+];
 
 function StudyMenuManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
@@ -196,7 +199,7 @@ function StudyMenuManagement() {
       {loading && <Loading />}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16}>
             <Section>
               <Heading>

--- a/frontend/src/components/admin/menu/StudyMenuManagement.js
+++ b/frontend/src/components/admin/menu/StudyMenuManagement.js
@@ -25,6 +25,10 @@ import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 let breadcrumbs = [
   { label: "home.label", link: "/" },
   { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "sidenav.label.admin.menu.study",
+    link: "/MasterListsPage#studyMenuManagement",
+  },
 ];
 
 function StudyMenuManagement() {

--- a/frontend/src/components/admin/program/ProgramManagement.js
+++ b/frontend/src/components/admin/program/ProgramManagement.js
@@ -27,7 +27,14 @@ import {
 import { FormattedMessage, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 
-let breadcrumbs = [{ label: "home.label", link: "/" }];
+let breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "sidenav.label.admin.program",
+    link: "/MasterListsPage#program",
+  },
+];
 function ProgramManagement() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);

--- a/frontend/src/components/admin/program/ProgramManagement.js
+++ b/frontend/src/components/admin/program/ProgramManagement.js
@@ -172,7 +172,7 @@ function ProgramManagement() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16}>
             <Section>
               <Heading>
@@ -182,7 +182,7 @@ function ProgramManagement() {
           </Column>
         </Grid>
         <Form onSubmit={handleSubmit}>
-          <Grid>
+          <Grid fullWidth={true}>
             <Column lg={8}>
               <Select
                 id="additionalQuestionsSelect"

--- a/frontend/src/components/admin/reflexTests/ReflexTestManagement.js
+++ b/frontend/src/components/admin/reflexTests/ReflexTestManagement.js
@@ -12,7 +12,7 @@ function ReflexTestManagement() {
     <>
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16}>
             <Section>
               <Heading>

--- a/frontend/src/components/admin/reflexTests/ReflexTestManagement.js
+++ b/frontend/src/components/admin/reflexTests/ReflexTestManagement.js
@@ -5,7 +5,14 @@ import { Grid, Column, Section, Heading } from "@carbon/react";
 import { FormattedMessage } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb";
 
-const breadcrumbs = [{ label: "home.label", link: "/" }];
+const breadcrumbs = [
+  { label: "home.label", link: "/" },
+  { label: "breadcrums.admin.managment", link: "/MasterListsPage" },
+  {
+    label: "sidenav.label.admin.testmgt.reflex",
+    link: "/MasterListsPage#reflex",
+  },
+];
 
 function ReflexTestManagement() {
   return (

--- a/frontend/src/components/admin/testManagement/ViewTestCatalog.js
+++ b/frontend/src/components/admin/testManagement/ViewTestCatalog.js
@@ -330,7 +330,7 @@ const TestCatalog = () => {
       <PageBreadCrumb breadcrumbs={breadcrumbs} />
       <br />
       <div className="orderLegendBody">
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={12}>
             <h1>
               {" "}

--- a/frontend/src/components/admin/testNotificationConfigMenu/TestNotificationConfigMenu.js
+++ b/frontend/src/components/admin/testNotificationConfigMenu/TestNotificationConfigMenu.js
@@ -38,7 +38,7 @@ import {
 } from "../../common/CustomNotification.js";
 import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
-import { Settings } from "@carbon/icons-react";
+import { Edit } from "@carbon/icons-react";
 import ActionPaginationButtonType from "../../common/ActionPaginationButtonType.js";
 
 let breadcrumbs = [
@@ -248,7 +248,7 @@ function TestNotificationConfigMenu() {
               id: "testnotification.testdefault.editIcon",
             })}
             onClick={() => handleEditButtonClick(row.cells[0].value)}
-            renderIcon={Settings}
+            renderIcon={Edit}
             kind="tertiary"
           />
         </TableCell>
@@ -265,41 +265,43 @@ function TestNotificationConfigMenu() {
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
         <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
+          <Column lg={16}>
             <Section>
-              <Section>
-                <Heading>
-                  <FormattedMessage id="testnotificationconfig.browse.title" />
-                </Heading>
-              </Section>
+              <Heading>
+                <FormattedMessage id="testnotificationconfig.browse.title" />
+              </Heading>
+            </Section>
+            <br />
+            <Section>
+              <Column
+                lg={16}
+                md={8}
+                sm={4}
+                style={{ display: "flex", gap: "10px" }}
+              >
+                <Button
+                  disabled={saveButton}
+                  onClick={testNotificationConfigMenuSavePostCall}
+                  type="button"
+                >
+                  <FormattedMessage id="label.button.save" />
+                </Button>{" "}
+                <Button
+                  onClick={() =>
+                    window.location.assign(
+                      "/MasterListsPage#testNotificationConfigMenu",
+                    )
+                  }
+                  kind="tertiary"
+                  type="button"
+                >
+                  <FormattedMessage id="label.button.exit" />
+                </Button>
+              </Column>
             </Section>
           </Column>
         </Grid>
         <div className="orderLegendBody">
-          <br />
-          <Grid fullWidth={true}>
-            <Column lg={16} md={8} sm={4}>
-              <Button
-                disabled={saveButton}
-                onClick={testNotificationConfigMenuSavePostCall}
-                type="button"
-              >
-                <FormattedMessage id="label.button.save" />
-              </Button>{" "}
-              <Button
-                onClick={() =>
-                  window.location.assign(
-                    "/MasterListsPage#testNotificationConfigMenu",
-                  )
-                }
-                kind="tertiary"
-                type="button"
-              >
-                <FormattedMessage id="label.button.exit" />
-              </Button>
-            </Column>
-          </Grid>
-          <br />
           <Grid fullWidth={true}>
             <Column lg={16} md={8} sm={4}>
               <br />

--- a/frontend/src/components/admin/testNotificationConfigMenu/TestNotificationConfigMenu.js
+++ b/frontend/src/components/admin/testNotificationConfigMenu/TestNotificationConfigMenu.js
@@ -38,7 +38,7 @@ import {
 } from "../../common/CustomNotification.js";
 import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
-import { Edit } from "@carbon/icons-react";
+import { Settings } from "@carbon/icons-react";
 import ActionPaginationButtonType from "../../common/ActionPaginationButtonType.js";
 
 let breadcrumbs = [
@@ -248,7 +248,7 @@ function TestNotificationConfigMenu() {
               id: "testnotification.testdefault.editIcon",
             })}
             onClick={() => handleEditButtonClick(row.cells[0].value)}
-            renderIcon={Edit}
+            renderIcon={Settings}
             kind="tertiary"
           />
         </TableCell>

--- a/frontend/src/components/admin/userManagement/UserManagement.js
+++ b/frontend/src/components/admin/userManagement/UserManagement.js
@@ -353,7 +353,7 @@ function UserManagement() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid>
+        <Grid fullWidth={true}>
           <Column lg={16} md={8} sm={4}>
             <Section>
               <Heading>


### PR DESCRIPTION
# Pull Requests Requirements
Most pages on the admin side have not been aligned and look really wierd. I just went ahead and added them to the fullwidth grid. 

## previously (one of so many pages)
<img width="1463" alt="prevop" src="https://github.com/user-attachments/assets/f1b7564c-b075-4e63-b90b-227a00f5b5e6">

## after changes
<img width="1463" alt="after" src="https://github.com/user-attachments/assets/bf726fdd-d3e9-400f-83f1-bd5208eab3ef">


- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and design
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
