### PR TITLE
Add SearchIndexManagement component in the Admin page

### DIFF
--- a/frontend/src/components/admin/Admin.js
+++ b/frontend/src/components/admin/Admin.js
@@ -30,6 +30,7 @@ import {
   User,
   BatchJob,
   Popup,
+  Search,
 } from "@carbon/icons-react";
 import PathRoute from "../utils/PathRoute";
 import CalculatedValue from "./calculatedValue/CalculatedValueForm";
@@ -57,6 +58,7 @@ import ManageMethod from "./testManagement/ManageMethod.js";
 import BatchTestReassignmentAndCancelation from "./BatchTestReassignmentAndCancellation/BatchTestReassignmentAndCancelation.js";
 import TestNotificationConfigMenu from "./testNotificationConfigMenu/TestNotificationConfigMenu.js";
 import TestNotificationConfigEdit from "./testNotificationConfigMenu/TestNotificationConfigEdit.js";
+import SearchIndexManagement from "./searchIndexManagement/SearchIndexManagement";
 
 function Admin() {
   const intl = useIntl();
@@ -200,6 +202,9 @@ function Admin() {
           <SideNavLink href="#NotifyUser" renderIcon={Bullhorn}>
             <FormattedMessage id="Notify User" />
           </SideNavLink>
+          <SideNavLink href="#SearchIndexManagement" renderIcon={Search}>
+            <FormattedMessage id="searchindexmanagement.label" />
+          </SideNavLink>
           <SideNavLink
             renderIcon={Catalog}
             target="_blank"
@@ -342,6 +347,9 @@ function Admin() {
       </PathRoute>
       <PathRoute path="#PluginFile">
         <PluginList />
+      </PathRoute>
+      <PathRoute path="#SearchIndexManagement">
+        <SearchIndexManagement />
       </PathRoute>
     </>
   );

--- a/frontend/src/components/admin/searchIndexManagement/SearchIndexManagement.js
+++ b/frontend/src/components/admin/searchIndexManagement/SearchIndexManagement.js
@@ -1,0 +1,96 @@
+import React, { useState, useContext } from "react";
+import { Button, Loading, Grid, Column, Section, Heading } from "@carbon/react";
+import { FormattedMessage, useIntl, injectIntl } from "react-intl";
+import { getFromOpenElisServer } from "../../utils/Utils";
+import PageBreadCrumb from "../../common/PageBreadCrumb";
+import { NotificationContext } from "../../layout/Layout";
+import {
+  AlertDialog,
+  NotificationKinds,
+} from "../../common/CustomNotification";
+
+function SearchIndexManagement() {
+  const [loading, setLoading] = useState(false);
+  const { notificationVisible, setNotificationVisible, addNotification } =
+    useContext(NotificationContext);
+  const intl = useIntl();
+  const rebuildIndex = async (res) => {
+    setNotificationVisible(true);
+    if (res) {
+      addNotification({
+        kind: NotificationKinds.success,
+        title: intl.formatMessage({ id: "notification.title" }),
+        message: intl.formatMessage({
+          id: "searchindexmanagement.reindex.success",
+        }),
+      });
+    } else {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({ id: "notification.title" }),
+        message: intl.formatMessage({
+          id: "searchindexmanagement.reindex.error",
+        }),
+      });
+    }
+    setLoading(false);
+  };
+  const handleReindexClick = async () => {
+    setLoading(true);
+    getFromOpenElisServer("/rest/reindex", rebuildIndex);
+  };
+
+  const breadcrumbs = [
+    { label: "home.label", link: "/" },
+    {
+      label: "breadcrums.admin.managment",
+      link: "/MasterListsPage",
+    },
+    {
+      label: "searchindexmanagement.label",
+      link: "/MasterListsPage#SearchIndexManagement",
+    },
+  ];
+
+  return (
+    <>
+      {notificationVisible === true ? <AlertDialog /> : ""}
+      {loading && <Loading />}
+      <div className="adminPageContent">
+        <PageBreadCrumb breadcrumbs={breadcrumbs} />
+        <Grid fullWidth={true}>
+          <Column lg={16} md={8} sm={4}>
+            <Section>
+              <Heading>
+                <FormattedMessage id="searchindexmanagement.label" />
+              </Heading>
+            </Section>
+          </Column>
+        </Grid>
+        <div className="orderLegendBody">
+          <Grid>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Section>
+                  <Heading>
+                    <FormattedMessage id="searchindexmanagement.reindex" />
+                  </Heading>
+                </Section>
+              </Section>
+              <br />
+              <Section>
+                <FormattedMessage id="searchindexmanagement.description" />
+              </Section>
+              <br />
+              <Button onClick={handleReindexClick} disabled={loading}>
+                <FormattedMessage id="searchindexmanagement.reindex" />
+              </Button>
+            </Column>
+          </Grid>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default injectIntl(SearchIndexManagement);

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -1271,5 +1271,10 @@
   "testnotification.testdefault.template": "Default Message for Test",
   "testnotification.testdefault.editIcon": "Edit Test Notification",
   "testnotification.bcc": "BCC",
-  "column.name.testId": "Test Id"
+  "column.name.testId": "Test Id",
+  "searchindexmanagement.label": "Search Index Management",
+  "searchindexmanagement.reindex.success": "Reindexing completed successfully",
+  "searchindexmanagement.reindex.error": "Reindexing failed",
+  "searchindexmanagement.description": "The search index updates automatically when data is added or modified. If you need to manually update the search index, click the Start Reindexing button. This may take some time.",
+  "searchindexmanagement.reindex": "Start Reindexing"
 }

--- a/src/main/java/org/openelisglobal/hibernate/search/massindexer/MassIndexerRestController.java
+++ b/src/main/java/org/openelisglobal/hibernate/search/massindexer/MassIndexerRestController.java
@@ -15,13 +15,12 @@ public class MassIndexerRestController {
     MassIndexerService massIndexerService;
 
     @GetMapping("/reindex")
-    public ResponseEntity<String> reindex() {
+    public ResponseEntity<Boolean> reindex() {
         try {
             massIndexerService.reindex();
-            return ResponseEntity.ok("Reindexing completed successfully.");
+            return ResponseEntity.ok(true);
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("Error occurred during reindexing: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(false);
         }
     }
 }


### PR DESCRIPTION
### Related Issue
#1049 
### Summary
This PR aims to add SearchIndexManagement component for manual re-indexing, which will be linked on the Admin SideNav.

### Screenshots

![Screenshot 2024-12-02 at 4 00 23 PM](https://github.com/user-attachments/assets/c3fe39e7-fe23-4209-960b-f1e5aad26eff)
