### PR TITLE
Add additional tests for SearchResultsService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -523,6 +523,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <version>${postgresql.version}</version>

--- a/src/test/java/org/openelisglobal/search/SearchResultsServiceTest.java
+++ b/src/test/java/org/openelisglobal/search/SearchResultsServiceTest.java
@@ -6,10 +6,10 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.*;
+import org.junit.runner.RunWith;
 import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.common.provider.query.PatientSearchResults;
 import org.openelisglobal.patient.service.PatientService;
@@ -19,8 +19,17 @@ import org.openelisglobal.person.valueholder.Person;
 import org.openelisglobal.search.service.SearchResultsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
 
+@RunWith(JUnitParamsRunner.class)
 public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
+
+    @ClassRule
+    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
+
+    @Rule
+    public final SpringMethodRule springMethodRule = new SpringMethodRule();
 
     @Autowired
     PatientService patientService;
@@ -47,20 +56,43 @@ public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
         personService.deleteAll(personService.getAll());
     }
 
+    private Object[] parametersForGetSearchResults_shouldGetSearchResultsFromDB() {
+        return new Object[] { new Object[] { "Jo", "Do", "12/12/1992", "M" }, new Object[] { "Jo", null, null, null },
+                new Object[] { null, "Do", null, null }, new Object[] { null, null, "12/12/1992", null },
+                new Object[] { null, null, null, "M" } };
+    }
+
+    private Object[] parametersForGetSearchResultsExact_shouldGetExactSearchResultsFromDB() {
+        return new Object[] { new Object[] { "John", "Doe", "12/12/1992", "M" },
+                new Object[] { "John", null, null, null }, new Object[] { null, "Doe", null, null },
+                new Object[] { null, null, "12/12/1992", null }, new Object[] { null, null, null, "M" } };
+    }
+
+    private Object[] parametersForGetSearchResults_shouldGetSearchResultsFromLuceneIndexes() {
+        return new Object[] { new Object[] { "Johm", "Doee", "12/12/1992", "M" },
+                new Object[] { "Johm", null, null, null }, new Object[] { null, "Doee", null, null },
+                new Object[] { null, null, "12/12/1992", null }, new Object[] { null, null, null, "M" } };
+    }
+
+    private Object[] parametersForGetSearchResultsExact_shouldGetExactSearchResultsFromLuceneIndexes() {
+        return new Object[] { new Object[] { "John", "Doe", "12/12/1992", "M" },
+                new Object[] { "John", null, null, null }, new Object[] { null, "Doe", null, null },
+                new Object[] { null, null, "12/12/1992", null }, new Object[] { null, null, null, "M" } };
+    }
+
     @Test
-    public void getSearchResults_shouldGetSearchResultsFromDB() throws Exception {
+    @Parameters
+    public void getSearchResults_shouldGetSearchResultsFromDB(String searchFirstName, String searchLastName,
+            String searchDateOfBirth, String searchGender) throws Exception {
         String firstName = "John";
         String lastname = "Doe";
         String dob = "12/12/1992";
         String gender = "M";
         Patient pat = createPatient(firstName, lastname, dob, gender);
         String patientId = patientService.insert(pat);
-
-        String searchFirstName = "Jo";
-        String searchLastName = "Do";
 
         List<PatientSearchResults> searchResults = DBSearchResultsServiceImpl.getSearchResults(searchLastName,
-                searchFirstName, null, null, null, null, null, null, dob, gender);
+                searchFirstName, null, null, null, null, null, null, searchDateOfBirth, searchGender);
 
         Assert.assertEquals(1, searchResults.size());
         PatientSearchResults result = searchResults.get(0);
@@ -68,10 +100,13 @@ public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
         Assert.assertEquals(firstName, result.getFirstName());
         Assert.assertEquals(lastname, result.getLastName());
         Assert.assertEquals(dob, result.getBirthdate());
+        Assert.assertEquals(gender, result.getGender());
     }
 
     @Test
-    public void getSearchResultsExact_shouldGetExactSearchResultsFromDB() throws Exception {
+    @Parameters
+    public void getSearchResultsExact_shouldGetExactSearchResultsFromDB(String searchFirstName, String searchLastName,
+            String searchDateOfBirth, String searchGender) throws Exception {
         String firstName = "John";
         String lastname = "Doe";
         String dob = "12/12/1992";
@@ -79,8 +114,8 @@ public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
         Patient pat = createPatient(firstName, lastname, dob, gender);
         String patientId = patientService.insert(pat);
 
-        List<PatientSearchResults> searchResults = DBSearchResultsServiceImpl.getSearchResultsExact(lastname, firstName,
-                null, null, null, null, null, null, dob, gender);
+        List<PatientSearchResults> searchResults = DBSearchResultsServiceImpl.getSearchResultsExact(searchLastName,
+                searchFirstName, null, null, null, null, null, null, searchDateOfBirth, searchGender);
 
         Assert.assertEquals(1, searchResults.size());
         PatientSearchResults result = searchResults.get(0);
@@ -88,22 +123,22 @@ public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
         Assert.assertEquals(firstName, result.getFirstName());
         Assert.assertEquals(lastname, result.getLastName());
         Assert.assertEquals(dob, result.getBirthdate());
+        Assert.assertEquals(gender, result.getGender());
     }
 
     @Test
-    public void getSearchResults_shouldGetSearchResultsFromLuceneIndexes() throws Exception {
+    @Parameters
+    public void getSearchResults_shouldGetSearchResultsFromLuceneIndexes(String searchFirstName, String searchLastName,
+            String searchDateOfBirth, String searchGender) throws Exception {
         String firstName = "John";
         String lastname = "Doe";
         String dob = "12/12/1992";
         String gender = "M";
         Patient pat = createPatient(firstName, lastname, dob, gender);
         String patientId = patientService.insert(pat);
-
-        String searchFirstName = "Johm";
-        String searchLastName = "Doee";
 
         List<PatientSearchResults> searchResults = luceneSearchResultsServiceImpl.getSearchResults(searchLastName,
-                searchFirstName, null, null, null, null, null, null, dob, gender);
+                searchFirstName, null, null, null, null, null, null, searchDateOfBirth, searchGender);
 
         Assert.assertEquals(1, searchResults.size());
         PatientSearchResults result = searchResults.get(0);
@@ -111,10 +146,13 @@ public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
         Assert.assertEquals(firstName, result.getFirstName());
         Assert.assertEquals(lastname, result.getLastName());
         Assert.assertEquals(dob, result.getBirthdate());
+        Assert.assertEquals(gender, result.getGender());
     }
 
     @Test
-    public void getSearchResultsExact_shouldGetExactSearchResultsFromLuceneIndexes() throws Exception {
+    @Parameters
+    public void getSearchResultsExact_shouldGetExactSearchResultsFromLuceneIndexes(String searchFirstName,
+            String searchLastName, String searchDateOfBirth, String searchGender) throws Exception {
         String firstName = "John";
         String lastname = "Doe";
         String dob = "12/12/1992";
@@ -122,8 +160,8 @@ public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
         Patient pat = createPatient(firstName, lastname, dob, gender);
         String patientId = patientService.insert(pat);
 
-        List<PatientSearchResults> searchResults = luceneSearchResultsServiceImpl.getSearchResultsExact(lastname,
-                firstName, null, null, null, null, null, null, dob, gender);
+        List<PatientSearchResults> searchResults = luceneSearchResultsServiceImpl.getSearchResultsExact(searchLastName,
+                searchFirstName, null, null, null, null, null, null, searchDateOfBirth, searchGender);
 
         Assert.assertEquals(1, searchResults.size());
         PatientSearchResults result = searchResults.get(0);
@@ -131,6 +169,7 @@ public class SearchResultsServiceTest extends BaseWebContextSensitiveTest {
         Assert.assertEquals(firstName, result.getFirstName());
         Assert.assertEquals(lastname, result.getLastName());
         Assert.assertEquals(dob, result.getBirthdate());
+        Assert.assertEquals(gender, result.getGender());
     }
 
     private Patient createPatient(String firstName, String LastName, String birthDate, String gender)


### PR DESCRIPTION
### Related Issue
#1049 

### Summary
- This PR aims to add additional tests for searching by each parameter (firstName, lastName, dob and gender) separately for both DB and Lucene search.
- I used the [JUnitParams](https://github.com/Pragmatists/JUnitParams) library to add parametrised test easily and in a more readable way.
- I also added missing Asserts for gender.

