### PR TITLE
fix: trim whitespace from password field during login validation

### DIFF
--- a/frontend/cypress/pages/ModifyOrderPage.js
+++ b/frontend/cypress/pages/ModifyOrderPage.js
@@ -41,9 +41,9 @@ class ModifyOrderPage {
 
   clickRespectivePatient() {
     return cy
-    .get('tbody tr')
-    .first()
-    .find('.cds--radio-button__appearance')
+      .get("tbody tr")
+      .first()
+      .find(".cds--radio-button__appearance")
       .click();
   }
 }

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -166,6 +166,9 @@ function Login(props) {
                   password: "",
                 }}
                 onSubmit={(values) => {
+                  // removing whitespaces in password before login validation.
+                  values.password = values.password.trim();
+
                   fetch(config.serverBaseUrl + "/LoginPage", {
                     //includes the browser sessionId in the Header for Authentication on the backend server
                     credentials: "include",

--- a/frontend/src/components/patient/CreatePatientForm.js
+++ b/frontend/src/components/patient/CreatePatientForm.js
@@ -143,8 +143,16 @@ function CreatePatientForm(props) {
   };
 
   function handleYearsChange(e, values) {
-    setPatientDetails(values);
-    let years = e.target.value;
+    // Ensure years is not negative
+    const years = Math.max(0, Number(e.target.value));
+
+    // Update form values with the validated years
+    setPatientDetails({
+      ...values,
+      // Update the specific field that contains years to ensure the form shows the corrected value
+      [e.target.name]: years,
+    });
+
     let dobFormatter = {
       ...dateOfBirthFormatter,
       years: years,
@@ -625,6 +633,7 @@ function CreatePatientForm(props) {
                   })}
                   id="years"
                   type="number"
+                  min="0"
                   onChange={(e) => handleYearsChange(e, values)}
                   placeholder={intl.formatMessage({
                     id: "patient.information.age",


### PR DESCRIPTION
fixes [issue#1382](https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1382)

## Summary
Currently, users cannot log in when their passwords contain leading or trailing whitespace characters. This is causing failed login attempts even with correct passwords. The fix implements password string trimming during validation to allow successful authentication by removing unintentional spaces.

# Changes
1. Added whitespace trimming for password field
2. Improves login form usability

## Screen Recording

[Screencast from 09-01-25 21:42:13.webm](https://github.com/user-attachments/assets/803c24ed-8bc4-4e19-a9dc-69d5b7e111e2)


## Related Issue

https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1382