### PR TITLE
fix: trim whitespace from password field during login validation

### DIFF
--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -166,6 +166,9 @@ function Login(props) {
                   password: "",
                 }}
                 onSubmit={(values) => {
+                  // trimming password before login validation
+                  values.password = values.password.trim();
+
                   fetch(config.serverBaseUrl + "/LoginPage", {
                     //includes the browser sessionId in the Header for Authentication on the backend server
                     credentials: "include",


### PR DESCRIPTION
fixes [issue#1382](https://github.com/I-TECH-UW/OpenELIS-Global-2/pull/1385)

## Summary
Currently, users cannot log in when their passwords contain leading or trailing whitespace characters. This is causing failed login attempts even with correct passwords. The fix implements password string trimming during validation to allow successful authentication by removing unintentional spaces.

# Changes
1. Added whitespace trimming for password field
2. Improves login form usability

## Screen-recording
[Screencast from 09-01-25 21:42:13.webm](https://github.com/user-attachments/assets/763dd969-0aae-453e-9608-dc41c2a08f13)

# Related Issue

https://github.com/I-TECH-UW/OpenELIS-Global-2/pull/1385
