### PR TITLE
Makes user manual accessible to all loged in users

### DIFF
--- a/src/main/java/org/openelisglobal/security/SecurityConfig.java
+++ b/src/main/java/org/openelisglobal/security/SecurityConfig.java
@@ -88,7 +88,7 @@ public class SecurityConfig {
     // TODO should we move these to the properties files?
     // pages that have special security constraints
     public static final String[] OPEN_PAGES = { "/pluginServlet/**", "/ChangePasswordLogin",
-            "/UpdateLoginChangePassword", "/health/**", "/rest/open-configuration-properties", "/docs/UserManual/**" };
+            "/UpdateLoginChangePassword", "/health/**", "/rest/open-configuration-properties", "/docs/UserManual" };
     public static final String[] LOGIN_PAGES = { "/LoginPage", "/ValidateLogin", "/session" };
 
     public static final String[] AUTH_OPEN_PAGES = { "/Home", "/Dashboard", "/Logout", "/MasterListsPage",

--- a/src/main/java/org/openelisglobal/security/SecurityConfig.java
+++ b/src/main/java/org/openelisglobal/security/SecurityConfig.java
@@ -88,7 +88,7 @@ public class SecurityConfig {
     // TODO should we move these to the properties files?
     // pages that have special security constraints
     public static final String[] OPEN_PAGES = { "/pluginServlet/**", "/ChangePasswordLogin",
-            "/UpdateLoginChangePassword", "/health/**", "/rest/open-configuration-properties" };
+            "/UpdateLoginChangePassword", "/health/**", "/rest/open-configuration-properties", "/docs/UserManual/**" };
     public static final String[] LOGIN_PAGES = { "/LoginPage", "/ValidateLogin", "/session" };
 
     public static final String[] AUTH_OPEN_PAGES = { "/Home", "/Dashboard", "/Logout", "/MasterListsPage",


### PR DESCRIPTION
## Summary
Currently user manual is only accessible to admin users this pr is in reference to [OGC-20](https://uwdigi.atlassian.net/jira/software/c/projects/OGC/issues/OGC-20?jql=project%20%3D%20%22OGC%22%20AND%20status%20%3D%20%22Community%20To%20Do%22%20ORDER%20BY%20created%20DESC)
## Screenshots

[Screencast from 13-01-25 05:00:40 PM IST.webm](https://github.com/user-attachments/assets/e009692f-39b0-4af2-af85-577b969ab239)


## Related Issue

#1397


[OGC-20]: https://uwdigi.atlassian.net/browse/OGC-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ