### PR TITLE
Fix DatePickerInput to Validate Numeric and Slash Characters Only

### DIFF
--- a/frontend/src/components/common/CustomDatePicker.js
+++ b/frontend/src/components/common/CustomDatePicker.js
@@ -20,6 +20,25 @@ const CustomDatePicker = (props) => {
     props.onChange(currentDate);
   }
 
+  function handleInputChange(e) {
+    const inputValue = event.target.value;
+
+  const isFrenchLocale = configurationProperties.DEFAULT_DATE_LOCALE === "fr-FR";
+  const partialDateRegex = isFrenchLocale
+    ? /^(\d{0,2})(\/(\d{0,2})(\/(\d{0,4})?)?)?$/ 
+    : /^(\d{0,2})(\/(\d{0,2})(\/(\d{0,4})?)?)?$/;
+
+  const fullDateRegex = isFrenchLocale
+    ? /^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/
+    : /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/; 
+
+  if (partialDateRegex.test(inputValue)) {
+    event.target.value = inputValue;
+  } else {
+    event.target.value = ""; // Clear invalid input
+  }
+  }
+
   useEffect(() => {
     props.onChange(currentDate);
   }, [currentDate]);
@@ -76,6 +95,7 @@ const CustomDatePicker = (props) => {
           invalid={props.invalid}
           invalidText={props.invalidText}
           disabled={props.disabled}
+          onChange={handleInputChange}
         />
       </DatePicker>
     </>

--- a/frontend/src/components/common/CustomDatePicker.js
+++ b/frontend/src/components/common/CustomDatePicker.js
@@ -23,20 +23,21 @@ const CustomDatePicker = (props) => {
   function handleInputChange(e) {
     const inputValue = event.target.value;
 
-  const isFrenchLocale = configurationProperties.DEFAULT_DATE_LOCALE === "fr-FR";
-  const partialDateRegex = isFrenchLocale
-    ? /^(\d{0,2})(\/(\d{0,2})(\/(\d{0,4})?)?)?$/ 
-    : /^(\d{0,2})(\/(\d{0,2})(\/(\d{0,4})?)?)?$/;
+    const isFrenchLocale =
+      configurationProperties.DEFAULT_DATE_LOCALE === "fr-FR";
+    const partialDateRegex = isFrenchLocale
+      ? /^(\d{0,2})(\/(\d{0,2})(\/(\d{0,4})?)?)?$/
+      : /^(\d{0,2})(\/(\d{0,2})(\/(\d{0,4})?)?)?$/;
 
-  const fullDateRegex = isFrenchLocale
-    ? /^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/
-    : /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/; 
+    const fullDateRegex = isFrenchLocale
+      ? /^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/
+      : /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/;
 
-  if (partialDateRegex.test(inputValue)) {
-    event.target.value = inputValue;
-  } else {
-    event.target.value = ""; // Clear invalid input
-  }
+    if (partialDateRegex.test(inputValue)) {
+      event.target.value = inputValue;
+    } else {
+      event.target.value = ""; // Clear invalid input
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
Fixes: [issue#1413](https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1413)

## Summary

This PR implements input validation for the DatePickerInput component in the Results/By Patient view. The changes enforce that users can only enter numbers and forward slashes while typing, preventing alphabetic and special character input. This improvement ensures proper date format entry and enhances form validation.

The User will no longer be allowed to input characters like (abc) etc. Instead when the user types a character that is not allowed, the input field will default to an empty string.

## Screen Recording

[Screencast from 20-01-25 00:51:56.webm](https://github.com/user-attachments/assets/c7bd703e-e236-4d86-a62f-e26e3abb0838)

## Related Issue

https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1413