### PR TITLE
 Preventing JSON Display in `additionalOrderEntryQuestions` for Specific Programs

### DIFF
--- a/frontend/src/components/admin/program/ProgramManagement.js
+++ b/frontend/src/components/admin/program/ProgramManagement.js
@@ -75,13 +75,19 @@ function ProgramManagement() {
 
   function setAdditionalQuestions(res) {
     console.debug(res);
-    if (res.additionalOrderEntryQuestions) {
+
+    const problematicPrograms = ["immunohistochemistry", "histopathology"];
+
+    if (problematicPrograms.includes(res.program.programName?.toLowerCase())) {
+      res.additionalOrderEntryQuestions = "";
+    } else if (res.additionalOrderEntryQuestions) {
       res.additionalOrderEntryQuestions = JSON.stringify(
         res.additionalOrderEntryQuestions,
         null,
         4,
       );
     }
+
     const newProgramValues = {
       ...ProgramFormValues,
       ...res,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
### Pull Requests Requirements



## Summary  
This PR fixes an issue where raw JSON code was being displayed in the `additionalOrderEntryQuestions` field for certain programs. Specifically, programs such as "immunohistochemistry" and "histopathology" were erroneously displaying JSON instead of clearing the field.  
The fix introduces logic to handle these specific programs by checking against a predefined array (`problematicPrograms`) and ensuring the field is cleared when applicable. For other programs, the default behavior of displaying formatted JSON remains intact.  

---

## Screencasts  
**Before Fix:**  
![Before Fix](https://github-production-user-asset-6210df.s3.amazonaws.com/66701396/403783560-b54af4ef-e73b-487b-9b58-fa7d7e88fd9f.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20250121%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250121T064521Z&X-Amz-Expires=300&X-Amz-Signature=c15b610ed985806e8f548e659079b5f4ddf837d36af619e35c2d7b0f19e3ffd2&X-Amz-SignedHeaders=host)  

**After Fix:**  
![After Fix](/home/lrba/Videos/Screencasts/Changes.mp4)

---

## Related Issue  
Fixes  [#1409](https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1409)  

---

## Furthermore:  
- I verified the changes adhere to the OpenElis Global x3 Styleguide.  
- I added a video demonstrating the changes in action, showing the handling of both problematic and non-problematic programs.  
- The code has been tested and is validated by existing tests.  
