### PR TITLE
Repeat password input field turns red when a value is entered in the repeat password field and it differs from the password.

### DIFF
--- a/frontend/src/components/admin/userManagement/UserAddModify.js
+++ b/frontend/src/components/admin/userManagement/UserAddModify.js
@@ -913,8 +913,9 @@ function UserAddModify() {
                           !passwordPatternRegex.test(
                             userDataShow.confirmPassword,
                           )) ||
-                        userDataShow.confirmPassword !==
-                          userDataShow.userPassword
+                        (passwordTouched.confirmPassword &&
+                          userDataShow.confirmPassword !==
+                          userDataShow.userPassword)
                       }
                       // invalidText={errors.order}
                       value={


### PR DESCRIPTION
## Summary
The condition of invalid repeat password has been changed. Now the repeat password field becomes red only when the repeat password input field has been changed and the repeat password is invalid as per the earlier conditions.

## Screen Recording
https://github.com/user-attachments/assets/b8dde5f6-77bc-49e7-a08c-9092539b3ef8

## Related Issue

#1426

## Other
This change will just enhance user experience.
