### PR TITLE
fix: modify dictionary item only when user explicitly click on select

### DIFF
--- a/frontend/src/components/admin/generalConfig/common/ConfigMenuDisplay.js
+++ b/frontend/src/components/admin/generalConfig/common/ConfigMenuDisplay.js
@@ -269,9 +269,7 @@ function ConfigMenuDisplay(props) {
                           <TableBody>
                             <>
                               {rows.map((row) => (
-                                <TableRow
-                                  key={row.id}
-                                >
+                                <TableRow key={row.id}>
                                   {row.cells.map((cell) =>
                                     renderCell(cell, row),
                                   )}

--- a/frontend/src/components/admin/menu/DictionaryManagement.js
+++ b/frontend/src/components/admin/menu/DictionaryManagement.js
@@ -650,9 +650,7 @@ function DictionaryManagement() {
                       </TableHead>
                       <TableBody>
                         {rows.map((row) => (
-                          <TableRow
-                            key={row.id}
-                          >
+                          <TableRow key={row.id}>
                             {row.cells.map((cell) => renderCell(cell, row))}
                           </TableRow>
                         ))}

--- a/frontend/src/components/admin/menu/DictionaryManagement.js
+++ b/frontend/src/components/admin/menu/DictionaryManagement.js
@@ -652,9 +652,6 @@ function DictionaryManagement() {
                         {rows.map((row) => (
                           <TableRow
                             key={row.id}
-                            onClick={() => {
-                              setSelectedRowId(row.id);
-                            }}
                           >
                             {row.cells.map((cell) => renderCell(cell, row))}
                           </TableRow>


### PR DESCRIPTION
Fixes: [issue#1438](https://github.com/I-TECH-UW/OpenELIS-Global-2/issues)

## Summary

This pull request fixes the issue of inconsistent state of radio buttons while selecting the dictionary item.

## Screenshots

![Screenshot from 2025-01-25 21-04-56](https://github.com/user-attachments/assets/b2416244-3ef2-4b2d-9c0e-ca370c2404eb)

## Related Issue

https://github.com/I-TECH-UW/OpenELIS-Global-2/issues