### PR TITLE
updated pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,8 +582,8 @@
 			<!-- openSaml -->
 			<url>https://build.shibboleth.net/maven/releases/</url>
 		</repository>
-		<!-- <repository> <id>uwdigi-repo-central</id> <name>DIGI Public Repository</name>
-			<url>https://packages.uwdigi.org/artifactory/public</url> </repository> -->
+		<repository> <id>uwdigi-repo-central</id> <name>DIGI Public Repository</name>
+			<url>https://repo1.maven.org/maven2/net/minidev/json-smart/maven-metadata.xml</url> </repository>
 	</repositories>
 	<build>
 		<finalName>OpenELIS-Global</finalName>


### PR DESCRIPTION
## Related Issue

#1534 

## Summary
fixed the broken repository url to the correct url
https://repo1.maven.org/maven2/net/minidev/json-smart/maven-metadata.xml
## Screenshots
![image](https://github.com/user-attachments/assets/dcc14232-0a9d-4804-8ad9-f936fe46cc87)
