### PR TITLE
Fix: Restrict First Name and Last Name Fields to Alphabetic Characters Only

### DIFF
--- a/frontend/src/components/patient/CreatePatientForm.js
+++ b/frontend/src/components/patient/CreatePatientForm.js
@@ -205,6 +205,20 @@ function CreatePatientForm(props) {
     );
   };
 
+  function handleFirstNameChange(event) {
+    const regex = /^[A-Za-z]*$/;
+    if (!regex.test(event.target.value)) {
+      event.target.value = event.target.value.replace(/[^A-Za-z]/g, "");
+    }
+  }
+
+  function handleLastNameChange(event) {
+    const regex = /^[A-Za-z]*$/;
+    if (!regex.test(event.target.value)) {
+      event.target.value = event.target.value.replace(/[^A-Za-z]/g, "");
+    }
+  }
+
   function fetchHealthDistrictsCallback(res) {
     setHealthDistricts(res);
   }
@@ -376,7 +390,7 @@ function CreatePatientForm(props) {
       addNotification({
         title: intl.formatMessage({ id: "notification.title" }),
         message: intl.formatMessage({ id: "error.save.patient" }),
-        kind: NotificationKinds.error,
+        kind: NotificationKinds.error  ,
       });
     }
   };
@@ -525,6 +539,7 @@ function CreatePatientForm(props) {
                       placeholder={intl.formatMessage({
                         id: "patient.information.lastname",
                       })}
+                      onChange={(e) => handleLastNameChange(e)}
                     />
                   )}
                 </Field>
@@ -544,6 +559,7 @@ function CreatePatientForm(props) {
                       placeholder={intl.formatMessage({
                         id: "patient.information.firstname",
                       })}
+                      onChange={(e) => handleFirstNameChange(e)}
                     />
                   )}
                 </Field>

--- a/frontend/src/components/patient/CreatePatientForm.js
+++ b/frontend/src/components/patient/CreatePatientForm.js
@@ -390,7 +390,7 @@ function CreatePatientForm(props) {
       addNotification({
         title: intl.formatMessage({ id: "notification.title" }),
         message: intl.formatMessage({ id: "error.save.patient" }),
-        kind: NotificationKinds.error  ,
+        kind: NotificationKinds.error,
       });
     }
   };

--- a/frontend/src/components/patient/SearchPatientForm.js
+++ b/frontend/src/components/patient/SearchPatientForm.js
@@ -231,6 +231,20 @@ function SearchPatientForm(props) {
     setDob(date);
   };
 
+  const handleFirstNameChange = (event) => {
+    const regex = /^[A-Za-z]*$/;
+    if (!regex.test(event.target.value)) {
+      event.target.value = event.target.value.replace(/[^A-Za-z]/g, "");
+    }
+  };
+
+  const handleLastNameChange = (event) => {
+    const regex = /^[A-Za-z]*$/;
+    if (!regex.test(event.target.value)) {
+      event.target.value = event.target.value.replace(/[^A-Za-z]/g, "");
+    }
+  };
+
   const patientSelected = (e) => {
     const patientSelected = patientSearchResults.find((patient) => {
       return patient.patientID == e.target.id;
@@ -349,6 +363,7 @@ function SearchPatientForm(props) {
                         defaultMessage: "Last Name",
                       })}
                       id={field.name}
+                      onChange={(e) => handleLastNameChange(e)}
                     />
                   )}
                 </Field>
@@ -366,6 +381,7 @@ function SearchPatientForm(props) {
                         defaultMessage: "First Name",
                       })}
                       id={field.name}
+                      onChange={(e) => handleFirstNameChange(e)}
                     />
                   )}
                 </Field>


### PR DESCRIPTION
## Summary

This pull request addresses the issue where users could enter numbers in the first name and last name fields. A validation function has been implemented to ensure that only alphabetic characters are allowed. This prevents invalid inputs and enhances data integrity.

## Screen Recording

[Screencast from 22-02-25 03:47:43 PM IST.webm](https://github.com/user-attachments/assets/c4b26ff3-7e76-45e5-b228-f1a8421c648f)

## Related Issue

Fixes: [issue#1596](https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/1596)
