### PR TITLE
Fix: Remove action URLs from Routine and Study menus

### DIFF
--- a/src/main/resources/liquibase/2.8.x.x/menu.xml
+++ b/src/main/resources/liquibase/2.8.x.x/menu.xml
@@ -333,5 +333,19 @@
         </update>
     </changeSet>
 
+    <changeSet author="HuzaifaOmar" id="17">
+        <comment>Remove action URLs for Routine and Study menus</comment>
+
+        <update tableName="menu" schemaName="clinlims">
+            <column name="action_url" value=""/>
+            <where>element_id = 'menu_reports_routine'</where>
+        </update>
+
+        <update tableName="menu" schemaName="clinlims">
+            <column name="action_url" value=""/>
+            <where>element_id = 'menu_reports_study'</where>
+        </update>
+    </changeSet>
+
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
Removed left link part of the Routing and Study menu items according to the issue
 
## Screenshots
![image](https://github.com/user-attachments/assets/f7638657-00e0-4353-8237-b882f7e5241c)
![image](https://github.com/user-attachments/assets/f677fd6e-64da-4dab-a3bb-c307b49ce301)

## Related Issue
#1578
