### PR TITLE
User can select date and time out correctly.

### DIFF
--- a/frontend/src/components/admin/userManagement/UserAddModify.js
+++ b/frontend/src/components/admin/userManagement/UserAddModify.js
@@ -1012,8 +1012,8 @@ function UserAddModify() {
                       placeholder={intl.formatMessage({
                         id: "login.password.expired.date.placeholder",
                       })}
-                      min={new Date().toJSON().slice(0, 10)}
                       required={true}
+                      min={new Date().toJSON().slice(0, 10)}
                       // invalid={errors.order && touched.order}
                       // invalidText={errors.order}
                       value={

--- a/frontend/src/components/admin/userManagement/UserAddModify.js
+++ b/frontend/src/components/admin/userManagement/UserAddModify.js
@@ -1008,7 +1008,6 @@ function UserAddModify() {
                       id="password-expire-date"
                       className="defalut"
                       type="date"
-                      labelText=""
                       placeholder={intl.formatMessage({
                         id: "login.password.expired.date.placeholder",
                       })}
@@ -1038,7 +1037,6 @@ function UserAddModify() {
                       id="login-timeout"
                       className="defalut"
                       type="number"
-                      labelText=""
                       placeholder={intl.formatMessage({
                         id: "login.timeout.placeholder",
                       })}

--- a/frontend/src/components/admin/userManagement/UserAddModify.js
+++ b/frontend/src/components/admin/userManagement/UserAddModify.js
@@ -32,6 +32,7 @@ import {
   postToOpenElisServer,
   postToOpenElisServerJsonResponse,
 } from "../../utils/Utils.js";
+import CustomDatePicker from "../../common/CustomDatePicker.js";
 import AutoComplete from "../../common/AutoComplete.js";
 
 const breadcrumbs = [
@@ -548,16 +549,16 @@ function UserAddModify() {
     }));
   }
 
-  function handleExpirationDateChange(e) {
+  function handleExpirationDateChange(date) {
     setSaveButton(false);
     setValidation({ ...validation, expDate: true });
     setUserDataPost((prevUserDataPost) => ({
       ...prevUserDataPost,
-      expirationDate: e.target.value,
+      expirationDate: date,
     }));
     setUserDataShow((prevUserData) => ({
       ...prevUserData,
-      expirationDate: e.target.value,
+      expirationDate: date,
     }));
   }
 
@@ -1004,23 +1005,20 @@ function UserAddModify() {
                     </>
                   </Column>
                   <Column lg={8} md={4} sm={4}>
-                    <input
+                    <CustomDatePicker
                       id="password-expire-date"
                       className="defalut"
-                      type="date"
-                      placeholder={intl.formatMessage({
+                      labelText={intl.formatMessage({
                         id: "login.password.expired.date.placeholder",
                       })}
                       required={true}
-                      min={new Date().toJSON().slice(0, 10)}
-                      // invalid={errors.order && touched.order}
-                      // invalidText={errors.order}
+                      disallowPastDate={true}
                       value={
                         userDataShow && userDataShow.expirationDate
                           ? userDataShow.expirationDate
                           : ""
                       }
-                      onChange={(e) => handleExpirationDateChange(e)}
+                      onChange={(date) => handleExpirationDateChange(date)}
                     />
                   </Column>
                 </Grid>
@@ -1033,7 +1031,7 @@ function UserAddModify() {
                     </>
                   </Column>
                   <Column lg={8} md={4} sm={4}>
-                    <input
+                    <TextInput
                       id="login-timeout"
                       className="defalut"
                       type="number"
@@ -1041,6 +1039,7 @@ function UserAddModify() {
                         id: "login.timeout.placeholder",
                       })}
                       required={true}
+                      labelText=""
                       min={0}
                       // invalid={errors.order && touched.order}
                       // invalidText={errors.order}

--- a/frontend/src/components/admin/userManagement/UserAddModify.js
+++ b/frontend/src/components/admin/userManagement/UserAddModify.js
@@ -995,6 +995,7 @@ function UserAddModify() {
                     />
                   </Column>
                 </Grid>
+                <br />
                 <Grid fullWidth={true}>
                   <Column lg={8} md={4} sm={4}>
                     <>
@@ -1003,14 +1004,15 @@ function UserAddModify() {
                     </>
                   </Column>
                   <Column lg={8} md={4} sm={4}>
-                    <TextInput
+                    <input
                       id="password-expire-date"
                       className="defalut"
-                      type="text"
+                      type="date"
                       labelText=""
                       placeholder={intl.formatMessage({
                         id: "login.password.expired.date.placeholder",
                       })}
+                      min={new Date().toJSON().slice(0, 10)}
                       required={true}
                       // invalid={errors.order && touched.order}
                       // invalidText={errors.order}
@@ -1023,6 +1025,7 @@ function UserAddModify() {
                     />
                   </Column>
                 </Grid>
+                <br />
                 <Grid fullWidth={true}>
                   <Column lg={8} md={4} sm={4}>
                     <>
@@ -1031,15 +1034,16 @@ function UserAddModify() {
                     </>
                   </Column>
                   <Column lg={8} md={4} sm={4}>
-                    <TextInput
+                    <input
                       id="login-timeout"
                       className="defalut"
-                      type="text"
+                      type="number"
                       labelText=""
                       placeholder={intl.formatMessage({
                         id: "login.timeout.placeholder",
                       })}
                       required={true}
+                      min={0}
                       // invalid={errors.order && touched.order}
                       // invalidText={errors.order}
                       value={

--- a/frontend/src/components/admin/userManagement/UserAddModify.js
+++ b/frontend/src/components/admin/userManagement/UserAddModify.js
@@ -891,6 +891,7 @@ function UserAddModify() {
                     />
                   </Column>
                 </Grid>
+                <br />
                 <Grid fullWidth={true}>
                   <Column lg={8} md={4} sm={4}>
                     <>
@@ -931,7 +932,7 @@ function UserAddModify() {
                   </Column>
                 </Grid>
                 <br />
-                <br />
+
                 <Grid fullWidth={true}>
                   <Column lg={8} md={4} sm={4}>
                     <>
@@ -964,6 +965,7 @@ function UserAddModify() {
                     />
                   </Column>
                 </Grid>
+                <br />
                 <Grid fullWidth={true}>
                   <Column lg={8} md={4} sm={4}>
                     <>
@@ -1008,11 +1010,10 @@ function UserAddModify() {
                     <CustomDatePicker
                       id="password-expire-date"
                       className="defalut"
-                      labelText={intl.formatMessage({
-                        id: "login.password.expired.date.placeholder",
-                      })}
+                      labelText=""
                       required={true}
                       disallowPastDate={true}
+                      updateStateValue={true}
                       value={
                         userDataShow && userDataShow.expirationDate
                           ? userDataShow.expirationDate

--- a/frontend/src/components/common/CustomDatePicker.js
+++ b/frontend/src/components/common/CustomDatePicker.js
@@ -17,7 +17,7 @@ const CustomDatePicker = (props) => {
         : "MM/dd/yyyy",
     );
     setCurrentDate(formatDate);
-    props.onChange(currentDate);
+    props.onChange(formatDate);
   }
 
   function handleInputChange(e) {


### PR DESCRIPTION
# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [X] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3 Styleguide and design
      documentation.
- [X] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing Guidelines of this project.

## Summary
Fixes #1608 
In user management user can only select today's or future date and can't select negative timeout.

## Screenshots


https://github.com/user-attachments/assets/70c9097c-69ae-4eea-809e-26e9de54f644

