### PR TITLE
issue-1253: Improve Responsiveness of General Configuration Pages

### DIFF
--- a/frontend/src/components/admin/generalConfig/common/GenericConfigEdit.js
+++ b/frontend/src/components/admin/generalConfig/common/GenericConfigEdit.js
@@ -208,31 +208,31 @@ const GenericConfigEdit = ({ menuType, ID }) => {
           <div className="orderLegendBody">
             <div className="gridBoundary">
               <Grid fullWidth={true}>
-                <Column lg={3}>
+                <Column lg={3} md={2} sm={1}>
                   <h4>
                     <FormattedMessage id="admin.page.configuration.formEntryConfigMenu.name" />
                   </h4>
                 </Column>
-                <Column lg={3}>{FormEntryConfig.paramName}</Column>
+                <Column lg={3} md={6} sm={3}>{FormEntryConfig.paramName}</Column>
               </Grid>
               <br />
               <Grid fullWidth={true}>
-                <Column lg={3}>
+                <Column lg={3} md={2} sm={2}>
                   <h4>
                     <FormattedMessage id="admin.page.configuration.formEntryConfigMenu.description" />
                   </h4>
                 </Column>
-                <Column lg={7}>{FormEntryConfig.description}</Column>
+                <Column lg={7} md={6} sm={4}>{FormEntryConfig.description}</Column>
               </Grid>
               <br />
               {FormEntryConfig.valueType === "boolean" && (
                 <Grid fullWidth={true}>
-                  <Column lg={3}>
+                  <Column lg={3} md={2} sm={1}>
                     <h4>
                       <FormattedMessage id="admin.page.configuration.formEntryConfigMenu.value" />
                     </h4>
                   </Column>
-                  <Column lg={5}>
+                  <Column lg={5} md={6} sm={3}>
                     <RadioButtonGroup
                       name="radioValue"
                       valueSelected={radioValue}
@@ -255,12 +255,12 @@ const GenericConfigEdit = ({ menuType, ID }) => {
               {FormEntryConfig.valueType === "dictionary" && (
                 <>
                   <Grid fullWidth={true}>
-                    <Column lg={3}>
+                    <Column lg={3} md={2} sm={1}>
                       <h4>
                         <FormattedMessage id="admin.page.configuration.formEntryConfigMenu.value" />
                       </h4>
                     </Column>
-                    <Column lg={3}>
+                    <Column lg={3} md={6} sm={3}>
                       <Dropdown
                         id="dictionaryDropdown"
                         items={FormEntryConfig.dictionaryValues}
@@ -279,7 +279,7 @@ const GenericConfigEdit = ({ menuType, ID }) => {
                         <FormattedMessage id="admin.page.configuration.formEntryConfigMenu.value" />
                       </h4>
                     </Column>
-                    <Column lg={3}>
+                    <Column lg={3} md={6} sm={3}>
                       {!removeImage && (
                         <FileUploader
                           buttonLabel="Choose file"
@@ -334,7 +334,7 @@ const GenericConfigEdit = ({ menuType, ID }) => {
                       </h4>
                     </Column>
                     {FormEntryConfig.tag !== "localization" && (
-                      <Column lg={8}>
+                      <Column lg={8} sm={3}>
                         <TextInput
                           id="textInput"
                           value={textInputValue}
@@ -347,7 +347,7 @@ const GenericConfigEdit = ({ menuType, ID }) => {
                     <>
                       <br />
                       <Grid>
-                        <Column lg={8}>
+                        <Column lg={8} sm={2} md={4}>
                           <TextInput
                             id="myInputEnglish"
                             labelText={<FormattedMessage id="english.label" />}
@@ -355,7 +355,7 @@ const GenericConfigEdit = ({ menuType, ID }) => {
                             onChange={handleInputEnglishChange}
                           />
                         </Column>
-                        <Column lg={8}>
+                        <Column lg={8} sm={2} md={4}>
                           <TextInput
                             id="myInputFrench"
                             labelText={<FormattedMessage id="french.label" />}
@@ -371,7 +371,7 @@ const GenericConfigEdit = ({ menuType, ID }) => {
               <br />
               <br />
               <Grid fullWidth={true}>
-                <Column lg={2}>
+                <Column lg={2} sm={2}>
                   <Button onClick={handleSubmitButton} disabled={isLoading}>
                     <FormattedMessage id="admin.page.configuration.formEntryConfigMenu.button.save" />
                   </Button>


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and design
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary

Added Carbon Grid breakpoints to improve responsiveness of general configuration pages on smaller screen sizes.

## Screenshots

**Before:**
 ![image](https://github.com/user-attachments/assets/3f1a35a4-0afc-475b-9770-7696362d56f5)
![image](https://github.com/user-attachments/assets/36803563-23cd-44a3-9bb4-f370bd8cc229)

**After:**
![image](https://github.com/user-attachments/assets/8ff5563e-8e9e-4a26-aefe-1bed3a8ce653)

![image](https://github.com/user-attachments/assets/5c55d2b2-5bef-4208-91d6-7dfb4649cda2)

![image](https://github.com/user-attachments/assets/8413e462-ca8f-42d6-8ef2-0c6138cec912)

## Related Issue

[#1253](https://github.com/DIGI-UW/OpenELIS-Global-2/issues/1253)

## Other

NA
