### PR TITLE
Red text only appears after user attempted

### DIFF
--- a/frontend/src/components/addOrder/AddOrder.js
+++ b/frontend/src/components/addOrder/AddOrder.js
@@ -29,8 +29,15 @@ const AddOrder = (props) => {
 
   const componentMounted = useRef(false);
 
-  const { orderFormValues, setOrderFormValues, samples, error, isModifyOrder } =
-    props;
+  const {
+    orderFormValues,
+    setOrderFormValues,
+    samples,
+    error,
+    isModifyOrder,
+    changed,
+    setChanged,
+  } = props;
   const [otherSamplingVisible, setOtherSamplingVisible] = useState(false);
   const [providers, setProviders] = useState([]);
   const [paymentOptions, setPaymentOptions] = useState([]);
@@ -129,6 +136,13 @@ const AddOrder = (props) => {
         ...orderFormValues.sampleOrderItems,
         providerFirstName: e.target.value,
       },
+    });
+  }
+  function handleChange(path) {
+    console.log([path]);
+    setChanged({
+      ...changed,
+      [path]: true,
     });
   }
 
@@ -484,6 +498,7 @@ const AddOrder = (props) => {
                       : orderFormValues.sampleOrderItems.labNo
                   }
                   //onMouseLeave={handleLabNoValidation}
+                  onClick={() => handleChange("sampleOrderItems.labNo")}
                   onChange={handleLabNo}
                   onKeyPress={handleKeyPress}
                   labelText={
@@ -493,7 +508,12 @@ const AddOrder = (props) => {
                     </>
                   }
                   id="labNo"
-                  invalid={error("sampleOrderItems.labNo") ? true : false}
+                  invalid={
+                    changed["sampleOrderItems.labNo"] &&
+                    error("sampleOrderItems.labNo")
+                      ? true
+                      : false
+                  }
                   invalidText={error("sampleOrderItems.labNo")}
                 />
                 <div>
@@ -700,9 +720,15 @@ const AddOrder = (props) => {
                   "true"
                 }
                 onChange={handleRequesterFirstName}
+                onClick={() =>
+                  handleChange("sampleOrderItems.providerFirstName")
+                }
                 value={orderFormValues.sampleOrderItems.providerFirstName}
                 invalid={
-                  error("sampleOrderItems.providerFirstName") ? true : false
+                  changed["sampleOrderItems.providerFirstName"] &&
+                  error("sampleOrderItems.providerFirstName")
+                    ? true
+                    : false
                 }
                 invalidText={error("sampleOrderItems.providerFirstName")}
                 id="requesterFirstName"
@@ -726,10 +752,16 @@ const AddOrder = (props) => {
                   "true"
                 }
                 value={orderFormValues.sampleOrderItems.providerLastName}
+                onClick={() =>
+                  handleChange("sampleOrderItems.providerLastName")
+                }
                 onChange={handleRequesterLastName}
                 id="requesterLastName"
                 invalid={
-                  error("sampleOrderItems.providerLastName") ? true : false
+                  changed["sampleOrderItems.providerLastName"] &&
+                  error("sampleOrderItems.providerLastName")
+                    ? true
+                    : false
                 }
                 invalidText={error("sampleOrderItems.providerLastName")}
               />

--- a/frontend/src/components/addOrder/Index.js
+++ b/frontend/src/components/addOrder/Index.js
@@ -40,7 +40,11 @@ const Index = () => {
   const samplePageNumber = firstPageNumber + 2;
   const orderPageNumber = firstPageNumber + 3;
   const successMsgPageNumber = lastPageNumber;
-
+  const [changed, setChanged] = useState({
+    "sampleOrderItems.providerFirstName": false,
+    "sampleOrderItems.providerLastName": false,
+    "sampleOrderItems.labNo": false,
+  });
   const [page, setPage] = useState(firstPageNumber);
   const [orderFormValues, setOrderFormValues] = useState(SampleOrderFormValues);
   const [samples, setSamples] = useState([sampleObject]);
@@ -564,46 +568,38 @@ const Index = () => {
 
   const handleSubmitOrderForm = (e) => {
     e.preventDefault();
-    OrderEntryValidationSchema.validate(orderFormValues, {
-      abortEarly: false,
-    })
-      .then(() => {
-        // Prevent multiple submissions.
-        if (isSubmitting) {
-          return;
-        }
-        setIsSubmitting(true);
-        if ("years" in orderFormValues.patientProperties) {
-          delete orderFormValues.patientProperties.years;
-        }
-        if ("months" in orderFormValues.patientProperties) {
-          delete orderFormValues.patientProperties.months;
-        }
-        if ("days" in orderFormValues.patientProperties) {
-          delete orderFormValues.patientProperties.days;
-        }
-        if ("questionnaire" in orderFormValues.sampleOrderItems) {
-          delete orderFormValues.sampleOrderItems.questionnaire;
-        }
-        //remove display Lists rom the form
-        orderFormValues.sampleOrderItems.priorityList = [];
-        orderFormValues.sampleOrderItems.programList = [];
-        orderFormValues.sampleOrderItems.referringSiteList = [];
-        orderFormValues.initialSampleConditionList = [];
-        orderFormValues.testSectionList = [];
-        orderFormValues.sampleOrderItems.providersList = [];
-        orderFormValues.sampleOrderItems.paymentOptions = [];
-        orderFormValues.sampleOrderItems.testLocationCodeList = [];
-        console.log(JSON.stringify(orderFormValues));
-        postToOpenElisServer(
-          "/rest/SamplePatientEntry",
-          JSON.stringify(orderFormValues),
-          handlePost,
-        );
-      })
-      .catch((validationErrors) => {
-        setErrors(validationErrors);
-      });
+    // Prevent multiple submissions.
+    if (isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
+    if ("years" in orderFormValues.patientProperties) {
+      delete orderFormValues.patientProperties.years;
+    }
+    if ("months" in orderFormValues.patientProperties) {
+      delete orderFormValues.patientProperties.months;
+    }
+    if ("days" in orderFormValues.patientProperties) {
+      delete orderFormValues.patientProperties.days;
+    }
+    if ("questionnaire" in orderFormValues.sampleOrderItems) {
+      delete orderFormValues.sampleOrderItems.questionnaire;
+    }
+    //remove display Lists rom the form
+    orderFormValues.sampleOrderItems.priorityList = [];
+    orderFormValues.sampleOrderItems.programList = [];
+    orderFormValues.sampleOrderItems.referringSiteList = [];
+    orderFormValues.initialSampleConditionList = [];
+    orderFormValues.testSectionList = [];
+    orderFormValues.sampleOrderItems.providersList = [];
+    orderFormValues.sampleOrderItems.paymentOptions = [];
+    orderFormValues.sampleOrderItems.testLocationCodeList = [];
+    console.log(JSON.stringify(orderFormValues));
+    postToOpenElisServer(
+      "/rest/SamplePatientEntry",
+      JSON.stringify(orderFormValues),
+      handlePost,
+    );
   };
 
   useEffect(() => {
@@ -611,6 +607,19 @@ const Index = () => {
       attacheSamplesToFormValues();
     }
   }, [page]);
+
+  useEffect(() => {
+    console.log(changed);
+    OrderEntryValidationSchema.validate(orderFormValues, { abortEarly: false })
+      .then((validData) => {
+        setErrors([]);
+        console.debug("Valid Data:", validData);
+      })
+      .catch((errors) => {
+        setErrors(errors);
+        console.error("Validation Errors:", errors.errors);
+      });
+  }, [changed, orderFormValues]);
 
   useEffect(() => {
     const labNumber = new URLSearchParams(window.location.search).get(
@@ -773,6 +782,8 @@ const Index = () => {
                 samples={samples}
                 error={elementError}
                 isModifyOrder={false}
+                changed={changed}
+                setChanged={setChanged}
               />
             )}
 

--- a/frontend/src/components/addOrder/Index.js
+++ b/frontend/src/components/addOrder/Index.js
@@ -564,38 +564,46 @@ const Index = () => {
 
   const handleSubmitOrderForm = (e) => {
     e.preventDefault();
-    // Prevent multiple submissions.
-    if (isSubmitting) {
-      return;
-    }
-    setIsSubmitting(true);
-    if ("years" in orderFormValues.patientProperties) {
-      delete orderFormValues.patientProperties.years;
-    }
-    if ("months" in orderFormValues.patientProperties) {
-      delete orderFormValues.patientProperties.months;
-    }
-    if ("days" in orderFormValues.patientProperties) {
-      delete orderFormValues.patientProperties.days;
-    }
-    if ("questionnaire" in orderFormValues.sampleOrderItems) {
-      delete orderFormValues.sampleOrderItems.questionnaire;
-    }
-    //remove display Lists rom the form
-    orderFormValues.sampleOrderItems.priorityList = [];
-    orderFormValues.sampleOrderItems.programList = [];
-    orderFormValues.sampleOrderItems.referringSiteList = [];
-    orderFormValues.initialSampleConditionList = [];
-    orderFormValues.testSectionList = [];
-    orderFormValues.sampleOrderItems.providersList = [];
-    orderFormValues.sampleOrderItems.paymentOptions = [];
-    orderFormValues.sampleOrderItems.testLocationCodeList = [];
-    console.log(JSON.stringify(orderFormValues));
-    postToOpenElisServer(
-      "/rest/SamplePatientEntry",
-      JSON.stringify(orderFormValues),
-      handlePost,
-    );
+    OrderEntryValidationSchema.validate(orderFormValues, {
+      abortEarly: false,
+    })
+      .then(() => {
+        // Prevent multiple submissions.
+        if (isSubmitting) {
+          return;
+        }
+        setIsSubmitting(true);
+        if ("years" in orderFormValues.patientProperties) {
+          delete orderFormValues.patientProperties.years;
+        }
+        if ("months" in orderFormValues.patientProperties) {
+          delete orderFormValues.patientProperties.months;
+        }
+        if ("days" in orderFormValues.patientProperties) {
+          delete orderFormValues.patientProperties.days;
+        }
+        if ("questionnaire" in orderFormValues.sampleOrderItems) {
+          delete orderFormValues.sampleOrderItems.questionnaire;
+        }
+        //remove display Lists rom the form
+        orderFormValues.sampleOrderItems.priorityList = [];
+        orderFormValues.sampleOrderItems.programList = [];
+        orderFormValues.sampleOrderItems.referringSiteList = [];
+        orderFormValues.initialSampleConditionList = [];
+        orderFormValues.testSectionList = [];
+        orderFormValues.sampleOrderItems.providersList = [];
+        orderFormValues.sampleOrderItems.paymentOptions = [];
+        orderFormValues.sampleOrderItems.testLocationCodeList = [];
+        console.log(JSON.stringify(orderFormValues));
+        postToOpenElisServer(
+          "/rest/SamplePatientEntry",
+          JSON.stringify(orderFormValues),
+          handlePost,
+        );
+      })
+      .catch((validationErrors) => {
+        setErrors(validationErrors);
+      });
   };
 
   useEffect(() => {
@@ -603,18 +611,6 @@ const Index = () => {
       attacheSamplesToFormValues();
     }
   }, [page]);
-
-  useEffect(() => {
-    OrderEntryValidationSchema.validate(orderFormValues, { abortEarly: false })
-      .then((validData) => {
-        setErrors([]);
-        console.debug("Valid Data:", validData);
-      })
-      .catch((errors) => {
-        setErrors(errors);
-        console.error("Validation Errors:", errors.errors);
-      });
-  }, [orderFormValues]);
 
   useEffect(() => {
     const labNumber = new URLSearchParams(window.location.search).get(

--- a/frontend/src/components/modifyOrder/ModifyOrder.js
+++ b/frontend/src/components/modifyOrder/ModifyOrder.js
@@ -54,6 +54,11 @@ const ModifyOrder = () => {
   const [samples, setSamples] = useState([sampleObject]);
   const [errors, setErrors] = useState([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [changed, setChanged] = useState({
+    "sampleOrderItems.providerFirstName": false,
+    "sampleOrderItems.providerLastName": false,
+    "sampleOrderItems.labNo": false,
+  });
 
   useEffect(() => {
     componentMounted.current = true;
@@ -89,7 +94,7 @@ const ModifyOrder = () => {
         setErrors(errors);
         console.error("Validation Errors:", errors.errors);
       });
-  }, [orderFormValues]);
+  }, [changed, orderFormValues]);
 
   const loadOrderValues = (data) => {
     if (componentMounted.current) {
@@ -310,6 +315,8 @@ const ModifyOrder = () => {
                   samples={samples}
                   error={elementError}
                   isModifyOrder={true}
+                  changed={changed}
+                  setChanged={setChanged}
                 />
               )}
 


### PR DESCRIPTION
# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [X] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3 Styleguide and design
      documentation.
- [X] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing Guidelines of this project.

## Summary
Fixes #839 
Red text is only displayed after user attempts to change the field. The validation check is applied only while changing the particular field.
This improves the user experience. 

## Screen Recording
As seen in the video the UI is not red initially. Only when the user clicks on that particular field the UI turns red indicating errors.




https://github.com/user-attachments/assets/9a69109a-f0eb-433f-b17c-bc2cb64f0e7d








