### PR TITLE
Issue 1863-Password Change Test Failing in Cypress Resolved

### DIFF
--- a/frontend/cypress/e2e/login.cy.js
+++ b/frontend/cypress/e2e/login.cy.js
@@ -36,14 +36,57 @@ describe("Login Test Cases", function () {
     cy.contains("Username or Password are incorrect").should("be.visible");
   });
 
+  // it("User changes from default credentials", function () {
+  //   login.changingPassword();
+  //   login.enterUsername(usersData[3].username);
+  //   login.enterCurrentPassword(usersData[3].password);
+  //   login.enterNewPassword(usersData[4].password);
+  //   login.repeatNewPassword(usersData[4].password);
+  //   login.submitNewPassword();
+  //   cy.contains("Password changed successfully").should("be.visible");
+  // });
+  // it("User changes from default credentials", function () {
+  //   login.changingPassword();
+
+  //   cy.log("Username: " + usersData[3].username);
+  //   cy.log("Current Password: " + usersData[3].password);
+  //   cy.log("New Password: " + usersData[4].password);
+
+  //   login.enterUsername(usersData[3].username);
+  //   login.enterCurrentPassword(usersData[3].password);
+  //   login.enterNewPassword(usersData[4].password);
+  //   login.repeatNewPassword(usersData[4].password);
+
+  //   login.submitNewPassword();
+
+  //   cy.contains("Password changed successfully", { timeout: 10000 }).should("be.visible");
+  // });
   it("User changes from default credentials", function () {
+    login.visit(); // Ensure fresh login page
+    login.clearInputs(); // Clear fields if needed
+
     login.changingPassword();
-    login.enterUsername(usersData[3].username);
-    login.enterCurrentPassword(usersData[3].password);
-    login.enterNewPassword(usersData[4].password);
-    login.repeatNewPassword(usersData[4].password);
+
+    // Ensure all fields are available and enabled before typing
+    cy.get("#loginName")
+      .should("be.visible")
+      .and("not.be.disabled")
+      .clear()
+      .type(usersData[3].username);
+    cy.get("#current-password")
+      .should("be.visible")
+      .type(usersData[3].password);
+    cy.get("#new-password").should("be.visible").type(usersData[4].password);
+    cy.get("#repeat-new-password")
+      .should("be.visible")
+      .type(usersData[4].password);
+
     login.submitNewPassword();
-    cy.contains("Password changed successfully").should("be.visible");
+
+    // Robust check for success message
+    cy.contains("Password changed successfully", { timeout: 15000 }).should(
+      "be.visible",
+    );
   });
 
   it("Logs in with correct credentials", function () {
@@ -53,15 +96,34 @@ describe("Login Test Cases", function () {
     login.signIn();
   });
 
+  // it("Resets the default credentials", function () {
+  //   login.changingPassword();
+  //   login.enterUsername(usersData[4].username);
+  //   login.enterCurrentPassword(usersData[4].password);
+  //   login.enterNewPassword(usersData[3].password);
+  //   login.repeatNewPassword(usersData[3].password);
+  //   login.submitNewPassword();
+  //   //cy.get("div[role='status']").should("be.visible");
+  //   cy.contains("Password changed successfully").should("be.visible");
+  // });
   it("Resets the default credentials", function () {
+    login.visit(); // Ensure you're on the login page
+    login.clearInputs(); // Clear any previous input
+
     login.changingPassword();
-    login.enterUsername(usersData[4].username);
+
+    cy.get("#loginName")
+      .should("not.be.disabled")
+      .clear()
+      .type(usersData[4].username);
     login.enterCurrentPassword(usersData[4].password);
     login.enterNewPassword(usersData[3].password);
     login.repeatNewPassword(usersData[3].password);
     login.submitNewPassword();
-    //cy.get("div[role='status']").should("be.visible");
-    cy.contains("Password changed successfully").should("be.visible");
+
+    cy.contains("Password changed successfully", { timeout: 10000 }).should(
+      "be.visible",
+    );
   });
 
   it("User exits password reset", function () {

--- a/frontend/cypress/e2e/login.cy.js
+++ b/frontend/cypress/e2e/login.cy.js
@@ -36,58 +36,23 @@ describe("Login Test Cases", function () {
     cy.contains("Username or Password are incorrect").should("be.visible");
   });
 
-  // it("User changes from default credentials", function () {
-  //   login.changingPassword();
-  //   login.enterUsername(usersData[3].username);
-  //   login.enterCurrentPassword(usersData[3].password);
-  //   login.enterNewPassword(usersData[4].password);
-  //   login.repeatNewPassword(usersData[4].password);
-  //   login.submitNewPassword();
-  //   cy.contains("Password changed successfully").should("be.visible");
-  // });
-  // it("User changes from default credentials", function () {
-  //   login.changingPassword();
-
-  //   cy.log("Username: " + usersData[3].username);
-  //   cy.log("Current Password: " + usersData[3].password);
-  //   cy.log("New Password: " + usersData[4].password);
-
-  //   login.enterUsername(usersData[3].username);
-  //   login.enterCurrentPassword(usersData[3].password);
-  //   login.enterNewPassword(usersData[4].password);
-  //   login.repeatNewPassword(usersData[4].password);
-
-  //   login.submitNewPassword();
-
-  //   cy.contains("Password changed successfully", { timeout: 10000 }).should("be.visible");
-  // });
   it("User changes from default credentials", function () {
     login.visit(); // Ensure fresh login page
-    login.clearInputs(); // Clear fields if needed
-
+    login.clearInputs(); 
+  
     login.changingPassword();
-
-    // Ensure all fields are available and enabled before typing
-    cy.get("#loginName")
-      .should("be.visible")
-      .and("not.be.disabled")
-      .clear()
-      .type(usersData[3].username);
-    cy.get("#current-password")
-      .should("be.visible")
-      .type(usersData[3].password);
+  
+    cy.get("#loginName").should("be.visible").and("not.be.disabled").clear().type(usersData[3].username);
+    cy.get("#current-password").should("be.visible").type(usersData[3].password);
     cy.get("#new-password").should("be.visible").type(usersData[4].password);
-    cy.get("#repeat-new-password")
-      .should("be.visible")
-      .type(usersData[4].password);
-
+    cy.get("#repeat-new-password").should("be.visible").type(usersData[4].password);
+  
     login.submitNewPassword();
-
+  
     // Robust check for success message
-    cy.contains("Password changed successfully", { timeout: 15000 }).should(
-      "be.visible",
-    );
+    cy.contains("Password changed successfully", { timeout: 15000 }).should("be.visible");
   });
+  
 
   it("Logs in with correct credentials", function () {
     let user = usersData[4];
@@ -96,34 +61,20 @@ describe("Login Test Cases", function () {
     login.signIn();
   });
 
-  // it("Resets the default credentials", function () {
-  //   login.changingPassword();
-  //   login.enterUsername(usersData[4].username);
-  //   login.enterCurrentPassword(usersData[4].password);
-  //   login.enterNewPassword(usersData[3].password);
-  //   login.repeatNewPassword(usersData[3].password);
-  //   login.submitNewPassword();
-  //   //cy.get("div[role='status']").should("be.visible");
-  //   cy.contains("Password changed successfully").should("be.visible");
-  // });
+
   it("Resets the default credentials", function () {
-    login.visit(); // Ensure you're on the login page
-    login.clearInputs(); // Clear any previous input
-
+    login.visit(); 
+    login.clearInputs(); 
+  
     login.changingPassword();
-
-    cy.get("#loginName")
-      .should("not.be.disabled")
-      .clear()
-      .type(usersData[4].username);
+  
+    cy.get("#loginName").should("not.be.disabled").clear().type(usersData[4].username);
     login.enterCurrentPassword(usersData[4].password);
     login.enterNewPassword(usersData[3].password);
     login.repeatNewPassword(usersData[3].password);
     login.submitNewPassword();
-
-    cy.contains("Password changed successfully", { timeout: 10000 }).should(
-      "be.visible",
-    );
+  
+    cy.contains("Password changed successfully", { timeout: 10000 }).should("be.visible");
   });
 
   it("User exits password reset", function () {


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and design
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary

Hi team,

While running the Cypress tests, the "User changes from default credentials" test was failing. The issue was that the username field was disabled when Cypress tried to type into it.

To fix this, I added a check to make sure the field is visible and enabled before typing, and also waited for the success message properly. After these changes, all tests are now passing.

It solves issue 1863.

## Screenshots


![Screenshot (236)](https://github.com/user-attachments/assets/bcc7b41a-15a2-4115-bd0a-2c92563901fe)

## Related Issue

[issue-1863]

## Other

Files Changed: Login.cy.js
