### PR TITLE
Replaced inline div to use carbon grid in reflex rule

### DIFF
--- a/frontend/src/components/admin/reflexTests/ReflexRuleForm.js
+++ b/frontend/src/components/admin/reflexTests/ReflexRuleForm.js
@@ -465,50 +465,60 @@ function ReflexRule() {
             <Form onSubmit={(e) => handleSubmit(e, index)}>
               <Stack gap={7}>
                 <div className="ruleBody">
-                  <div className="inlineDiv">
-                    <div>
-                      <TextInput
-                        name="ruleName"
-                        className="reflexInputText"
-                        type="text"
-                        id={index + "_rulename"}
-                        labelText={
-                          <FormattedMessage id="rulebuilder.label.ruleName" />
-                        }
-                        value={rule.ruleName}
-                        onChange={(e) => handleRuleFieldChange(e, index)}
-                        required
-                      />
-                    </div>
-                    <div>&nbsp; &nbsp;</div>
-                    <div>
-                      <Toggle
-                        toggled={rule.toggled}
-                        aria-label="toggle button"
-                        id={index + "_toggle"}
-                        labelText={
-                          <FormattedMessage id="rulebuilder.label.toggleRule" />
-                        }
-                        onToggle={(e) => toggleRule(e, index)}
-                        onClick={handleClick}
-                      />
-                    </div>
-                    <div>&nbsp; &nbsp; &nbsp; &nbsp;</div>
-                    <div>
-                      <Checkbox
-                        labelText={"Active: " + rule.active}
-                        name="active"
-                        id={index + "_active"}
-                        checked={rule.active}
-                        disabled={rule.active}
-                        onChange={(e) => {
-                          const list = [...ruleList];
-                          list[index]["active"] = e.target.checked;
-                          setRuleList(list);
-                        }}
-                      />
-                    </div>
-                  </div>
+                  <Grid>
+                    <Column lg={16} md={8} sm={4}>
+                      <Grid>
+                        <Column lg={3} md={2} sm={4}>
+                          <div>
+                            <TextInput
+                              name="ruleName"
+                              className="reflexInputText"
+                              type="text"
+                              id={index + "_rulename"}
+                              labelText={
+                                <FormattedMessage id="rulebuilder.label.ruleName" />
+                              }
+                              value={rule.ruleName}
+                              onChange={(e) => handleRuleFieldChange(e, index)}
+                              required
+                            />
+                          </div>
+                        </Column>
+
+                        <Column lg={1} md={1} sm={4}>
+                          <div>
+                            <Toggle
+                              toggled={rule.toggled}
+                              aria-label="toggle button"
+                              id={index + "_toggle"}
+                              labelText={
+                                <FormattedMessage id="rulebuilder.label.toggleRule" />
+                              }
+                              onToggle={(e) => toggleRule(e, index)}
+                              onClick={handleClick}
+                            />
+                          </div>
+                        </Column>
+                        <div>&nbsp; &nbsp; &nbsp; &nbsp;</div>
+                        <Column lg={5} md={2} sm={4}>
+                          <div>
+                            <Checkbox
+                              labelText={"Active: " + rule.active}
+                              name="active"
+                              id={index + "_active"}
+                              checked={rule.active}
+                              disabled={rule.active}
+                              onChange={(e) => {
+                                const list = [...ruleList];
+                                list[index]["active"] = e.target.checked;
+                                setRuleList(list);
+                              }}
+                            />
+                          </div>
+                        </Column>
+                      </Grid>
+                    </Column>
+                  </Grid>
                   {rule.toggled && (
                     <>
                       <div className="section">


### PR DESCRIPTION
# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [X] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3 Styleguide and design
      documentation.
- [X] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing Guidelines of this project.

## Summary
This individually removes inline div to use carbon grid

## Screenshots
Desktop
Before:

![Screenshot 2025-04-16 065848](https://github.com/user-attachments/assets/712175ae-3485-46df-9556-fe5033947d85)

After:

![Screenshot 2025-04-16 071345](https://github.com/user-attachments/assets/74f34770-aa2c-43fe-b521-afc48fdd62fc)

Mobile:
![Screenshot 2025-04-16 071501](https://github.com/user-attachments/assets/91c84afd-5b8e-4179-a557-c407ef951186)

After:
![Screenshot 2025-04-16 071540](https://github.com/user-attachments/assets/834ff72b-e919-42ae-9f30-63e9b091241b)


