### PR TITLE
Replaced inline div to use carbon grid in order component

### DIFF
--- a/frontend/src/components/addOrder/AddSample.js
+++ b/frontend/src/components/addOrder/AddSample.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Button, Link, Row, Stack } from "@carbon/react";
+import { Button, Link, Row, Stack, Column, Grid } from "@carbon/react";
 import { Add } from "@carbon/react/icons";
 import { getFromOpenElisServer } from "../utils/Utils";
 import SampleType from "./SampleType";
@@ -106,45 +106,44 @@ const AddSample = (props) => {
       <h3>
         <FormattedMessage id="label.button.sample" />
       </h3>
-      <Stack gap={10}>
-        <div className="orderLegendBody">
-          {samples.map((sample, i) => {
-            return (
-              <div className="sampleType" key={i}>
-                <h4>
-                  <FormattedMessage id="label.button.sample" /> {i + 1}
-                  <span className="requiredlabel">*</span>
-                </h4>
-                <Link href="#" onClick={(e) => handleRemoveSample(e, sample)}>
-                  {<FormattedMessage id="sample.remove.action" />}
-                </Link>
-                <SampleType
-                  index={i}
-                  rejectSampleReasons={rejectSampleReasons}
-                  removeSample={removeSample}
-                  sample={sample}
-                  setSample={(newSample) => {
-                    let newSamples = [...samples];
-                    newSamples[i] = newSample;
-                    setSamples(newSamples);
-                  }}
-                  sampleTypeObject={sampleTypeObject}
-                  error={error}
-                />
-              </div>
-            );
-          })}
-          <Row>
-            <div className="inlineDiv">
-              <Button onClick={handleAddNewSample}>
-                {<FormattedMessage id="sample.add.action" />}
-                &nbsp; &nbsp;
-                <Add size={16} />
-              </Button>
-            </div>
-          </Row>
-        </div>
-      </Stack>
+      <Grid>
+        <Column lg={16} md={8} sm={4}>
+          <div className="orderLegendBody">
+            {samples.map((sample, i) => {
+              return (
+                <div className="sampleType" key={i}>
+                  <h4>
+                    <FormattedMessage id="label.button.sample" /> {i + 1}
+                    <span className="requiredlabel">*</span>
+                  </h4>
+                  <Link href="#" onClick={(e) => handleRemoveSample(e, sample)}>
+                    {<FormattedMessage id="sample.remove.action" />}
+                  </Link>
+                  <SampleType
+                    index={i}
+                    rejectSampleReasons={rejectSampleReasons}
+                    removeSample={removeSample}
+                    sample={sample}
+                    setSample={(newSample) => {
+                      let newSamples = [...samples];
+                      newSamples[i] = newSample;
+                      setSamples(newSamples);
+                    }}
+                    sampleTypeObject={sampleTypeObject}
+                    error={error}
+                  />
+                </div>
+              );
+            })}
+
+            <Button onClick={handleAddNewSample}>
+              {<FormattedMessage id="sample.add.action" />}
+              &nbsp; &nbsp;
+              <Add size={16} />
+            </Button>
+          </div>
+        </Column>
+      </Grid>
     </>
   );
 };

--- a/frontend/src/components/addOrder/OrderEntryAdditionalQuestions.js
+++ b/frontend/src/components/addOrder/OrderEntryAdditionalQuestions.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Select, SelectItem, Stack } from "@carbon/react";
+import { Select, SelectItem, Stack, Column, Grid } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import "../../index.css";
 import "../../App.css";
@@ -48,9 +48,9 @@ export const ProgramSelect = ({
 
   return (
     <>
-      <div className="formInlineDiv">
-        {programs.length > 0 && (
-          <div className="inputText">
+      <Grid fullWidth={true}>
+        <Column lg={16} md={8} sm={4}>
+          {programs.length > 0 && (
             <Select
               id="additionalQuestionsSelect"
               labelText={intl.formatMessage({ id: "label.program" })}
@@ -69,9 +69,9 @@ export const ProgramSelect = ({
                 );
               })}
             </Select>
-          </div>
-        )}
-      </div>
+          )}
+        </Column>
+      </Grid>
     </>
   );
 };
@@ -274,29 +274,31 @@ const OrderEntryAdditionalQuestions = ({
 
   return (
     <>
-      <Stack gap={10}>
-        <div className="orderLegendBody">
-          <h3>
-            <FormattedMessage id="select.program" />
-          </h3>
-          <ProgramSelect
-            programChange={handleProgramSelection}
-            orderFormValues={orderFormValues}
-          />
-          <Questionnaire
-            questionnaire={questionnaire}
-            onAnswerChange={answerChange}
-            getAnswer={getAnswer}
-          />
-          {questionnaireResponse && (
-            <input
-              type="hidden"
-              name="additionalQuestions"
-              value={questionnaireResponse}
+      <Grid fullWidth={true}>
+        <Column lg={16} md={8} sm={4}>
+          <div className="orderLegendBody">
+            <h3>
+              <FormattedMessage id="select.program" />
+            </h3>
+            <ProgramSelect
+              programChange={handleProgramSelection}
+              orderFormValues={orderFormValues}
             />
-          )}
-        </div>
-      </Stack>
+            <Questionnaire
+              questionnaire={questionnaire}
+              onAnswerChange={answerChange}
+              getAnswer={getAnswer}
+            />
+            {questionnaireResponse && (
+              <input
+                type="hidden"
+                name="additionalQuestions"
+                value={questionnaireResponse}
+              />
+            )}
+          </div>
+        </Column>
+      </Grid>
     </>
   );
 };

--- a/frontend/src/components/modifyOrder/ModifyOrder.js
+++ b/frontend/src/components/modifyOrder/ModifyOrder.js
@@ -7,6 +7,8 @@ import {
   Stack,
   Section,
   Tag,
+  Grid,
+  Column,
 } from "@carbon/react";
 import EditSample from "./EditSample";
 import AddOrder from "../addOrder/AddOrder";
@@ -278,108 +280,117 @@ const ModifyOrder = () => {
       >
         {" "}
       </PatientHeader>
-      <Stack gap={10}>
-        <div className="pageContent">
-          {notificationVisible === true ? <AlertDialog /> : ""}
-          {orderFormValues?.sampleOrderItems && (
-            <div className="orderWorkFlowDiv">
-              <h2>
-                <FormattedMessage id="order.test.request.heading" />
-              </h2>
-              {page <= orderPageNumber && (
-                <ProgressIndicator
-                  currentIndex={page}
-                  className="ProgressIndicator"
-                  spaceEqually={true}
-                  onChange={(e) => handleTabClickHandler(e)}
-                >
-                  <ProgressStep
-                    disabled={orderFormValues.sampleOrderItems.labNo == ""}
-                    label={intl.formatMessage({
-                      id: "order.step.program.selection",
-                    })}
-                  />
-                  <ProgressStep
-                    disabled={orderFormValues.sampleOrderItems.labNo == ""}
-                    label={intl.formatMessage({ id: "sample.add.action" })}
-                  />
-                  <ProgressStep
-                    disabled={orderFormValues.sampleOrderItems.labNo == ""}
-                    label={intl.formatMessage({ id: "order.label.add" })}
-                  />
-                </ProgressIndicator>
-              )}
-              {page === programPageNumber && (
-                <EditOrderEntryAdditionalQuestions
-                  orderFormValues={orderFormValues}
-                  setOrderFormValues={setOrderFormValues}
-                />
-              )}
-              {page === samplePageNumber && (
-                <EditSample
-                  orderFormValues={orderFormValues}
-                  setOrderFormValues={setOrderFormValues}
-                  setSamples={setSamples}
-                  samples={samples}
-                  error={elementError}
-                />
-              )}
-              {page === orderPageNumber && (
-                <AddOrder
-                  orderFormValues={orderFormValues}
-                  setOrderFormValues={setOrderFormValues}
-                  samples={samples}
-                  error={elementError}
-                  isModifyOrder={true}
-                  changed={changed}
-                  setChanged={setChanged}
-                />
-              )}
+      <Grid>
+        <Column lg={16} md={8} sm={4}>
+          <Stack gap={10}>
+            <div className="pageContent">
+              {notificationVisible === true ? <AlertDialog /> : ""}
+              {orderFormValues?.sampleOrderItems && (
+                <div className="orderWorkFlowDiv">
+                  <h2>
+                    <FormattedMessage id="order.test.request.heading" />
+                  </h2>
+                  {page <= orderPageNumber && (
+                    <ProgressIndicator
+                      currentIndex={page}
+                      className="ProgressIndicator"
+                      spaceEqually={true}
+                      onChange={(e) => handleTabClickHandler(e)}
+                    >
+                      <ProgressStep
+                        disabled={orderFormValues.sampleOrderItems.labNo == ""}
+                        label={intl.formatMessage({
+                          id: "order.step.program.selection",
+                        })}
+                      />
+                      <ProgressStep
+                        disabled={orderFormValues.sampleOrderItems.labNo == ""}
+                        label={intl.formatMessage({ id: "sample.add.action" })}
+                      />
+                      <ProgressStep
+                        disabled={orderFormValues.sampleOrderItems.labNo == ""}
+                        label={intl.formatMessage({ id: "order.label.add" })}
+                      />
+                    </ProgressIndicator>
+                  )}
+                  {page === programPageNumber && (
+                    <EditOrderEntryAdditionalQuestions
+                      orderFormValues={orderFormValues}
+                      setOrderFormValues={setOrderFormValues}
+                    />
+                  )}
+                  {page === samplePageNumber && (
+                    <EditSample
+                      orderFormValues={orderFormValues}
+                      setOrderFormValues={setOrderFormValues}
+                      setSamples={setSamples}
+                      samples={samples}
+                      error={elementError}
+                    />
+                  )}
+                  {page === orderPageNumber && (
+                    <AddOrder
+                      orderFormValues={orderFormValues}
+                      setOrderFormValues={setOrderFormValues}
+                      samples={samples}
+                      error={elementError}
+                      isModifyOrder={true}
+                      changed={changed}
+                      setChanged={setChanged}
+                    />
+                  )}
 
-              {page === successMsgPageNumber && (
-                <OrderSuccessMessage
-                  orderFormValues={orderFormValues}
-                  setOrderFormValues={setOrderFormValues}
-                  setSamples={setSamples}
-                  setPage={setPage}
-                />
+                  {page === successMsgPageNumber && (
+                    <OrderSuccessMessage
+                      orderFormValues={orderFormValues}
+                      setOrderFormValues={setOrderFormValues}
+                      setSamples={setSamples}
+                      setPage={setPage}
+                    />
+                  )}
+                  <div className="navigationButtonsLayout">
+                    {page !== firstPageNumber && page <= orderPageNumber && (
+                      <Button
+                        kind="tertiary"
+                        onClick={() => navigateBackWards()}
+                      >
+                        <FormattedMessage id="back.action.button" />
+                      </Button>
+                    )}
+
+                    {page < orderPageNumber && (
+                      <Button
+                        data-cy="next-button"
+                        kind="primary"
+                        className="forwardButton"
+                        onClick={() => navigateForward()}
+                      >
+                        <FormattedMessage id="next.action.button" />
+                      </Button>
+                    )}
+
+                    {page === orderPageNumber && (
+                      <Button
+                        data-cy="submit-order"
+                        kind="primary"
+                        className="forwardButton"
+                        onClick={handleSubmitOrderForm}
+                        disabled={
+                          isSubmitting || errors?.errors?.length > 0
+                            ? true
+                            : false
+                        }
+                      >
+                        <FormattedMessage id="label.button.submit" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
               )}
-              <div className="navigationButtonsLayout">
-                {page !== firstPageNumber && page <= orderPageNumber && (
-                  <Button kind="tertiary" onClick={() => navigateBackWards()}>
-                    <FormattedMessage id="back.action.button" />
-                  </Button>
-                )}
-
-                {page < orderPageNumber && (
-                  <Button
-                    data-cy="next-button"
-                    kind="primary"
-                    className="forwardButton"
-                    onClick={() => navigateForward()}
-                  >
-                    <FormattedMessage id="next.action.button" />
-                  </Button>
-                )}
-
-                {page === orderPageNumber && (
-                  <Button
-                    data-cy="submit-order"
-                    kind="primary"
-                    className="forwardButton"
-                    onClick={handleSubmitOrderForm}
-                    disabled={
-                      isSubmitting || errors?.errors?.length > 0 ? true : false
-                    }
-                  >
-                    <FormattedMessage id="label.button.submit" />
-                  </Button>
-                )}
-              </div>
             </div>
-          )}
-        </div>
-      </Stack>
+          </Stack>
+        </Column>
+      </Grid>
     </>
   );
 };


### PR DESCRIPTION
# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [X] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3 Styleguide and design
      documentation.
- [X] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing Guidelines of this project.

## Summary
This PR deals with replacing inline div with carbon grid in add sample and additional questions component.
I made same pr as they both are inside order component.
The pages are working fine in add order as well as edit order page.

## Screenshots
**Add Sample**(Add order)
Desktop
before:

![Screenshot 2025-04-16 075710](https://github.com/user-attachments/assets/75eef267-72ff-40aa-8f3e-bcc9f8936dcf)

after:

![Screenshot 2025-04-16 075228](https://github.com/user-attachments/assets/7717a032-8401-4d77-bf0e-c3ea46d9c240)

Mobile:
before:
![Screenshot 2025-04-16 075545](https://github.com/user-attachments/assets/8fa24bf9-8ace-47fc-8ba1-f4240ecb204b)
after:
![Screenshot 2025-04-16 075728](https://github.com/user-attachments/assets/2d81dad1-b2cf-40e8-beb4-6ddfc817ef04)

**Order Entry Additional Questions**
_**Add order:**_

Desktop
before:
![Screenshot 2025-04-18 125942](https://github.com/user-attachments/assets/a55e1ddc-83e7-4071-ae59-dfc020771c37)

after:
![Screenshot 2025-04-18 130035](https://github.com/user-attachments/assets/e67a0220-f64c-48f1-83fa-b4da9fff7460)

Mobile:
before:
![image](https://github.com/user-attachments/assets/7a12823d-bb6b-483c-9fea-8ba15a2607e9)
after:
![Screenshot 2025-04-18 130244](https://github.com/user-attachments/assets/bb1d7f07-7081-4e1d-b7d5-34cd38defb0d)

**_Edit order:_**
Desktop:
before:
![Screenshot 2025-04-18 130352](https://github.com/user-attachments/assets/cf54c1db-29a6-4259-924f-b3eb8a78a348)
after:
![Screenshot 2025-04-18 130447](https://github.com/user-attachments/assets/f82f2f92-6f6b-4368-abc0-7310acec19a4)


Mobile:
before:
![Screenshot 2025-04-16 075522](https://github.com/user-attachments/assets/07d091ca-ab57-4844-a6a7-70410b3bc697)
after:
![Screenshot 2025-04-18 121053](https://github.com/user-attachments/assets/c145428d-d699-436f-85ed-846488fc36c2)




