### PR TITLE
fix(TADP): sorting test issue on POST data fix

### DIFF
--- a/frontend/src/components/admin/testManagementConfigMenu/TestActivation.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/TestActivation.js
@@ -932,9 +932,9 @@ function TestActivation() {
       ...(changedTestActivationData?.activeTestList?.flatMap(
         (sample) => sample.activeTests,
       ) || []),
-      // ...(changedTestActivationData?.activeTestList?.flatMap(
-      //   (sample) => sample.inactiveTests,
-      // ) || []),
+      ...(changedTestActivationData?.activeTestList?.flatMap(
+        (sample) => sample.inactiveTests,
+      ) || []),
       ...(changedTestActivationData?.inactiveTestList?.flatMap(
         (sample) => sample.activeTests,
       ) || []),
@@ -1283,6 +1283,26 @@ function TestActivation() {
                         const newArrangement = [...prev];
                         newArrangement[index] = updatedTests;
                         return newArrangement;
+                      });
+                      setJsonChangeList((prev) => {
+                        const updatedActivateTest = prev.activateTest.map(
+                          (test) => {
+                            const matchIndex = updatedTests.findIndex(
+                              (t) => t.id === test.id,
+                            );
+                            if (matchIndex !== -1) {
+                              return {
+                                ...test,
+                                sortOrder: matchIndex,
+                              };
+                            }
+                            return test;
+                          },
+                        );
+                        return {
+                          ...prev,
+                          activateTest: updatedActivateTest,
+                        };
                       });
                     }}
                   />


### PR DESCRIPTION
- referencing #1988 

![image](https://github.com/user-attachments/assets/749826db-d6d9-4e9d-af16-92d831d65478)

ON POST request, now it will SORT the activated { which was a bug previously }. Activation Deactivation was working, but SORTING mean {sortOrder} Sort Order was not working!

now its fixed

#### Fixed workflow video { wait 5 sec let the video load }

![tadpBugFix](https://github.com/user-attachments/assets/b03244b9-abe1-45e8-aa54-b54880429a26)


