### PR TITLE
feat(STC): Rewriting sample type create from Sample Type Management

### DIFF
--- a/frontend/src/components/admin/testManagementConfigMenu/PanelCreate.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/PanelCreate.js
@@ -1,6 +1,5 @@
 import React, { useContext, useState, useEffect, useRef } from "react";
 import {
-  Form,
   Heading,
   Button,
   Loading,
@@ -42,6 +41,8 @@ import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 import CustomCheckBox from "../../common/CustomCheckBox.js";
 import ActionPaginationButtonType from "../../common/ActionPaginationButtonType.js";
+import { Formik, Form } from "formik";
+import * as Yup from "yup";
 
 let breadcrumbs = [
   { label: "home.label", link: "/" },
@@ -67,10 +68,6 @@ function PanelCreate() {
   const intl = useIntl();
   const [isLoading, setIsLoading] = useState(true);
   const [bothFilled, setBothFilled] = useState(false);
-  const [englishLangPost, setEnglishLangPost] = useState("");
-  const [frenchLangPost, setFrenchLangPost] = useState("");
-  const [selectedSampleTypeId, setSelectedSampleTypeId] = useState("");
-  const [inputError, setInputError] = useState(false);
   const [panelCreateList, setPanelCreateList] = useState({});
 
   const componentMounted = useRef(false);
@@ -83,14 +80,11 @@ function PanelCreate() {
     }
   };
 
-  const handlePanelCreateListCall = () => {
-    if (
-      !englishLangPost ||
-      (!frenchLangPost && inputError && selectedSampleTypeId)
-    ) {
-      setInputError(true);
-      return;
-    }
+  const handlePanelCreateListCall = ({
+    englishLangPost,
+    frenchLangPost,
+    selectedSampleTypeId,
+  }) => {
     postToOpenElisServerJsonResponse(
       "/rest/PanelCreate",
       JSON.stringify({
@@ -132,30 +126,37 @@ function PanelCreate() {
     }
   };
 
-  const handleSampleTypeChange = (e) => {
-    setSelectedSampleTypeId(e.target.value);
-  };
+  const validationSchema = Yup.object({
+    englishLangPost: Yup.string()
+      .required("fill this field")
+      .test(
+        "duplicate-check",
+        intl.formatMessage({ id: "input.error.same.panel.type" }),
+        (value) => !validatePanelType(value),
+      )
+      .trim(),
+    frenchLangPost: Yup.string()
+      .required("fill this field")
+      .test(
+        "duplicate-check",
+        intl.formatMessage({ id: "input.error.same.panel.type" }),
+        (value) => !validatePanelType(value),
+      )
+      .trim(),
+  });
+
+  const allPanels = [
+    ...(panelCreateList?.existingPanelList
+      ? panelCreateList.existingPanelList.flatMap((epl) => epl?.panels || [])
+      : []),
+    ...(panelCreateList?.inactivePanelList
+      ? panelCreateList.inactivePanelList.flatMap((epl) => epl?.panels || [])
+      : []),
+  ];
 
   const validatePanelType = (name) => {
-    const allPanels = [
-      ...(panelCreateList?.existingPanelList
-        ? panelCreateList.existingPanelList.flatMap((epl) => epl?.panels || [])
-        : []),
-      ...(panelCreateList?.inactivePanelList
-        ? panelCreateList.inactivePanelList.flatMap((epl) => epl?.panels || [])
-        : []),
-    ];
-
     return allPanels.some((panel) => panel?.panelName === name);
   };
-
-  useEffect(() => {
-    if (englishLangPost || frenchLangPost) {
-      const isPanelExists =
-        validatePanelType(englishLangPost) || validatePanelType(frenchLangPost);
-      setInputError(isPanelExists);
-    }
-  }, [englishLangPost, frenchLangPost, panelCreateList]);
 
   useEffect(() => {
     componentMounted.current = true;
@@ -223,131 +224,173 @@ function PanelCreate() {
           <br />
           <hr />
           <br />
-          <Grid fullWidth={true}>
-            <Column lg={8} md={4} sm={4}>
-              <>
-                <FormattedMessage id="english.label" />
-                <span className="requiredlabel">*</span> :
-              </>
-            </Column>
-            <Column lg={8} md={4} sm={4}>
-              <TextInput
-                id={`eng`}
-                labelText=""
-                hideLabel
-                disabled={bothFilled}
-                value={`${englishLangPost}` || ""}
-                onChange={(e) => {
-                  setEnglishLangPost(e.target.value);
-                }}
-                required
-                invalid={inputError}
-                invalidText={
-                  <FormattedMessage id="input.error.same.panel.type" />
-                }
-              />
-            </Column>
-            <Column lg={8} md={4} sm={4}>
-              <>
-                <FormattedMessage id="french.label" />
-                <span className="requiredlabel">*</span> :
-              </>
-            </Column>
-            <Column lg={8} md={4} sm={4}>
-              <TextInput
-                id={`fr`}
-                labelText=""
-                hideLabel
-                disabled={bothFilled}
-                value={`${frenchLangPost}` || ""}
-                onChange={(e) => {
-                  setFrenchLangPost(e.target.value);
-                }}
-                required
-                invalid={inputError}
-                invalidText={
-                  <FormattedMessage id="input.error.same.panel.type" />
-                }
-              />
-            </Column>
-            <Column lg={8} md={4} sm={4}>
-              <>
-                <FormattedMessage id="sample.type" />
-                <span className="requiredlabel">*</span> :
-              </>
-            </Column>
-            <Column lg={8} md={4} sm={4}>
-              <Select
-                id="smapleTypeSelect"
-                name="SampleType"
-                labelText={intl.formatMessage({ id: "sample.select.type" })}
-                onChange={handleSampleTypeChange}
-                required
-              >
-                {panelCreateList &&
-                  panelCreateList?.existingSampleTypeList?.map((st, index) => {
-                    return (
-                      <SelectItem key={index} text={st.value} value={st.id} />
-                    );
-                  })}
-              </Select>
-            </Column>
-          </Grid>
-          {bothFilled && (
-            <>
-              <br />
-              <Grid fullWidth={true}>
-                <Column lg={16} md={8} sm={4}>
-                  <Section>
-                    <Section>
-                      <Section>
+          <Formik
+            initialValues={{
+              englishLangPost: "",
+              frenchLangPost: "",
+              selectedSampleTypeId: "32",
+            }}
+            validationSchema={validationSchema}
+            onSubmit={(values, actions) => {
+              if (bothFilled) {
+                handlePanelCreateListCall(values);
+              } else {
+                setBothFilled(true);
+                actions.setSubmitting(false);
+              }
+            }}
+          >
+            {({
+              values,
+              errors,
+              touched,
+              handleChange,
+              handleBlur,
+              handleSubmit,
+              isSubmitting,
+            }) => (
+              <Form onSubmit={handleSubmit}>
+                <Grid fullWidth={true}>
+                  <Column lg={8} md={4} sm={4}>
+                    <>
+                      <FormattedMessage id="english.label" />
+                      <span className="requiredlabel">*</span> :
+                    </>
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <TextInput
+                      id={`eng`}
+                      name="englishLangPost"
+                      labelText=""
+                      hideLabel
+                      disabled={bothFilled}
+                      value={values.englishLangPost}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      required
+                      invalid={
+                        touched.englishLangPost && !!errors.englishLangPost
+                      }
+                      invalidText={
+                        touched.englishLangPost && errors.englishLangPost
+                      }
+                    />
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <>
+                      <FormattedMessage id="french.label" />
+                      <span className="requiredlabel">*</span> :
+                    </>
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <TextInput
+                      id={`fr`}
+                      name="frenchLangPost"
+                      labelText=""
+                      hideLabel
+                      disabled={bothFilled}
+                      value={values.frenchLangPost}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      required
+                      invalid={
+                        touched.frenchLangPost && !!errors.frenchLangPost
+                      }
+                      invalidText={
+                        touched.frenchLangPost && errors.frenchLangPost
+                      }
+                    />
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <>
+                      <FormattedMessage id="sample.type" />
+                      <span className="requiredlabel">*</span> :
+                    </>
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <Select
+                      id="smapleTypeSelect"
+                      name="selectedSampleTypeId"
+                      value={values.selectedSampleTypeId}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      labelText={intl.formatMessage({
+                        id: "sample.select.type",
+                      })}
+                      invalid={
+                        touched.selectedSampleTypeId &&
+                        !!errors.selectedSampleTypeId
+                      }
+                      invalidText={
+                        touched.selectedSampleTypeId &&
+                        errors.selectedSampleTypeId
+                      }
+                      required
+                    >
+                      {panelCreateList?.existingSampleTypeList?.map(
+                        (st, index) => (
+                          <SelectItem
+                            key={index}
+                            text={st.value}
+                            value={st.id}
+                          />
+                        ),
+                      )}
+                    </Select>
+                  </Column>
+                </Grid>
+                {bothFilled && (
+                  <>
+                    <br />
+                    <Grid fullWidth={true}>
+                      <Column lg={16} md={8} sm={4}>
                         <Section>
-                          <Heading>
-                            <FormattedMessage id="configuration.panel.confirmation.explain" />
-                          </Heading>
+                          <Section>
+                            <Section>
+                              <Section>
+                                <Heading>
+                                  <FormattedMessage id="configuration.panel.confirmation.explain" />
+                                </Heading>
+                              </Section>
+                            </Section>
+                          </Section>
                         </Section>
-                      </Section>
-                    </Section>
-                  </Section>
-                </Column>
-              </Grid>
-            </>
-          )}
-          <br />
-          <Grid fullWidth={true}>
-            <Column lg={8} md={8} sm={4}>
-              <Button
-                onClick={() => {
-                  if (bothFilled) {
-                    handlePanelCreateListCall();
-                  }
-                  setBothFilled(true);
-                  setInputError(false);
-                }}
-                type="button"
-                kind="primary"
-              >
-                {bothFilled ? (
-                  <FormattedMessage id="accept.action.button" />
-                ) : (
-                  <FormattedMessage id="next.action.button" />
+                      </Column>
+                    </Grid>
+                  </>
                 )}
-              </Button>{" "}
-              <Button
-                type="button"
-                kind="tertiary"
-                onClick={() => {
-                  window.location.reload();
-                }}
-              >
-                {bothFilled ? (
-                  <FormattedMessage id="reject.action.button" />
-                ) : (
-                  <FormattedMessage id="label.button.previous" />
-                )}
-              </Button>
-            </Column>
-          </Grid>
+                <br />
+                <Grid fullWidth={true}>
+                  <Column lg={8} md={8} sm={4}>
+                    <Button
+                      disabled={isSubmitting}
+                      type="submit"
+                      kind="primary"
+                    >
+                      {bothFilled ? (
+                        <FormattedMessage id="accept.action.button" />
+                      ) : (
+                        <FormattedMessage id="next.action.button" />
+                      )}
+                    </Button>{" "}
+                    <Button
+                      type="button"
+                      kind="tertiary"
+                      onClick={() => {
+                        window.location.reload();
+                      }}
+                    >
+                      {bothFilled ? (
+                        <FormattedMessage id="reject.action.button" />
+                      ) : (
+                        <FormattedMessage id="label.button.previous" />
+                      )}
+                    </Button>
+                  </Column>
+                </Grid>
+              </Form>
+            )}
+          </Formik>
           <br />
           <hr />
           <br />

--- a/frontend/src/components/admin/testManagementConfigMenu/SampleTypeCreate.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/SampleTypeCreate.js
@@ -1,6 +1,5 @@
 import React, { useContext, useState, useEffect, useRef } from "react";
 import {
-  Form,
   Heading,
   Button,
   Loading,
@@ -24,6 +23,7 @@ import {
   Stack,
   UnorderedList,
   ListItem,
+  TextInput,
 } from "@carbon/react";
 import {
   getFromOpenElisServer,
@@ -41,6 +41,8 @@ import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 import CustomCheckBox from "../../common/CustomCheckBox.js";
 import ActionPaginationButtonType from "../../common/ActionPaginationButtonType.js";
+import { Formik, Form } from "formik";
+import * as Yup from "yup";
 
 let breadcrumbs = [
   { label: "home.label", link: "/" },
@@ -64,35 +66,350 @@ function SampleTypeCreate() {
     useContext(NotificationContext);
 
   const intl = useIntl();
+  const [isLoading, setIsLoading] = useState(true);
+  const [bothFilled, setBothFilled] = useState(false);
+  const [sampleTypeCreateList, setSampleTypeCreateList] = useState({});
 
   const componentMounted = useRef(false);
+
+  const handleSampleTypeCreateList = (res) => {
+    if (!res) {
+      setIsLoading(true);
+    } else {
+      setSampleTypeCreateList(res);
+    }
+  };
+
+  const handleSampleTypeCreateListCall = ({
+    englishLangPost,
+    frenchLangPost,
+  }) => {
+    postToOpenElisServerJsonResponse(
+      "/rest/SampleTypeCreate",
+      JSON.stringify({
+        sampleTypeEnglishName: englishLangPost,
+        sampleTypeFrenchName: frenchLangPost,
+      }),
+      (res) => {
+        handlePostSampleTypeCreateListCallBack(res);
+      },
+    );
+  };
+
+  const handlePostSampleTypeCreateListCallBack = (res) => {
+    if (res) {
+      if (res) {
+        setIsLoading(false);
+        addNotification({
+          title: intl.formatMessage({
+            id: "notification.title",
+          }),
+          message: intl.formatMessage({
+            id: "notification.user.post.delete.success",
+          }),
+          kind: NotificationKinds.success,
+        });
+        setTimeout(() => {
+          window.location.reload();
+        }, 200);
+        setNotificationVisible(true);
+      }
+    } else {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({ id: "notification.title" }),
+        message: intl.formatMessage({ id: "server.error.msg" }),
+      });
+      setNotificationVisible(true);
+    }
+  };
+
+  const allSampleTypeValues = [
+    ...(sampleTypeCreateList?.existingSampleTypeList || []).map((item) =>
+      item?.value?.trim().toLowerCase(),
+    ),
+    ...(sampleTypeCreateList?.inactiveSampleTypeList || []).map((item) =>
+      item?.value?.trim().toLowerCase(),
+    ),
+  ];
+
+  const validateSampleType = (name) => {
+    if (!name) return false;
+    return allSampleTypeValues.includes(name.trim().toLowerCase());
+  };
+
+  useEffect(() => {
+    componentMounted.current = true;
+    setIsLoading(true);
+    getFromOpenElisServer(`/rest/SampleTypeCreate`, handleSampleTypeCreateList);
+    return () => {
+      componentMounted.current = false;
+      setIsLoading(false);
+    };
+  }, []);
+
+  const validationSchema = Yup.object({
+    englishLangPost: Yup.string()
+      .required("fill this field")
+      .test(
+        "duplicate-check",
+        intl.formatMessage({ id: "configuration.sampleType.create.duplicate" }),
+        (value) => !validateSampleType(value),
+      )
+      .trim(),
+    frenchLangPost: Yup.string()
+      .required("fill this field")
+      .test(
+        "duplicate-check",
+        intl.formatMessage({ id: "configuration.sampleType.create.duplicate" }),
+        (value) => !validateSampleType(value),
+      )
+      .trim(),
+  });
+
+  if (!isLoading) {
+    return (
+      <>
+        <Loading />
+      </>
+    );
+  }
 
   return (
     <>
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
-            <Section>
-              <Heading>
-                <FormattedMessage id="banner.menu.patientEdit" />
-              </Heading>
-            </Section>
-          </Column>
-        </Grid>
-        <br />
-        <hr />
-        <br />
-        <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
-            <Section>
-              <Heading>
-                <FormattedMessage id="configuration.sampleType.create" />
-              </Heading>
-            </Section>
-          </Column>
-        </Grid>
+        <div className="orderLegendBody">
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Heading>
+                  <FormattedMessage id="banner.menu.patientEdit" />
+                </Heading>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Section>
+                  <Heading>
+                    <FormattedMessage id="configuration.sampleType.create" />
+                  </Heading>
+                </Section>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Section>
+                  <Section>
+                    <Heading>
+                      <FormattedMessage id="sampleType.new" />
+                    </Heading>
+                  </Section>
+                </Section>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <Formik
+            initialValues={{ englishLangPost: "", frenchLangPost: "" }}
+            validationSchema={validationSchema}
+            onSubmit={(values, actions) => {
+              if (bothFilled) {
+                handleSampleTypeCreateListCall(values);
+              } else {
+                setBothFilled(true);
+                actions.setSubmitting(false);
+              }
+            }}
+          >
+            {({
+              values,
+              errors,
+              touched,
+              handleChange,
+              handleBlur,
+              handleSubmit,
+              isSubmitting,
+            }) => (
+              <Form onSubmit={handleSubmit}>
+                <Grid fullWidth={true}>
+                  <Column lg={8} md={4} sm={4}>
+                    <>
+                      <FormattedMessage id="english.label" />
+                      <span className="requiredlabel">*</span> :
+                    </>
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <TextInput
+                      id={`eng`}
+                      name="englishLangPost"
+                      labelText=""
+                      hideLabel
+                      disabled={bothFilled}
+                      value={values.englishLangPost}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      required
+                      invalid={
+                        touched.englishLangPost && !!errors.englishLangPost
+                      }
+                      invalidText={
+                        touched.englishLangPost && errors.englishLangPost
+                      }
+                    />
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <>
+                      <FormattedMessage id="french.label" />
+                      <span className="requiredlabel">*</span> :
+                    </>
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <TextInput
+                      id={`fr`}
+                      name="frenchLangPost"
+                      labelText=""
+                      hideLabel
+                      disabled={bothFilled}
+                      value={values.frenchLangPost}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      required
+                      invalid={
+                        touched.frenchLangPost && !!errors.frenchLangPost
+                      }
+                      invalidText={
+                        touched.frenchLangPost && errors.frenchLangPost
+                      }
+                    />
+                  </Column>
+                </Grid>
+                {bothFilled && (
+                  <>
+                    <br />
+                    <Grid fullWidth={true}>
+                      <Column lg={16} md={8} sm={4}>
+                        <Section>
+                          <Section>
+                            <Section>
+                              <Section>
+                                <Heading>
+                                  <FormattedMessage id="configuration.sampleType.confirmation.explain" />
+                                </Heading>
+                              </Section>
+                            </Section>
+                          </Section>
+                        </Section>
+                      </Column>
+                    </Grid>
+                  </>
+                )}
+                <br />
+                <Grid fullWidth={true}>
+                  <Column lg={8} md={8} sm={4}>
+                    <Button
+                      disabled={isSubmitting}
+                      type="submit"
+                      kind="primary"
+                    >
+                      {bothFilled ? (
+                        <FormattedMessage id="accept.action.button" />
+                      ) : (
+                        <FormattedMessage id="next.action.button" />
+                      )}
+                    </Button>{" "}
+                    <Button
+                      type="button"
+                      kind="tertiary"
+                      onClick={() => {
+                        window.location.reload();
+                      }}
+                    >
+                      {bothFilled ? (
+                        <FormattedMessage id="reject.action.button" />
+                      ) : (
+                        <FormattedMessage id="label.button.previous" />
+                      )}
+                    </Button>
+                  </Column>
+                </Grid>
+              </Form>
+            )}
+          </Formik>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Section>
+                  <Section>
+                    <Heading>
+                      <FormattedMessage id="sampleType.existing" />
+                    </Heading>
+                  </Section>
+                </Section>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            {sampleTypeCreateList &&
+              sampleTypeCreateList?.existingSampleTypeList?.map(
+                (stl, index) => {
+                  return (
+                    <Column lg={4} md={4} sm={4} key={index}>
+                      {stl?.value}
+                    </Column>
+                  );
+                },
+              )}
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Section>
+                  <Section>
+                    <Heading>
+                      <FormattedMessage id="sampleType.existing.inactive" />
+                    </Heading>
+                  </Section>
+                </Section>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            {sampleTypeCreateList &&
+              sampleTypeCreateList?.inactiveSampleTypeList?.map(
+                (stl, index) => {
+                  return (
+                    <Column lg={4} md={4} sm={4} key={index}>
+                      {stl?.value}
+                    </Column>
+                  );
+                },
+              )}
+          </Grid>
+        </div>
       </div>
     </>
   );

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -1413,5 +1413,10 @@
   "panel.existing": "Existing Panels",
   "panel.existing.inactive": "Inactive Panels (Assign tests to activate)",
   "configuration.panel.confirmation.explain": "This panel will not be active until at least one test has been assigned to it.",
-  "input.error.same.panel.type": "An existing panel type with the same name has been found.  Please cancel or use a different name."
+  "input.error.same.panel.type": "An existing panel type with the same name has been found.  Please cancel or use a different name.",
+  "sampleType.new": "New Sample Type",
+  "sampleType.existing": "Existing Sample Types",
+  "sampleType.existing.inactive": "Inactive Sample Types.  Assign tests to activate.",
+  "configuration.sampleType.confirmation.explain": "This sample type will not be active until at least one test has been assigned to it.",
+  "configuration.sampleType.create.duplicate": "An existing test sample type with the same name has been found.  Please cancel or use a different name."
 }

--- a/frontend/src/languages/fr.json
+++ b/frontend/src/languages/fr.json
@@ -1412,5 +1412,10 @@
   "panel.existing": "Panneaux existants",
   "panel.existing.inactive": "Panneaux inactifs (Attribuer des tests pour activer)",
   "configuration.panel.confirmation.explain": "Ce panneau ne sera pas actif tant qu'au moins un test ne lui aura pas été attribué.",
-  "input.error.same.panel.type": "Un panneau existant avec le même nom a été trouvé. Veuillez annuler ou utiliser un nom différent."
+  "input.error.same.panel.type": "Un panneau existant avec le même nom a été trouvé. Veuillez annuler ou utiliser un nom différent.",
+  "sampleType.new": "New Sample Type",
+  "sampleType.existing": "Existing Sample Types",
+  "sampleType.existing.inactive": "Inactive Sample Types.  Assign tests to activate.",
+  "configuration.sampleType.confirmation.explain": "This sample type will not be active until at least one test has been assigned to it.",
+  "configuration.sampleType.create.duplicate": "An existing test sample type with the same name has been found.  Please cancel or use a different name."
 }


### PR DESCRIPTION
- referencing #1988 

### Route 

OLD UI

https://localhost/api/OpenELIS-Global/SampleTypeCreate

New UI 

https://localhost/admin#SampleTypeCreate

#### Before

![image](https://github.com/user-attachments/assets/bf14cfc6-044e-4eca-8d2a-154d2d08f381)


#### After 

![image](https://github.com/user-attachments/assets/c93ff4f1-7b2a-4cbd-8c5d-90e751cb55c7)


#### WOrkFLow video ( wait 5-10 sec let the video load )

![sampleTypeCreat](https://github.com/user-attachments/assets/71c8ae58-a9d1-4477-90e6-aa6d98a39244)



Thank You :slightly_smiling_face: 

lmk if any cahges need 