### PR TITLE
feat(ORDER-pages): sampleType & testSection order pages ui + post req working

### DIFF
--- a/frontend/src/components/admin/testManagementConfigMenu/PanelManagement.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/PanelManagement.js
@@ -85,36 +85,25 @@ function PanelManagement() {
           <Grid fullWidth={true}>
             <Column lg={16} md={8} sm={4}>
               <UnorderedList>
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/MasterListsPage#PanelCreate");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.panel.create" />
-                  </ListItem>
+                <ClickableTile
+                  href="/MasterListsPage#PanelCreate"
+                  id="PanelCreate"
+                >
+                  <FormattedMessage id="configuration.panel.create" />
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/MasterListsPage#PanelOrder");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.panel.order" />
-                  </ListItem>
+                <ClickableTile
+                  href="/MasterListsPage#PanelOrder"
+                  id="PanelOrder"
+                >
+                  <FormattedMessage id="configuration.panel.order" />
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign(
-                        "/MasterListsPage#PanelTestAssign",
-                      );
-                    }}
-                  >
-                    <FormattedMessage id="configuration.panel.assign" />
-                  </ListItem>
+                <ClickableTile
+                  href="/MasterListsPage#PanelTestAssign"
+                  id="PanelTestAssign"
+                >
+                  <FormattedMessage id="configuration.panel.assign" />
                 </ClickableTile>
               </UnorderedList>
             </Column>

--- a/frontend/src/components/admin/testManagementConfigMenu/PanelOrder.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/PanelOrder.js
@@ -41,7 +41,7 @@ import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 import CustomCheckBox from "../../common/CustomCheckBox.js";
 import ActionPaginationButtonType from "../../common/ActionPaginationButtonType.js";
-import { SortablePanelOrderList } from "./sortableListComponent/SortableList.js";
+import { CustomCommonSortableOrderList } from "./sortableListComponent/SortableList.js";
 
 let breadcrumbs = [
   { label: "home.label", link: "/" },
@@ -201,7 +201,7 @@ function PanelOrder() {
               {panelOrderList &&
                 panelOrderList?.panelList &&
                 panelOrderList?.panelList?.length > 0 && (
-                  <SortablePanelOrderList
+                  <CustomCommonSortableOrderList
                     test={panelOrderList?.panelList}
                     onSort={(updatedList) => {
                       setPanelOrderList((prev) => ({

--- a/frontend/src/components/admin/testManagementConfigMenu/SampleTypeManagement.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/SampleTypeManagement.js
@@ -24,6 +24,7 @@ import {
   Stack,
   UnorderedList,
   ListItem,
+  ClickableTile,
 } from "@carbon/react";
 import {
   getFromOpenElisServer,
@@ -68,49 +69,46 @@ function TestSectionManagement() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
-            <Section>
-              <Heading>
-                <FormattedMessage id="configuration.sampleType.manage" />
-              </Heading>
-            </Section>
-          </Column>
-        </Grid>
-        <br />
-        <hr />
-        <br />
-        <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
-            <UnorderedList>
-              <ListItem
-                onClick={() => {
-                  window.location.assign("/MasterListsPage#SampleTypeCreate");
-                }}
-              >
-                <FormattedMessage id="configuration.sampleType.create" />
-              </ListItem>
-              <br />
-              <ListItem
-                onClick={() => {
-                  window.location.assign("/MasterListsPage#SampleTypeOrder");
-                }}
-              >
-                <FormattedMessage id="configuration.sampleType.order" />
-              </ListItem>
-              <br />
-              <ListItem
-                onClick={() => {
-                  window.location.assign(
-                    "/MasterListsPage#SampleTypeTestAssign",
-                  );
-                }}
-              >
-                <FormattedMessage id="configuration.panel.assign" />
-              </ListItem>
-            </UnorderedList>
-          </Column>
-        </Grid>
+        <div className="orderLegendBody">
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Heading>
+                  <FormattedMessage id="configuration.sampleType.manage" />
+                </Heading>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <UnorderedList>
+                <ClickableTile
+                  href="/MasterListsPage#SampleTypeCreate"
+                  id="SampleTypeCreate"
+                >
+                  <FormattedMessage id="configuration.sampleType.create" />
+                </ClickableTile>
+                <br />
+                <ClickableTile
+                  href="/MasterListsPage#SampleTypeOrder"
+                  id="SampleTypeOrder"
+                >
+                  <FormattedMessage id="configuration.sampleType.order" />
+                </ClickableTile>
+                <br />
+                <ClickableTile
+                  href="/MasterListsPage#SampleTypeTestAssign"
+                  id="SampleTypeTestAssign"
+                >
+                  <FormattedMessage id="configuration.panel.assign" />
+                </ClickableTile>
+              </UnorderedList>
+            </Column>
+          </Grid>
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/admin/testManagementConfigMenu/SampleTypeOrder.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/SampleTypeOrder.js
@@ -41,7 +41,7 @@ import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 import CustomCheckBox from "../../common/CustomCheckBox.js";
 import ActionPaginationButtonType from "../../common/ActionPaginationButtonType.js";
-import { SortablePanelOrderList } from "./sortableListComponent/SortableList.js";
+import { CustomCommonSortableOrderList } from "./sortableListComponent/SortableList.js";
 
 let breadcrumbs = [
   { label: "home.label", link: "/" },
@@ -201,7 +201,7 @@ function SampleTypeOrder() {
               {sampleTypeOrderList &&
                 sampleTypeOrderList?.testSectionList &&
                 sampleTypeOrderList?.testSectionList?.length > 0 && (
-                  <SortablePanelOrderList
+                  <CustomCommonSortableOrderList
                     test={sampleTypeOrderList?.testSectionList}
                     onSort={(updatedList) => {
                       setSampleTypeOrderList((prev) => ({

--- a/frontend/src/components/admin/testManagementConfigMenu/SampleTypeOrder.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/SampleTypeOrder.js
@@ -88,7 +88,7 @@ function SampleTypeOrder() {
       }, 200);
     }
     postToOpenElisServerJsonResponse(
-      "/rest/TestSectionOrder",
+      "/rest/SampleTypeOrder",
       JSON.stringify({
         jsonChangeList: JSON.stringify({
           sampleTypes: JSON.stringify(sampleTypeOrderListPost),
@@ -131,7 +131,7 @@ function SampleTypeOrder() {
   useEffect(() => {
     componentMounted.current = true;
     setIsLoading(true);
-    getFromOpenElisServer(`/rest/TestSectionOrder`, handleSampleTypeOrderList);
+    getFromOpenElisServer(`/rest/SampleTypeOrder`, handleSampleTypeOrderList);
     return () => {
       componentMounted.current = false;
       setIsLoading(false);
@@ -199,14 +199,14 @@ function SampleTypeOrder() {
           <Grid fullWidth={true}>
             <Column lg={16} md={8} sm={4}>
               {sampleTypeOrderList &&
-                sampleTypeOrderList?.testSectionList &&
-                sampleTypeOrderList?.testSectionList?.length > 0 && (
+                sampleTypeOrderList?.sampleTypeList &&
+                sampleTypeOrderList?.sampleTypeList?.length > 0 && (
                   <CustomCommonSortableOrderList
-                    test={sampleTypeOrderList?.testSectionList}
+                    test={sampleTypeOrderList?.sampleTypeList}
                     onSort={(updatedList) => {
                       setSampleTypeOrderList((prev) => ({
                         ...prev,
-                        testSectionList: updatedList,
+                        sampleTypeList: updatedList,
                       }));
                       setSampleTypeOrderListPost(
                         updatedList.map(({ id, sortOrder }) => ({

--- a/frontend/src/components/admin/testManagementConfigMenu/TestManagementConfigMenu.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/TestManagementConfigMenu.js
@@ -319,9 +319,7 @@ function TestManagementConfigMenu() {
                 <ClickableTile>
                   <ListItem
                     onClick={() => {
-                      window.location.assign(
-                        "/api/OpenELIS-Global/TestSectionManagement",
-                      );
+                      window.location.assign("/admin#TestSectionManagement");
                     }}
                   >
                     <FormattedMessage id="configuration.testUnit.manage" />
@@ -336,9 +334,7 @@ function TestManagementConfigMenu() {
                 <ClickableTile>
                   <ListItem
                     onClick={() => {
-                      window.location.assign(
-                        "/api/OpenELIS-Global/SampleTypeManagement",
-                      );
+                      window.location.assign("/admin#SampleTypeManagement");
                     }}
                   >
                     <FormattedMessage id="configuration.sampleType.manage" />
@@ -368,9 +364,7 @@ function TestManagementConfigMenu() {
                 <ClickableTile>
                   <ListItem
                     onClick={() => {
-                      window.location.assign(
-                        "/api/OpenELIS-Global/PanelManagement",
-                      );
+                      window.location.assign("/admin#PanelManagement");
                     }}
                   >
                     <FormattedMessage id="configuration.panel.manage" />

--- a/frontend/src/components/admin/testManagementConfigMenu/TestManagementConfigMenu.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/TestManagementConfigMenu.js
@@ -95,109 +95,85 @@ function TestManagementConfigMenu() {
           <Grid fullWidth={true}>
             <Column lg={16} md={8} sm={4}>
               <UnorderedList>
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#TestRenameEntry");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.test.rename" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.test.rename.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#TestRenameEntry"
+                  id="TestRenameEntry"
+                >
+                  <FormattedMessage id="configuration.test.rename" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.test.rename.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#PanelRenameEntry");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.panel.rename" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.panel.rename.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#PanelRenameEntry"
+                  id="PanelRenameEntry"
+                >
+                  <FormattedMessage id="configuration.panel.rename" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.panel.rename.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#SampleTypeRenameEntry");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.type.rename" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.type.rename.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#SampleTypeRenameEntry"
+                  id="SampleTypeRenameEntry"
+                >
+                  <FormattedMessage id="configuration.type.rename" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.type.rename.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#TestSectionRenameEntry");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.testSection.rename" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.testSection.rename.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#TestSectionRenameEntry"
+                  id="TestSectionRenameEntry"
+                >
+                  <FormattedMessage id="configuration.testSection.rename" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.testSection.rename.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#UomRenameEntry");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.uom.rename" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.uom.rename.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile href="/admin#UomRenameEntry" id="UomRenameEntry">
+                  <FormattedMessage id="configuration.uom.rename" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.uom.rename.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#SelectListRenameEntry");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.selectList.rename" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.selectList.rename.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#SelectListRenameEntry"
+                  id="SelectListRenameEntry"
+                >
+                  <FormattedMessage id="configuration.selectList.rename" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.selectList.rename.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#MethodRenameEntry");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.method.rename" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.method.rename.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#MethodRenameEntry"
+                  id="MethodRenameEntry"
+                >
+                  <FormattedMessage id="configuration.method.rename" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.method.rename.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
               </UnorderedList>
             </Column>
@@ -224,194 +200,135 @@ function TestManagementConfigMenu() {
           <Grid fullWidth={true}>
             <Column lg={16} md={8} sm={4}>
               <UnorderedList>
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#TestCatalog");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.test.catalog" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.test.catalog.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile href="/admin#TestCatalog" id="TestCatalog">
+                  <FormattedMessage id="configuration.test.catalog" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.test.catalog.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#MethodManagement");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.method" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.method.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#MethodManagement"
+                  id="MethodManagement"
+                >
+                  <FormattedMessage id="configuration.method" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.method.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/api/OpenELIS-Global/TestAdd");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.test.add" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.test.add.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile href="/api/OpenELIS-Global/TestAdd" id="TestAdd">
+                  <FormattedMessage id="configuration.test.add" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.test.add.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign(
-                        "/api/OpenELIS-Global/TestModifyEntry",
-                      );
-                    }}
-                  >
-                    <FormattedMessage id="configuration.test.modify" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.test.modify.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/api/OpenELIS-Global/TestModifyEntry"
+                  id="TestModifyEntry"
+                >
+                  <FormattedMessage id="configuration.test.modify" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.test.modify.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#TestActivation");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.test.activate" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.test.activate.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile href="/admin#TestActivation" id="TestActivation">
+                  <FormattedMessage id="configuration.test.activate" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.test.activate.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#TestOrderability");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.test.orderable" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.test.orderable.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#TestOrderability"
+                  id="TestOrderability"
+                >
+                  <FormattedMessage id="configuration.test.orderable" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.test.orderable.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#TestSectionManagement");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.testUnit.manage" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.testUnit.manage.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#TestSectionManagement"
+                  id="TestSectionManagement"
+                >
+                  <FormattedMessage id="configuration.testUnit.manage" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.testUnit.manage.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#SampleTypeManagement");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.sampleType.manage" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.sampleType.manage.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#SampleTypeManagement"
+                  id="SampleTypeManagement"
+                >
+                  <FormattedMessage id="configuration.sampleType.manage" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.sampleType.manage.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#UomManagement");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.uom.manage" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.uom.manage.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile href="/admin#UomManagement" id="UomManagement">
+                  <FormattedMessage id="configuration.uom.manage" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.uom.manage.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#PanelManagement");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.panel.manage" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.panel.manage.explain" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#PanelManagement"
+                  id="PanelManagement"
+                >
+                  <FormattedMessage id="configuration.panel.manage" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.panel.manage.explain" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/admin#ResultSelectListAdd");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.selectList.add" />
-                    <UnorderedList nested>
-                      <ListItem>
-                        <FormattedMessage id="configuration.selectList.add.explain" />
-                      </ListItem>
-                      <ListItem>
-                        <FormattedMessage id="configuration.selectList.add.alert" />
-                      </ListItem>
-                    </UnorderedList>
-                  </ListItem>
+                <ClickableTile
+                  href="/admin#ResultSelectListAdd"
+                  id="ResultSelectListAdd"
+                >
+                  <FormattedMessage id="configuration.selectList.add" />
+                  <UnorderedList nested>
+                    <ListItem>
+                      <FormattedMessage id="configuration.selectList.add.explain" />
+                    </ListItem>
+                    <ListItem>
+                      <FormattedMessage id="configuration.selectList.add.alert" />
+                    </ListItem>
+                  </UnorderedList>
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("#reflex");
-                    }}
-                  >
-                    <FormattedMessage id="sidenav.label.admin.testmgt.reflex" />
-                  </ListItem>
+                <ClickableTile href="#reflex" id="reflex">
+                  <FormattedMessage id="sidenav.label.admin.testmgt.reflex" />
                 </ClickableTile>
                 <br />
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("#calculatedValue");
-                    }}
-                  >
-                    <FormattedMessage id="sidenav.label.admin.testmgt.calculated" />
-                  </ListItem>
+                <ClickableTile href="#calculatedValue" id="calculatedValue">
+                  <FormattedMessage id="sidenav.label.admin.testmgt.calculated" />
                 </ClickableTile>
               </UnorderedList>
             </Column>

--- a/frontend/src/components/admin/testManagementConfigMenu/TestSectionManagement.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/TestSectionManagement.js
@@ -24,6 +24,7 @@ import {
   Stack,
   UnorderedList,
   ListItem,
+  ClickableTile,
 } from "@carbon/react";
 import {
   getFromOpenElisServer,
@@ -68,49 +69,46 @@ function TestSectionManagement() {
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
-            <Section>
-              <Heading>
-                <FormattedMessage id="configuration.testUnit.manage" />
-              </Heading>
-            </Section>
-          </Column>
-        </Grid>
-        <br />
-        <hr />
-        <br />
-        <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
-            <UnorderedList>
-              <ListItem
-                onClick={() => {
-                  window.location.assign("/MasterListsPage#TestSectionCreate");
-                }}
-              >
-                <FormattedMessage id="configuration.method.create" />
-              </ListItem>
-              <br />
-              <ListItem
-                onClick={() => {
-                  window.location.assign("/MasterListsPage#TestSectionOrder");
-                }}
-              >
-                <FormattedMessage id="configuration.testUnit.order" />
-              </ListItem>
-              <br />
-              <ListItem
-                onClick={() => {
-                  window.location.assign(
-                    "/MasterListsPage#TestSectionTestAssign",
-                  );
-                }}
-              >
-                <FormattedMessage id="configuration.panel.assign" />
-              </ListItem>
-            </UnorderedList>
-          </Column>
-        </Grid>
+        <div className="orderLegendBody">
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Heading>
+                  <FormattedMessage id="configuration.testUnit.manage" />
+                </Heading>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <UnorderedList>
+                <ClickableTile
+                  id="TestSectionCreate"
+                  href="/MasterListsPage#TestSectionCreate"
+                >
+                  <FormattedMessage id="configuration.method.create" />
+                </ClickableTile>
+                <br />
+                <ClickableTile
+                  id="TestSectionOrder"
+                  href="/MasterListsPage#TestSectionOrder"
+                >
+                  <FormattedMessage id="configuration.testUnit.order" />
+                </ClickableTile>
+                <br />
+                <ClickableTile
+                  href="/MasterListsPage#TestSectionTestAssign"
+                  id="TestSectionTestAssign"
+                >
+                  <FormattedMessage id="configuration.panel.assign" />
+                </ClickableTile>
+              </UnorderedList>
+            </Column>
+          </Grid>
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/admin/testManagementConfigMenu/TestSectionOrder.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/TestSectionOrder.js
@@ -39,7 +39,7 @@ import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 import CustomCheckBox from "../../common/CustomCheckBox.js";
 import ActionPaginationButtonType from "../../common/ActionPaginationButtonType.js";
-import { SortablePanelOrderList } from "./sortableListComponent/SortableList.js";
+import { CustomCommonSortableOrderList } from "./sortableListComponent/SortableList.js";
 
 let breadcrumbs = [
   { label: "home.label", link: "/" },
@@ -199,7 +199,7 @@ function TestSectionOrder() {
               {testSectionOrderList &&
                 testSectionOrderList?.testSectionList &&
                 testSectionOrderList?.testSectionList?.length > 0 && (
-                  <SortablePanelOrderList
+                  <CustomCommonSortableOrderList
                     test={testSectionOrderList?.testSectionList}
                     onSort={(updatedList) => {
                       setTestSectionOrderList((prev) => ({

--- a/frontend/src/components/admin/testManagementConfigMenu/TestSectionOrder.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/TestSectionOrder.js
@@ -39,6 +39,7 @@ import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 import PageBreadCrumb from "../../common/PageBreadCrumb.js";
 import CustomCheckBox from "../../common/CustomCheckBox.js";
 import ActionPaginationButtonType from "../../common/ActionPaginationButtonType.js";
+import { SortablePanelOrderList } from "./sortableListComponent/SortableList.js";
 
 let breadcrumbs = [
   { label: "home.label", link: "/" },
@@ -62,35 +63,212 @@ function TestSectionOrder() {
     useContext(NotificationContext);
 
   const intl = useIntl();
+  const [isLoading, setIsLoading] = useState(false);
+  const [confirmSelection, setConfirmSelection] = useState(false);
+  const [testSectionOrderList, setTestSectionOrderList] = useState({});
+  const [testSectionOrderListPost, setTestSectionOrderListPost] = useState([]);
 
   const componentMounted = useRef(false);
+
+  const handleTestSectionOrderList = (res) => {
+    if (!res) {
+      setIsLoading(true);
+    } else {
+      setTestSectionOrderList(res);
+    }
+  };
+
+  const handleTestSectionOrderListCall = () => {
+    if (!testSectionOrderListPost) {
+      setIsLoading(true);
+      setTimeout(() => {
+        window.location.reload();
+      }, 200);
+    }
+    postToOpenElisServerJsonResponse(
+      "/rest/TestSectionOrder",
+      JSON.stringify({
+        jsonChangeList: JSON.stringify({
+          testSections: JSON.stringify(testSectionOrderListPost),
+        }),
+      }),
+      (res) => {
+        handlePostTestSectionOrderListCallBack(res);
+      },
+    );
+  };
+
+  const handlePostTestSectionOrderListCallBack = (res) => {
+    if (res) {
+      if (res) {
+        setIsLoading(false);
+        addNotification({
+          title: intl.formatMessage({
+            id: "notification.title",
+          }),
+          message: intl.formatMessage({
+            id: "notification.user.post.delete.success",
+          }),
+          kind: NotificationKinds.success,
+        });
+        setTimeout(() => {
+          window.location.reload();
+        }, 200);
+        setNotificationVisible(true);
+      }
+    } else {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({ id: "notification.title" }),
+        message: intl.formatMessage({ id: "server.error.msg" }),
+      });
+      setNotificationVisible(true);
+    }
+  };
+
+  useEffect(() => {
+    componentMounted.current = true;
+    setIsLoading(true);
+    getFromOpenElisServer(`/rest/TestSectionOrder`, handleTestSectionOrderList);
+    return () => {
+      componentMounted.current = false;
+      setIsLoading(false);
+    };
+  }, []);
+
+  if (!isLoading) {
+    return (
+      <>
+        <Loading />
+      </>
+    );
+  }
 
   return (
     <>
       {notificationVisible === true ? <AlertDialog /> : ""}
       <div className="adminPageContent">
         <PageBreadCrumb breadcrumbs={breadcrumbs} />
-        <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
-            <Section>
-              <Heading>
-                <FormattedMessage id="banner.menu.patientEdit" />
-              </Heading>
-            </Section>
-          </Column>
-        </Grid>
-        <br />
-        <hr />
-        <br />
-        <Grid fullWidth={true}>
-          <Column lg={16} md={8} sm={4}>
-            <Section>
-              <Heading>
-                <FormattedMessage id="configuration.testUnit.order.explain" />
-              </Heading>
-            </Section>
-          </Column>
-        </Grid>
+        <div className="orderLegendBody">
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Heading>
+                  <FormattedMessage id="banner.menu.patientEdit" />
+                </Heading>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Section>
+                  <Section>
+                    <Heading>
+                      <FormattedMessage id="configuration.testUnit.order.explain" />
+                    </Heading>
+                  </Section>
+                </Section>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <hr />
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <Section>
+                  <Section>
+                    <Section>
+                      <Heading>
+                        <FormattedMessage id="configuration.testUnit.order.explain.limits" />
+                      </Heading>
+                    </Section>
+                  </Section>
+                </Section>
+              </Section>
+            </Column>
+          </Grid>
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              {testSectionOrderList &&
+                testSectionOrderList?.testSectionList &&
+                testSectionOrderList?.testSectionList?.length > 0 && (
+                  <SortablePanelOrderList
+                    test={testSectionOrderList?.testSectionList}
+                    onSort={(updatedList) => {
+                      setTestSectionOrderList((prev) => ({
+                        ...prev,
+                        testSectionList: updatedList,
+                      }));
+                      setTestSectionOrderListPost(
+                        updatedList.map(({ id, sortOrder }) => ({
+                          id: Number(id),
+                          sortOrder,
+                        })),
+                      );
+                    }}
+                    disableSorting={confirmSelection}
+                  />
+                )}
+            </Column>
+          </Grid>
+          {confirmSelection && (
+            <>
+              <br />
+              <Grid fullWidth={true}>
+                <Column lg={16} md={8} sm={4}>
+                  <Section>
+                    <Section>
+                      <Heading>
+                        <FormattedMessage id="uom.create.heading.confirmation" />
+                      </Heading>
+                    </Section>
+                  </Section>
+                </Column>
+              </Grid>
+            </>
+          )}
+          <br />
+          <Grid fullWidth={true}>
+            <Column lg={8} md={8} sm={4}>
+              <Button
+                onClick={() => {
+                  if (confirmSelection) {
+                    handleTestSectionOrderListCall();
+                  }
+                  setConfirmSelection(true);
+                }}
+                type="button"
+                kind="primary"
+              >
+                {confirmSelection ? (
+                  <FormattedMessage id="accept.action.button" />
+                ) : (
+                  <FormattedMessage id="next.action.button" />
+                )}
+              </Button>{" "}
+              <Button
+                type="button"
+                kind="tertiary"
+                onClick={() => {
+                  window.location.reload();
+                }}
+              >
+                {confirmSelection ? (
+                  <FormattedMessage id="reject.action.button" />
+                ) : (
+                  <FormattedMessage id="label.button.previous" />
+                )}
+              </Button>
+            </Column>
+          </Grid>
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/admin/testManagementConfigMenu/UomManagement.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/UomManagement.js
@@ -85,14 +85,8 @@ function UomManagement() {
           <Grid fullWidth={true}>
             <Column lg={16} md={8} sm={4}>
               <UnorderedList>
-                <ClickableTile>
-                  <ListItem
-                    onClick={() => {
-                      window.location.assign("/MasterListsPage#UomCreate");
-                    }}
-                  >
-                    <FormattedMessage id="configuration.uom.create" />
-                  </ListItem>
+                <ClickableTile href="/MasterListsPage#UomCreate" id="UomCreate">
+                  <FormattedMessage id="configuration.uom.create" />
                 </ClickableTile>
               </UnorderedList>
             </Column>

--- a/frontend/src/components/admin/testManagementConfigMenu/sortableListComponent/SortableList.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/sortableListComponent/SortableList.js
@@ -290,7 +290,11 @@ export const SortableResultSelectionOptionList = ({
   );
 };
 
-export const SortablePanelOrderList = ({ test, onSort, disableSorting }) => {
+export const CustomCommonSortableOrderList = ({
+  test,
+  onSort,
+  disableSorting,
+}) => {
   const [tests, setTests] = useState(test);
 
   const handleDragStart = (e, index) => {

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -1414,6 +1414,8 @@
   "panel.existing.inactive": "Inactive Panels (Assign tests to activate)",
   "configuration.panel.confirmation.explain": "This panel will not be active until at least one test has been assigned to it.",
   "input.error.same.panel.type": "An existing panel type with the same name has been found.  Please cancel or use a different name.",
+  "configuration.testUnit.order.explain.limits": "Only test sections with tests assigned may be ordered.  For new sections please assign tests before ordering.",
+  "configuration.sampleType.order.explain.limits": "Only sample types with tests assigned may be ordered.  For new types please assign tests before ordering.",
   "sampleType.new": "New Sample Type",
   "sampleType.existing": "Existing Sample Types",
   "sampleType.existing.inactive": "Inactive Sample Types.  Assign tests to activate.",

--- a/frontend/src/languages/fr.json
+++ b/frontend/src/languages/fr.json
@@ -1413,6 +1413,8 @@
   "panel.existing.inactive": "Panneaux inactifs (Attribuer des tests pour activer)",
   "configuration.panel.confirmation.explain": "Ce panneau ne sera pas actif tant qu'au moins un test ne lui aura pas été attribué.",
   "input.error.same.panel.type": "Un panneau existant avec le même nom a été trouvé. Veuillez annuler ou utiliser un nom différent.",
+  "configuration.testUnit.order.explain.limits": "Seules les sections de test contenant des tests assignés peuvent être ordonnées. Pour les nouvelles sections, veuillez d’abord assigner des tests avant de définir l’ordre.",
+  "configuration.sampleType.order.explain.limits": "Seuls les types d’échantillon contenant des tests assignés peuvent être ordonnés. Pour les nouveaux types, veuillez d’abord assigner des tests avant de définir l’ordre.",
   "sampleType.new": "New Sample Type",
   "sampleType.existing": "Existing Sample Types",
   "sampleType.existing.inactive": "Inactive Sample Types.  Assign tests to activate.",


### PR DESCRIPTION
- referencing #1988 

## NOTE : only merge this PR after #1991 

### Ordering Pages

### Routes

https://testing.openelis-global.org/api/OpenELIS-Global/SampleTypeOrder

https://testing.openelis-global.org/api/OpenELIS-Global/TestSectionOrder

#### OLD UI

![image](https://github.com/user-attachments/assets/f8a44d1f-da21-474a-9eb5-c3777ea1eb1c)

![image](https://github.com/user-attachments/assets/8e8e92bd-a487-48be-9508-c619a1033002)


#### New UI

![image](https://github.com/user-attachments/assets/ede8878a-1dd2-4153-8325-9a12ea6d8e01)


![image](https://github.com/user-attachments/assets/d8a0aaec-23ae-406f-8cbb-5d182a9c8fd5)


### WorkFlow VIDEO { wait 5 -10 second let video load }


![testSection_SampleType_Order](https://github.com/user-attachments/assets/3b90ceab-3895-46ce-8cf1-c0eecf64b7e8)


Thank YOu :slightly_smiling_face: 