### PR TITLE
WIP: Reflex rule method breaking during testing

### DIFF
--- a/src/main/resources/persistence/persistence.xml
+++ b/src/main/resources/persistence/persistence.xml
@@ -22,6 +22,7 @@
         <class>org.openelisglobal.externalconnections.valueholder.ExternalConnectionContact</class>
         <class>org.openelisglobal.externalconnections.valueholder.CertificateAuthenticationData</class>
         <class>org.openelisglobal.externalconnections.valueholder.BasicAuthenticationData</class>
+        <class>org.openelisglobal.testreflex.action.bean.ReflexRule</class>
 
         <class>org.itech.fhir.dataexport.core.model.DataExportAttempt</class>
         <class>org.itech.fhir.dataexport.core.model.DataExportTask</class>

--- a/src/test/java/org/openelisglobal/AppTestConfig.java
+++ b/src/test/java/org/openelisglobal/AppTestConfig.java
@@ -22,7 +22,6 @@ import org.openelisglobal.dataexchange.fhir.FhirConfig;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
-import org.openelisglobal.dataexchange.service.order.ElectronicOrderService;
 import org.openelisglobal.externalconnections.service.BasicAuthenticationDataService;
 import org.openelisglobal.externalconnections.service.ExternalConnectionService;
 import org.openelisglobal.internationalization.MessageUtil;
@@ -82,7 +81,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         "org.openelisglobal.sampleproject", "org.openelisglobal.project", "org.openelisglobal.sampleqaevent",
         "org.openelisglobal.patientrelation", "org.openelisglobal.inventory", "org.openelisglobal.testcodes",
         "org.openelisglobal.datasubmission", "org.openelisglobal.label", "org.openelisglobal.renametestsection",
-        "org.openelisglobal.action" }, excludeFilters = {
+        "org.openelisglobal.action", "org.openelisglobal.dataexchange",
+        "org.openelisglobal.testreflex" }, excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.patient.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.organization.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.sample.controller.*"),
@@ -182,11 +182,11 @@ public class AppTestConfig implements WebMvcConfigurer {
         return mock(UnsatisfiedDependencyException.class);
     }
 
-    @Bean()
-    @Profile("test")
-    public ElectronicOrderService electronicOrderService() {
-        return mock(ElectronicOrderService.class);
-    }
+//    @Bean()
+//    @Profile("test")
+//    public ElectronicOrderService electronicOrderService() {
+//        return mock(ElectronicOrderService.class);
+//    }
 
     @Bean()
     @Profile("test")
@@ -283,5 +283,16 @@ public class AppTestConfig implements WebMvcConfigurer {
         converters.add(new StringHttpMessageConverter());
         converters.add(jsonConverter());
     }
-
+//
+//    @Bean()
+//    @Profile("test")
+//    public HL7MessageOutService hL7MessageOutService(){
+//        return mock(HL7MessageOutService.class);
+//    }
+//
+//    @Bean
+//    @Profile("test")
+//    public ReportExternalExportService reportExternalExportService(){
+//        return mock(ReportExternalExportService.class);
+//    }
 }

--- a/src/test/java/org/openelisglobal/dataexchange/service/aggregatereporting/ReportExternalExportServiceTest.java
+++ b/src/test/java/org/openelisglobal/dataexchange/service/aggregatereporting/ReportExternalExportServiceTest.java
@@ -1,0 +1,27 @@
+package org.openelisglobal.dataexchange.service.aggregatereporting;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Timestamp;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ReportExternalExportServiceTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private ReportExternalExportService reportExternalExportService;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/report-external-export.xml");
+    }
+
+    @Test
+    public void testGetLastCollectedTimestamp() {
+        Timestamp lastTimestamp = reportExternalExportService.getLastCollectedTimestamp();
+        assertEquals(Timestamp.valueOf("2023-01-11 00:00:00"), lastTimestamp);
+    }
+
+}

--- a/src/test/java/org/openelisglobal/dataexchange/service/order/ElectronicOrderServiceTest.java
+++ b/src/test/java/org/openelisglobal/dataexchange/service/order/ElectronicOrderServiceTest.java
@@ -1,0 +1,30 @@
+package org.openelisglobal.dataexchange.service.order;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.dataexchange.order.valueholder.ElectronicOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ElectronicOrderServiceTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private ElectronicOrderService electronicOrderService;
+
+    @Before
+    public void setup() throws Exception {
+        executeDataSetWithStateManagement("testdata/electronic-order.xml");
+    }
+
+    @Test
+    public void testGetAllElectronicOrdersOrderedBy() {
+        List<ElectronicOrder> electronicOrders = electronicOrderService
+                .getAllElectronicOrdersOrderedBy(ElectronicOrder.SortOrder.LAST_UPDATED_DESC);
+        assertEquals(3, electronicOrders.size());
+        assertEquals("2", electronicOrders.get(0).getId());
+    }
+
+}

--- a/src/test/java/org/openelisglobal/dataexchange/service/orderresult/HL7MessageOutServiceTest.java
+++ b/src/test/java/org/openelisglobal/dataexchange/service/orderresult/HL7MessageOutServiceTest.java
@@ -1,0 +1,26 @@
+package org.openelisglobal.dataexchange.service.orderresult;
+
+import org.junit.Before;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class HL7MessageOutServiceTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private HL7MessageOutService hL7MessageOutService;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/HL7Message-out.xml");
+    }
+
+//    TODO: Method not yet implemented.
+//    @Test
+//    public void testGetByData(){
+//        HL7MessageOut message = hL7MessageOutService.getByData("You are requested");
+//
+//        assertNotNull(message);
+//        assertEquals("2", message.getId());
+//        assertEquals("SENT", message.getStatus());
+//    }
+}

--- a/src/test/java/org/openelisglobal/testreflex/TestReflex.java
+++ b/src/test/java/org/openelisglobal/testreflex/TestReflex.java
@@ -1,0 +1,27 @@
+package org.openelisglobal.testreflex;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.testreflex.action.bean.ReflexRule;
+import org.openelisglobal.testreflex.service.TestReflexService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class TestReflex extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private TestReflexService reflexService;
+    @Autowired
+    private TestReflexService testReflexService;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/test-reflex.xml");
+    }
+
+    @Test
+    public void testGetReflexRuleByAnalyteId() {
+        ReflexRule reflexRule = testReflexService.getReflexRuleByAnalyteId("3002");
+    }
+
+}

--- a/src/test/resources/testdata/HL7Message-out.xml
+++ b/src/test/resources/testdata/HL7Message-out.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <hl7_message_out id="1"
+        data="MSH|^~\SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250619||ADT^A01|123456|P|2.3"
+        lastupdated="2025-12-31 00:00:00" status="PENDING" />
+
+    <hl7_message_out id="2" data="You are requested"
+        lastupdated="2026-01-15 00:00:00" status="SENT" />
+
+    <hl7_message_out id="3"
+        data="MSH|^~\SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250617||ORM^O01|987654|P|2.3"
+        lastupdated="2025-11-30 00:00:00" status="FAILED" />
+</dataset>

--- a/src/test/resources/testdata/electronic-order.xml
+++ b/src/test/resources/testdata/electronic-order.xml
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+
+    <person id="5001" last_name="Doe" first_name="John"
+        middle_name="joddy" city="Kampala" state="Kampala metropolitan"
+        zip_code="256" country="Uganda" work_phone="12345678"
+        home_phone="87654321" cell_phone="09785432" primary_phone="12345678"
+        fax="3456" email="john@gmail.com" lastUpdated="2023-11-01 12:00:00" />
+    <person id="5002" last_name="Mulizi" first_name="James"
+        middle_name="Mark" city="Orion" state="Texas" zip_code="001"
+        country="USA" work_phone="10000001" home_phone="8000001"
+        cell_phone="0000000" primary_phone="10000001" fax="0001"
+        email="james@gmail.com" lastUpdated="2023-11-01 12:00:00" />
+    <person id="5003" last_name="Kukki" first_name="Faith"
+        middle_name="Siannah" city="Dallas" state="Texas" zip_code="001"
+        country="USA" work_phone="10000002" home_phone="8000003"
+        cell_phone="0000001" primary_phone="10000002" fax="0002"
+        email="siannah@gmail.com" lastUpdated="2023-11-01 12:00:00" />
+
+    <patient id="1001" person_id="5001" race="A" gender="M"
+        national_id="NAT123456" ethnicity="1" school_attend="Springfield High"
+        medicare_id="MED123" medicaid_id="MEDCAID456"
+        birth_place="Springfield" lastupdated="2023-01-01 00:00:00" />
+
+
+    <patient id="1002" person_id="5002" race="B" gender="F"
+        national_id="NAT654321" ethnicity="2"
+        school_attend="Riverdale Academy" medicare_id="MED456"
+        medicaid_id="MEDCAID789" birth_place="Riverdale"
+        lastupdated="2023-01-01 00:00:00" />
+
+
+    <patient id="1003" person_id="5003" race="C" gender="M"
+        national_id="NAT789012" ethnicity="1"
+        school_attend="Lincoln Elementary" medicare_id="MED789"
+        medicaid_id="MEDCAID012" birth_place="Lincoln Town"
+        lastupdated="2023-01-01 00:00:00" />
+
+    <electronic_order id="1" external_id="EXT123456"
+        patient_id="1001" status_id="1" order_timestamp="2024-03-03 12:00:00"
+        data="Order details for EXT123456" lastupdated="2024-01-12 00:00:00" />
+
+    <electronic_order id="2" external_id="EXT654321"
+        patient_id="1002" status_id="2" order_timestamp="2024-03-04 12:00:00"
+        data="Order details for EXT654321" lastupdated="2025-05-01 00:00:00" />
+
+    <electronic_order id="3" external_id="EXT789012"
+        patient_id="1003" status_id="3" order_timestamp="2024-03-02 12:00:00"
+        data="Order details for EXT789012" lastupdated="2025-01-01 00:00:00" />
+</dataset>

--- a/src/test/resources/testdata/report-external-export.xml
+++ b/src/test/resources/testdata/report-external-export.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+
+    <report_queue_type id="101" name="DailyReport"
+        description="Queue for daily reports" />
+
+    <report_queue_type id="102" name="WeeklySummary"
+        description="Queue for weekly summary generation" />
+
+    <report_queue_type id="103" name="UrgentAlert"
+        description="Queue for urgent alerts" />
+
+    <report_external_export id="1"
+        event_date="2022-11-01 12:00:00" collection_date="2023-01-01 00:00:00"
+        sent_date="2024-01-01 00:00:00" type="101"
+        data="{'status':'exported','source':'systemA'}"
+        lastupdated="2025-05-11 00:30:00" send_flag="true"
+        bookkeeping="Initial export by system A" />
+
+    <report_external_export id="2"
+        event_date="2022-01-01 00:00:00" collection_date="2023-01-11 00:00:00"
+        sent_date="2024-01-01 00:00:00" type="102"
+        data="{'status':'exported','source':'systemB'}"
+        lastupdated="2025-01-01 00:00:00" send_flag="false"
+        bookkeeping="Export flagged for review" />
+
+    <report_external_export id="3"
+        event_date="2019-01-01 00:00:00" collection_date="2021-01-11 00:00:00"
+        sent_date="2023-07-12 00:10:00" type="103"
+        data="{'status':'queued','source':'systemC'}"
+        lastupdated="2025-01-01 00:00:00" send_flag="true"
+        bookkeeping="Awaiting confirmation" />
+</dataset>

--- a/src/test/resources/testdata/test-reflex.xml
+++ b/src/test/resources/testdata/test-reflex.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+
+</dataset>


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

The TestReflexService class contains ` ReflexRule getReflexRuleByAnalyteId(String analyteId);` which is supposed to return a ReflexRule, though it breaks during execution making the test fail even before the assertion stage


## Related Issue

[Add TestReflexService Tests](https://github.com/DIGI-UW/OpenELIS-Global-2/issues/1934)

## Other

[Add any additional information or notes here]
