### PR TITLE
add tests for Loinc mapping

### DIFF
--- a/src/test/java/org/openelisglobal/dictionary/service/DictionaryServiceTest.java
+++ b/src/test/java/org/openelisglobal/dictionary/service/DictionaryServiceTest.java
@@ -1,5 +1,9 @@
 package org.openelisglobal.dictionary.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
@@ -7,7 +11,6 @@ import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.dictionary.valueholder.Dictionary;
 import org.openelisglobal.dictionarycategory.service.DictionaryCategoryService;
-import org.openelisglobal.dictionarycategory.valueholder.DictionaryCategory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 
@@ -25,27 +28,15 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
         executeDataSetWithStateManagement("testdata/dictionary.xml");
     }
 
-    // @Test
-    public void verifyTestData() {
-        List<DictionaryCategory> categories = dictionaryCategoryService.getAll();
-        System.out.println("Dictionary Categories: " + categories.size());
-        categories.forEach(cat -> System.out
-                .println(cat.getCategoryName() + " - " + cat.getLocalAbbreviation() + " - " + cat.getDescription()));
-
-        List<Dictionary> dictionaries = dictionaryService.getAll();
-        System.out.println("Dictionaries: " + dictionaries.size());
-        dictionaries.forEach(dict -> System.out.println(dict.getDictEntry() + " - " + dict.getIsActive()));
-    }
-
     @Test
     public void delete_shouldDeleteDictionary() {
         Dictionary dictionaryToDelete = dictionaryService.get("1");
         dictionaryToDelete.setSysUserId("admin");
 
-        Assert.assertNotNull(dictionaryToDelete);
+        assertNotNull(dictionaryToDelete);
 
         dictionaryService.delete(dictionaryToDelete);
-        Assert.assertEquals("N", dictionaryService.get("1").getIsActive());
+        assertEquals("N", dictionaryService.get("1").getIsActive());
     }
 
     @Test
@@ -53,9 +44,9 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
         List<Dictionary> dictionaries = dictionaryService.getDictionaryEntriesByCategoryId("1");
         Assert.assertNotEquals(0, dictionaries.size());
 
-        Assert.assertEquals("Dictionary Entry 1", dictionaries.get(0).getDictEntry());
-        Assert.assertEquals("Y", dictionaries.get(0).getIsActive());
-        Assert.assertEquals("DE1", dictionaries.get(0).getLocalAbbreviation());
+        assertEquals("Dictionary Entry 1", dictionaries.get(0).getDictEntry());
+        assertEquals("Y", dictionaries.get(0).getIsActive());
+        assertEquals("DE1", dictionaries.get(0).getLocalAbbreviation());
     }
 
     @Test
@@ -64,42 +55,42 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
 
         Dictionary dictionary = dictionaryService.getDictionaryByLocalAbbrev(dictionaryToGetByLocalAbbrev);
 
-        Assert.assertNotNull(dictionary);
-        Assert.assertEquals("Dictionary Entry 1", dictionary.getDictEntry());
-        Assert.assertEquals("Y", dictionary.getIsActive());
-        Assert.assertEquals("DE1", dictionary.getLocalAbbreviation());
+        assertNotNull(dictionary);
+        assertEquals("Dictionary Entry 1", dictionary.getDictEntry());
+        assertEquals("Y", dictionary.getIsActive());
+        assertEquals("DE1", dictionary.getLocalAbbreviation());
     }
 
     @Test
     public void getDictionaryByDictEntry_shouldReturnDictionaryWhenGivenDictEntry() {
         Dictionary dictionary = dictionaryService.getDictionaryByDictEntry("Dictionary Entry 2");
 
-        Assert.assertNotNull(dictionary);
-        Assert.assertEquals("Y", dictionary.getIsActive());
-        Assert.assertEquals("DE2", dictionary.getLocalAbbreviation());
-        Assert.assertEquals("2", dictionary.getId());
+        assertNotNull(dictionary);
+        assertEquals("Y", dictionary.getIsActive());
+        assertEquals("DE2", dictionary.getLocalAbbreviation());
+        assertEquals("2", dictionary.getId());
     }
 
     @Test
     public void getDictionaryById_shouldReturnDictionaryWhenGivenDictionaryId() {
         Dictionary dictionary = dictionaryService.getDictionaryById("2");
 
-        Assert.assertNotNull(dictionary);
-        Assert.assertEquals("Dictionary Entry 2", dictionary.getDictEntry());
-        Assert.assertEquals("DE2", dictionary.getLocalAbbreviation());
-        Assert.assertEquals("2", dictionary.getId());
-        Assert.assertEquals("Y", dictionary.getIsActive());
+        assertNotNull(dictionary);
+        assertEquals("Dictionary Entry 2", dictionary.getDictEntry());
+        assertEquals("DE2", dictionary.getLocalAbbreviation());
+        assertEquals("2", dictionary.getId());
+        assertEquals("Y", dictionary.getIsActive());
     }
 
     @Test
     public void getDictionaryEntrysByNameAndCategoryDescription_shouldGetDictionaryEntrysByNameAndCategoryDescription() {
         Dictionary dictionary = dictionaryService.getDictionaryEntrysByNameAndCategoryDescription("Dictionary Entry 1",
                 "Category Description 1");
-        Assert.assertNotNull(dictionary);
+        assertNotNull(dictionary);
 
-        Assert.assertEquals("Dictionary Entry 1", dictionary.getDictEntry());
-        Assert.assertEquals("Y", dictionary.getIsActive());
-        Assert.assertEquals("DE1", dictionary.getLocalAbbreviation());
+        assertEquals("Dictionary Entry 1", dictionary.getDictEntry());
+        assertEquals("Y", dictionary.getIsActive());
+        assertEquals("DE1", dictionary.getLocalAbbreviation());
     }
 
     @Test
@@ -108,19 +99,19 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
                 .getDictionaryEntrysByCategoryNameLocalizedSort("Category Name 1");
         Assert.assertNotEquals(0, dictionaries.size());
 
-        Assert.assertEquals("Dictionary Entry 1", dictionaries.get(0).getDictEntry());
-        Assert.assertEquals("Y", dictionaries.get(0).getIsActive());
-        Assert.assertEquals("DE1", dictionaries.get(0).getLocalAbbreviation());
+        assertEquals("Dictionary Entry 1", dictionaries.get(0).getDictEntry());
+        assertEquals("Y", dictionaries.get(0).getIsActive());
+        assertEquals("DE1", dictionaries.get(0).getLocalAbbreviation());
     }
 
     @Test
     public void getDataForId_shouldReturnDictionaryDataForTheProvidedDictionaryId() {
         Dictionary dictionary = dictionaryService.getDataForId("1");
 
-        Assert.assertNotNull(dictionary);
-        Assert.assertEquals("Dictionary Entry 1", dictionary.getDictEntry());
-        Assert.assertEquals("Y", dictionary.getIsActive());
-        Assert.assertEquals("DE1", dictionary.getLocalAbbreviation());
+        assertNotNull(dictionary);
+        assertEquals("Dictionary Entry 1", dictionary.getDictEntry());
+        assertEquals("Y", dictionary.getIsActive());
+        assertEquals("DE1", dictionary.getLocalAbbreviation());
     }
 
     @Test
@@ -129,10 +120,10 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
 
         dictionaryService.getData(dictionaryToGet);
 
-        Assert.assertNotNull(dictionaryToGet);
-        Assert.assertEquals("Dictionary Entry 1", dictionaryToGet.getDictEntry());
-        Assert.assertEquals("Y", dictionaryToGet.getIsActive());
-        Assert.assertEquals("DE1", dictionaryToGet.getLocalAbbreviation());
+        assertNotNull(dictionaryToGet);
+        assertEquals("Dictionary Entry 1", dictionaryToGet.getDictEntry());
+        assertEquals("Y", dictionaryToGet.getIsActive());
+        assertEquals("DE1", dictionaryToGet.getLocalAbbreviation());
     }
 
     @Test
@@ -141,9 +132,9 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
 
         Assert.assertNotEquals(0, dictionaries.size());
 
-        Assert.assertEquals("Dictionary Entry 1", dictionaries.get(0).getDictEntry());
-        Assert.assertEquals("Y", dictionaries.get(0).getIsActive());
-        Assert.assertEquals("DE1", dictionaries.get(0).getLocalAbbreviation());
+        assertEquals("Dictionary Entry 1", dictionaries.get(0).getDictEntry());
+        assertEquals("Y", dictionaries.get(0).getIsActive());
+        assertEquals("DE1", dictionaries.get(0).getLocalAbbreviation());
     }
 
     @Test
@@ -152,10 +143,10 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
         dictionaryToUpdate.setDictEntry("INFLUENZA VIRUS A RNA DETECTEDetest");
 
         Dictionary updatedDictionary = dictionaryService.update(dictionaryToUpdate);
-        Assert.assertNotNull(updatedDictionary);
+        assertNotNull(updatedDictionary);
 
-        Assert.assertEquals("Y", dictionaryService.get("1").getIsActive());
-        Assert.assertEquals("INFLUENZA VIRUS A RNA DETECTEDetest", dictionaryService.get("1").getDictEntry());
+        assertEquals("Y", dictionaryService.get("1").getIsActive());
+        assertEquals("INFLUENZA VIRUS A RNA DETECTEDetest", dictionaryService.get("1").getDictEntry());
     }
 
     @Test
@@ -165,8 +156,8 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
 
         dictionaryService.update(dictionaryToUpdate, true);
 
-        Assert.assertEquals("Y", dictionaryService.get("1").getIsActive());
-        Assert.assertEquals("INFLUENZA VIRUS A RNA DETECTEDetest", dictionaryService.get("1").getDictEntry());
+        assertEquals("Y", dictionaryService.get("1").getIsActive());
+        assertEquals("INFLUENZA VIRUS A RNA DETECTEDetest", dictionaryService.get("1").getDictEntry());
     }
 
     @Test
@@ -176,8 +167,8 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
 
         dictionaryService.update(dictionaryToUpdate, false);
 
-        Assert.assertEquals("Y", dictionaryService.get("1").getIsActive());
-        Assert.assertEquals("INFLUENZA VIRUS A RNA DETECTEDetest", dictionaryService.get("1").getDictEntry());
+        assertEquals("Y", dictionaryService.get("1").getIsActive());
+        assertEquals("INFLUENZA VIRUS A RNA DETECTEDetest", dictionaryService.get("1").getDictEntry());
     }
 
     @Test
@@ -187,8 +178,55 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
         String inserted = dictionaryService.insert(dict);
         Dictionary dictionary = dictionaryService.get(inserted);
 
-        Assert.assertEquals("Dictionary Entry 4", dictionary.getDictEntry());
-        Assert.assertEquals("Y", dictionary.getIsActive());
+        assertEquals("Dictionary Entry 4", dictionary.getDictEntry());
+        assertEquals("Y", dictionary.getIsActive());
+    }
+
+    @Test
+    public void getDictionary_shouldReturnWithLoincCodeWhenExists() {
+
+        Dictionary dictionary = dictionaryService.get("1");
+        dictionary.setLoincCode("LA9663-1");
+        dictionaryService.update(dictionary);
+        Dictionary updated = dictionaryService.get("1");
+        assertNotNull(updated);
+        assertEquals("LA9663-1", updated.getLoincCode());
+    }
+
+    @Test
+    public void getDictionary_shouldReturnNullLoincCodeWhenNotExists() {
+        Dictionary dictionary = dictionaryService.get("6");
+        assertNotNull(dictionary);
+        assertNull(dictionary.getLoincCode());
+    }
+
+    @Test
+    public void update_shouldPersistLoincCode() {
+        Dictionary dictionary = dictionaryService.get("1");
+        dictionary.setLoincCode("LA12345-6");
+
+        dictionaryService.update(dictionary);
+
+        Dictionary updated = dictionaryService.get("1");
+        assertEquals("LA12345-6", updated.getLoincCode());
+    }
+
+    @Test
+    public void createDictionary_shouldStoreLoincCode() throws Exception {
+        Dictionary dict = createDictionaryObject();
+        dict.setLoincCode("LA54321-0");
+
+        String id = dictionaryService.insert(dict);
+        Dictionary saved = dictionaryService.get(id);
+
+        assertEquals("LA54321-0", saved.getLoincCode());
+    }
+
+    @Test
+    public void getPagesOfSearchedDictionaries_shouldFindByDictionaryText() {
+        List<Dictionary> results = dictionaryService.getPagesOfSearchedDictionaries(1, "Dictionary Entry 1");
+        assertEquals(1, results.size());
+        assertEquals("Dictionary Entry 1", results.get(0).getDictEntry());
     }
 
     private Dictionary createDictionaryObject() {

--- a/src/test/resources/testdata/dictionary.xml
+++ b/src/test/resources/testdata/dictionary.xml
@@ -46,4 +46,16 @@
         dict_entry="Dictionary Entry 3" local_Abbrev="DE3"
         dictionary_category_id="3" sort_order="3"
         lastUpdated="2023-10-01 12:00:00" />
+    <dictionary id="4" is_active="Y" dict_entry="Positive"
+        local_Abbrev="POS" dictionary_category_id="1" sort_order="4"
+        loinc_code="LA9663-1" lastUpdated="2023-11-02 12:00:00" />
+
+    <dictionary id="5" is_active="Y" dict_entry="Negative"
+        local_Abbrev="NEG" dictionary_category_id="1" sort_order="5"
+        loinc_code="LA9664-9" lastUpdated="2023-11-02 12:00:00" />
+
+    <dictionary id="6" is_active="Y" dict_entry="Invalid"
+        local_Abbrev="INV" dictionary_category_id="1" sort_order="6"
+        lastUpdated="2023-11-02 12:00:00" />
+
 </dataset>


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
I have added tests for loinc mapping in the existing Dictionary Service Tests
## Screenshots

![Screenshot from 2025-06-25 16-05-24](https://github.com/user-attachments/assets/18b8fd9d-24cb-43dd-b9f0-de666bd33ff5)

## Related Issue
Closes #2073

## Other

