### PR TITLE
Added tests for the ClientResultsViewInfoService class

### DIFF
--- a/src/test/java/org/openelisglobal/AppTestConfig.java
+++ b/src/test/java/org/openelisglobal/AppTestConfig.java
@@ -81,7 +81,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         "org.openelisglobal.dataexchange", "org.openelisglobal.samplepdf", "org.openelisglobal.samplenewborn",
         "org.openelisglobal.sampleqaeventaction", "org.openelisglobal.analyzerresults", "org.openelisglobal.testreflex",
         "org.openelisglobal.county", "org.openelisglobal.sampletracking", "org.openelisglobal.testresultsview",
-        "org.openelisglobal.projectorganization" ,"org.openelisglobal.sourceofsample" }, excludeFilters = {
+        "org.openelisglobal.projectorganization", "org.openelisglobal.sourceofsample" }, excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.patient.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.organization.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.sample.controller.*"),

--- a/src/test/java/org/openelisglobal/AppTestConfig.java
+++ b/src/test/java/org/openelisglobal/AppTestConfig.java
@@ -80,7 +80,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         "org.openelisglobal.action", "org.openelisglobal.analysisqaevent", "org.openelisglobal.analysisqaeventaction",
         "org.openelisglobal.dataexchange", "org.openelisglobal.samplepdf", "org.openelisglobal.samplenewborn",
         "org.openelisglobal.sampleqaeventaction", "org.openelisglobal.analyzerresults", "org.openelisglobal.testreflex",
-        "org.openelisglobal.county", "org.openelisglobal.sampletracking",
+        "org.openelisglobal.county", "org.openelisglobal.sampletracking", "org.openelisglobal.testresultsview",
         "org.openelisglobal.projectorganization" }, excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.patient.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.organization.controller.*"),

--- a/src/test/java/org/openelisglobal/AppTestConfig.java
+++ b/src/test/java/org/openelisglobal/AppTestConfig.java
@@ -79,7 +79,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         "org.openelisglobal.action", "org.openelisglobal.analysisqaevent", "org.openelisglobal.analysisqaeventaction",
         "org.openelisglobal.dataexchange", "org.openelisglobal.samplepdf", "org.openelisglobal.samplenewborn",
         "org.openelisglobal.sampleqaeventaction", "org.openelisglobal.analyzerresults", "org.openelisglobal.testreflex",
-        "org.openelisglobal.county" }, excludeFilters = {
+        "org.openelisglobal.county", "org.openelisglobal.testResultsView" }, excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.patient.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.organization.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.sample.controller.*"),

--- a/src/test/java/org/openelisglobal/patient/PatientContactServiceTest.java
+++ b/src/test/java/org/openelisglobal/patient/PatientContactServiceTest.java
@@ -145,7 +145,7 @@ public class PatientContactServiceTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void getOrderedPage_ShouldReturnAPageOfResultsGivenAListAndOrderedInDescendingOrder() {
+    public void getOrderedPage_ShouldReturnAPageOfResultsGivenAListAndOrderedInAscendingOrder() {
         patientContacts = patientContactService.getOrderedPage(orderProperties, false, 7);
         PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         assertNotNull(patientContacts);

--- a/src/test/java/org/openelisglobal/testresultsview/ClientResultsViewInfoServiceTest.java
+++ b/src/test/java/org/openelisglobal/testresultsview/ClientResultsViewInfoServiceTest.java
@@ -113,36 +113,42 @@ public class ClientResultsViewInfoServiceTest extends BaseWebContextSensitiveTes
     }
 
     @Test
-    public void getPage_ShouldReturnAPageOfClientResultsViewBeans_UsingAPageNumber() {
+    public void getPage_ShouldReturnAPageOfResultsGivenPageNumber() {
         PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
-        clientResultsViewInfoList = clientResultsViewInfoService.getPage(1);
+        clientResultsViewInfoList = clientResultsViewInfoService.getPage(3);
+        assertEquals(Integer.valueOf("7005"), clientResultsViewInfoList.get(2).getId());
         assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+        assertEquals(6, clientResultsViewInfoList.size());
     }
 
     @Test
-    public void getMatchingPage_ShouldReturnAPageOfClientResultsViewBeans_UsingAPropertyNameAndValue() {
+    public void getMatchingPage_ShouldReturnAPageOfResultsFilteredByAPropertyNameAndValue() {
         PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         clientResultsViewInfoList = clientResultsViewInfoService.getMatchingPage("password",
                 "encrypted-password-string", 1);
+        assertEquals(Integer.valueOf("7007"), clientResultsViewInfoList.get(3).getId());
         assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+        assertEquals(4, clientResultsViewInfoList.size());
     }
 
     @Test
-    public void getMatchingPage_ShouldReturnAPageOfClientResultsViewBeans_UsingAMap() {
+    public void getMatchingPage_ShouldReturnAPageOfResultsFilteredByAMap() {
         PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         clientResultsViewInfoList = clientResultsViewInfoService.getMatchingPage(propertyValues, 1);
+        assertEquals(Integer.valueOf("7004"), clientResultsViewInfoList.get(1).getId());
         assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+        assertEquals(3, clientResultsViewInfoList.size());
     }
 
     @Test
-    public void getOrderedPage_ShouldReturnAnOrderedPageOfClientResultsViewBeans_UsingAnOrderProperty() {
+    public void getOrderedPage_ShouldReturnAPageOfResultsFilteredByAnOrderPropertyInDescendingOrder() {
         PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         clientResultsViewInfoList = clientResultsViewInfoService.getOrderedPage("id", true, 1);
         assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
     }
 
     @Test
-    public void getOrderedPage_ShouldReturnAnOrderedPageOfClientResultsViewBeans_UsingAList() {
+    public void getOrderedPage_ShouldReturnAPageOfResultsGivenAListAndOrderedInAscendingOrder() {
         PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         clientResultsViewInfoList = clientResultsViewInfoService.getOrderedPage(orderProperties, false, 1);
         assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());

--- a/src/test/java/org/openelisglobal/testresultsview/ClientResultsViewInfoServiceTest.java
+++ b/src/test/java/org/openelisglobal/testresultsview/ClientResultsViewInfoServiceTest.java
@@ -1,0 +1,182 @@
+package org.openelisglobal.testresultsview;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.testresultsview.service.ClientResultsViewInfoService;
+import org.openelisglobal.testresultsview.valueholder.ClientResultsViewBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ClientResultsViewInfoServiceTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private ClientResultsViewInfoService clientResultsViewInfoService;
+
+    private List<ClientResultsViewBean> clientResultsViewInfoList;
+    private Map<String, Object> propertyValues;
+    private List<String> orderProperties;
+    private static int PAGE_SIZE = 0;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/client-results-view.xml");
+
+        propertyValues = new HashMap<>();
+        propertyValues.put("result", 1001);
+        orderProperties = new ArrayList<>();
+        orderProperties.add("password");
+    }
+
+    @Test
+    public void getAll_ShouldReturnAllClientResultsViewBeans() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAll();
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(8, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7005"), clientResultsViewInfoList.get(4).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingClientResultsViewBeans_UsingPropertyNameAndValue() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAllMatching("password",
+                "encrypted-password-string");
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(4, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7007"), clientResultsViewInfoList.get(3).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingClientResultsViewBeans_UsingAMap() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAllMatching(propertyValues);
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(3, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7004"), clientResultsViewInfoList.get(1).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrderedClientResultsViewBeans_UsingAnOrderProperty() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAllOrdered("id", false);
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(8, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7006"), clientResultsViewInfoList.get(5).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrdered_UsingAList() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAllOrdered(orderProperties, true);
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(8, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7002"), clientResultsViewInfoList.get(6).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedClientResultsViewBeans_UsingPropertyNameAndValueAndAnOrderProperty() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAllMatchingOrdered("password", "encryptedpassword",
+                "result", false);
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(1, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7002"), clientResultsViewInfoList.get(0).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedClientResultsViewBeans_UsingPropertyNameAndValueAndAList() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAllMatchingOrdered("password", "encryptedpassword",
+                orderProperties, true);
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(1, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7002"), clientResultsViewInfoList.get(0).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedClientResultsViewBeans_UsingAMapAndAnOrderProperty() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAllMatchingOrdered(propertyValues, "result", true);
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(3, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7004"), clientResultsViewInfoList.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedClientResultsViewBeans_UsingAMapAndAList() {
+        clientResultsViewInfoList = clientResultsViewInfoService.getAllMatchingOrdered(propertyValues, orderProperties,
+                false);
+        assertNotNull(clientResultsViewInfoList);
+        assertEquals(3, clientResultsViewInfoList.size());
+        assertEquals(Integer.valueOf("7007"), clientResultsViewInfoList.get(2).getId());
+    }
+
+    @Test
+    public void getPage_ShouldReturnAPageOfClientResultsViewBeans_UsingAPageNumber() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getPage(1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfClientResultsViewBeans_UsingAPropertyNameAndValue() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getMatchingPage("password",
+                "encrypted-password-string", 1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfClientResultsViewBeans_UsingAMap() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getMatchingPage(propertyValues, 1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfClientResultsViewBeans_UsingAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getOrderedPage("id", true, 1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfClientResultsViewBeans_UsingAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getOrderedPage(orderProperties, false, 1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfClientResultsViewBeans_UsingAPropertyNameAndValueAndAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getMatchingOrderedPage("password",
+                "encrypted-password-string", "id", true, 1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfClientResultsViewBeans_UsingAPropertyNameAndValueAndAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getMatchingOrderedPage("id", "7002", orderProperties,
+                true, 1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfClientResultsViewBeans_UsingAMapAndAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getMatchingOrderedPage(propertyValues, "password",
+                false, 1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfClientResultsViewBeans_UsingAMapAndAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        clientResultsViewInfoList = clientResultsViewInfoService.getMatchingOrderedPage(propertyValues, orderProperties,
+                false, 1);
+        assertTrue(PAGE_SIZE >= clientResultsViewInfoList.size());
+    }
+}

--- a/src/test/resources/persistence/test-persistence.xml
+++ b/src/test/resources/persistence/test-persistence.xml
@@ -22,6 +22,7 @@
         <class>org.openelisglobal.externalconnections.valueholder.ExternalConnectionContact</class>
         <class>org.openelisglobal.externalconnections.valueholder.CertificateAuthenticationData</class>
         <class>org.openelisglobal.externalconnections.valueholder.BasicAuthenticationData</class>
+        <class>org.openelisglobal.testresultsview.valueholder.ClientResultsViewBean</class>
 
         <class>org.itech.fhir.dataexport.core.model.DataExportAttempt</class>
         <class>org.itech.fhir.dataexport.core.model.DataExportTask</class>

--- a/src/test/resources/testdata/client-results-view.xml
+++ b/src/test/resources/testdata/client-results-view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <result id="1001" sort_order="1" is_reportable="Y"
+        result_type="N" lastupdated="2025-07-10 12:00:00" />
+    <result id="1002" sort_order="1" is_reportable="Y"
+        result_type="N" lastupdated="2025-07-10 12:00:00" />
+    <result id="1003" sort_order="3" is_reportable="Y"
+        result_type="M" lastupdated="2023-07-07 12:00:00" />
+    <result id="1004" sort_order="2" is_reportable="Y"
+        result_type="M" lastupdated="2000-07-14 16:00:00" />
+    <result id="1005" sort_order="3" is_reportable="Y"
+        result_type="M" lastupdated="2022-09-10 12:00:00" />
+
+    <client_results_view id="7001"
+        password="encrypted-password-string" result_id="1001" />
+    <client_results_view id="7002"
+        password="encryptedpassword" result_id="1003" />
+    <client_results_view id="7003"
+        password="encrypted-password-string" result_id="1004" />
+    <client_results_view id="7004"
+        password="digital-password" result_id="1001" />
+    <client_results_view id="7005"
+        password="encrypted-password-string" result_id="1003" />
+    <client_results_view id="7006"
+        password="strong-password" result_id="1002" />
+    <client_results_view id="7007"
+        password="encrypted-password-string" result_id="1001" />
+    <client_results_view id="7008"
+        password="weak-password" result_id="1005" />
+</dataset>


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Added tests for the `ClientResultsViewInfoService` class


## Related Issue

[Add integration tests for ClientResultsViewInfoService class](https://github.com/DIGI-UW/OpenELIS-Global-2/issues/2141)

## Other

Fixes <https://github.com/DIGI-UW/OpenELIS-Global-2/issues/2141>
