### PR TITLE
Added missing integration tests in the Qaevent services

### DIFF
--- a/src/main/java/org/openelisglobal/qaevent/daoimpl/NceActionLogDAOImpl.java
+++ b/src/main/java/org/openelisglobal/qaevent/daoimpl/NceActionLogDAOImpl.java
@@ -1,8 +1,12 @@
 package org.openelisglobal.qaevent.daoimpl;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
+import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.qaevent.dao.NceActionLogDAO;
 import org.openelisglobal.qaevent.valueholder.NceActionLog;
 import org.springframework.stereotype.Component;
@@ -19,6 +23,18 @@ public class NceActionLogDAOImpl extends BaseDAOImpl<NceActionLog, String> imple
     @Override
     @Transactional(readOnly = true)
     public List<NceActionLog> getNceActionLogByNceId(String nceId) throws LIMSRuntimeException {
-        return null;
+        List<NceActionLog> list = new ArrayList<>();
+        try {
+            String sqlString = "from NceActionLog nc where nc.ncEventId = :param";
+
+            Query<NceActionLog> query = entityManager.unwrap(Session.class).createQuery(sqlString, NceActionLog.class);
+            query.setParameter("param", Integer.parseInt(nceId));
+
+            list = query.list();
+            return list;
+        } catch (RuntimeException exception) {
+            LogEvent.logError(exception);
+            throw new LIMSRuntimeException("Error in NceActionLog getNceActionLogByNceId(String nceId)", exception);
+        }
     }
 }

--- a/src/main/java/org/openelisglobal/qaevent/daoimpl/NceSpecimenDAOImpl.java
+++ b/src/main/java/org/openelisglobal/qaevent/daoimpl/NceSpecimenDAOImpl.java
@@ -25,11 +25,11 @@ public class NceSpecimenDAOImpl extends BaseDAOImpl<NceSpecimen, String> impleme
         try {
             String sql = "from NceSpecimen ns where ns.nceId=:nceId ";
             Query<NceSpecimen> query = entityManager.unwrap(Session.class).createQuery(sql, NceSpecimen.class);
-            query.setParameter("nceId", nceId);
+            query.setParameter("nceId", Integer.parseInt(nceId));
             list = query.list();
         } catch (RuntimeException e) {
             LogEvent.logError(e);
-            throw new LIMSRuntimeException("Error in NceCategory getAllNceCategory()", e);
+            throw new LIMSRuntimeException("Error in NceSpecimen getSpecimenByNceId(String nceId)", e);
         }
         return list;
     }

--- a/src/main/java/org/openelisglobal/qaevent/service/NceActionLogServiceImpl.java
+++ b/src/main/java/org/openelisglobal/qaevent/service/NceActionLogServiceImpl.java
@@ -23,7 +23,7 @@ public class NceActionLogServiceImpl extends AuditableBaseObjectServiceImpl<NceA
     @Override
     @Transactional
     public List<NceActionLog> getNceActionLogByNceId(String nceId) throws LIMSRuntimeException {
-        return null;
+        return getBaseObjectDAO().getNceActionLogByNceId(nceId);
     }
 
     @Override

--- a/src/test/java/org/openelisglobal/qaevent/LabComponentServiceTest.java
+++ b/src/test/java/org/openelisglobal/qaevent/LabComponentServiceTest.java
@@ -26,7 +26,7 @@ public class LabComponentServiceTest extends BaseWebContextSensitiveTest {
     private List<LabComponent> labComponents;
     private Map<String, Object> propertyValues;
     private List<String> orderProperties;
-    private static int NUMBER_OF_PAGES = 0;
+    private static int PAGE_SIZE = 0;
 
     @Before
     public void setUp() throws Exception {
@@ -113,75 +113,66 @@ public class LabComponentServiceTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void getPage_ShouldReturnAPageOfLabComponents_UsingAPageNumber() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getPage(1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
     public void getMatchingPage_ShouldReturnAPageOfLabComponents_UsingAPropertyNameAndValue() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getMatchingPage("lastmodified", Timestamp.valueOf("2024-01-12 11:15:00"),
                 1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
     public void getMatchingPage_ShouldReturnAPageOfLabComponents_UsingAMap() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getMatchingPage(propertyValues, 1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
     public void getOrderedPage_ShouldReturnAnOrderedPageOfLabComponents_UsingAnOrderProperty() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getOrderedPage("lastmodified", true, 1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
     public void getOrderedPage_ShouldReturnAnOrderedPageOfLabComponents_UsingAList() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getOrderedPage(orderProperties, false, 1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
     public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfLabComponents_UsingAPropertyNameAndValueAndAnOrderProperty() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getMatchingOrderedPage("id", "10", "lastmodified", true, 1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
     public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfLabComponents_UsingAPropertyNameAndValueAndAList() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getMatchingOrderedPage("name", "freezer", orderProperties, true, 1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
     public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfLabComponents_UsingAMapAndAnOrderProperty() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getMatchingOrderedPage(propertyValues, "id", false, 1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
     public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfLabComponents_UsingAMapAndAList() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         labComponents = labComponentService.getMatchingOrderedPage(propertyValues, orderProperties, false, 1);
-        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+        assertTrue(PAGE_SIZE >= labComponents.size());
     }
 
     @Test
@@ -192,7 +183,7 @@ public class LabComponentServiceTest extends BaseWebContextSensitiveTest {
         LabComponent labComponent = labComponentService.get("2");
         labComponentService.delete(labComponent);
         List<LabComponent> newLabComponents = labComponentService.getAll();
-        assertFalse(labComponents.stream().anyMatch(lc -> "ph meter".equals(lc.getNameKey())));
+        assertFalse(newLabComponents.stream().anyMatch(lc -> "ph meter".equals(lc.getNameKey())));
         assertEquals(9, newLabComponents.size());
     }
 

--- a/src/test/java/org/openelisglobal/qaevent/LabComponentServiceTest.java
+++ b/src/test/java/org/openelisglobal/qaevent/LabComponentServiceTest.java
@@ -1,0 +1,209 @@
+package org.openelisglobal.qaevent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.qaevent.service.LabComponentService;
+import org.openelisglobal.qaevent.valueholder.LabComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class LabComponentServiceTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private LabComponentService labComponentService;
+
+    private List<LabComponent> labComponents;
+    private Map<String, Object> propertyValues;
+    private List<String> orderProperties;
+    private static int NUMBER_OF_PAGES = 0;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/lap-component.xml");
+
+        propertyValues = new HashMap<>();
+        propertyValues.put("lastmodified", Timestamp.valueOf("2024-01-13 13:00:00"));
+        orderProperties = new ArrayList<>();
+        orderProperties.add("name");
+    }
+
+    @Test
+    public void getAll_ShouldReturnAllLabComponents() {
+        labComponents = labComponentService.getAll();
+        assertNotNull(labComponents);
+        assertEquals(10, labComponents.size());
+        assertEquals("3", labComponents.get(2).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingLabComponents_UsingPropertyNameAndValue() {
+        labComponents = labComponentService.getAllMatching("name", "centrifuge");
+        assertNotNull(labComponents);
+        assertEquals(2, labComponents.size());
+        assertEquals("6", labComponents.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingLabComponents_UsingAMap() {
+        labComponents = labComponentService.getAllMatching(propertyValues);
+        assertNotNull(labComponents);
+        assertEquals(4, labComponents.size());
+        assertEquals("9", labComponents.get(3).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrderedLabComponents_UsingAnOrderProperty() {
+        labComponents = labComponentService.getAllOrdered("id", false);
+        assertNotNull(labComponents);
+        assertEquals(10, labComponents.size());
+        assertEquals("10", labComponents.get(9).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrdered_UsingAList() {
+        labComponents = labComponentService.getAllOrdered(orderProperties, true);
+        assertNotNull(labComponents);
+        assertEquals(10, labComponents.size());
+        assertEquals("6", labComponents.get(6).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedLabComponents_UsingPropertyNameAndValueAndAnOrderProperty() {
+        labComponents = labComponentService.getAllMatchingOrdered("name", "incubator", "lastmodified", true);
+        assertNotNull(labComponents);
+        assertEquals(2, labComponents.size());
+        assertEquals("10", labComponents.get(0).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedLabComponents_UsingPropertyNameAndValueAndAList() {
+        labComponents = labComponentService.getAllMatchingOrdered("lastmodified",
+                Timestamp.valueOf("2024-01-17 17:35:00"), orderProperties, true);
+        assertNotNull(labComponents);
+        assertEquals(2, labComponents.size());
+        assertEquals("1", labComponents.get(0).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedLabComponents_UsingAMapAndAnOrderProperty() {
+        labComponents = labComponentService.getAllMatchingOrdered(propertyValues, "lastmodified", true);
+        assertNotNull(labComponents);
+        assertEquals(4, labComponents.size());
+        assertEquals("4", labComponents.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedLabComponents_UsingAMapAndAList() {
+        labComponents = labComponentService.getAllMatchingOrdered(propertyValues, orderProperties, false);
+        assertNotNull(labComponents);
+        assertEquals(4, labComponents.size());
+        assertEquals("2", labComponents.get(2).getId());
+    }
+
+    @Test
+    public void getPage_ShouldReturnAPageOfLabComponents_UsingAPageNumber() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getPage(1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfLabComponents_UsingAPropertyNameAndValue() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getMatchingPage("lastmodified", Timestamp.valueOf("2024-01-12 11:15:00"),
+                1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfLabComponents_UsingAMap() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getMatchingPage(propertyValues, 1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfLabComponents_UsingAnOrderProperty() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getOrderedPage("lastmodified", true, 1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfLabComponents_UsingAList() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getOrderedPage(orderProperties, false, 1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfLabComponents_UsingAPropertyNameAndValueAndAnOrderProperty() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getMatchingOrderedPage("id", "10", "lastmodified", true, 1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfLabComponents_UsingAPropertyNameAndValueAndAList() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getMatchingOrderedPage("name", "freezer", orderProperties, true, 1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfLabComponents_UsingAMapAndAnOrderProperty() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getMatchingOrderedPage(propertyValues, "id", false, 1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfLabComponents_UsingAMapAndAList() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        labComponents = labComponentService.getMatchingOrderedPage(propertyValues, orderProperties, false, 1);
+        assertTrue(NUMBER_OF_PAGES >= labComponents.size());
+    }
+
+    @Test
+    public void delete_ShouldDeleteALabComponent() {
+        labComponents = labComponentService.getAll();
+        assertEquals(10, labComponents.size());
+        assertTrue(labComponents.stream().anyMatch(lc -> "ph meter".equals(lc.getName())));
+        LabComponent labComponent = labComponentService.get("2");
+        labComponentService.delete(labComponent);
+        List<LabComponent> newLabComponents = labComponentService.getAll();
+        assertFalse(labComponents.stream().anyMatch(lc -> "ph meter".equals(lc.getNameKey())));
+        assertEquals(9, newLabComponents.size());
+    }
+
+    @Test
+    public void deleteAll_ShouldDeleteAllLabComponents() {
+        labComponents = labComponentService.getAll();
+        assertFalse(labComponents.isEmpty());
+        assertEquals(10, labComponents.size());
+        labComponentService.deleteAll(labComponents);
+        List<LabComponent> updatedLabComponents = labComponentService.getAll();
+        assertTrue(updatedLabComponents.isEmpty());
+    }
+
+}

--- a/src/test/java/org/openelisglobal/qaevent/NceActionLogServiceTest.java
+++ b/src/test/java/org/openelisglobal/qaevent/NceActionLogServiceTest.java
@@ -38,6 +38,15 @@ public class NceActionLogServiceTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
+    public void getNceActionLogByNceId_ShouldReturnAllNceActionLogsWithAnNceIdMatchingTheParameterValue() {
+        nceActionLogs = nceActionLogService.getNceActionLogByNceId("901");
+        assertNotNull(nceActionLogs);
+        assertEquals(6, nceActionLogs.size());
+        assertEquals("8", nceActionLogs.get(3).getId());
+        assertEquals("fix calibration issue", nceActionLogs.get(4).getCorrectiveAction());
+    }
+
+    @Test
     public void getAll_ShouldReturnAllNceActionLogs() {
         nceActionLogs = nceActionLogService.getAll();
         assertNotNull(nceActionLogs);

--- a/src/test/java/org/openelisglobal/qaevent/NceActionLogServiceTest.java
+++ b/src/test/java/org/openelisglobal/qaevent/NceActionLogServiceTest.java
@@ -1,0 +1,198 @@
+package org.openelisglobal.qaevent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.qaevent.service.NceActionLogService;
+import org.openelisglobal.qaevent.valueholder.NceActionLog;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class NceActionLogServiceTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private NceActionLogService nceActionLogService;
+
+    private List<NceActionLog> nceActionLogs;
+    private Map<String, Object> propertyValues;
+    private List<String> orderProperties;
+    private static int PAGE_SIZE = 0;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/nce-action-log.xml");
+
+        propertyValues = new HashMap<>();
+        propertyValues.put("actionType", "corrective");
+        orderProperties = new ArrayList<>();
+        orderProperties.add("correctiveAction");
+    }
+
+    @Test
+    public void getAll_ShouldReturnAllNceActionLogs() {
+        nceActionLogs = nceActionLogService.getAll();
+        assertNotNull(nceActionLogs);
+        assertEquals(10, nceActionLogs.size());
+        assertEquals("3", nceActionLogs.get(2).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingNceActionLogs_UsingPropertyNameAndValue() {
+        nceActionLogs = nceActionLogService.getAllMatching("turnAroundTime", "40");
+        assertNotNull(nceActionLogs);
+        assertEquals(3, nceActionLogs.size());
+        assertEquals("5", nceActionLogs.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingNceActionLogs_UsingAMap() {
+        nceActionLogs = nceActionLogService.getAllMatching(propertyValues);
+        assertNotNull(nceActionLogs);
+        assertEquals(7, nceActionLogs.size());
+        assertEquals("9", nceActionLogs.get(6).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrderedNceActionLogs_UsingAnOrderProperty() {
+        nceActionLogs = nceActionLogService.getAllOrdered("personResponsible", false);
+        assertNotNull(nceActionLogs);
+        assertEquals(10, nceActionLogs.size());
+        assertEquals("9", nceActionLogs.get(7).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrdered_UsingAList() {
+        nceActionLogs = nceActionLogService.getAllOrdered(orderProperties, true);
+        assertNotNull(nceActionLogs);
+        assertEquals(10, nceActionLogs.size());
+        assertEquals("8", nceActionLogs.get(8).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceActionLogs_UsingPropertyNameAndValueAndAnOrderProperty() {
+        nceActionLogs = nceActionLogService.getAllMatchingOrdered("ncEventId", "903", "dateCompleted", true);
+        assertNotNull(nceActionLogs);
+        assertEquals(2, nceActionLogs.size());
+        assertEquals("3", nceActionLogs.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceActionLogs_UsingPropertyNameAndValueAndAList() {
+        nceActionLogs = nceActionLogService.getAllMatchingOrdered("ncEventId", "901", orderProperties, true);
+        assertNotNull(nceActionLogs);
+        assertEquals(6, nceActionLogs.size());
+        assertEquals("8", nceActionLogs.get(4).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceActionLogs_UsingAMapAndAnOrderProperty() {
+        nceActionLogs = nceActionLogService.getAllMatchingOrdered(propertyValues, "personResponsible", true);
+        assertNotNull(nceActionLogs);
+        assertEquals(7, nceActionLogs.size());
+        assertEquals("1", nceActionLogs.get(4).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceActionLogs_UsingAMapAndAList() {
+        nceActionLogs = nceActionLogService.getAllMatchingOrdered(propertyValues, orderProperties, false);
+        assertNotNull(nceActionLogs);
+        assertEquals(7, nceActionLogs.size());
+        assertEquals("5", nceActionLogs.get(5).getId());
+    }
+
+    @Test
+    public void getPage_ShouldReturnAPageOfNceActionLogs_UsingAPageNumber() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getPage(1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfNceActionLogs_UsingAPropertyNameAndValue() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getMatchingPage("personResponsible", "mark brown", 1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfNceActionLogs_UsingAMap() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getMatchingPage(propertyValues, 1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfNceActionLogs_UsingAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getOrderedPage("dateCompleted", true, 1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfNceActionLogs_UsingAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getOrderedPage(orderProperties, false, 1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceActionLogs_UsingAPropertyNameAndValueAndAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getMatchingOrderedPage("actionType", "preventive", "dateCompleted", true,
+                1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceActionLogs_UsingAPropertyNameAndValueAndAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getMatchingOrderedPage("correctiveAction", "replace reagent",
+                orderProperties, true, 1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceActionLogs_UsingAMapAndAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getMatchingOrderedPage(propertyValues, "id", false, 1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceActionLogs_UsingAMapAndAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceActionLogs = nceActionLogService.getMatchingOrderedPage(propertyValues, orderProperties, false, 1);
+        assertTrue(PAGE_SIZE >= nceActionLogs.size());
+    }
+
+    @Test
+    public void delete_ShouldDeleteANceActionLog() {
+        nceActionLogs = nceActionLogService.getAll();
+        assertEquals(10, nceActionLogs.size());
+        assertTrue(nceActionLogs.stream().anyMatch(nal -> "update software".equals(nal.getCorrectiveAction())));
+        NceActionLog nceActionLog = nceActionLogService.get("6");
+        nceActionLogService.delete(nceActionLog);
+        List<NceActionLog> newNceActionLogs = nceActionLogService.getAll();
+        assertFalse(newNceActionLogs.stream().anyMatch(nal -> "update software".equals(nal.getCorrectiveAction())));
+        assertEquals(9, newNceActionLogs.size());
+    }
+
+    @Test
+    public void deleteAll_ShouldDeleteAllNceActionLogs() {
+        nceActionLogs = nceActionLogService.getAll();
+        assertFalse(nceActionLogs.isEmpty());
+        assertEquals(10, nceActionLogs.size());
+        nceActionLogService.deleteAll(nceActionLogs);
+        List<NceActionLog> updatedNceActionLogs = nceActionLogService.getAll();
+        assertTrue(updatedNceActionLogs.isEmpty());
+    }
+}

--- a/src/test/java/org/openelisglobal/qaevent/NceCategoryServiceTest.java
+++ b/src/test/java/org/openelisglobal/qaevent/NceCategoryServiceTest.java
@@ -1,0 +1,202 @@
+package org.openelisglobal.qaevent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.qaevent.service.NceCategoryService;
+import org.openelisglobal.qaevent.valueholder.NceCategory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class NceCategoryServiceTest extends BaseWebContextSensitiveTest {
+    @Autowired
+    private NceCategoryService nceCategoryService;
+
+    private List<NceCategory> nceCategoryList;
+    private Map<String, Object> propertyValues;
+    private List<String> orderProperties;
+    private static int PAGE_SIZE = 0;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/nce-category.xml");
+
+        propertyValues = new HashMap<>();
+        propertyValues.put("lastupdated", Timestamp.valueOf("2025-07-25 10:15:00"));
+        orderProperties = new ArrayList<>();
+        orderProperties.add("name");
+    }
+
+    @Test
+    public void getAllNceCategories_ShouldReturnAllNceCategoriesInTheDB() {
+        nceCategoryList = nceCategoryService.getAllNceCategories();
+        assertNotNull(nceCategoryList);
+        assertEquals(5, nceCategoryList.size());
+        assertEquals("1004", nceCategoryList.get(3).getId());
+        assertEquals("nce.improper_storage_conditions", nceCategoryList.get(1).getDisplayKey());
+        assertEquals("f", nceCategoryList.get(3).getActive());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingNceCategories_UsingPropertyNameAndValue() {
+        nceCategoryList = nceCategoryService.getAllMatching("lastupdated", Timestamp.valueOf("2025-07-25 10:30:00"));
+        assertNotNull(nceCategoryList);
+        assertEquals(2, nceCategoryList.size());
+        assertEquals("1003", nceCategoryList.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingNceCategories_UsingAMap() {
+        nceCategoryList = nceCategoryService.getAllMatching(propertyValues);
+        assertNotNull(nceCategoryList);
+        assertEquals(3, nceCategoryList.size());
+        assertEquals("1004", nceCategoryList.get(1).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrderedNceCategories_UsingAnOrderProperty() {
+        nceCategoryList = nceCategoryService.getAllOrdered("id", false);
+        assertNotNull(nceCategoryList);
+        assertEquals(5, nceCategoryList.size());
+        assertEquals("1005", nceCategoryList.get(4).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrdered_UsingAList() {
+        nceCategoryList = nceCategoryService.getAllOrdered(orderProperties, true);
+        assertNotNull(nceCategoryList);
+        assertEquals(5, nceCategoryList.size());
+        assertEquals("1002", nceCategoryList.get(3).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceCategories_UsingPropertyNameAndValueAndAnOrderProperty() {
+        nceCategoryList = nceCategoryService.getAllMatchingOrdered("name", "Delayed Sample Transport", "lastupdated",
+                true);
+        assertNotNull(nceCategoryList);
+        assertEquals(1, nceCategoryList.size());
+        assertEquals("1003", nceCategoryList.get(0).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceCategories_UsingPropertyNameAndValueAndAList() {
+        nceCategoryList = nceCategoryService.getAllMatchingOrdered("displayKey", "nce.delayed_sample_transport",
+                orderProperties, true);
+        assertNotNull(nceCategoryList);
+        assertEquals(1, nceCategoryList.size());
+        assertEquals("1003", nceCategoryList.get(0).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceCategories_UsingAMapAndAnOrderProperty() {
+        nceCategoryList = nceCategoryService.getAllMatchingOrdered(propertyValues, "id", true);
+        assertNotNull(nceCategoryList);
+        assertEquals(3, nceCategoryList.size());
+        assertEquals("1002", nceCategoryList.get(2).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceCategories_UsingAMapAndAList() {
+        nceCategoryList = nceCategoryService.getAllMatchingOrdered(propertyValues, orderProperties, false);
+        assertNotNull(nceCategoryList);
+        assertEquals(3, nceCategoryList.size());
+        assertEquals("1005", nceCategoryList.get(2).getId());
+    }
+
+    @Test
+    public void getPage_ShouldReturnAPageOfNceCategories_UsingAPageNumber() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getPage(1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfNceCategories_UsingAPropertyNameAndValue() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getMatchingPage("displayKey", "nce.incomplete_patient_info", 1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfNceCategories_UsingAMap() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getMatchingPage(propertyValues, 1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfNceCategories_UsingAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getOrderedPage("lastupdated", true, 1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfNceCategories_UsingAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getOrderedPage(orderProperties, false, 1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceCategories_UsingAPropertyNameAndValueAndAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getMatchingOrderedPage("name", "Instrument Calibration Error",
+                "lastupdated", true, 1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceCategories_UsingAPropertyNameAndValueAndAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getMatchingOrderedPage("lastupdated",
+                Timestamp.valueOf("2025-07-25 10:15:00"), orderProperties, true, 1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceCategories_UsingAMapAndAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getMatchingOrderedPage(propertyValues, "id", false, 1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceCategories_UsingAMapAndAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceCategoryList = nceCategoryService.getMatchingOrderedPage(propertyValues, orderProperties, false, 1);
+        assertTrue(PAGE_SIZE >= nceCategoryList.size());
+    }
+
+    @Test
+    public void delete_ShouldDeleteANceCategory() {
+        nceCategoryList = nceCategoryService.getAll();
+        assertEquals(5, nceCategoryList.size());
+        assertTrue(nceCategoryList.stream().anyMatch(nca -> "Instrument Calibration Error".equals(nca.getName())));
+        NceCategory nceCategory = nceCategoryService.get("1005");
+        nceCategoryService.delete(nceCategory);
+        List<NceCategory> newNceCategories = nceCategoryService.getAll();
+        assertFalse(newNceCategories.stream().anyMatch(nca -> "Instrument Calibration Error".equals(nca.getName())));
+        assertEquals(4, newNceCategories.size());
+    }
+
+    @Test
+    public void deleteAll_ShouldDeleteAllNceCategories() {
+        nceCategoryList = nceCategoryService.getAll();
+        assertFalse(nceCategoryList.isEmpty());
+        assertEquals(5, nceCategoryList.size());
+        nceCategoryService.deleteAll(nceCategoryList);
+        List<NceCategory> updatedNceCategories = nceCategoryService.getAll();
+        assertTrue(updatedNceCategories.isEmpty());
+    }
+}

--- a/src/test/java/org/openelisglobal/qaevent/NceSpecimenServiceTest.java
+++ b/src/test/java/org/openelisglobal/qaevent/NceSpecimenServiceTest.java
@@ -1,6 +1,9 @@
 package org.openelisglobal.qaevent;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,7 +25,7 @@ public class NceSpecimenServiceTest extends BaseWebContextSensitiveTest {
     private List<NceSpecimen> nceSpecimenList;
     private Map<String, Object> propertyValues;
     private List<String> orderProperties;
-    private static int NUMBER_OF_PAGES = 0;
+    private static int PAGE_SIZE = 0;
 
     @Before
     public void setUp() throws Exception {
@@ -125,74 +128,65 @@ public class NceSpecimenServiceTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void getPage_ShouldReturnAPageOfNceSpecimens_UsingAPageNumber() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getPage(1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test
     public void getMatchingPage_ShouldReturnAPageOfNceSpecimens_UsingAPropertyNameAndValue() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getMatchingPage("nceId", "1001", 1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test
     public void getMatchingPage_ShouldReturnAPageOfNceSpecimens_UsingAMap() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getMatchingPage(propertyValues, 1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test
     public void getOrderedPage_ShouldReturnAnOrderedPageOfNceSpecimens_UsingAnOrderProperty() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getOrderedPage("id", true, 1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test
     public void getOrderedPage_ShouldReturnAnOrderedPageOfNceSpecimens_UsingAList() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getOrderedPage(orderProperties, false, 1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test
     public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceSpecimens_UsingAPropertyNameAndValueAndAnOrderProperty() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getMatchingOrderedPage("sampleItemId", "601", "nceId", true, 1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test
     public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceSpecimens_UsingAPropertyNameAndValueAndAList() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getMatchingOrderedPage("sampleItemId", "603", orderProperties, true, 1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test
     public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceSpecimens_UsingAMapAndAnOrderProperty() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getMatchingOrderedPage(propertyValues, "id", false, 1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test
     public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceSpecimens_UsingAMapAndAList() {
-        NUMBER_OF_PAGES = Integer
-                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
         nceSpecimenList = nceSpecimenService.getMatchingOrderedPage(propertyValues, orderProperties, false, 1);
-        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+        assertTrue(PAGE_SIZE >= nceSpecimenList.size());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/qaevent/NceSpecimenServiceTest.java
+++ b/src/test/java/org/openelisglobal/qaevent/NceSpecimenServiceTest.java
@@ -1,0 +1,219 @@
+package org.openelisglobal.qaevent;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.qaevent.service.NceSpecimenService;
+import org.openelisglobal.qaevent.valueholder.NceSpecimen;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class NceSpecimenServiceTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private NceSpecimenService nceSpecimenService;
+
+    private List<NceSpecimen> nceSpecimenList;
+    private Map<String, Object> propertyValues;
+    private List<String> orderProperties;
+    private static int NUMBER_OF_PAGES = 0;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/nce-specimen.xml");
+
+        propertyValues = new HashMap<>();
+        propertyValues.put("sampleItemId", "602");
+        orderProperties = new ArrayList<>();
+        orderProperties.add("nceId");
+    }
+
+    @Test
+    public void getSpecimenByNceId_ShouldReturnAllNceSpecimensWithAnNceIdMatchingTheParameterValue() {
+        nceSpecimenList = nceSpecimenService.getSpecimenByNceId("1002");
+        assertNotNull(nceSpecimenList);
+        assertEquals(3, nceSpecimenList.size());
+        assertEquals("2", nceSpecimenList.get(0).getId());
+    }
+
+    @Test
+    public void getSpecimenBySampleItemId_ShouldReturnAllNceSpecimensWithASampleIdMatchingTheParameterValue() {
+        nceSpecimenList = nceSpecimenService.getSpecimenBySampleItemId("601");
+        assertNotNull(nceSpecimenList);
+        assertEquals(2, nceSpecimenList.size());
+        assertEquals("5", nceSpecimenList.get(1).getId());
+        assertEquals("4", nceSpecimenList.get(0).getId());
+    }
+
+    @Test
+    public void getAll_ShouldReturnAllNceSpecimens() {
+        nceSpecimenList = nceSpecimenService.getAll();
+        assertNotNull(nceSpecimenList);
+        assertEquals(5, nceSpecimenList.size());
+        assertEquals("3", nceSpecimenList.get(2).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingNceSpecimens_UsingPropertyNameAndValue() {
+        nceSpecimenList = nceSpecimenService.getAllMatching("nceId", "1002");
+        assertNotNull(nceSpecimenList);
+        assertEquals(3, nceSpecimenList.size());
+        assertEquals("4", nceSpecimenList.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingNceSpecimens_UsingAMap() {
+        nceSpecimenList = nceSpecimenService.getAllMatching(propertyValues);
+        assertNotNull(nceSpecimenList);
+        assertEquals(2, nceSpecimenList.size());
+        assertEquals("2", nceSpecimenList.get(1).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrderedNceSpecimens_UsingAnOrderProperty() {
+        nceSpecimenList = nceSpecimenService.getAllOrdered("id", false);
+        assertNotNull(nceSpecimenList);
+        assertEquals(5, nceSpecimenList.size());
+        assertEquals("3", nceSpecimenList.get(2).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrdered_UsingAList() {
+        nceSpecimenList = nceSpecimenService.getAllOrdered(orderProperties, true);
+        assertNotNull(nceSpecimenList);
+        assertEquals(5, nceSpecimenList.size());
+        assertEquals("1", nceSpecimenList.get(4).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceSpecimens_UsingPropertyNameAndValueAndAnOrderProperty() {
+        nceSpecimenList = nceSpecimenService.getAllMatchingOrdered("nceId", "1002", "sampleItemId", true);
+        assertNotNull(nceSpecimenList);
+        assertEquals(3, nceSpecimenList.size());
+        assertEquals("4", nceSpecimenList.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceSpecimens_UsingPropertyNameAndValueAndAList() {
+        nceSpecimenList = nceSpecimenService.getAllMatchingOrdered("nceId", "1002", orderProperties, true);
+        assertNotNull(nceSpecimenList);
+        assertEquals(3, nceSpecimenList.size());
+        assertEquals("5", nceSpecimenList.get(2).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceSpecimens_UsingAMapAndAnOrderProperty() {
+        nceSpecimenList = nceSpecimenService.getAllMatchingOrdered(propertyValues, "sampleItemId", true);
+        assertNotNull(nceSpecimenList);
+        assertEquals(2, nceSpecimenList.size());
+        assertEquals("1", nceSpecimenList.get(0).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceSpecimens_UsingAMapAndAList() {
+        nceSpecimenList = nceSpecimenService.getAllMatchingOrdered(propertyValues, orderProperties, false);
+        assertNotNull(nceSpecimenList);
+        assertEquals(2, nceSpecimenList.size());
+        assertEquals("1", nceSpecimenList.get(0).getId());
+    }
+
+    @Test
+    public void getPage_ShouldReturnAPageOfNceSpecimens_UsingAPageNumber() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getPage(1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfNceSpecimens_UsingAPropertyNameAndValue() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getMatchingPage("nceId", "1001", 1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfNceSpecimens_UsingAMap() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getMatchingPage(propertyValues, 1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfNceSpecimens_UsingAnOrderProperty() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getOrderedPage("id", true, 1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfNceSpecimens_UsingAList() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getOrderedPage(orderProperties, false, 1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceSpecimens_UsingAPropertyNameAndValueAndAnOrderProperty() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getMatchingOrderedPage("sampleItemId", "601", "nceId", true, 1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceSpecimens_UsingAPropertyNameAndValueAndAList() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getMatchingOrderedPage("sampleItemId", "603", orderProperties, true, 1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceSpecimens_UsingAMapAndAnOrderProperty() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getMatchingOrderedPage(propertyValues, "id", false, 1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceSpecimens_UsingAMapAndAList() {
+        NUMBER_OF_PAGES = Integer
+                .parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceSpecimenList = nceSpecimenService.getMatchingOrderedPage(propertyValues, orderProperties, false, 1);
+        assertTrue(NUMBER_OF_PAGES >= nceSpecimenList.size());
+    }
+
+    @Test
+    public void delete_ShouldDeleteANceSpecimen() {
+        nceSpecimenList = nceSpecimenService.getAll();
+        assertEquals(5, nceSpecimenList.size());
+        assertTrue(nceSpecimenList.stream().anyMatch(ncs -> "2".equals(ncs.getId())));
+        NceSpecimen nceSpecimen = nceSpecimenService.get("2");
+        nceSpecimenService.delete(nceSpecimen);
+        List<NceSpecimen> newNceSpecimens = nceSpecimenService.getAll();
+        assertFalse(newNceSpecimens.stream().anyMatch(ncs -> "2".equals(ncs.getId())));
+        assertEquals(4, newNceSpecimens.size());
+    }
+
+    @Test
+    public void deleteAll_ShouldDeleteAllNceSpecimens() {
+        nceSpecimenList = nceSpecimenService.getAll();
+        assertFalse(nceSpecimenList.isEmpty());
+        assertEquals(5, nceSpecimenList.size());
+        nceSpecimenService.deleteAll(nceSpecimenList);
+        List<NceSpecimen> updatedNceSpecimens = nceSpecimenService.getAll();
+        assertTrue(updatedNceSpecimens.isEmpty());
+    }
+}

--- a/src/test/java/org/openelisglobal/qaevent/NceTypeServiceTest.java
+++ b/src/test/java/org/openelisglobal/qaevent/NceTypeServiceTest.java
@@ -1,0 +1,197 @@
+package org.openelisglobal.qaevent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.qaevent.service.NceTypeService;
+import org.openelisglobal.qaevent.valueholder.NceType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class NceTypeServiceTest extends BaseWebContextSensitiveTest {
+    @Autowired
+    private NceTypeService nceTypeService;
+
+    private List<NceType> nceTypes;
+    private Map<String, Object> propertyValues;
+    private List<String> orderProperties;
+    private static int PAGE_SIZE = 0;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/nce-type.xml");
+
+        propertyValues = new HashMap<>();
+        propertyValues.put("lastupdated", Timestamp.valueOf("2025-07-25 10:05:00"));
+        orderProperties = new ArrayList<>();
+        orderProperties.add("name");
+    }
+
+    @Test
+    public void getAllNceTypes_ShouldReturnAllNceTypesInTheDB() {
+        List<NceType> nceTypes = nceTypeService.getAllNceTypes();
+        assertNotNull(nceTypes);
+        assertEquals(5, nceTypes.size());
+        assertEquals("2", nceTypes.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingNceTypes_UsingPropertyNameAndValue() {
+        nceTypes = nceTypeService.getAllMatching("categoryId", "1002");
+        assertNotNull(nceTypes);
+        assertEquals(2, nceTypes.size());
+        assertEquals("5", nceTypes.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatching_ShouldReturnAllMatchingNceTypes_UsingAMap() {
+        nceTypes = nceTypeService.getAllMatching(propertyValues);
+        assertNotNull(nceTypes);
+        assertEquals(3, nceTypes.size());
+        assertEquals("4", nceTypes.get(1).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrderedNceTypes_UsingAnOrderProperty() {
+        nceTypes = nceTypeService.getAllOrdered("lastupdated", false);
+        assertNotNull(nceTypes);
+        assertEquals(5, nceTypes.size());
+        assertEquals("4", nceTypes.get(2).getId());
+    }
+
+    @Test
+    public void getAllOrdered_ShouldReturnAllOrdered_UsingAList() {
+        nceTypes = nceTypeService.getAllOrdered(orderProperties, true);
+        assertNotNull(nceTypes);
+        assertEquals(5, nceTypes.size());
+        assertEquals("3", nceTypes.get(3).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceTypes_UsingPropertyNameAndValueAndAnOrderProperty() {
+        nceTypes = nceTypeService.getAllMatchingOrdered("categoryId", "1001", "lastupdated", true);
+        assertNotNull(nceTypes);
+        assertEquals(3, nceTypes.size());
+        assertEquals("4", nceTypes.get(1).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceTypes_UsingPropertyNameAndValueAndAList() {
+        nceTypes = nceTypeService.getAllMatchingOrdered("categoryId", "1001", orderProperties, true);
+        assertNotNull(nceTypes);
+        assertEquals(3, nceTypes.size());
+        assertEquals("1", nceTypes.get(0).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceTypes_UsingAMapAndAnOrderProperty() {
+        nceTypes = nceTypeService.getAllMatchingOrdered(propertyValues, "id", true);
+        assertNotNull(nceTypes);
+        assertEquals(3, nceTypes.size());
+        assertEquals("2", nceTypes.get(2).getId());
+    }
+
+    @Test
+    public void getAllMatchingOrdered_ShouldReturnAllMatchingOrderedNceTypes_UsingAMapAndAList() {
+        nceTypes = nceTypeService.getAllMatchingOrdered(propertyValues, orderProperties, false);
+        assertNotNull(nceTypes);
+        assertEquals(3, nceTypes.size());
+        assertEquals("5", nceTypes.get(0).getId());
+    }
+
+    @Test
+    public void getPage_ShouldReturnAPageOfNceTypes_UsingAPageNumber() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getPage(1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfNceTypes_UsingAPropertyNameAndValue() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getMatchingPage("categoryId", "1001", 1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void getMatchingPage_ShouldReturnAPageOfNceTypes_UsingAMap() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getMatchingPage(propertyValues, 1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfNceTypes_UsingAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getOrderedPage("lastupdated", true, 1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void getOrderedPage_ShouldReturnAnOrderedPageOfNceTypes_UsingAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getOrderedPage(orderProperties, false, 1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceTypes_UsingAPropertyNameAndValueAndAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getMatchingOrderedPage("displayKey", "incorrect_result", "lastupdated", true, 1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceTypes_UsingAPropertyNameAndValueAndAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getMatchingOrderedPage("name", "broken container", orderProperties, true, 1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceTypes_UsingAMapAndAnOrderProperty() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getMatchingOrderedPage(propertyValues, "id", false, 1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void getMatchingOrderedPage_ShouldReturnAMatchingOrderedPageOfNceTypes_UsingAMapAndAList() {
+        PAGE_SIZE = Integer.parseInt(ConfigurationProperties.getInstance().getPropertyValue("page.defaultPageSize"));
+        nceTypes = nceTypeService.getMatchingOrderedPage(propertyValues, orderProperties, false, 1);
+        assertTrue(PAGE_SIZE >= nceTypes.size());
+    }
+
+    @Test
+    public void delete_ShouldDeleteANceType() {
+        nceTypes = nceTypeService.getAll();
+        assertEquals(5, nceTypes.size());
+        assertTrue(nceTypes.stream().anyMatch(nct -> "expired reagent".equals(nct.getName())));
+        NceType nceType = nceTypeService.get("3");
+        nceTypeService.delete(nceType);
+        List<NceType> newNceTypes = nceTypeService.getAll();
+        assertFalse(newNceTypes.stream().anyMatch(nct -> "expired reagent".equals(nct.getName())));
+        assertEquals(4, newNceTypes.size());
+    }
+
+    @Test
+    public void deleteAll_ShouldDeleteAllNceTypes() {
+        nceTypes = nceTypeService.getAll();
+        assertFalse(nceTypes.isEmpty());
+        assertEquals(5, nceTypes.size());
+        nceTypeService.deleteAll(nceTypes);
+        List<NceType> updatedNceTypes = nceTypeService.getAll();
+        assertTrue(updatedNceTypes.isEmpty());
+    }
+
+}

--- a/src/test/resources/testdata/lap-component.xml
+++ b/src/test/resources/testdata/lap-component.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <lab_component id="1" name="temperature monitor"
+        display_key="temp_monitor" lastmodified="2024-01-17 17:35:00" />
+    <lab_component id="2" name="ph meter"
+        display_key="ph_meter" lastmodified="2024-01-13 13:00:00" />
+    <lab_component id="3" name="centrifuge"
+        display_key="centrifuge" lastmodified="2024-01-12 11:15:00" />
+    <lab_component id="4" name="incubator"
+        display_key="autoclave" lastmodified="2024-01-13 13:00:00" />
+    <lab_component id="5" name="biosafety cabinet"
+        display_key="biosafety_cabinet" lastmodified="2024-01-14 14:20:00" />
+    <lab_component id="6" name="centrifuge"
+        display_key="incubator-centrifuge" lastmodified="2024-01-15 15:25:00" />
+    <lab_component id="7" name="balance scale"
+        display_key="balance_scale" lastmodified="2024-01-13 13:00:00" />
+    <lab_component id="8" name="freezer"
+        display_key="freezer" lastmodified="2024-01-17 17:35:00" />
+    <lab_component id="9" name="refrigerator"
+        display_key="refrigerator" lastmodified="2024-01-13 13:00:00" />
+    <lab_component id="10" name="incubator"
+        display_key="water_bath" lastmodified="2024-01-19 19:40:00" />
+</dataset>

--- a/src/test/resources/testdata/nce-action-log.xml
+++ b/src/test/resources/testdata/nce-action-log.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <nc_event id="901" name="Sample Mislabeling"
+        name_of_reporter="Dr. Jane Doe" report_date="2025-04-15"
+        nce_number="1744721660206" date_of_event="2025-04-14"
+        lab_order_number="DEV01250000000000008" prescriber_name="JOHN , SMITH"
+        site="UE - AMBASSADE DES USA"
+        description="Sample was mislabeled at accessioning desk."
+        suspected_causes="Human error during sample reception."
+        proposed_action="Retrain staff on accession procedures."
+        laboratory_component="3" severity_score="5" color_code="RED"
+        corrective_action="Sample re-collection and staff training."
+        control_action="Double-check label against order form."
+        comments="Incident detected early, no patient harm." effective="YES"
+        signature="Jane Doe" date_completed="2025-04-16" status="Resolved"
+        discussion_date="2025-04-17 13:00:00.0" />
+
+    <nc_event id="902" name="Reagent Expiry Overlooked"
+        name_of_reporter="Mr. John Tester" report_date="2025-04-10"
+        nce_number="1744721660205" date_of_event="2025-04-09"
+        lab_order_number="DEV01250000000000002" prescriber_name="ALI , ALICE"
+        site="UE - AMBASSADE DES USA"
+        description="Expired reagent was used for testing."
+        suspected_causes="Inventory tracking failure."
+        proposed_action="Introduce reagent expiry alarms in LIS."
+        laboratory_component="4" severity_score="4" color_code="ORANGE"
+        corrective_action="Retest all affected samples."
+        control_action="Implement expiry checks before use."
+        comments="Issue addressed quickly, no impact on results."
+        effective="YES" signature="John Tester" date_completed="2025-04-12"
+        status="Closed" discussion_date="2025-04-13 13:00:00.0" />
+
+    <nc_event id="903" name="Instrument Calibration Error"
+        name_of_reporter="Dr. Lee" report_date="2025-03-30"
+        nce_number="1744721660208" date_of_event="2025-03-29"
+        lab_order_number="DEV01250000000000003" prescriber_name="KIM , YUN"
+        site="UE - AMBASSADE DES USA"
+        description="Analyzer produced out-of-range values due to missed calibration."
+        suspected_causes="Calibration schedule not followed."
+        proposed_action="Automate calibration reminders."
+        laboratory_component="5" severity_score="3" color_code="YELLOW"
+        corrective_action="Recalibrate instrument and repeat tests."
+        control_action="Enforce pre-run calibration verification."
+        comments="Error identified post-run, corrective action completed."
+        effective="YES" signature="Dr. Lee" date_completed="2025-04-01"
+        status="Resolved" discussion_date="2025-04-02 13:00:00.0" />
+
+
+    <nce_action_log id="1"
+        corrective_action="replace faulty cable" action_type="corrective"
+        person_responsible="jane doe" date_completed="2024-05-01 10:15:00"
+        turn_around_time="40" nce_event_id="901" />
+    <nce_action_log id="2" corrective_action="update SOP"
+        action_type="preventive" person_responsible="john smith"
+        date_completed="2024-05-03 14:00:00" turn_around_time="72"
+        nce_event_id="901" />
+    <nce_action_log id="3"
+        corrective_action="retrain technician" action_type="corrective"
+        person_responsible="alice green" date_completed="2024-05-04 09:45:00"
+        turn_around_time="24" nce_event_id="903" />
+    <nce_action_log id="4"
+        corrective_action="clean incubator" action_type="corrective"
+        person_responsible="mark brown" date_completed="2024-05-05 11:30:00"
+        turn_around_time="36" nce_event_id="903" />
+    <nce_action_log id="5"
+        corrective_action="replace reagent" action_type="corrective"
+        person_responsible="emily white" date_completed="2024-05-06 16:20:00"
+        turn_around_time="40" nce_event_id="902" />
+    <nce_action_log id="6"
+        corrective_action="update software" action_type="preventive"
+        person_responsible="oliver stone" date_completed="2024-05-07 08:10:00"
+        turn_around_time="120" nce_event_id="902" />
+    <nce_action_log id="7"
+        corrective_action="adjust temperature settings"
+        action_type="corrective" person_responsible="mark brown"
+        date_completed="2024-05-08 13:50:00" turn_around_time="30"
+        nce_event_id="901" />
+    <nce_action_log id="8" corrective_action="change filter"
+        action_type="corrective" person_responsible="michael thompson"
+        date_completed="2024-05-09 15:05:00" turn_around_time="40"
+        nce_event_id="901" />
+    <nce_action_log id="9"
+        corrective_action="fix calibration issue" action_type="corrective"
+        person_responsible="mark brown" date_completed="2024-05-10 12:30:00"
+        turn_around_time="96" nce_event_id="901" />
+    <nce_action_log id="10"
+        corrective_action="improve labeling system" action_type="preventive"
+        person_responsible="david reed" date_completed="2024-05-11 10:00:00"
+        turn_around_time="72" nce_event_id="901" />
+</dataset>

--- a/src/test/resources/testdata/nce-category.xml
+++ b/src/test/resources/testdata/nce-category.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <nce_category id="1001" active="0"
+        name="Incorrect Sample Labeling"
+        display_key="nce.incorrect_sample_labeling"
+        last_updated="2025-07-25 10:30:00" />
+
+    <nce_category id="1002" active="1"
+        name="Improper Storage Conditions"
+        display_key="nce.improper_storage_conditions"
+        last_updated="2025-07-25 10:15:00" />
+
+    <nce_category id="1003" active="1"
+        name="Delayed Sample Transport"
+        display_key="nce.delayed_sample_transport"
+        last_updated="2025-07-25 10:30:00" />
+
+    <nce_category id="1004" active="0"
+        name="Incomplete Patient Information"
+        display_key="nce.incomplete_patient_info"
+        last_updated="2025-07-25 10:15:00" />
+
+    <nce_category id="1005" active="1"
+        name="Instrument Calibration Error"
+        display_key="nce.instrument_calibration_error"
+        last_updated="2025-07-25 10:15:00" />
+</dataset>

--- a/src/test/resources/testdata/nce-specimen.xml
+++ b/src/test/resources/testdata/nce-specimen.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <sample_item id="601" sort_order="1" status_id="1"
+        collection_date="2023-11-15 10:00:00"
+        lastupdated="2023-12-01 12:00:00" />
+    <sample_item id="602" sort_order="12" status_id="1"
+        collection_date="2023-11-16 10:00:00"
+        lastupdated="2023-12-01 12:00:00" />
+    <sample_item id="603" sort_order="24" status_id="3"
+        collection_date="2023-11-16 10:00:00"
+        lastupdated="2023-12-01 12:00:00" />
+
+    <nc_event id="1001" name="Sample Mislabeling"
+        name_of_reporter="Dr. Jane Doe" report_date="2025-04-15"
+        nce_number="1744721660206" date_of_event="2025-04-14"
+        lab_order_number="DEV01250000000000008" prescriber_name="JOHN , SMITH"
+        site="UE - AMBASSADE DES USA"
+        description="Sample was mislabeled at accessioning desk."
+        suspected_causes="Human error during sample reception."
+        proposed_action="Retrain staff on accession procedures."
+        laboratory_component="3" severity_score="5" color_code="RED"
+        corrective_action="Sample re-collection and staff training."
+        control_action="Double-check label against order form."
+        comments="Incident detected early, no patient harm." effective="YES"
+        signature="Jane Doe" date_completed="2025-04-16" status="Resolved"
+        discussion_date="2025-04-17 13:00:00.0" />
+
+    <nc_event id="1002" name="Reagent Expiry Overlooked"
+        name_of_reporter="Mr. John Tester" report_date="2025-04-10"
+        nce_number="1744721660205" date_of_event="2025-04-09"
+        lab_order_number="DEV01250000000000002" prescriber_name="ALI , ALICE"
+        site="UE - AMBASSADE DES USA"
+        description="Expired reagent was used for testing."
+        suspected_causes="Inventory tracking failure."
+        proposed_action="Introduce reagent expiry alarms in LIS."
+        laboratory_component="4" severity_score="4" color_code="ORANGE"
+        corrective_action="Retest all affected samples."
+        control_action="Implement expiry checks before use."
+        comments="Issue addressed quickly, no impact on results."
+        effective="YES" signature="John Tester" date_completed="2025-04-12"
+        status="Closed" discussion_date="2025-04-13 13:00:00.0" />
+
+    <nc_event id="1003" name="Instrument Calibration Error"
+        name_of_reporter="Dr. Lee" report_date="2025-03-30"
+        nce_number="1744721660208" date_of_event="2025-03-29"
+        lab_order_number="DEV01250000000000003" prescriber_name="KIM , YUN"
+        site="UE - AMBASSADE DES USA" reporting_unit_id="3"
+        description="Analyzer produced out-of-range values due to missed calibration."
+        suspected_causes="Calibration schedule not followed."
+        proposed_action="Automate calibration reminders."
+        laboratory_component="5" nce_category_id="3" severity_score="3"
+        color_code="YELLOW"
+        corrective_action="Recalibrate instrument and repeat tests."
+        control_action="Enforce pre-run calibration verification."
+        comments="Error identified post-run, corrective action completed."
+        effective="YES" signature="Dr. Lee" date_completed="2025-04-01"
+        nce_type_id="3" status="Resolved"
+        discussion_date="2025-04-02 13:00:00.0" />
+
+    <nce_specimen id="1" nce_id="1001" sample_item_id="602" />
+    <nce_specimen id="2" nce_id="1002" sample_item_id="602" />
+    <nce_specimen id="3" nce_id="1003" sample_item_id="603" />
+    <nce_specimen id="4" nce_id="1002" sample_item_id="601" />
+    <nce_specimen id="5" nce_id="1002" sample_item_id="601" />
+</dataset>

--- a/src/test/resources/testdata/nce-type.xml
+++ b/src/test/resources/testdata/nce-type.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <nce_category id="1001" active="0"
+        name="Incorrect Sample Labeling"
+        display_key="nce.incorrect_sample_labeling"
+        last_updated="2025-07-25 10:30:00" />
+
+    <nce_category id="1002" active="1"
+        name="Improper Storage Conditions"
+        display_key="nce.improper_storage_conditions"
+        last_updated="2025-07-25 10:15:00" />
+
+
+    <nce_type id="1" name="specimen damaged"
+        display_key="specimen_damaged" category_id="1001" active="true"
+        last_updated="2025-07-25 10:00:00" />
+    <nce_type id="2" name="missing label"
+        display_key="missing_label" category_id="1001" active="true"
+        last_updated="2025-07-25 10:05:00" />
+    <nce_type id="3" name="expired reagent"
+        display_key="expired_reagent" category_id="1002" active="false"
+        last_updated="2025-07-25 10:10:00" />
+    <nce_type id="4" name="incorrect result"
+        display_key="incorrect_result" category_id="1001" active="true"
+        last_updated="2025-07-25 10:05:00" />
+    <nce_type id="5" name="broken container"
+        display_key="broken_container" category_id="1002" active="true"
+        last_updated="2025-07-25 10:05:00" />
+</dataset>


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
This PR contains test classes that were missing in the `qaevent/service` package

## Related Issue

[Add missing tests in the Qaevent services](https://github.com/DIGI-UW/OpenELIS-Global-2/issues/2187)

## Other

Closes <https://github.com/DIGI-UW/OpenELIS-Global-2/issues/2187>
