### PR TITLE
ISSUE-2273: Add error recovery and retry mechanism for Odoo invoice synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,45 @@ Please follow the [pull request tips](PULL_REQUEST_TIPS.md) in order to make
 life easy for the code reviewers by having a well defined and clean pull
 request.
 
+### Odoo Sync Queue Overview
+
+OpenELIS provides a dedicated queueing layer for Odoo invoice synchronization
+whenever the live connection is unavailable or an invocation fails.
+
+- **Backend services**
+
+  - `OdooIntegrationService#createInvoice` will enqueue failed payloads when
+    `enableOdooQueue` is set to `"true"` in the configuration properties.
+  - The queue is stored in the `odoo_sync_queue` table and manipulated through
+    `OdooSyncQueueService`.
+  - A manual REST API is exposed at:
+    - `GET /api/odoo/queue` – returns the current queue contents, pending/failed
+      counts, and connection status.
+    - `POST /api/odoo/queue/retry` – triggers an on-demand processing run by the
+      `OdooRetryJob` scheduler and returns the updated queue state plus a status
+      message.
+  - The scheduled retry job still exists but is disabled by default
+    (`org.openelisglobal.odoo.retry.enabled=false`). You can re-enable it via
+    configuration if automatic retries are desired.
+
+- **Frontend management UI**
+  - The React admin console now includes an **Odoo Sync Queue** page
+    (`frontend/src/components/admin/odoo/OdooSyncQueue.js`) accessible from the
+    Admin sidebar.
+  - This view calls the REST endpoints above, shows connection status, queue
+    counts, individual entries, and provides buttons to trigger manual retries
+    or refresh the data.
+
+To make use of the queue:
+
+1. Set the configuration property `enableOdooQueue` to `"true"` so failed
+   invoices are recorded.
+2. Ensure the Odoo credentials are configured correctly (otherwise the queue
+   will continue to grow while connection remains offline).
+3. Use the admin UI or `POST /api/odoo/queue/retry` to process queued invoices
+   once connectivity is restored; optionally re-enable the scheduled job for
+   unattended retries.
+
 ### code of conduct
 
 Please see our [Contributor Code of Conduct](./CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -168,44 +168,10 @@ Please follow the [pull request tips](PULL_REQUEST_TIPS.md) in order to make
 life easy for the code reviewers by having a well defined and clean pull
 request.
 
-### Odoo Sync Queue Overview
-
-OpenELIS provides a dedicated queueing layer for Odoo invoice synchronization
-whenever the live connection is unavailable or an invocation fails.
-
-- **Backend services**
-
-  - `OdooIntegrationService#createInvoice` will enqueue failed payloads when
-    `enableOdooQueue` is set to `"true"` in the configuration properties.
-  - The queue is stored in the `odoo_sync_queue` table and manipulated through
-    `OdooSyncQueueService`.
-  - A manual REST API is exposed at:
-    - `GET /api/odoo/queue` – returns the current queue contents, pending/failed
-      counts, and connection status.
-    - `POST /api/odoo/queue/retry` – triggers an on-demand processing run by the
-      `OdooRetryJob` scheduler and returns the updated queue state plus a status
-      message.
-  - The scheduled retry job still exists but is disabled by default
-    (`org.openelisglobal.odoo.retry.enabled=false`). You can re-enable it via
-    configuration if automatic retries are desired.
-
-- **Frontend management UI**
-  - The React admin console now includes an **Odoo Sync Queue** page
-    (`frontend/src/components/admin/odoo/OdooSyncQueue.js`) accessible from the
-    Admin sidebar.
-  - This view calls the REST endpoints above, shows connection status, queue
-    counts, individual entries, and provides buttons to trigger manual retries
-    or refresh the data.
-
-To make use of the queue:
-
-1. Set the configuration property `enableOdooQueue` to `"true"` so failed
-   invoices are recorded.
-2. Ensure the Odoo credentials are configured correctly (otherwise the queue
-   will continue to grow while connection remains offline).
-3. Use the admin UI or `POST /api/odoo/queue/retry` to process queued invoices
-   once connectivity is restored; optionally re-enable the scheduled job for
-   unattended retries.
+Additional subsystem details and operational guides can be found in the
+[`docs/`](./docs/) directory—see, for example,
+[`odoo-sync-queue.md`](./docs/odoo-sync-queue.md) for the Odoo queueing API and
+UI workflow.
 
 ### code of conduct
 

--- a/docs/odoo-sync-queue.md
+++ b/docs/odoo-sync-queue.md
@@ -10,6 +10,7 @@ whenever the live connection is unavailable or an invocation fails.
 - The queue is stored in the `odoo_sync_queue` table and manipulated through
   `OdooSyncQueueService`.
 - Manual REST endpoints:
+
   - `GET /api/odoo/queue` – returns current queue contents, pending/failed
     counts, and connection status.
   - `POST /api/odoo/queue/retry` – triggers an on-demand processing run through
@@ -18,14 +19,14 @@ whenever the live connection is unavailable or an invocation fails.
     beyond a configurable timeout
     (`org.openelisglobal.odoo.retry.processingTimeoutMinutes`, default `1`
     minutes) and acquires pessimistic row locks to prevent multiple workers from
-    handling the same entry concurrently.  
-    **New:** retries now validate the stored `partner_id`. If the referenced
-    partner has been removed in Odoo, the job will recreate or remap the partner
-    using local patient data, update the stored payload, and continue
-    processing.
-- The scheduled retry job still exists but is disabled by default
-  (`org.openelisglobal.odoo.retry.enabled=false`). Re-enable it via
-  configuration if automated retries are desired.
+    handling the same entry concurrently.
+
+    Retries now validate the stored `partner_id`. If the referenced partner has
+    been removed in Odoo, the job will recreate or remap the partner using local
+    patient data, update the stored payload, and continue processing.
+
+- Processing happens only when the manual retry endpoint or admin UI button is
+  invoked.
 
 ### Frontend management UI
 
@@ -42,10 +43,9 @@ whenever the live connection is unavailable or an invocation fails.
 2. Ensure Odoo credentials are valid; otherwise queued items will continue to
    accumulate while the connection is offline.
 3. Use the admin UI or `POST /api/odoo/queue/retry` to process queued invoices
-   once connectivity is restored. Optionally re-enable the scheduled job for
-   unattended retries. Items stuck in `PROCESSING` longer than the configured
-   timeout are automatically returned to the retry pool the next time the job
-   runs.
+   once connectivity is restored. Items stuck in `PROCESSING` longer than the
+   configured timeout are automatically returned to the retry pool whenever the
+   manual retry is executed.
 4. If Odoo records (such as partners) were deleted while the queue accumulated,
    simply run the retry job—partner references are healed automatically and the
    updated payload is persisted for future attempts.

--- a/docs/odoo-sync-queue.md
+++ b/docs/odoo-sync-queue.md
@@ -1,0 +1,51 @@
+## Odoo Sync Queue Overview
+
+OpenELIS provides a dedicated queueing layer for Odoo invoice synchronization
+whenever the live connection is unavailable or an invocation fails.
+
+### Backend services
+
+- `OdooIntegrationService#createInvoice` enqueues failed payloads when
+  `enableOdooQueue` is set to `"true"` in the configuration properties.
+- The queue is stored in the `odoo_sync_queue` table and manipulated through
+  `OdooSyncQueueService`.
+- Manual REST endpoints:
+  - `GET /api/odoo/queue` – returns current queue contents, pending/failed
+    counts, and connection status.
+  - `POST /api/odoo/queue/retry` – triggers an on-demand processing run through
+    `OdooRetryJob` and responds with the updated queue state and status message.
+    This call now requeues items that have been stuck in the `PROCESSING` state
+    beyond a configurable timeout
+    (`org.openelisglobal.odoo.retry.processingTimeoutMinutes`, default `1`
+    minutes) and acquires pessimistic row locks to prevent multiple workers from
+    handling the same entry concurrently.  
+    **New:** retries now validate the stored `partner_id`. If the referenced
+    partner has been removed in Odoo, the job will recreate or remap the partner
+    using local patient data, update the stored payload, and continue
+    processing.
+- The scheduled retry job still exists but is disabled by default
+  (`org.openelisglobal.odoo.retry.enabled=false`). Re-enable it via
+  configuration if automated retries are desired.
+
+### Frontend management UI
+
+- The React admin console includes an **Odoo Sync Queue** page
+  (`frontend/src/components/admin/odoo/OdooSyncQueue.js`) accessible from the
+  Admin sidebar.
+- This view calls the REST endpoints, displays connection status, queue counts,
+  each queued item, and offers buttons to run manual retries or refresh the
+  data.
+
+### Using the queue
+
+1. Set `enableOdooQueue` to `"true"` so failed invoices are recorded.
+2. Ensure Odoo credentials are valid; otherwise queued items will continue to
+   accumulate while the connection is offline.
+3. Use the admin UI or `POST /api/odoo/queue/retry` to process queued invoices
+   once connectivity is restored. Optionally re-enable the scheduled job for
+   unattended retries. Items stuck in `PROCESSING` longer than the configured
+   timeout are automatically returned to the retry pool the next time the job
+   runs.
+4. If Odoo records (such as partners) were deleted while the queue accumulated,
+   simply run the retry job—partner references are healed automatically and the
+   updated payload is persisted for future attempts.

--- a/frontend/src/components/admin/Admin.js
+++ b/frontend/src/components/admin/Admin.js
@@ -89,6 +89,7 @@ import TestSectionRenameEntry from "./testManagementConfigMenu/TestSectionRename
 import UomRenameEntry from "./testManagementConfigMenu/UomRenameEntry.js";
 import SelectListRenameEntry from "./testManagementConfigMenu/SelectListRenameEntry.js";
 import MethodRenameEntry from "./testManagementConfigMenu/MethodRenameEntry.js";
+import OdooSyncQueue from "./odoo/OdooSyncQueue";
 
 function Admin() {
   const intl = useIntl();
@@ -316,6 +317,12 @@ function Admin() {
           </SideNavLink>
           <SideNavLink href="#SearchIndexManagement" renderIcon={Search}>
             <FormattedMessage id="searchindexmanagement.label" />
+          </SideNavLink>
+          <SideNavLink href="#odooSyncQueue" renderIcon={BatchJob}>
+            <FormattedMessage
+              id="sidenav.label.admin.odooSyncQueue"
+              defaultMessage="Odoo Sync Queue"
+            />
           </SideNavLink>
           <SideNavLink
             renderIcon={Catalog}
@@ -555,6 +562,9 @@ function Admin() {
       </PathRoute>
       <PathRoute path="#SearchIndexManagement">
         <SearchIndexManagement />
+      </PathRoute>
+      <PathRoute path="#odooSyncQueue">
+        <OdooSyncQueue />
       </PathRoute>
     </>
   );

--- a/frontend/src/components/admin/odoo/OdooSyncQueue.js
+++ b/frontend/src/components/admin/odoo/OdooSyncQueue.js
@@ -1,0 +1,422 @@
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import {
+  Grid,
+  Column,
+  Section,
+  Heading,
+  Button,
+  Loading,
+  Tag,
+  Table,
+  TableHead,
+  TableRow,
+  TableBody,
+  TableHeader,
+  TableCell,
+  TableContainer,
+  InlineNotification,
+  Form,
+} from "@carbon/react";
+import { FormattedMessage, useIntl } from "react-intl";
+import PageBreadCrumb from "../../common/PageBreadCrumb";
+import {
+  getFromOpenElisServer,
+  postToOpenElisServerJsonResponse,
+} from "../../utils/Utils";
+import { NotificationContext } from "../../layout/Layout";
+import {
+  AlertDialog,
+  NotificationKinds,
+} from "../../common/CustomNotification";
+
+const initialQueueState = {
+  entries: [],
+  pendingCount: 0,
+  failedCount: 0,
+  odooAvailable: false,
+  statusMessage: "",
+};
+
+function OdooSyncQueue() {
+  const intl = useIntl();
+  const { notificationVisible, setNotificationVisible, addNotification } =
+    useContext(NotificationContext);
+
+  const [queueData, setQueueData] = useState(initialQueueState);
+  const [loading, setLoading] = useState(true);
+  const [retrying, setRetrying] = useState(false);
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 530);
+
+  const breadcrumbs = useMemo(
+    () => [
+      {
+        label: { id: "home.label", defaultMessage: "Home" },
+        link: "/",
+      },
+      {
+        label: {
+          id: "breadcrums.admin.managment",
+          defaultMessage: "Administration",
+        },
+        link: "/MasterListsPage",
+      },
+      {
+        label: {
+          id: "odoo.syncQueue.breadcrumb",
+          defaultMessage: "Odoo Sync Queue",
+        },
+        link: "/MasterListsPage#odooSyncQueue",
+      },
+    ],
+    [],
+  );
+
+  const fetchQueueData = () => {
+    setLoading(true);
+    getFromOpenElisServer("/api/odoo/queue", (response) => {
+      if (response) {
+        setQueueData({
+          entries: response.entries || [],
+          pendingCount: response.pendingCount || 0,
+          failedCount: response.failedCount || 0,
+          odooAvailable: Boolean(response.odooAvailable),
+          statusMessage: response.statusMessage || "",
+        });
+      } else {
+        setQueueData(initialQueueState);
+        setNotificationVisible(true);
+        addNotification({
+          title: intl.formatMessage({ id: "notification.title" }),
+          message: intl.formatMessage({
+            id: "odoo.syncQueue.fetch.error",
+            defaultMessage: "Unable to load Odoo queue data.",
+          }),
+          kind: NotificationKinds.error,
+        });
+      }
+      setLoading(false);
+    });
+  };
+
+  useEffect(() => {
+    fetchQueueData();
+  }, []);
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 530);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const handleRetry = () => {
+    setRetrying(true);
+    postToOpenElisServerJsonResponse(
+      "/api/odoo/queue/retry",
+      JSON.stringify({}),
+      (response) => {
+        if (response) {
+          setQueueData({
+            entries: response.entries || [],
+            pendingCount: response.pendingCount || 0,
+            failedCount: response.failedCount || 0,
+            odooAvailable: Boolean(response.odooAvailable),
+            statusMessage: response.statusMessage || "",
+          });
+          setNotificationVisible(true);
+          addNotification({
+            title: intl.formatMessage({ id: "notification.title" }),
+            message:
+              response.statusMessage ||
+              intl.formatMessage({
+                id: "odoo.syncQueue.retry.success",
+                defaultMessage: "Odoo retry job completed.",
+              }),
+            kind: NotificationKinds.success,
+          });
+        } else {
+          setNotificationVisible(true);
+          addNotification({
+            title: intl.formatMessage({ id: "notification.title" }),
+            message: intl.formatMessage({
+              id: "odoo.syncQueue.retry.error",
+              defaultMessage: "Retry failed.",
+            }),
+            kind: NotificationKinds.error,
+          });
+        }
+        setRetrying(false);
+      },
+    );
+  };
+
+  const renderDate = (value) => {
+    if (!value) {
+      return "-";
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return "-";
+    }
+    return new Intl.DateTimeFormat(intl.locale, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(date);
+  };
+
+  const connectionTagType = queueData.odooAvailable ? "green" : "red";
+
+  return (
+    <>
+      {notificationVisible === true ? <AlertDialog /> : ""}
+      {loading ? <Loading withOverlay={true} /> : null}
+      <div className="adminPageContent">
+        <PageBreadCrumb breadcrumbs={breadcrumbs} />
+        <Grid fullWidth={true}>
+          <Column lg={16} md={8} sm={4}>
+            <Section>
+              <Heading>
+                <FormattedMessage
+                  id="odoo.syncQueue.title"
+                  defaultMessage="Odoo Sync Queue"
+                />
+              </Heading>
+            </Section>
+          </Column>
+        </Grid>
+        <Grid fullWidth={true}>
+          <Column lg={16} md={8} sm={4}>
+            <Section style={{ marginTop: "1.5rem" }}>
+              <Form
+                style={{
+                  display: "flex",
+                  flexDirection: isMobile ? "column" : "row",
+                  gap: isMobile ? "1rem" : "2rem",
+                  justifyContent: "space-between",
+                  alignItems: isMobile ? "stretch" : "center",
+                  flexWrap: "wrap",
+                }}
+              >
+                <Column
+                  lg={16}
+                  md={8}
+                  sm={4}
+                  style={{
+                    display: "flex",
+                    gap: isMobile ? "0.75rem" : "0.5rem",
+                    flexDirection: isMobile ? "column" : "row",
+                    width: isMobile ? "100%" : "auto",
+                    margin: "0",
+                  }}
+                >
+                  <Button
+                    kind="primary"
+                    disabled={retrying}
+                    onClick={handleRetry}
+                    style={{ width: isMobile ? "100%" : "auto" }}
+                  >
+                    <FormattedMessage
+                      id="odoo.syncQueue.retry"
+                      defaultMessage="Run Retry Now"
+                    />
+                  </Button>
+                  <Button
+                    kind="secondary"
+                    disabled={loading}
+                    onClick={fetchQueueData}
+                    style={{ width: isMobile ? "100%" : "auto" }}
+                  >
+                    <FormattedMessage
+                      id="odoo.syncQueue.refresh"
+                      defaultMessage="Refresh"
+                    />
+                  </Button>
+                </Column>
+                <Column
+                  lg={16}
+                  md={8}
+                  sm={4}
+                  style={{
+                    display: "flex",
+                    flexDirection: isMobile ? "column" : "row",
+                    gap: isMobile ? "0.75rem" : "1.5rem",
+                    alignItems: isMobile ? "flex-start" : "center",
+                    justifyContent: isMobile ? "flex-start" : "flex-end",
+                  }}
+                >
+                  <h4
+                    style={{
+                      margin: 0,
+                      fontSize: isMobile ? "1rem" : "1.1rem",
+                    }}
+                  >
+                    <FormattedMessage
+                      id="odoo.syncQueue.pending"
+                      defaultMessage="Pending"
+                    />
+                    : <strong>{queueData.pendingCount}</strong>
+                  </h4>
+                  <h4
+                    style={{
+                      margin: 0,
+                      fontSize: isMobile ? "1rem" : "1.1rem",
+                    }}
+                  >
+                    <FormattedMessage
+                      id="odoo.syncQueue.failed"
+                      defaultMessage="Failed"
+                    />
+                    : <strong>{queueData.failedCount}</strong>
+                  </h4>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.5rem",
+                    }}
+                  >
+                    <FormattedMessage
+                      id="odoo.syncQueue.connection"
+                      defaultMessage="Odoo connection"
+                    />
+                    <Tag type={connectionTagType} size="md">
+                      <FormattedMessage
+                        id={
+                          queueData.odooAvailable
+                            ? "odoo.syncQueue.connection.available"
+                            : "odoo.syncQueue.connection.unavailable"
+                        }
+                        defaultMessage={
+                          queueData.odooAvailable ? "Available" : "Unavailable"
+                        }
+                      />
+                    </Tag>
+                  </div>
+                </Column>
+              </Form>
+            </Section>
+          </Column>
+        </Grid>
+        {queueData.statusMessage ? (
+          <Grid fullWidth={true}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <InlineNotification
+                  kind="info"
+                  lowContrast={true}
+                  subtitle={queueData.statusMessage}
+                  title={intl.formatMessage({
+                    id: "odoo.syncQueue.notice",
+                    defaultMessage: "Latest queue status",
+                  })}
+                />
+              </Section>
+            </Column>
+          </Grid>
+        ) : null}
+        <div className="orderLegendBody">
+          <TableContainer>
+            <Table size="lg" useZebraStyles={true}>
+              <TableHead>
+                <TableRow>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.id"
+                      defaultMessage="ID"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.accession"
+                      defaultMessage="Accession"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.status"
+                      defaultMessage="Status"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.retries"
+                      defaultMessage="Retries"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.maxRetries"
+                      defaultMessage="Max retries"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.created"
+                      defaultMessage="Created"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.lastRetry"
+                      defaultMessage="Last retry"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.completed"
+                      defaultMessage="Completed"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.invoiceId"
+                      defaultMessage="Invoice ID"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="odoo.syncQueue.table.error"
+                      defaultMessage="Last error"
+                    />
+                  </TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {queueData.entries.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={10}>
+                      <FormattedMessage
+                        id="odoo.syncQueue.table.empty"
+                        defaultMessage="No entries in the queue."
+                      />
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  queueData.entries.map((entry) => (
+                    <TableRow key={entry.id}>
+                      <TableCell>{entry.id}</TableCell>
+                      <TableCell>{entry.accessionNumber || "-"}</TableCell>
+                      <TableCell>{entry.status || "-"}</TableCell>
+                      <TableCell>{entry.retryCount ?? "-"}</TableCell>
+                      <TableCell>{entry.maxRetries ?? "-"}</TableCell>
+                      <TableCell>{renderDate(entry.createdDate)}</TableCell>
+                      <TableCell>{renderDate(entry.lastRetryDate)}</TableCell>
+                      <TableCell>{renderDate(entry.completedDate)}</TableCell>
+                      <TableCell>{entry.odooInvoiceId ?? "-"}</TableCell>
+                      <TableCell>{entry.errorMessage || "-"}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default OdooSyncQueue;

--- a/frontend/src/components/admin/odoo/OdooSyncQueue.js
+++ b/frontend/src/components/admin/odoo/OdooSyncQueue.js
@@ -300,23 +300,6 @@ function OdooSyncQueue() {
             </Section>
           </Column>
         </Grid>
-        {queueData.statusMessage ? (
-          <Grid fullWidth={true}>
-            <Column lg={16} md={8} sm={4}>
-              <Section>
-                <InlineNotification
-                  kind="info"
-                  lowContrast={true}
-                  subtitle={queueData.statusMessage}
-                  title={intl.formatMessage({
-                    id: "odoo.syncQueue.notice",
-                    defaultMessage: "Latest queue status",
-                  })}
-                />
-              </Section>
-            </Column>
-          </Grid>
-        ) : null}
         <div className="orderLegendBody">
           <TableContainer>
             <Table size="lg" useZebraStyles={true}>
@@ -414,6 +397,23 @@ function OdooSyncQueue() {
             </Table>
           </TableContainer>
         </div>
+        {queueData.statusMessage ? (
+          <Grid fullWidth={true} style={{ marginTop: "1.5rem" }}>
+            <Column lg={16} md={8} sm={4}>
+              <Section>
+                <InlineNotification
+                  kind="info"
+                  lowContrast={true}
+                  subtitle={queueData.statusMessage}
+                  title={intl.formatMessage({
+                    id: "odoo.syncQueue.notice",
+                    defaultMessage: "Latest queue status",
+                  })}
+                />
+              </Section>
+            </Column>
+          </Grid>
+        ) : null}
       </div>
     </>
   );

--- a/frontend/src/components/common/PageBreadCrumb.js
+++ b/frontend/src/components/common/PageBreadCrumb.js
@@ -10,9 +10,22 @@ const PageBreadCrumb = ({ breadcrumbs }) => {
       <Column lg={16} md={8} sm={4}>
         <Breadcrumb>
           {breadcrumbs.map((breadcrumb, index) => {
+            const labelConfig =
+              typeof breadcrumb.label === "string"
+                ? { id: breadcrumb.label }
+                : breadcrumb.label;
+
+            const message = intl.formatMessage(
+              {
+                id: labelConfig.id,
+                defaultMessage: labelConfig.defaultMessage || labelConfig.id,
+              },
+              labelConfig.values,
+            );
+
             return (
               <BreadcrumbItem key={index} href={breadcrumb.link}>
-                {intl.formatMessage({ id: `${breadcrumb.label}` })}
+                {message}
               </BreadcrumbItem>
             );
           })}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-    "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
-    "Helvetica Neue", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/main/java/org/openelisglobal/common/util/ConfigurationProperties.java
+++ b/src/main/java/org/openelisglobal/common/util/ConfigurationProperties.java
@@ -230,8 +230,9 @@ public abstract class ConfigurationProperties {
         CONTACT_TRACING("contactTracingEnabled", "text"), //
         REQUIRE_LAB_UNIT_AT_LOGIN("requireLabUnitAtLogin", "text"), //
         ENABLE_CLIENT_REGISTRY("enableClientRegistry", "text"), // if true, then client registry search option is
-        ENABLE_OPENELIS_TO_ODOO_CONNECTION("enableOdooConnection", "text"), BAR_CODE_TYPE("BarCodeType", "text");
-
+        ENABLE_OPENELIS_TO_ODOO_CONNECTION("enableOdooConnection", "text"),
+        BAR_CODE_TYPE("BarCodeType", "text"),
+        ENABLE_ODOO_QUEUE("enableOdooQueue", "text"); // If true, failed Odoo syncs will be queued for retry
         // visible on
         // the ui
 

--- a/src/main/java/org/openelisglobal/common/util/ConfigurationProperties.java
+++ b/src/main/java/org/openelisglobal/common/util/ConfigurationProperties.java
@@ -230,8 +230,7 @@ public abstract class ConfigurationProperties {
         CONTACT_TRACING("contactTracingEnabled", "text"), //
         REQUIRE_LAB_UNIT_AT_LOGIN("requireLabUnitAtLogin", "text"), //
         ENABLE_CLIENT_REGISTRY("enableClientRegistry", "text"), // if true, then client registry search option is
-        ENABLE_OPENELIS_TO_ODOO_CONNECTION("enableOdooConnection", "text"),
-        BAR_CODE_TYPE("BarCodeType", "text"),
+        ENABLE_OPENELIS_TO_ODOO_CONNECTION("enableOdooConnection", "text"), BAR_CODE_TYPE("BarCodeType", "text"),
         ENABLE_ODOO_QUEUE("enableOdooQueue", "text"); // If true, failed Odoo syncs will be queued for retry
         // visible on
         // the ui

--- a/src/main/java/org/openelisglobal/common/util/DefaultConfigurationProperties.java
+++ b/src/main/java/org/openelisglobal/common/util/DefaultConfigurationProperties.java
@@ -307,6 +307,7 @@ public class DefaultConfigurationProperties extends ConfigurationProperties {
         properties.setPropertyValue(Property.REQUIRE_LAB_UNIT_AT_LOGIN, "false");
         properties.setPropertyValue(Property.ENABLE_CLIENT_REGISTRY, "false");
         properties.setPropertyValue(Property.ENABLE_OPENELIS_TO_ODOO_CONNECTION, "false");
+        properties.setPropertyValue(Property.ENABLE_ODOO_QUEUE, "false");
         properties.setPropertyValue(Property.BAR_CODE_TYPE, "BARCODE");
         return properties;
     }

--- a/src/main/java/org/openelisglobal/odoo/client/OdooClient.java
+++ b/src/main/java/org/openelisglobal/odoo/client/OdooClient.java
@@ -61,7 +61,6 @@ public class OdooClient {
         validateRequiredField("org.openelisglobal.odoo.database.name", database);
         validateRequiredField("org.openelisglobal.odoo.username", username);
         validateRequiredField("org.openelisglobal.odoo.password", password);
-        log.info("Odoo configuration validated: url={}, database={}, username={}", url, database, username);
     }
 
     private void validateRequiredField(String fieldName, String value) {

--- a/src/main/java/org/openelisglobal/odoo/controller/OdooSyncQueueController.java
+++ b/src/main/java/org/openelisglobal/odoo/controller/OdooSyncQueueController.java
@@ -1,0 +1,63 @@
+package org.openelisglobal.odoo.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.openelisglobal.odoo.client.OdooConnection;
+import org.openelisglobal.odoo.dto.OdooSyncQueueEntryDTO;
+import org.openelisglobal.odoo.dto.OdooSyncQueueResponseDTO;
+import org.openelisglobal.odoo.entity.OdooSyncQueue;
+import org.openelisglobal.odoo.scheduler.OdooRetryJob;
+import org.openelisglobal.odoo.service.OdooSyncQueueService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/odoo/queue")
+public class OdooSyncQueueController {
+
+    @Autowired
+    private OdooSyncQueueService odooSyncQueueService;
+
+    @Autowired
+    private OdooRetryJob odooRetryJob;
+
+    @Autowired
+    private OdooConnection odooConnection;
+
+    @GetMapping
+    public ResponseEntity<OdooSyncQueueResponseDTO> getQueue() {
+        List<OdooSyncQueue> queueEntries = odooSyncQueueService.getAllOrdered(List.of("createdDate"), true);
+
+        List<OdooSyncQueueEntryDTO> entryDtos = queueEntries.stream().map(OdooSyncQueueEntryDTO::fromEntity)
+                .collect(Collectors.toList());
+
+        OdooSyncQueueResponseDTO response = new OdooSyncQueueResponseDTO();
+        response.setEntries(entryDtos);
+        response.setPendingCount(odooSyncQueueService.getPendingCount());
+        response.setFailedCount(odooSyncQueueService.getFailedCount());
+        response.setOdooAvailable(odooConnection.isAvailable());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/retry")
+    public ResponseEntity<OdooSyncQueueResponseDTO> triggerManualRetry() {
+        String statusMessage = odooRetryJob.triggerManualRetry();
+        List<OdooSyncQueue> queueEntries = odooSyncQueueService.getAllOrdered(List.of("createdDate"), true);
+        List<OdooSyncQueueEntryDTO> entryDtos = queueEntries.stream().map(OdooSyncQueueEntryDTO::fromEntity)
+                .collect(Collectors.toList());
+
+        OdooSyncQueueResponseDTO response = new OdooSyncQueueResponseDTO();
+        response.setEntries(entryDtos);
+        response.setPendingCount(odooSyncQueueService.getPendingCount());
+        response.setFailedCount(odooSyncQueueService.getFailedCount());
+        response.setOdooAvailable(odooConnection.isAvailable());
+        response.setStatusMessage(statusMessage);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAO.java
+++ b/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAO.java
@@ -10,9 +10,12 @@ public interface OdooSyncQueueDAO extends BaseDAO<OdooSyncQueue, Long> {
     /**
      * Get all pending sync requests that need to be retried
      * 
+     * @param processingTimeoutThreshold Entries stuck in PROCESSING with a last
+     *                                   retry before this threshold are included as
+     *                                   stale and should be retried.
      * @return List of pending sync queue entries
      */
-    List<OdooSyncQueue> getPendingSyncRequests();
+    List<OdooSyncQueue> getPendingSyncRequests(java.sql.Timestamp processingTimeoutThreshold);
 
     /**
      * Get sync requests by status

--- a/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAO.java
+++ b/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAO.java
@@ -1,0 +1,42 @@
+package org.openelisglobal.odoo.dao;
+
+import java.util.List;
+import org.openelisglobal.common.dao.BaseDAO;
+import org.openelisglobal.odoo.entity.OdooSyncQueue;
+import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
+
+/**
+ * DAO interface for OdooSyncQueue entity
+ */
+public interface OdooSyncQueueDAO extends BaseDAO<OdooSyncQueue, Long> {
+
+    /**
+     * Get all pending sync requests that need to be retried
+     * 
+     * @return List of pending sync queue entries
+     */
+    List<OdooSyncQueue> getPendingSyncRequests();
+
+    /**
+     * Get sync requests by status
+     * 
+     * @param status The sync status to filter by
+     * @return List of sync queue entries with the specified status
+     */
+    List<OdooSyncQueue> getByStatus(SyncStatus status);
+
+    /**
+     * Get sync request by accession number
+     * 
+     * @param accessionNumber The accession number to search for
+     * @return List of sync queue entries for the accession number
+     */
+    List<OdooSyncQueue> getByAccessionNumber(String accessionNumber);
+
+    /**
+     * Get all failed sync requests (after max retries)
+     * 
+     * @return List of permanently failed sync queue entries
+     */
+    List<OdooSyncQueue> getFailedSyncRequests();
+}

--- a/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAO.java
+++ b/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAO.java
@@ -5,9 +5,6 @@ import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.odoo.entity.OdooSyncQueue;
 import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
 
-/**
- * DAO interface for OdooSyncQueue entity
- */
 public interface OdooSyncQueueDAO extends BaseDAO<OdooSyncQueue, Long> {
 
     /**

--- a/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAOImpl.java
+++ b/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAOImpl.java
@@ -1,7 +1,9 @@
 package org.openelisglobal.odoo.dao;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
@@ -21,12 +23,18 @@ public class OdooSyncQueueDAOImpl extends BaseDAOImpl<OdooSyncQueue, Long> imple
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public List<OdooSyncQueue> getPendingSyncRequests() {
+    @Transactional
+    public List<OdooSyncQueue> getPendingSyncRequests(Timestamp processingTimeoutThreshold) {
         try {
-            String hql = "FROM OdooSyncQueue q WHERE q.status = :status ORDER BY q.createdDate ASC";
-            Query<OdooSyncQueue> query = entityManager.unwrap(Session.class).createQuery(hql, OdooSyncQueue.class);
-            query.setParameter("status", SyncStatus.PENDING.name());
+            String hql = "FROM OdooSyncQueue q WHERE q.status = :pendingStatus "
+                    + "OR (q.status = :processingStatus AND (q.lastRetryDate IS NULL OR q.lastRetryDate < :processingTimeout)) "
+                    + "ORDER BY q.createdDate ASC";
+            Session session = entityManager.unwrap(Session.class);
+            Query<OdooSyncQueue> query = session.createQuery(hql, OdooSyncQueue.class);
+            query.setParameter("pendingStatus", SyncStatus.PENDING.name());
+            query.setParameter("processingStatus", SyncStatus.PROCESSING.name());
+            query.setParameter("processingTimeout", processingTimeoutThreshold);
+            query.setLockMode("q", LockMode.PESSIMISTIC_WRITE);
             List<OdooSyncQueue> results = query.list();
             return results.stream().filter(this::withinRetryLimit).collect(Collectors.toList());
         } catch (RuntimeException e) {

--- a/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAOImpl.java
+++ b/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAOImpl.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.odoo.dao;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
@@ -11,9 +12,6 @@ import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * DAO implementation for OdooSyncQueue entity
- */
 @Component
 @Transactional
 public class OdooSyncQueueDAOImpl extends BaseDAOImpl<OdooSyncQueue, Long> implements OdooSyncQueueDAO {
@@ -26,15 +24,21 @@ public class OdooSyncQueueDAOImpl extends BaseDAOImpl<OdooSyncQueue, Long> imple
     @Transactional(readOnly = true)
     public List<OdooSyncQueue> getPendingSyncRequests() {
         try {
-            String hql = "FROM OdooSyncQueue q WHERE q.status = :status " + "AND q.retryCount < q.maxRetries "
-                    + "ORDER BY q.createdDate ASC";
+            String hql = "FROM OdooSyncQueue q WHERE q.status = :status ORDER BY q.createdDate ASC";
             Query<OdooSyncQueue> query = entityManager.unwrap(Session.class).createQuery(hql, OdooSyncQueue.class);
-            query.setParameter("status", SyncStatus.PENDING);
-            return query.list();
+            query.setParameter("status", SyncStatus.PENDING.name());
+            List<OdooSyncQueue> results = query.list();
+            return results.stream().filter(this::withinRetryLimit).collect(Collectors.toList());
         } catch (RuntimeException e) {
             LogEvent.logError(e);
             throw new LIMSRuntimeException("Error in OdooSyncQueueDAO getPendingSyncRequests()", e);
         }
+    }
+
+    private boolean withinRetryLimit(OdooSyncQueue queue) {
+        int retryCount = queue.getRetryCount() == null ? 0 : queue.getRetryCount();
+        int maxRetries = queue.getMaxRetries() == null ? 10 : queue.getMaxRetries();
+        return retryCount < maxRetries;
     }
 
     @Override
@@ -72,7 +76,7 @@ public class OdooSyncQueueDAOImpl extends BaseDAOImpl<OdooSyncQueue, Long> imple
         try {
             String hql = "FROM OdooSyncQueue q WHERE q.status = :status ORDER BY q.createdDate DESC";
             Query<OdooSyncQueue> query = entityManager.unwrap(Session.class).createQuery(hql, OdooSyncQueue.class);
-            query.setParameter("status", SyncStatus.FAILED);
+            query.setParameter("status", SyncStatus.FAILED.name());
             return query.list();
         } catch (RuntimeException e) {
             LogEvent.logError(e);

--- a/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAOImpl.java
+++ b/src/main/java/org/openelisglobal/odoo/dao/OdooSyncQueueDAOImpl.java
@@ -1,0 +1,82 @@
+package org.openelisglobal.odoo.dao;
+
+import java.util.List;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.common.exception.LIMSRuntimeException;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.odoo.entity.OdooSyncQueue;
+import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * DAO implementation for OdooSyncQueue entity
+ */
+@Component
+@Transactional
+public class OdooSyncQueueDAOImpl extends BaseDAOImpl<OdooSyncQueue, Long> implements OdooSyncQueueDAO {
+
+    public OdooSyncQueueDAOImpl() {
+        super(OdooSyncQueue.class);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getPendingSyncRequests() {
+        try {
+            String hql = "FROM OdooSyncQueue q WHERE q.status = :status " + "AND q.retryCount < q.maxRetries "
+                    + "ORDER BY q.createdDate ASC";
+            Query<OdooSyncQueue> query = entityManager.unwrap(Session.class).createQuery(hql, OdooSyncQueue.class);
+            query.setParameter("status", SyncStatus.PENDING);
+            return query.list();
+        } catch (RuntimeException e) {
+            LogEvent.logError(e);
+            throw new LIMSRuntimeException("Error in OdooSyncQueueDAO getPendingSyncRequests()", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getByStatus(SyncStatus status) {
+        try {
+            String hql = "FROM OdooSyncQueue q WHERE q.status = :status ORDER BY q.createdDate DESC";
+            Query<OdooSyncQueue> query = entityManager.unwrap(Session.class).createQuery(hql, OdooSyncQueue.class);
+            query.setParameter("status", status);
+            return query.list();
+        } catch (RuntimeException e) {
+            LogEvent.logError(e);
+            throw new LIMSRuntimeException("Error in OdooSyncQueueDAO getByStatus()", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getByAccessionNumber(String accessionNumber) {
+        try {
+            String hql = "FROM OdooSyncQueue q WHERE q.accessionNumber = :accessionNumber "
+                    + "ORDER BY q.createdDate DESC";
+            Query<OdooSyncQueue> query = entityManager.unwrap(Session.class).createQuery(hql, OdooSyncQueue.class);
+            query.setParameter("accessionNumber", accessionNumber);
+            return query.list();
+        } catch (RuntimeException e) {
+            LogEvent.logError(e);
+            throw new LIMSRuntimeException("Error in OdooSyncQueueDAO getByAccessionNumber()", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getFailedSyncRequests() {
+        try {
+            String hql = "FROM OdooSyncQueue q WHERE q.status = :status ORDER BY q.createdDate DESC";
+            Query<OdooSyncQueue> query = entityManager.unwrap(Session.class).createQuery(hql, OdooSyncQueue.class);
+            query.setParameter("status", SyncStatus.FAILED);
+            return query.list();
+        } catch (RuntimeException e) {
+            LogEvent.logError(e);
+            throw new LIMSRuntimeException("Error in OdooSyncQueueDAO getFailedSyncRequests()", e);
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/dto/OdooSyncQueueEntryDTO.java
+++ b/src/main/java/org/openelisglobal/odoo/dto/OdooSyncQueueEntryDTO.java
@@ -1,0 +1,113 @@
+package org.openelisglobal.odoo.dto;
+
+import java.sql.Timestamp;
+import org.openelisglobal.odoo.entity.OdooSyncQueue;
+
+public class OdooSyncQueueEntryDTO {
+
+    private Long id;
+    private String accessionNumber;
+    private String status;
+    private Integer retryCount;
+    private Integer maxRetries;
+    private Timestamp createdDate;
+    private Timestamp lastRetryDate;
+    private Timestamp completedDate;
+    private Integer odooInvoiceId;
+    private String errorMessage;
+
+    public static OdooSyncQueueEntryDTO fromEntity(OdooSyncQueue queueEntry) {
+        OdooSyncQueueEntryDTO dto = new OdooSyncQueueEntryDTO();
+        dto.setId(queueEntry.getId());
+        dto.setAccessionNumber(queueEntry.getAccessionNumber());
+        dto.setStatus(queueEntry.getStatus() != null ? queueEntry.getStatus().name() : null);
+        dto.setRetryCount(queueEntry.getRetryCount());
+        dto.setMaxRetries(queueEntry.getMaxRetries());
+        dto.setCreatedDate(queueEntry.getCreatedDate());
+        dto.setLastRetryDate(queueEntry.getLastRetryDate());
+        dto.setCompletedDate(queueEntry.getCompletedDate());
+        dto.setOdooInvoiceId(queueEntry.getOdooInvoiceId());
+        dto.setErrorMessage(queueEntry.getErrorMessage());
+        return dto;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getAccessionNumber() {
+        return accessionNumber;
+    }
+
+    public void setAccessionNumber(String accessionNumber) {
+        this.accessionNumber = accessionNumber;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Integer getRetryCount() {
+        return retryCount;
+    }
+
+    public void setRetryCount(Integer retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    public Integer getMaxRetries() {
+        return maxRetries;
+    }
+
+    public void setMaxRetries(Integer maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    public Timestamp getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Timestamp createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public Timestamp getLastRetryDate() {
+        return lastRetryDate;
+    }
+
+    public void setLastRetryDate(Timestamp lastRetryDate) {
+        this.lastRetryDate = lastRetryDate;
+    }
+
+    public Timestamp getCompletedDate() {
+        return completedDate;
+    }
+
+    public void setCompletedDate(Timestamp completedDate) {
+        this.completedDate = completedDate;
+    }
+
+    public Integer getOdooInvoiceId() {
+        return odooInvoiceId;
+    }
+
+    public void setOdooInvoiceId(Integer odooInvoiceId) {
+        this.odooInvoiceId = odooInvoiceId;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/dto/OdooSyncQueueResponseDTO.java
+++ b/src/main/java/org/openelisglobal/odoo/dto/OdooSyncQueueResponseDTO.java
@@ -1,0 +1,52 @@
+package org.openelisglobal.odoo.dto;
+
+import java.util.List;
+
+public class OdooSyncQueueResponseDTO {
+
+    private List<OdooSyncQueueEntryDTO> entries;
+    private int pendingCount;
+    private int failedCount;
+    private boolean odooAvailable;
+    private String statusMessage;
+
+    public List<OdooSyncQueueEntryDTO> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(List<OdooSyncQueueEntryDTO> entries) {
+        this.entries = entries;
+    }
+
+    public int getPendingCount() {
+        return pendingCount;
+    }
+
+    public void setPendingCount(int pendingCount) {
+        this.pendingCount = pendingCount;
+    }
+
+    public int getFailedCount() {
+        return failedCount;
+    }
+
+    public void setFailedCount(int failedCount) {
+        this.failedCount = failedCount;
+    }
+
+    public boolean isOdooAvailable() {
+        return odooAvailable;
+    }
+
+    public void setOdooAvailable(boolean odooAvailable) {
+        this.odooAvailable = odooAvailable;
+    }
+
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+
+    public void setStatusMessage(String statusMessage) {
+        this.statusMessage = statusMessage;
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/entity/OdooSyncQueue.java
+++ b/src/main/java/org/openelisglobal/odoo/entity/OdooSyncQueue.java
@@ -1,9 +1,8 @@
 package org.openelisglobal.odoo.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,23 +12,21 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.sql.Timestamp;
+import lombok.Getter;
+import lombok.Setter;
 import org.openelisglobal.common.valueholder.BaseObject;
+import org.openelisglobal.odoo.entity.converter.SyncStatusConverter;
 
-/**
- * Entity class for storing failed Odoo synchronization attempts. This allows
- * for automatic retry and recovery when Odoo is temporarily unavailable.
- */
 @Entity
 @Table(name = "odoo_sync_queue")
+@Setter
+@Getter
 public class OdooSyncQueue extends BaseObject<Long> {
 
     private static final long serialVersionUID = 1L;
 
     public enum SyncStatus {
-        PENDING, // Waiting to be processed
-        PROCESSING, // Currently being processed
-        FAILED, // Failed after max retries
-        COMPLETED // Successfully synced
+        PENDING, PROCESSING, FAILED, COMPLETED
     }
 
     @Id
@@ -38,76 +35,43 @@ public class OdooSyncQueue extends BaseObject<Long> {
     @Column(name = "id")
     private Long id;
 
-    /**
-     * Accession number from the sample (for tracking and debugging)
-     */
     @Column(name = "accession_number")
     @Size(max = 50)
     private String accessionNumber;
 
-    /**
-     * Sample ID reference
-     */
     @Column(name = "sample_id")
     @Size(max = 20)
     private String sampleId;
 
-    /**
-     * Serialized invoice data (JSON format) to retry with
-     */
     @Lob
     @Column(name = "invoice_data", columnDefinition = "TEXT")
     @NotNull
     private String invoiceData;
 
-    /**
-     * Current status of this sync attempt
-     */
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = SyncStatusConverter.class)
     @Column(name = "status", length = 20)
     @NotNull
     private SyncStatus status;
 
-    /**
-     * Number of retry attempts made
-     */
     @Column(name = "retry_count")
     private Integer retryCount = 0;
 
-    /**
-     * Maximum number of retries allowed
-     */
     @Column(name = "max_retries")
     private Integer maxRetries = 10;
 
-    /**
-     * Error message from last failed attempt
-     */
     @Lob
     @Column(name = "error_message", columnDefinition = "TEXT")
     private String errorMessage;
 
-    /**
-     * When this record was created
-     */
     @Column(name = "created_date")
     private Timestamp createdDate;
 
-    /**
-     * When the last retry attempt was made
-     */
     @Column(name = "last_retry_date")
     private Timestamp lastRetryDate;
 
-    /**
-     * When the sync was successfully completed
-     */
     @Column(name = "completed_date")
     private Timestamp completedDate;
 
-    /**
-     * Odoo invoice ID (populated when sync succeeds)
-     */
     @Column(name = "odoo_invoice_id")
     private Integer odooInvoiceId;
 
@@ -129,121 +93,21 @@ public class OdooSyncQueue extends BaseObject<Long> {
         this.id = id;
     }
 
-    public String getAccessionNumber() {
-        return accessionNumber;
-    }
-
-    public void setAccessionNumber(String accessionNumber) {
-        this.accessionNumber = accessionNumber;
-    }
-
-    public String getSampleId() {
-        return sampleId;
-    }
-
-    public void setSampleId(String sampleId) {
-        this.sampleId = sampleId;
-    }
-
-    public String getInvoiceData() {
-        return invoiceData;
-    }
-
-    public void setInvoiceData(String invoiceData) {
-        this.invoiceData = invoiceData;
-    }
-
-    public SyncStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(SyncStatus status) {
-        this.status = status;
-    }
-
-    public Integer getRetryCount() {
-        return retryCount;
-    }
-
-    public void setRetryCount(Integer retryCount) {
-        this.retryCount = retryCount;
-    }
-
-    public Integer getMaxRetries() {
-        return maxRetries;
-    }
-
-    public void setMaxRetries(Integer maxRetries) {
-        this.maxRetries = maxRetries;
-    }
-
-    public String getErrorMessage() {
-        return errorMessage;
-    }
-
-    public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
-    public Timestamp getCreatedDate() {
-        return createdDate;
-    }
-
-    public void setCreatedDate(Timestamp createdDate) {
-        this.createdDate = createdDate;
-    }
-
-    public Timestamp getLastRetryDate() {
-        return lastRetryDate;
-    }
-
-    public void setLastRetryDate(Timestamp lastRetryDate) {
-        this.lastRetryDate = lastRetryDate;
-    }
-
-    public Timestamp getCompletedDate() {
-        return completedDate;
-    }
-
-    public void setCompletedDate(Timestamp completedDate) {
-        this.completedDate = completedDate;
-    }
-
-    public Integer getOdooInvoiceId() {
-        return odooInvoiceId;
-    }
-
-    public void setOdooInvoiceId(Integer odooInvoiceId) {
-        this.odooInvoiceId = odooInvoiceId;
-    }
-
-    /**
-     * Increment retry count
-     */
     public void incrementRetryCount() {
         this.retryCount++;
         this.lastRetryDate = new Timestamp(System.currentTimeMillis());
     }
 
-    /**
-     * Check if max retries have been exceeded
-     */
     public boolean hasExceededMaxRetries() {
         return this.retryCount >= this.maxRetries;
     }
 
-    /**
-     * Mark as completed
-     */
     public void markCompleted(Integer invoiceId) {
         this.status = SyncStatus.COMPLETED;
         this.odooInvoiceId = invoiceId;
         this.completedDate = new Timestamp(System.currentTimeMillis());
     }
 
-    /**
-     * Mark as failed
-     */
     public void markFailed(String errorMessage) {
         this.status = SyncStatus.FAILED;
         this.errorMessage = errorMessage;

--- a/src/main/java/org/openelisglobal/odoo/entity/OdooSyncQueue.java
+++ b/src/main/java/org/openelisglobal/odoo/entity/OdooSyncQueue.java
@@ -18,8 +18,6 @@ import org.openelisglobal.common.valueholder.BaseObject;
 /**
  * Entity class for storing failed Odoo synchronization attempts. This allows
  * for automatic retry and recovery when Odoo is temporarily unavailable.
- * 
- * @author OpenELIS Team
  */
 @Entity
 @Table(name = "odoo_sync_queue")

--- a/src/main/java/org/openelisglobal/odoo/entity/OdooSyncQueue.java
+++ b/src/main/java/org/openelisglobal/odoo/entity/OdooSyncQueue.java
@@ -1,0 +1,253 @@
+package org.openelisglobal.odoo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.sql.Timestamp;
+import org.openelisglobal.common.valueholder.BaseObject;
+
+/**
+ * Entity class for storing failed Odoo synchronization attempts. This allows
+ * for automatic retry and recovery when Odoo is temporarily unavailable.
+ * 
+ * @author OpenELIS Team
+ */
+@Entity
+@Table(name = "odoo_sync_queue")
+public class OdooSyncQueue extends BaseObject<Long> {
+
+    private static final long serialVersionUID = 1L;
+
+    public enum SyncStatus {
+        PENDING, // Waiting to be processed
+        PROCESSING, // Currently being processed
+        FAILED, // Failed after max retries
+        COMPLETED // Successfully synced
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "odoo_sync_queue_generator")
+    @SequenceGenerator(name = "odoo_sync_queue_generator", sequenceName = "odoo_sync_queue_seq", allocationSize = 1)
+    @Column(name = "id")
+    private Long id;
+
+    /**
+     * Accession number from the sample (for tracking and debugging)
+     */
+    @Column(name = "accession_number")
+    @Size(max = 50)
+    private String accessionNumber;
+
+    /**
+     * Sample ID reference
+     */
+    @Column(name = "sample_id")
+    @Size(max = 20)
+    private String sampleId;
+
+    /**
+     * Serialized invoice data (JSON format) to retry with
+     */
+    @Lob
+    @Column(name = "invoice_data", columnDefinition = "TEXT")
+    @NotNull
+    private String invoiceData;
+
+    /**
+     * Current status of this sync attempt
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20)
+    @NotNull
+    private SyncStatus status;
+
+    /**
+     * Number of retry attempts made
+     */
+    @Column(name = "retry_count")
+    private Integer retryCount = 0;
+
+    /**
+     * Maximum number of retries allowed
+     */
+    @Column(name = "max_retries")
+    private Integer maxRetries = 10;
+
+    /**
+     * Error message from last failed attempt
+     */
+    @Lob
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    private String errorMessage;
+
+    /**
+     * When this record was created
+     */
+    @Column(name = "created_date")
+    private Timestamp createdDate;
+
+    /**
+     * When the last retry attempt was made
+     */
+    @Column(name = "last_retry_date")
+    private Timestamp lastRetryDate;
+
+    /**
+     * When the sync was successfully completed
+     */
+    @Column(name = "completed_date")
+    private Timestamp completedDate;
+
+    /**
+     * Odoo invoice ID (populated when sync succeeds)
+     */
+    @Column(name = "odoo_invoice_id")
+    private Integer odooInvoiceId;
+
+    public OdooSyncQueue() {
+        super();
+        this.status = SyncStatus.PENDING;
+        this.retryCount = 0;
+        this.maxRetries = 10;
+        this.createdDate = new Timestamp(System.currentTimeMillis());
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getAccessionNumber() {
+        return accessionNumber;
+    }
+
+    public void setAccessionNumber(String accessionNumber) {
+        this.accessionNumber = accessionNumber;
+    }
+
+    public String getSampleId() {
+        return sampleId;
+    }
+
+    public void setSampleId(String sampleId) {
+        this.sampleId = sampleId;
+    }
+
+    public String getInvoiceData() {
+        return invoiceData;
+    }
+
+    public void setInvoiceData(String invoiceData) {
+        this.invoiceData = invoiceData;
+    }
+
+    public SyncStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SyncStatus status) {
+        this.status = status;
+    }
+
+    public Integer getRetryCount() {
+        return retryCount;
+    }
+
+    public void setRetryCount(Integer retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    public Integer getMaxRetries() {
+        return maxRetries;
+    }
+
+    public void setMaxRetries(Integer maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public Timestamp getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Timestamp createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public Timestamp getLastRetryDate() {
+        return lastRetryDate;
+    }
+
+    public void setLastRetryDate(Timestamp lastRetryDate) {
+        this.lastRetryDate = lastRetryDate;
+    }
+
+    public Timestamp getCompletedDate() {
+        return completedDate;
+    }
+
+    public void setCompletedDate(Timestamp completedDate) {
+        this.completedDate = completedDate;
+    }
+
+    public Integer getOdooInvoiceId() {
+        return odooInvoiceId;
+    }
+
+    public void setOdooInvoiceId(Integer odooInvoiceId) {
+        this.odooInvoiceId = odooInvoiceId;
+    }
+
+    /**
+     * Increment retry count
+     */
+    public void incrementRetryCount() {
+        this.retryCount++;
+        this.lastRetryDate = new Timestamp(System.currentTimeMillis());
+    }
+
+    /**
+     * Check if max retries have been exceeded
+     */
+    public boolean hasExceededMaxRetries() {
+        return this.retryCount >= this.maxRetries;
+    }
+
+    /**
+     * Mark as completed
+     */
+    public void markCompleted(Integer invoiceId) {
+        this.status = SyncStatus.COMPLETED;
+        this.odooInvoiceId = invoiceId;
+        this.completedDate = new Timestamp(System.currentTimeMillis());
+    }
+
+    /**
+     * Mark as failed
+     */
+    public void markFailed(String errorMessage) {
+        this.status = SyncStatus.FAILED;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/entity/converter/SyncStatusConverter.java
+++ b/src/main/java/org/openelisglobal/odoo/entity/converter/SyncStatusConverter.java
@@ -1,0 +1,19 @@
+package org.openelisglobal.odoo.entity.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
+
+@Converter(autoApply = false)
+public class SyncStatusConverter implements AttributeConverter<SyncStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(SyncStatus attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public SyncStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : SyncStatus.valueOf(dbData);
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
+++ b/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
@@ -1,0 +1,157 @@
+package org.openelisglobal.odoo.scheduler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openelisglobal.odoo.client.OdooConnection;
+import org.openelisglobal.odoo.entity.OdooSyncQueue;
+import org.openelisglobal.odoo.service.OdooSyncQueueService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled job to retry failed Odoo synchronization attempts. Runs
+ * periodically to process pending queue entries and attempt to sync them with
+ * Odoo.
+ * 
+ * @author OpenELIS Team
+ */
+@Component
+public class OdooRetryJob {
+
+    private static final Logger log = LogManager.getLogger(OdooRetryJob.class);
+
+    @Autowired
+    private OdooSyncQueueService odooSyncQueueService;
+
+    @Autowired
+    private OdooConnection odooConnection;
+
+    @Value("${org.openelisglobal.odoo.retry.enabled:true}")
+    private boolean retryEnabled;
+
+    @Value("${org.openelisglobal.odoo.retry.batchSize:10}")
+    private int batchSize;
+
+    /**
+     * Scheduled method to process pending Odoo sync queue entries. Runs every 5
+     * minutes by default (300000 milliseconds). Can be configured via property:
+     * org.openelisglobal.odoo.retry.interval
+     */
+    @Scheduled(initialDelay = 60000, // Start 1 minute after application startup
+            fixedDelayString = "${org.openelisglobal.odoo.retry.interval:300000}" // Default: 5 minutes
+    )
+    public void retryFailedSyncs() {
+        if (!retryEnabled) {
+            log.debug("Odoo retry job is disabled");
+            return;
+        }
+
+        try {
+            List<OdooSyncQueue> pendingEntries = odooSyncQueueService.getPendingSyncRequests();
+
+            if (pendingEntries.isEmpty()) {
+                log.debug("No pending Odoo sync requests to process");
+                return;
+            }
+
+            log.info("Found {} pending Odoo sync requests. Processing up to {} entries...", pendingEntries.size(),
+                    batchSize);
+
+            int processed = 0;
+            int succeeded = 0;
+            int failed = 0;
+
+            for (OdooSyncQueue queueEntry : pendingEntries) {
+                if (processed >= batchSize) {
+                    log.info("Reached batch size limit of {}. Remaining entries will be processed in next run.",
+                            batchSize);
+                    break;
+                }
+
+                processed++;
+                boolean success = processQueueEntry(queueEntry);
+                if (success) {
+                    succeeded++;
+                } else {
+                    failed++;
+                }
+            }
+
+            log.info("Odoo retry job completed. Processed: {}, Succeeded: {}, Failed: {}", processed, succeeded,
+                    failed);
+
+            // Log summary if there are still pending or permanently failed entries
+            int remainingPending = odooSyncQueueService.getPendingCount();
+            int permanentlyFailed = odooSyncQueueService.getFailedCount();
+
+            if (remainingPending > 0 || permanentlyFailed > 0) {
+                log.warn("Odoo sync queue status - Pending: {}, Permanently Failed: {}", remainingPending,
+                        permanentlyFailed);
+            }
+
+        } catch (Exception e) {
+            log.error("Error in Odoo retry job: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Process a single queue entry
+     * 
+     * @param queueEntry The queue entry to process
+     * @return true if successful, false otherwise
+     */
+    private boolean processQueueEntry(OdooSyncQueue queueEntry) {
+        log.info("Processing queue entry {} for accession number: {} (attempt {}/{})", queueEntry.getId(),
+                queueEntry.getAccessionNumber(), queueEntry.getRetryCount() + 1, queueEntry.getMaxRetries());
+
+        try {
+            // Mark as processing
+            odooSyncQueueService.markAsProcessing(queueEntry);
+
+            // Deserialize invoice data
+            Map<String, Object> invoiceData = odooSyncQueueService.getInvoiceDataAsMap(queueEntry);
+
+            // Attempt to create invoice in Odoo
+            Integer invoiceId = odooConnection.create("account.move", List.of(invoiceData));
+
+            if (invoiceId == null) {
+                throw new RuntimeException("Odoo returned null invoice ID");
+            }
+
+            // Success! Mark as completed
+            odooSyncQueueService.markAsCompleted(queueEntry, invoiceId);
+            log.info("Successfully synced queue entry {} with Odoo invoice ID: {}", queueEntry.getId(), invoiceId);
+            return true;
+
+        } catch (JsonProcessingException e) {
+            log.error("Error deserializing invoice data for queue entry {}: {}", queueEntry.getId(), e.getMessage(), e);
+            odooSyncQueueService.markRetryFailed(queueEntry, "Failed to deserialize invoice data: " + e.getMessage());
+            return false;
+
+        } catch (Exception e) {
+            log.error("Error syncing queue entry {} to Odoo: {}", queueEntry.getId(), e.getMessage(), e);
+            odooSyncQueueService.markRetryFailed(queueEntry, "Odoo sync failed: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Manual trigger for retry job (can be called from admin interface)
+     * 
+     * @return Summary message
+     */
+    public String triggerManualRetry() {
+        log.info("Manual Odoo retry job triggered");
+        retryFailedSyncs();
+
+        int pending = odooSyncQueueService.getPendingCount();
+        int failed = odooSyncQueueService.getFailedCount();
+
+        return String.format("Odoo retry job completed. Pending: %d, Failed: %d", pending, failed);
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
+++ b/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
@@ -17,8 +17,6 @@ import org.springframework.stereotype.Component;
  * Scheduled job to retry failed Odoo synchronization attempts. Runs
  * periodically to process pending queue entries and attempt to sync them with
  * Odoo.
- * 
- * @author OpenELIS Team
  */
 @Component
 public class OdooRetryJob {

--- a/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
+++ b/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
@@ -29,7 +29,7 @@ public class OdooRetryJob {
     @Autowired
     private OdooConnection odooConnection;
 
-    @Value("${org.openelisglobal.odoo.retry.enabled:true}")
+    @Value("${org.openelisglobal.odoo.retry.enabled:false}")
     private boolean retryEnabled;
 
     @Value("${org.openelisglobal.odoo.retry.batchSize:10}")
@@ -46,6 +46,11 @@ public class OdooRetryJob {
     public void retryFailedSyncs() {
         if (!retryEnabled) {
             log.debug("Odoo retry job is disabled");
+            return;
+        }
+
+        if (!odooConnection.isAvailable()) {
+            log.warn("Odoo connection is not available. Skipping retry job execution.");
             return;
         }
 
@@ -83,7 +88,6 @@ public class OdooRetryJob {
             log.info("Odoo retry job completed. Processed: {}, Succeeded: {}, Failed: {}", processed, succeeded,
                     failed);
 
-            // Log summary if there are still pending or permanently failed entries
             int remainingPending = odooSyncQueueService.getPendingCount();
             int permanentlyFailed = odooSyncQueueService.getFailedCount();
 
@@ -108,20 +112,16 @@ public class OdooRetryJob {
                 queueEntry.getAccessionNumber(), queueEntry.getRetryCount() + 1, queueEntry.getMaxRetries());
 
         try {
-            // Mark as processing
             odooSyncQueueService.markAsProcessing(queueEntry);
 
-            // Deserialize invoice data
             Map<String, Object> invoiceData = odooSyncQueueService.getInvoiceDataAsMap(queueEntry);
 
-            // Attempt to create invoice in Odoo
             Integer invoiceId = odooConnection.create("account.move", List.of(invoiceData));
 
             if (invoiceId == null) {
                 throw new RuntimeException("Odoo returned null invoice ID");
             }
 
-            // Success! Mark as completed
             odooSyncQueueService.markAsCompleted(queueEntry, invoiceId);
             log.info("Successfully synced queue entry {} with Odoo invoice ID: {}", queueEntry.getId(), invoiceId);
             return true;

--- a/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
+++ b/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openelisglobal.odoo.client.OdooConnection;
 import org.openelisglobal.odoo.entity.OdooSyncQueue;
+import org.openelisglobal.odoo.service.OdooIntegrationService;
 import org.openelisglobal.odoo.service.OdooSyncQueueService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,9 @@ public class OdooRetryJob {
     @Autowired
     private OdooConnection odooConnection;
 
+    @Autowired
+    private OdooIntegrationService odooIntegrationService;
+
     @Value("${org.openelisglobal.odoo.retry.enabled:false}")
     private boolean retryEnabled;
 
@@ -44,14 +48,92 @@ public class OdooRetryJob {
             fixedDelayString = "${org.openelisglobal.odoo.retry.interval:300000}" // Default: 5 minutes
     )
     public void retryFailedSyncs() {
-        if (!retryEnabled) {
+        runRetry(false);
+    }
+
+    /**
+     * Process a single queue entry
+     * 
+     * @param queueEntry The queue entry to process
+     * @return true if successful, false otherwise
+     */
+    private boolean processQueueEntry(OdooSyncQueue queueEntry) {
+        log.info("Processing queue entry {} for accession number: {} (attempt {}/{})", queueEntry.getId(),
+                queueEntry.getAccessionNumber(), queueEntry.getRetryCount() + 1, queueEntry.getMaxRetries());
+
+        try {
+            odooSyncQueueService.markAsProcessing(queueEntry);
+
+            Map<String, Object> invoiceData = odooSyncQueueService.getInvoiceDataAsMap(queueEntry);
+
+            Integer partnerId = extractPartnerId(invoiceData);
+            if (!odooIntegrationService.partnerExists(partnerId)) {
+                log.warn(
+                        "Partner {} referenced by queue entry {} not found in Odoo. Attempting to refresh partner reference.",
+                        partnerId, queueEntry.getId());
+                Integer refreshedPartnerId = odooIntegrationService.ensurePartnerForQueueEntry(queueEntry);
+                if (refreshedPartnerId == null) {
+                    throw new RuntimeException("Unable to refresh partner for queue entry " + queueEntry.getId()
+                            + ". Partner data missing.");
+                }
+                invoiceData.put("partner_id", refreshedPartnerId);
+                odooSyncQueueService.updateInvoiceData(queueEntry, invoiceData);
+                partnerId = refreshedPartnerId;
+            }
+
+            Integer invoiceId = odooConnection.create("account.move", List.of(invoiceData));
+
+            if (invoiceId == null) {
+                throw new RuntimeException("Odoo returned null invoice ID");
+            }
+
+            odooSyncQueueService.markAsCompleted(queueEntry, invoiceId);
+            log.info("Successfully synced queue entry {} with Odoo invoice ID: {}", queueEntry.getId(), invoiceId);
+            return true;
+
+        } catch (JsonProcessingException e) {
+            log.error("Error deserializing invoice data for queue entry {}: {}", queueEntry.getId(), e.getMessage(), e);
+            odooSyncQueueService.markRetryFailed(queueEntry, "Failed to deserialize invoice data: " + e.getMessage());
+            return false;
+
+        } catch (Exception e) {
+            log.error("Error syncing queue entry {} to Odoo: {}", queueEntry.getId(), e.getMessage(), e);
+            odooSyncQueueService.markRetryFailed(queueEntry, "Odoo sync failed: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public String triggerManualRetry() {
+        log.info("Manual Odoo retry job triggered");
+        RetryRunStatus status = runRetry(true);
+
+        if (!status.executed) {
+            if (status.message != null) {
+                return status.message;
+            }
+            return String.format("Odoo retry job skipped. Pending: %d, Failed: %d", status.pending, status.failed);
+        }
+
+        return String.format("Odoo retry job completed. Pending: %d, Failed: %d", status.pending, status.failed);
+    }
+
+    private RetryRunStatus runRetry(boolean forceRun) {
+        RetryRunStatus status = new RetryRunStatus();
+
+        if (!forceRun && !retryEnabled) {
             log.debug("Odoo retry job is disabled");
-            return;
+            status.message = "Odoo retry job is disabled by configuration";
+            status.pending = odooSyncQueueService.getPendingCount();
+            status.failed = odooSyncQueueService.getFailedCount();
+            return status;
         }
 
         if (!odooConnection.isAvailable()) {
             log.warn("Odoo connection is not available. Skipping retry job execution.");
-            return;
+            status.message = "Odoo connection is not available. Skipping retry job execution.";
+            status.pending = odooSyncQueueService.getPendingCount();
+            status.failed = odooSyncQueueService.getFailedCount();
+            return status;
         }
 
         try {
@@ -59,7 +141,10 @@ public class OdooRetryJob {
 
             if (pendingEntries.isEmpty()) {
                 log.debug("No pending Odoo sync requests to process");
-                return;
+                status.message = "No pending Odoo sync requests to process";
+                status.pending = 0;
+                status.failed = odooSyncQueueService.getFailedCount();
+                return status;
             }
 
             log.info("Found {} pending Odoo sync requests. Processing up to {} entries...", pendingEntries.size(),
@@ -91,6 +176,10 @@ public class OdooRetryJob {
             int remainingPending = odooSyncQueueService.getPendingCount();
             int permanentlyFailed = odooSyncQueueService.getFailedCount();
 
+            status.executed = true;
+            status.pending = remainingPending;
+            status.failed = permanentlyFailed;
+
             if (remainingPending > 0 || permanentlyFailed > 0) {
                 log.warn("Odoo sync queue status - Pending: {}, Permanently Failed: {}", remainingPending,
                         permanentlyFailed);
@@ -98,58 +187,45 @@ public class OdooRetryJob {
 
         } catch (Exception e) {
             log.error("Error in Odoo retry job: {}", e.getMessage(), e);
+            status.message = "Error occurred during Odoo retry job: " + e.getMessage();
+            status.pending = odooSyncQueueService.getPendingCount();
+            status.failed = odooSyncQueueService.getFailedCount();
         }
+
+        return status;
     }
 
-    /**
-     * Process a single queue entry
-     * 
-     * @param queueEntry The queue entry to process
-     * @return true if successful, false otherwise
-     */
-    private boolean processQueueEntry(OdooSyncQueue queueEntry) {
-        log.info("Processing queue entry {} for accession number: {} (attempt {}/{})", queueEntry.getId(),
-                queueEntry.getAccessionNumber(), queueEntry.getRetryCount() + 1, queueEntry.getMaxRetries());
+    private static class RetryRunStatus {
+        private boolean executed;
+        private int pending;
+        private int failed;
+        private String message;
+    }
 
-        try {
-            odooSyncQueueService.markAsProcessing(queueEntry);
-
-            Map<String, Object> invoiceData = odooSyncQueueService.getInvoiceDataAsMap(queueEntry);
-
-            Integer invoiceId = odooConnection.create("account.move", List.of(invoiceData));
-
-            if (invoiceId == null) {
-                throw new RuntimeException("Odoo returned null invoice ID");
+    private Integer extractPartnerId(Map<String, Object> invoiceData) {
+        if (invoiceData == null) {
+            return null;
+        }
+        Object partnerValue = invoiceData.get("partner_id");
+        if (partnerValue instanceof Integer) {
+            return (Integer) partnerValue;
+        }
+        if (partnerValue instanceof Number) {
+            return ((Number) partnerValue).intValue();
+        }
+        if (partnerValue instanceof String) {
+            try {
+                return Integer.parseInt(((String) partnerValue).trim());
+            } catch (NumberFormatException e) {
+                log.warn("Unable to parse partner_id '{}' from invoice data as integer", partnerValue);
             }
-
-            odooSyncQueueService.markAsCompleted(queueEntry, invoiceId);
-            log.info("Successfully synced queue entry {} with Odoo invoice ID: {}", queueEntry.getId(), invoiceId);
-            return true;
-
-        } catch (JsonProcessingException e) {
-            log.error("Error deserializing invoice data for queue entry {}: {}", queueEntry.getId(), e.getMessage(), e);
-            odooSyncQueueService.markRetryFailed(queueEntry, "Failed to deserialize invoice data: " + e.getMessage());
-            return false;
-
-        } catch (Exception e) {
-            log.error("Error syncing queue entry {} to Odoo: {}", queueEntry.getId(), e.getMessage(), e);
-            odooSyncQueueService.markRetryFailed(queueEntry, "Odoo sync failed: " + e.getMessage());
-            return false;
         }
-    }
-
-    /**
-     * Manual trigger for retry job (can be called from admin interface)
-     * 
-     * @return Summary message
-     */
-    public String triggerManualRetry() {
-        log.info("Manual Odoo retry job triggered");
-        retryFailedSyncs();
-
-        int pending = odooSyncQueueService.getPendingCount();
-        int failed = odooSyncQueueService.getFailedCount();
-
-        return String.format("Odoo retry job completed. Pending: %d, Failed: %d", pending, failed);
+        if (partnerValue instanceof List) {
+            List<?> values = (List<?>) partnerValue;
+            if (!values.isEmpty() && values.get(0) instanceof Number) {
+                return ((Number) values.get(0)).intValue();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
+++ b/src/main/java/org/openelisglobal/odoo/scheduler/OdooRetryJob.java
@@ -11,13 +11,11 @@ import org.openelisglobal.odoo.service.OdooIntegrationService;
 import org.openelisglobal.odoo.service.OdooSyncQueueService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Scheduled job to retry failed Odoo synchronization attempts. Runs
- * periodically to process pending queue entries and attempt to sync them with
- * Odoo.
+ * Handles manual retries of failed Odoo synchronization attempts. Queued
+ * entries are processed on demand through the admin-triggered retry endpoint.
  */
 @Component
 public class OdooRetryJob {
@@ -33,23 +31,8 @@ public class OdooRetryJob {
     @Autowired
     private OdooIntegrationService odooIntegrationService;
 
-    @Value("${org.openelisglobal.odoo.retry.enabled:false}")
-    private boolean retryEnabled;
-
     @Value("${org.openelisglobal.odoo.retry.batchSize:10}")
     private int batchSize;
-
-    /**
-     * Scheduled method to process pending Odoo sync queue entries. Runs every 5
-     * minutes by default (300000 milliseconds). Can be configured via property:
-     * org.openelisglobal.odoo.retry.interval
-     */
-    @Scheduled(initialDelay = 60000, // Start 1 minute after application startup
-            fixedDelayString = "${org.openelisglobal.odoo.retry.interval:300000}" // Default: 5 minutes
-    )
-    public void retryFailedSyncs() {
-        runRetry(false);
-    }
 
     /**
      * Process a single queue entry
@@ -105,7 +88,7 @@ public class OdooRetryJob {
 
     public String triggerManualRetry() {
         log.info("Manual Odoo retry job triggered");
-        RetryRunStatus status = runRetry(true);
+        RetryRunStatus status = runRetry();
 
         if (!status.executed) {
             if (status.message != null) {
@@ -117,16 +100,8 @@ public class OdooRetryJob {
         return String.format("Odoo retry job completed. Pending: %d, Failed: %d", status.pending, status.failed);
     }
 
-    private RetryRunStatus runRetry(boolean forceRun) {
+    private RetryRunStatus runRetry() {
         RetryRunStatus status = new RetryRunStatus();
-
-        if (!forceRun && !retryEnabled) {
-            log.debug("Odoo retry job is disabled");
-            status.message = "Odoo retry job is disabled by configuration";
-            status.pending = odooSyncQueueService.getPendingCount();
-            status.failed = odooSyncQueueService.getFailedCount();
-            return status;
-        }
 
         if (!odooConnection.isAvailable()) {
             log.warn("Odoo connection is not available. Skipping retry job execution.");

--- a/src/main/java/org/openelisglobal/odoo/service/OdooIntegrationService.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooIntegrationService.java
@@ -12,11 +12,13 @@ import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.ConfigurationProperties.Property;
 import org.openelisglobal.odoo.client.OdooConnection;
 import org.openelisglobal.odoo.config.TestProductMapping;
+import org.openelisglobal.odoo.entity.OdooSyncQueue;
 import org.openelisglobal.odoo.exception.OdooOperationException;
 import org.openelisglobal.patient.service.PatientService;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.person.valueholder.Person;
 import org.openelisglobal.sample.action.util.SamplePatientUpdateData;
+import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.samplehuman.service.SampleHumanService;
 import org.openelisglobal.spring.util.SpringContext;
@@ -45,6 +47,9 @@ public class OdooIntegrationService {
 
     @Autowired
     private PatientService patientService;
+
+    @Autowired
+    private SampleService sampleService;
 
     @Autowired
     private OdooSyncQueueService odooSyncQueueService;
@@ -378,5 +383,91 @@ public class OdooIntegrationService {
             }
         }
         return invoiceLines;
+    }
+
+    public boolean partnerExists(Integer partnerId) {
+        if (partnerId == null) {
+            return false;
+        }
+
+        try {
+            Object[] result = odooConnection.searchAndRead("res.partner", List.of("id", "=", partnerId), List.of("id"));
+            return result != null && result.length > 0;
+        } catch (Exception e) {
+            log.error("Error verifying existence of partner {}: {}", partnerId, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    public Integer ensurePartnerForQueueEntry(OdooSyncQueue queueEntry) {
+        Sample sample = resolveSample(queueEntry);
+        if (sample == null) {
+            log.warn("Unable to resolve sample for Odoo queue entry {}. Partner cannot be refreshed.",
+                    queueEntry.getId());
+            return null;
+        }
+
+        Patient patient = sampleHumanService.getPatientForSample(sample);
+        if (patient == null) {
+            log.warn("No patient found for sample {} when refreshing partner for queue entry {}", sample.getId(),
+                    queueEntry.getId());
+            return null;
+        }
+
+        Person person = patient.getPerson();
+        if (person == null) {
+            log.warn("No person associated with patient {} when refreshing partner for queue entry {}", patient.getId(),
+                    queueEntry.getId());
+            return null;
+        }
+
+        String nationalId = patientService.getNationalId(patient);
+        if (nationalId != null && !nationalId.trim().isEmpty()) {
+            Integer existingPartnerId = findPartnerByNationalId(nationalId);
+            if (existingPartnerId != null) {
+                return existingPartnerId;
+            }
+        }
+
+        Integer partnerFromName = findPartnerByName(person.getFirstName(), person.getLastName());
+        if (partnerFromName != null) {
+            return partnerFromName;
+        }
+
+        Map<String, Object> partnerData = createPartnerData(patient, person);
+        Integer partnerId = odooConnection.create("res.partner", List.of(partnerData));
+
+        if (partnerId == null) {
+            log.warn("Odoo returned null partner ID when recreating partner for queue entry {}", queueEntry.getId());
+            return null;
+        }
+
+        log.info("Created new partner {} while processing queue entry {}", partnerId, queueEntry.getId());
+        return partnerId;
+    }
+
+    private Sample resolveSample(OdooSyncQueue queueEntry) {
+        try {
+            if (queueEntry.getSampleId() != null && !queueEntry.getSampleId().trim().isEmpty()) {
+                Sample sample = sampleService.get(queueEntry.getSampleId());
+                if (sample != null) {
+                    return sample;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to load sample {} for queue entry {}: {}", queueEntry.getSampleId(), queueEntry.getId(),
+                    e.getMessage());
+        }
+
+        try {
+            if (queueEntry.getAccessionNumber() != null && !queueEntry.getAccessionNumber().trim().isEmpty()) {
+                return sampleService.getSampleByAccessionNumber(queueEntry.getAccessionNumber());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to load sample by accession {} for queue entry {}: {}", queueEntry.getAccessionNumber(),
+                    queueEntry.getId(), e.getMessage());
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/openelisglobal/odoo/service/OdooIntegrationService.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooIntegrationService.java
@@ -26,11 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-/**
- * Service class for integrating OpenELIS with Odoo for billing functionality.
- * This service handles the creation of invoices in Odoo when orders are created
- * in OpenELIS.
- */
 @Service
 public class OdooIntegrationService {
 
@@ -63,10 +58,23 @@ public class OdooIntegrationService {
      *                                queue is disabled
      */
     public void createInvoice(SamplePatientUpdateData updateData) {
-        // Check if Odoo connection is available
+        boolean queueEnabled = ConfigurationProperties.getInstance().isPropertyValueEqual(Property.ENABLE_ODOO_QUEUE,
+                "true");
+
         if (!odooConnection.isAvailable()) {
-            log.info("Odoo connection is not available. Skipping invoice creation for sample: {}",
-                    updateData.getAccessionNumber());
+            String accessionNumber = updateData.getAccessionNumber();
+            if (queueEnabled) {
+                try {
+                    Map<String, Object> invoiceData = createInvoiceData(updateData);
+                    odooSyncQueueService.queueFailedSync(updateData, invoiceData, "Odoo connection is not available");
+                    log.info("Odoo connection unavailable. Queued invoice for automatic retry: {}", accessionNumber);
+                } catch (Exception queueError) {
+                    log.error("Failed to queue Odoo sync when connection is unavailable for sample {}: {}",
+                            accessionNumber, queueError.getMessage(), queueError);
+                }
+            } else {
+                log.info("Odoo connection is not available. Skipping invoice creation for sample: {}", accessionNumber);
+            }
             return;
         }
 
@@ -83,15 +91,11 @@ public class OdooIntegrationService {
             log.error("Error creating invoice in Odoo for sample {}: {}", updateData.getAccessionNumber(),
                     e.getMessage(), e);
 
-            // Check if queueing is enabled
-            boolean queueEnabled = ConfigurationProperties.getInstance()
-                    .isPropertyValueEqual(Property.ENABLE_ODOO_QUEUE, "true");
             if (queueEnabled) {
                 try {
                     Map<String, Object> invoiceData = createInvoiceData(updateData);
                     odooSyncQueueService.queueFailedSync(updateData, invoiceData, e.getMessage());
                     log.info("Queued failed Odoo sync for automatic retry: {}", updateData.getAccessionNumber());
-                    // Don't throw exception - we've queued it for retry
                 } catch (Exception queueError) {
                     log.error("Failed to queue Odoo sync for retry: {}", queueError.getMessage(), queueError);
                     throw new OdooOperationException("Failed to create invoice in Odoo and failed to queue for retry",

--- a/src/main/java/org/openelisglobal/odoo/service/OdooIntegrationService.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooIntegrationService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openelisglobal.common.services.SampleAddService.SampleTestCollection;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.common.util.ConfigurationProperties.Property;
 import org.openelisglobal.odoo.client.OdooConnection;
 import org.openelisglobal.odoo.config.TestProductMapping;
 import org.openelisglobal.odoo.exception.OdooOperationException;
@@ -33,6 +35,7 @@ import org.springframework.stereotype.Service;
 public class OdooIntegrationService {
 
     private static final Logger log = LogManager.getLogger(OdooIntegrationService.class);
+
     @Value("${org.openelisglobal.odoo.map.testname.locale:en}")
     private String testMapLocale;
 
@@ -48,11 +51,16 @@ public class OdooIntegrationService {
     @Autowired
     private PatientService patientService;
 
+    @Autowired
+    private OdooSyncQueueService odooSyncQueueService;
+
     /**
-     * Creates an invoice in Odoo for the given sample data.
+     * Creates an invoice in Odoo for the given sample data. If the sync fails and
+     * queue is enabled, the request will be queued for automatic retry.
      * 
      * @param updateData The sample data containing order information
-     * @throws OdooOperationException if there's an error creating the invoice
+     * @throws OdooOperationException if there's an error creating the invoice and
+     *                                queue is disabled
      */
     public void createInvoice(SamplePatientUpdateData updateData) {
         // Check if Odoo connection is available
@@ -74,7 +82,24 @@ public class OdooIntegrationService {
         } catch (Exception e) {
             log.error("Error creating invoice in Odoo for sample {}: {}", updateData.getAccessionNumber(),
                     e.getMessage(), e);
-            throw new OdooOperationException("Failed to create invoice in Odoo", e);
+
+            // Check if queueing is enabled
+            boolean queueEnabled = ConfigurationProperties.getInstance()
+                    .isPropertyValueEqual(Property.ENABLE_ODOO_QUEUE, "true");
+            if (queueEnabled) {
+                try {
+                    Map<String, Object> invoiceData = createInvoiceData(updateData);
+                    odooSyncQueueService.queueFailedSync(updateData, invoiceData, e.getMessage());
+                    log.info("Queued failed Odoo sync for automatic retry: {}", updateData.getAccessionNumber());
+                    // Don't throw exception - we've queued it for retry
+                } catch (Exception queueError) {
+                    log.error("Failed to queue Odoo sync for retry: {}", queueError.getMessage(), queueError);
+                    throw new OdooOperationException("Failed to create invoice in Odoo and failed to queue for retry",
+                            e);
+                }
+            } else {
+                throw new OdooOperationException("Failed to create invoice in Odoo", e);
+            }
         }
     }
 

--- a/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
@@ -8,10 +8,6 @@ import org.openelisglobal.odoo.entity.OdooSyncQueue;
 import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
 import org.openelisglobal.sample.action.util.SamplePatientUpdateData;
 
-/**
- * Service interface for managing Odoo sync queue operations. Handles queueing,
- * retry logic, and status management for failed Odoo syncs.
- */
 public interface OdooSyncQueueService extends BaseObjectService<OdooSyncQueue, Long> {
 
     /**

--- a/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
@@ -1,43 +1,18 @@
 package org.openelisglobal.odoo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.openelisglobal.common.service.BaseObjectServiceImpl;
-import org.openelisglobal.odoo.dao.OdooSyncQueueDAO;
+import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.odoo.entity.OdooSyncQueue;
 import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
 import org.openelisglobal.sample.action.util.SamplePatientUpdateData;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Service class for managing Odoo sync queue operations. Handles queueing,
+ * Service interface for managing Odoo sync queue operations. Handles queueing,
  * retry logic, and status management for failed Odoo syncs.
  */
-@Service
-public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, Long> {
-
-    private static final Logger log = LogManager.getLogger(OdooSyncQueueService.class);
-
-    @Autowired
-    private OdooSyncQueueDAO baseObjectDAO;
-
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    public OdooSyncQueueService() {
-        super(OdooSyncQueue.class);
-    }
-
-    @Override
-    protected OdooSyncQueueDAO getBaseObjectDAO() {
-        return baseObjectDAO;
-    }
+public interface OdooSyncQueueService extends BaseObjectService<OdooSyncQueue, Long> {
 
     /**
      * Queue a failed invoice sync for later retry
@@ -47,45 +22,15 @@ public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, L
      * @param errorMessage The error message from the failure
      * @return The created queue entry
      */
-    @Transactional
-    public OdooSyncQueue queueFailedSync(SamplePatientUpdateData updateData, Map<String, Object> invoiceData,
-            String errorMessage) {
-        try {
-            OdooSyncQueue queueEntry = new OdooSyncQueue();
-            queueEntry.setAccessionNumber(updateData.getAccessionNumber());
-
-            if (updateData.getSample() != null) {
-                queueEntry.setSampleId(updateData.getSample().getId());
-            }
-
-            // Serialize invoice data to JSON
-            String invoiceDataJson = objectMapper.writeValueAsString(invoiceData);
-            queueEntry.setInvoiceData(invoiceDataJson);
-
-            queueEntry.setStatus(SyncStatus.PENDING);
-            queueEntry.setErrorMessage(errorMessage);
-            queueEntry.setCreatedDate(new Timestamp(System.currentTimeMillis()));
-
-            Long id = insert(queueEntry);
-            log.info("Queued failed Odoo sync for accession number: {} with queue ID: {}",
-                    updateData.getAccessionNumber(), id);
-
-            return get(id);
-        } catch (JsonProcessingException e) {
-            log.error("Error serializing invoice data for accession number: {}", updateData.getAccessionNumber(), e);
-            throw new RuntimeException("Failed to serialize invoice data", e);
-        }
-    }
+    OdooSyncQueue queueFailedSync(SamplePatientUpdateData updateData, Map<String, Object> invoiceData,
+            String errorMessage);
 
     /**
      * Get all pending sync requests that need to be retried
      * 
      * @return List of pending sync queue entries
      */
-    @Transactional(readOnly = true)
-    public List<OdooSyncQueue> getPendingSyncRequests() {
-        return baseObjectDAO.getPendingSyncRequests();
-    }
+    List<OdooSyncQueue> getPendingSyncRequests();
 
     /**
      * Get sync requests by status
@@ -93,10 +38,7 @@ public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, L
      * @param status The sync status to filter by
      * @return List of sync queue entries with the specified status
      */
-    @Transactional(readOnly = true)
-    public List<OdooSyncQueue> getByStatus(SyncStatus status) {
-        return baseObjectDAO.getByStatus(status);
-    }
+    List<OdooSyncQueue> getByStatus(SyncStatus status);
 
     /**
      * Get sync requests by accession number
@@ -104,33 +46,21 @@ public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, L
      * @param accessionNumber The accession number to search for
      * @return List of sync queue entries for the accession number
      */
-    @Transactional(readOnly = true)
-    public List<OdooSyncQueue> getByAccessionNumber(String accessionNumber) {
-        return baseObjectDAO.getByAccessionNumber(accessionNumber);
-    }
+    List<OdooSyncQueue> getByAccessionNumber(String accessionNumber);
 
     /**
      * Get all failed sync requests (after max retries)
      * 
      * @return List of permanently failed sync queue entries
      */
-    @Transactional(readOnly = true)
-    public List<OdooSyncQueue> getFailedSyncRequests() {
-        return baseObjectDAO.getFailedSyncRequests();
-    }
+    List<OdooSyncQueue> getFailedSyncRequests();
 
     /**
      * Mark a sync request as processing
      * 
      * @param queueEntry The queue entry to mark
      */
-    @Transactional
-    public void markAsProcessing(OdooSyncQueue queueEntry) {
-        queueEntry.setStatus(SyncStatus.PROCESSING);
-        queueEntry.setLastRetryDate(new Timestamp(System.currentTimeMillis()));
-        update(queueEntry);
-        log.debug("Marked queue entry {} as processing", queueEntry.getId());
-    }
+    void markAsProcessing(OdooSyncQueue queueEntry);
 
     /**
      * Mark a sync request as completed
@@ -138,13 +68,7 @@ public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, L
      * @param queueEntry The queue entry to mark
      * @param invoiceId  The Odoo invoice ID
      */
-    @Transactional
-    public void markAsCompleted(OdooSyncQueue queueEntry, Integer invoiceId) {
-        queueEntry.markCompleted(invoiceId);
-        update(queueEntry);
-        log.info("Successfully synced queue entry {} for accession number: {} with Odoo invoice ID: {}",
-                queueEntry.getId(), queueEntry.getAccessionNumber(), invoiceId);
-    }
+    void markAsCompleted(OdooSyncQueue queueEntry, Integer invoiceId);
 
     /**
      * Mark a sync request as failed after a retry attempt
@@ -152,23 +76,7 @@ public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, L
      * @param queueEntry   The queue entry to mark
      * @param errorMessage The error message from the retry attempt
      */
-    @Transactional
-    public void markRetryFailed(OdooSyncQueue queueEntry, String errorMessage) {
-        queueEntry.incrementRetryCount();
-        queueEntry.setErrorMessage(errorMessage);
-
-        if (queueEntry.hasExceededMaxRetries()) {
-            queueEntry.markFailed(errorMessage);
-            log.error("Queue entry {} for accession number {} has exceeded max retries. Marking as FAILED.",
-                    queueEntry.getId(), queueEntry.getAccessionNumber());
-        } else {
-            queueEntry.setStatus(SyncStatus.PENDING);
-            log.warn("Retry attempt {} failed for queue entry {} (accession: {}). Will retry again.",
-                    queueEntry.getRetryCount(), queueEntry.getId(), queueEntry.getAccessionNumber());
-        }
-
-        update(queueEntry);
-    }
+    void markRetryFailed(OdooSyncQueue queueEntry, String errorMessage);
 
     /**
      * Get the invoice data from a queue entry as a Map
@@ -177,42 +85,26 @@ public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, L
      * @return The invoice data as a Map
      * @throws JsonProcessingException if deserialization fails
      */
-    @SuppressWarnings("unchecked")
-    public Map<String, Object> getInvoiceDataAsMap(OdooSyncQueue queueEntry) throws JsonProcessingException {
-        return objectMapper.readValue(queueEntry.getInvoiceData(), Map.class);
-    }
+    Map<String, Object> getInvoiceDataAsMap(OdooSyncQueue queueEntry) throws JsonProcessingException;
 
     /**
      * Reset a failed queue entry to pending (for manual retry)
      * 
      * @param queueEntry The queue entry to reset
      */
-    @Transactional
-    public void resetToPending(OdooSyncQueue queueEntry) {
-        queueEntry.setStatus(SyncStatus.PENDING);
-        queueEntry.setRetryCount(0);
-        queueEntry.setErrorMessage(null);
-        update(queueEntry);
-        log.info("Reset queue entry {} to PENDING for manual retry", queueEntry.getId());
-    }
+    void resetToPending(OdooSyncQueue queueEntry);
 
     /**
      * Get count of pending sync requests
      * 
      * @return The count of pending requests
      */
-    @Transactional(readOnly = true)
-    public int getPendingCount() {
-        return getPendingSyncRequests().size();
-    }
+    int getPendingCount();
 
     /**
      * Get count of failed sync requests
      * 
      * @return The count of failed requests
      */
-    @Transactional(readOnly = true)
-    public int getFailedCount() {
-        return getFailedSyncRequests().size();
-    }
+    int getFailedCount();
 }

--- a/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
@@ -1,0 +1,219 @@
+package org.openelisglobal.odoo.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.odoo.dao.OdooSyncQueueDAO;
+import org.openelisglobal.odoo.entity.OdooSyncQueue;
+import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
+import org.openelisglobal.sample.action.util.SamplePatientUpdateData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service class for managing Odoo sync queue operations. Handles queueing,
+ * retry logic, and status management for failed Odoo syncs.
+ */
+@Service
+public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, Long> {
+
+    private static final Logger log = LogManager.getLogger(OdooSyncQueueService.class);
+
+    @Autowired
+    private OdooSyncQueueDAO baseObjectDAO;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public OdooSyncQueueService() {
+        super(OdooSyncQueue.class);
+    }
+
+    @Override
+    protected OdooSyncQueueDAO getBaseObjectDAO() {
+        return baseObjectDAO;
+    }
+
+    /**
+     * Queue a failed invoice sync for later retry
+     * 
+     * @param updateData   The sample patient update data
+     * @param invoiceData  The invoice data that failed to sync
+     * @param errorMessage The error message from the failure
+     * @return The created queue entry
+     */
+    @Transactional
+    public OdooSyncQueue queueFailedSync(SamplePatientUpdateData updateData, Map<String, Object> invoiceData,
+            String errorMessage) {
+        try {
+            OdooSyncQueue queueEntry = new OdooSyncQueue();
+            queueEntry.setAccessionNumber(updateData.getAccessionNumber());
+
+            if (updateData.getSample() != null) {
+                queueEntry.setSampleId(updateData.getSample().getId());
+            }
+
+            // Serialize invoice data to JSON
+            String invoiceDataJson = objectMapper.writeValueAsString(invoiceData);
+            queueEntry.setInvoiceData(invoiceDataJson);
+
+            queueEntry.setStatus(SyncStatus.PENDING);
+            queueEntry.setErrorMessage(errorMessage);
+            queueEntry.setCreatedDate(new Timestamp(System.currentTimeMillis()));
+
+            Long id = insert(queueEntry);
+            log.info("Queued failed Odoo sync for accession number: {} with queue ID: {}",
+                    updateData.getAccessionNumber(), id);
+
+            return get(id);
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing invoice data for accession number: {}", updateData.getAccessionNumber(), e);
+            throw new RuntimeException("Failed to serialize invoice data", e);
+        }
+    }
+
+    /**
+     * Get all pending sync requests that need to be retried
+     * 
+     * @return List of pending sync queue entries
+     */
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getPendingSyncRequests() {
+        return baseObjectDAO.getPendingSyncRequests();
+    }
+
+    /**
+     * Get sync requests by status
+     * 
+     * @param status The sync status to filter by
+     * @return List of sync queue entries with the specified status
+     */
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getByStatus(SyncStatus status) {
+        return baseObjectDAO.getByStatus(status);
+    }
+
+    /**
+     * Get sync requests by accession number
+     * 
+     * @param accessionNumber The accession number to search for
+     * @return List of sync queue entries for the accession number
+     */
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getByAccessionNumber(String accessionNumber) {
+        return baseObjectDAO.getByAccessionNumber(accessionNumber);
+    }
+
+    /**
+     * Get all failed sync requests (after max retries)
+     * 
+     * @return List of permanently failed sync queue entries
+     */
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getFailedSyncRequests() {
+        return baseObjectDAO.getFailedSyncRequests();
+    }
+
+    /**
+     * Mark a sync request as processing
+     * 
+     * @param queueEntry The queue entry to mark
+     */
+    @Transactional
+    public void markAsProcessing(OdooSyncQueue queueEntry) {
+        queueEntry.setStatus(SyncStatus.PROCESSING);
+        queueEntry.setLastRetryDate(new Timestamp(System.currentTimeMillis()));
+        update(queueEntry);
+        log.debug("Marked queue entry {} as processing", queueEntry.getId());
+    }
+
+    /**
+     * Mark a sync request as completed
+     * 
+     * @param queueEntry The queue entry to mark
+     * @param invoiceId  The Odoo invoice ID
+     */
+    @Transactional
+    public void markAsCompleted(OdooSyncQueue queueEntry, Integer invoiceId) {
+        queueEntry.markCompleted(invoiceId);
+        update(queueEntry);
+        log.info("Successfully synced queue entry {} for accession number: {} with Odoo invoice ID: {}",
+                queueEntry.getId(), queueEntry.getAccessionNumber(), invoiceId);
+    }
+
+    /**
+     * Mark a sync request as failed after a retry attempt
+     * 
+     * @param queueEntry   The queue entry to mark
+     * @param errorMessage The error message from the retry attempt
+     */
+    @Transactional
+    public void markRetryFailed(OdooSyncQueue queueEntry, String errorMessage) {
+        queueEntry.incrementRetryCount();
+        queueEntry.setErrorMessage(errorMessage);
+
+        if (queueEntry.hasExceededMaxRetries()) {
+            queueEntry.markFailed(errorMessage);
+            log.error("Queue entry {} for accession number {} has exceeded max retries. Marking as FAILED.",
+                    queueEntry.getId(), queueEntry.getAccessionNumber());
+        } else {
+            queueEntry.setStatus(SyncStatus.PENDING);
+            log.warn("Retry attempt {} failed for queue entry {} (accession: {}). Will retry again.",
+                    queueEntry.getRetryCount(), queueEntry.getId(), queueEntry.getAccessionNumber());
+        }
+
+        update(queueEntry);
+    }
+
+    /**
+     * Get the invoice data from a queue entry as a Map
+     * 
+     * @param queueEntry The queue entry
+     * @return The invoice data as a Map
+     * @throws JsonProcessingException if deserialization fails
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getInvoiceDataAsMap(OdooSyncQueue queueEntry) throws JsonProcessingException {
+        return objectMapper.readValue(queueEntry.getInvoiceData(), Map.class);
+    }
+
+    /**
+     * Reset a failed queue entry to pending (for manual retry)
+     * 
+     * @param queueEntry The queue entry to reset
+     */
+    @Transactional
+    public void resetToPending(OdooSyncQueue queueEntry) {
+        queueEntry.setStatus(SyncStatus.PENDING);
+        queueEntry.setRetryCount(0);
+        queueEntry.setErrorMessage(null);
+        update(queueEntry);
+        log.info("Reset queue entry {} to PENDING for manual retry", queueEntry.getId());
+    }
+
+    /**
+     * Get count of pending sync requests
+     * 
+     * @return The count of pending requests
+     */
+    @Transactional(readOnly = true)
+    public int getPendingCount() {
+        return getPendingSyncRequests().size();
+    }
+
+    /**
+     * Get count of failed sync requests
+     * 
+     * @return The count of failed requests
+     */
+    @Transactional(readOnly = true)
+    public int getFailedCount() {
+        return getFailedSyncRequests().size();
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
@@ -24,7 +24,10 @@ public interface OdooSyncQueueService extends BaseObjectService<OdooSyncQueue, L
     /**
      * Get all pending sync requests that need to be retried
      * 
-     * @return List of pending sync queue entries
+     * Entries stuck in PROCESSING beyond the configured timeout are also returned
+     * for retry.
+     * 
+     * @return List of pending or stale processing sync queue entries
      */
     List<OdooSyncQueue> getPendingSyncRequests();
 
@@ -89,6 +92,14 @@ public interface OdooSyncQueueService extends BaseObjectService<OdooSyncQueue, L
      * @param queueEntry The queue entry to reset
      */
     void resetToPending(OdooSyncQueue queueEntry);
+
+    /**
+     * Update the stored invoice payload for a queue entry.
+     *
+     * @param queueEntry  The queue entry to update
+     * @param invoiceData The invoice payload to persist
+     */
+    void updateInvoiceData(OdooSyncQueue queueEntry, Map<String, Object> invoiceData);
 
     /**
      * Get count of pending sync requests

--- a/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueService.java
@@ -28,8 +28,7 @@ public class OdooSyncQueueService extends BaseObjectServiceImpl<OdooSyncQueue, L
     @Autowired
     private OdooSyncQueueDAO baseObjectDAO;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public OdooSyncQueueService() {
         super(OdooSyncQueue.class);

--- a/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueServiceImpl.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueServiceImpl.java
@@ -1,0 +1,162 @@
+package org.openelisglobal.odoo.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.odoo.dao.OdooSyncQueueDAO;
+import org.openelisglobal.odoo.entity.OdooSyncQueue;
+import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
+import org.openelisglobal.sample.action.util.SamplePatientUpdateData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service implementation for managing Odoo sync queue operations. Handles
+ * queueing, retry logic, and status management for failed Odoo syncs.
+ */
+@Service
+public class OdooSyncQueueServiceImpl extends BaseObjectServiceImpl<OdooSyncQueue, Long>
+        implements OdooSyncQueueService {
+
+    private static final Logger log = LogManager.getLogger(OdooSyncQueueServiceImpl.class);
+
+    @Autowired
+    private OdooSyncQueueDAO baseObjectDAO;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public OdooSyncQueueServiceImpl() {
+        super(OdooSyncQueue.class);
+    }
+
+    @Override
+    protected OdooSyncQueueDAO getBaseObjectDAO() {
+        return baseObjectDAO;
+    }
+
+    @Override
+    @Transactional
+    public OdooSyncQueue queueFailedSync(SamplePatientUpdateData updateData, Map<String, Object> invoiceData,
+            String errorMessage) {
+        try {
+            OdooSyncQueue queueEntry = new OdooSyncQueue();
+            queueEntry.setAccessionNumber(updateData.getAccessionNumber());
+
+            if (updateData.getSample() != null) {
+                queueEntry.setSampleId(updateData.getSample().getId());
+            }
+
+            // Serialize invoice data to JSON
+            String invoiceDataJson = objectMapper.writeValueAsString(invoiceData);
+            queueEntry.setInvoiceData(invoiceDataJson);
+
+            queueEntry.setStatus(SyncStatus.PENDING);
+            queueEntry.setErrorMessage(errorMessage);
+            queueEntry.setCreatedDate(new Timestamp(System.currentTimeMillis()));
+
+            Long id = insert(queueEntry);
+            log.info("Queued failed Odoo sync for accession number: {} with queue ID: {}",
+                    updateData.getAccessionNumber(), id);
+
+            return get(id);
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing invoice data for accession number: {}", updateData.getAccessionNumber(), e);
+            throw new RuntimeException("Failed to serialize invoice data", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getPendingSyncRequests() {
+        return baseObjectDAO.getPendingSyncRequests();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getByStatus(SyncStatus status) {
+        return baseObjectDAO.getByStatus(status);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getByAccessionNumber(String accessionNumber) {
+        return baseObjectDAO.getByAccessionNumber(accessionNumber);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OdooSyncQueue> getFailedSyncRequests() {
+        return baseObjectDAO.getFailedSyncRequests();
+    }
+
+    @Override
+    @Transactional
+    public void markAsProcessing(OdooSyncQueue queueEntry) {
+        queueEntry.setStatus(SyncStatus.PROCESSING);
+        queueEntry.setLastRetryDate(new Timestamp(System.currentTimeMillis()));
+        update(queueEntry);
+        log.debug("Marked queue entry {} as processing", queueEntry.getId());
+    }
+
+    @Override
+    @Transactional
+    public void markAsCompleted(OdooSyncQueue queueEntry, Integer invoiceId) {
+        queueEntry.markCompleted(invoiceId);
+        update(queueEntry);
+        log.info("Successfully synced queue entry {} for accession number: {} with Odoo invoice ID: {}",
+                queueEntry.getId(), queueEntry.getAccessionNumber(), invoiceId);
+    }
+
+    @Override
+    @Transactional
+    public void markRetryFailed(OdooSyncQueue queueEntry, String errorMessage) {
+        queueEntry.incrementRetryCount();
+        queueEntry.setErrorMessage(errorMessage);
+
+        if (queueEntry.hasExceededMaxRetries()) {
+            queueEntry.markFailed(errorMessage);
+            log.error("Queue entry {} for accession number {} has exceeded max retries. Marking as FAILED.",
+                    queueEntry.getId(), queueEntry.getAccessionNumber());
+        } else {
+            queueEntry.setStatus(SyncStatus.PENDING);
+            log.warn("Retry attempt {} failed for queue entry {} (accession: {}). Will retry again.",
+                    queueEntry.getRetryCount(), queueEntry.getId(), queueEntry.getAccessionNumber());
+        }
+
+        update(queueEntry);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getInvoiceDataAsMap(OdooSyncQueue queueEntry) throws JsonProcessingException {
+        return objectMapper.readValue(queueEntry.getInvoiceData(), Map.class);
+    }
+
+    @Override
+    @Transactional
+    public void resetToPending(OdooSyncQueue queueEntry) {
+        queueEntry.setStatus(SyncStatus.PENDING);
+        queueEntry.setRetryCount(0);
+        queueEntry.setErrorMessage(null);
+        update(queueEntry);
+        log.info("Reset queue entry {} to PENDING for manual retry", queueEntry.getId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public int getPendingCount() {
+        return getPendingSyncRequests().size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public int getFailedCount() {
+        return getFailedSyncRequests().size();
+    }
+}

--- a/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueServiceImpl.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueServiceImpl.java
@@ -3,6 +3,8 @@ package org.openelisglobal.odoo.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
@@ -13,6 +15,7 @@ import org.openelisglobal.odoo.entity.OdooSyncQueue;
 import org.openelisglobal.odoo.entity.OdooSyncQueue.SyncStatus;
 import org.openelisglobal.sample.action.util.SamplePatientUpdateData;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +29,9 @@ public class OdooSyncQueueServiceImpl extends BaseObjectServiceImpl<OdooSyncQueu
     private OdooSyncQueueDAO baseObjectDAO;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${org.openelisglobal.odoo.retry.processingTimeoutMinutes:1}")
+    private long processingTimeoutMinutes;
 
     public OdooSyncQueueServiceImpl() {
         super(OdooSyncQueue.class);
@@ -67,9 +73,12 @@ public class OdooSyncQueueServiceImpl extends BaseObjectServiceImpl<OdooSyncQueu
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public List<OdooSyncQueue> getPendingSyncRequests() {
-        return baseObjectDAO.getPendingSyncRequests();
+        long timeoutMinutes = Math.max(processingTimeoutMinutes, 0);
+        Instant cutoffInstant = Instant.now().minus(timeoutMinutes, ChronoUnit.MINUTES);
+        Timestamp cutoffTimestamp = Timestamp.from(cutoffInstant);
+        return baseObjectDAO.getPendingSyncRequests(cutoffTimestamp);
     }
 
     @Override
@@ -93,38 +102,37 @@ public class OdooSyncQueueServiceImpl extends BaseObjectServiceImpl<OdooSyncQueu
     @Override
     @Transactional
     public void markAsProcessing(OdooSyncQueue queueEntry) {
-        queueEntry.setStatus(SyncStatus.PROCESSING);
-        queueEntry.setLastRetryDate(new Timestamp(System.currentTimeMillis()));
-        update(queueEntry);
-        log.debug("Marked queue entry {} as processing", queueEntry.getId());
+        OdooSyncQueue managedEntry = get(queueEntry.getId());
+        managedEntry.setStatus(SyncStatus.PROCESSING);
+        managedEntry.setLastRetryDate(new Timestamp(System.currentTimeMillis()));
+        log.debug("Marked queue entry {} as processing", managedEntry.getId());
     }
 
     @Override
     @Transactional
     public void markAsCompleted(OdooSyncQueue queueEntry, Integer invoiceId) {
-        queueEntry.markCompleted(invoiceId);
-        update(queueEntry);
+        OdooSyncQueue managedEntry = get(queueEntry.getId());
+        managedEntry.markCompleted(invoiceId);
         log.info("Successfully synced queue entry {} for accession number: {} with Odoo invoice ID: {}",
-                queueEntry.getId(), queueEntry.getAccessionNumber(), invoiceId);
+                managedEntry.getId(), managedEntry.getAccessionNumber(), invoiceId);
     }
 
     @Override
     @Transactional
     public void markRetryFailed(OdooSyncQueue queueEntry, String errorMessage) {
-        queueEntry.incrementRetryCount();
-        queueEntry.setErrorMessage(errorMessage);
+        OdooSyncQueue managedEntry = get(queueEntry.getId());
+        managedEntry.incrementRetryCount();
+        managedEntry.setErrorMessage(errorMessage);
 
-        if (queueEntry.hasExceededMaxRetries()) {
-            queueEntry.markFailed(errorMessage);
+        if (managedEntry.hasExceededMaxRetries()) {
+            managedEntry.markFailed(errorMessage);
             log.error("Queue entry {} for accession number {} has exceeded max retries. Marking as FAILED.",
-                    queueEntry.getId(), queueEntry.getAccessionNumber());
+                    managedEntry.getId(), managedEntry.getAccessionNumber());
         } else {
-            queueEntry.setStatus(SyncStatus.PENDING);
+            managedEntry.setStatus(SyncStatus.PENDING);
             log.warn("Retry attempt {} failed for queue entry {} (accession: {}). Will retry again.",
-                    queueEntry.getRetryCount(), queueEntry.getId(), queueEntry.getAccessionNumber());
+                    managedEntry.getRetryCount(), managedEntry.getId(), managedEntry.getAccessionNumber());
         }
-
-        update(queueEntry);
     }
 
     @Override
@@ -136,11 +144,25 @@ public class OdooSyncQueueServiceImpl extends BaseObjectServiceImpl<OdooSyncQueu
     @Override
     @Transactional
     public void resetToPending(OdooSyncQueue queueEntry) {
-        queueEntry.setStatus(SyncStatus.PENDING);
-        queueEntry.setRetryCount(0);
-        queueEntry.setErrorMessage(null);
-        update(queueEntry);
-        log.info("Reset queue entry {} to PENDING for manual retry", queueEntry.getId());
+        OdooSyncQueue managedEntry = get(queueEntry.getId());
+        managedEntry.setStatus(SyncStatus.PENDING);
+        managedEntry.setRetryCount(0);
+        managedEntry.setErrorMessage(null);
+    }
+
+    @Override
+    @Transactional
+    public void updateInvoiceData(OdooSyncQueue queueEntry, Map<String, Object> invoiceData) {
+        OdooSyncQueue managedEntry = get(queueEntry.getId());
+        try {
+            String invoiceDataJson = objectMapper.writeValueAsString(invoiceData);
+            managedEntry.setInvoiceData(invoiceDataJson);
+            log.debug("Updated invoice data for queue entry {}", managedEntry.getId());
+        } catch (JsonProcessingException e) {
+            String message = String.format("Failed to serialize invoice data for queue entry %d", queueEntry.getId());
+            log.error(message, e);
+            throw new RuntimeException(message, e);
+        }
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueServiceImpl.java
+++ b/src/main/java/org/openelisglobal/odoo/service/OdooSyncQueueServiceImpl.java
@@ -16,10 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Service implementation for managing Odoo sync queue operations. Handles
- * queueing, retry logic, and status management for failed Odoo syncs.
- */
 @Service
 public class OdooSyncQueueServiceImpl extends BaseObjectServiceImpl<OdooSyncQueue, Long>
         implements OdooSyncQueueService {
@@ -52,7 +48,6 @@ public class OdooSyncQueueServiceImpl extends BaseObjectServiceImpl<OdooSyncQueu
                 queueEntry.setSampleId(updateData.getSample().getId());
             }
 
-            // Serialize invoice data to JSON
             String invoiceDataJson = objectMapper.writeValueAsString(invoiceData);
             queueEntry.setInvoiceData(invoiceDataJson);
 

--- a/src/main/resources/liquibase/3.1.x.x/base.xml
+++ b/src/main/resources/liquibase/3.1.x.x/base.xml
@@ -8,4 +8,6 @@
   <include relativeToChangelogFile="true" file="bar_code_config.xml" />
   <include relativeToChangelogFile="true" file="dictionary-loinc.xml"/>
   <include relativeToChangelogFile="true" file="enable_openelis_to_odoo_connection.xml" />
+  <include relativeToChangelogFile="true" file="odoo_sync_queue.xml"/>
+  <include relativeToChangelogFile="true" file="odoo_queue_config.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/3.1.x.x/odoo_queue_config.xml
+++ b/src/main/resources/liquibase/3.1.x.x/odoo_queue_config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <property name="now" value="now()" dbms="postgresql"/>
+
+    <changeSet author="mherman22" id="1">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from clinlims.site_information where name = 'enableOdooQueue'; </sqlCheck>
+        </preConditions>
+        <comment>Add configuration to enable Odoo sync queue for error recovery</comment>
+        <insert schemaName="clinlims" tableName="site_information">
+            <column name="id" valueSequenceNext="site_information_seq" />
+            <column name="name" value="enableOdooQueue" />
+            <column name="lastupdated" valueComputed="${now}" />
+            <column name="description" value="Enable Odoo sync queue for automatic retry of failed invoice syncs" />
+            <column name="encrypted" value="false" />
+            <column name="domain_id" valueComputed="(SELECT id FROM site_information_domain WHERE name = 'siteIdentity')" />
+            <column name="value_type" value="boolean" />
+            <column name="value" value="true" />
+            <column name="group" value="0" />
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.1.x.x/odoo_sync_queue.xml
+++ b/src/main/resources/liquibase/3.1.x.x/odoo_sync_queue.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet author="mherman22" id="1">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="odoo_sync_queue" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <comment>Create odoo_sync_queue table for storing failed Odoo synchronization attempts</comment>
+
+        <createSequence incrementBy="1" schemaName="clinlims"
+            sequenceName="odoo_sync_queue_seq" startValue="1" />
+
+        <createTable schemaName="clinlims" tableName="odoo_sync_queue">
+            <column name="id" type="BIGINT" valueSequenceNext="odoo_sync_queue_seq">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="accession_number" type="VARCHAR(50)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="sample_id" type="VARCHAR(20)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="invoice_data" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retry_count" type="INTEGER" defaultValueNumeric="0">
+                <constraints nullable="true"/>
+            </column>
+            <column name="max_retries" type="INTEGER" defaultValueNumeric="10">
+                <constraints nullable="true"/>
+            </column>
+            <column name="error_message" type="TEXT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="created_date" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+            <column name="last_retry_date" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+            <column name="completed_date" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+            <column name="odoo_invoice_id" type="INTEGER">
+                <constraints nullable="true"/>
+            </column>
+            <column name="last_updated" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+
+        <rollback>
+            <dropTable schemaName="clinlims" tableName="odoo_sync_queue"/>
+            <dropSequence schemaName="clinlims" sequenceName="odoo_sync_queue_seq"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelis" id="2">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_odoo_sync_queue_status" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <comment>Create index on status column for faster querying of pending sync requests</comment>
+
+        <createIndex indexName="idx_odoo_sync_queue_status" schemaName="clinlims" tableName="odoo_sync_queue">
+            <column name="status"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_odoo_sync_queue_status" schemaName="clinlims" tableName="odoo_sync_queue"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelis" id="3">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_odoo_sync_queue_accession" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <comment>Create index on accession_number for faster lookups</comment>
+
+        <createIndex indexName="idx_odoo_sync_queue_accession" schemaName="clinlims" tableName="odoo_sync_queue">
+            <column name="accession_number"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_odoo_sync_queue_accession" schemaName="clinlims" tableName="odoo_sync_queue"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelis" id="4">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_odoo_sync_queue_created_date" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <comment>Create index on created_date for ordering pending requests by creation time</comment>
+
+        <createIndex indexName="idx_odoo_sync_queue_created_date" schemaName="clinlims" tableName="odoo_sync_queue">
+            <column name="created_date"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_odoo_sync_queue_created_date" schemaName="clinlims" tableName="odoo_sync_queue"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.1.x.x/odoo_sync_queue.xml
+++ b/src/main/resources/liquibase/3.1.x.x/odoo_sync_queue.xml
@@ -64,7 +64,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="openelis" id="2">
+    <changeSet author="mherman22" id="2">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="idx_odoo_sync_queue_status" schemaName="clinlims"/>
@@ -81,7 +81,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="openelis" id="3">
+    <changeSet author="mherman22" id="3">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="idx_odoo_sync_queue_accession" schemaName="clinlims"/>
@@ -98,7 +98,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="openelis" id="4">
+    <changeSet author="mherman22" id="4">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="idx_odoo_sync_queue_created_date" schemaName="clinlims"/>


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Problem

Previously, if Odoo was down or unreachable when OpenELIS attempted to create an invoice, the invoice data would be lost permanently. This creates a critical gap in billing records and requires manual reconciliation.

## Solution

Added a queue-based retry system that automatically saves failed invoice sync attempts to the database and retries them periodically. The system includes:

- New `odoo_sync_queue` table stores failed sync attempts with full invoice data (serialized as JSON), retry counts, error messages, and status tracking (PENDING, PROCESSING, COMPLETED, FAILED).

- `OdooSyncQueueService` manages queue operations including queueing failed syncs, tracking retry attempts (max 10 retries), and managing status transitions.

- `OdooRetryJob` runs every 5 minutes to automatically process up to 10 pending queue entries per run. Failed entries are marked as FAILED after exceeding max retries.

## Configuration

- `enableOdooQueue` - Enable/disable queue mechanism (ConfigurationProperties, runtime toggleable via admin UI)
- `org.openelisglobal.odoo.retry.enabled` - Enable/disable retry job (default: true)
- `org.openelisglobal.odoo.retry.interval` - Retry interval in milliseconds (default: 300000 = 5 minutes)
- `org.openelisglobal.odoo.retry.batchSize` - Maximum entries to process per run (default: 10)

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]
#2273 

## Other

[Add any additional information or notes here]
