### PR TITLE
Update Spring Security to 6.4.2 and PostgreSQL driver to 42.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,10 @@
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
         <hibernate-search.version>6.1.8.Final</hibernate-search.version>
-        <postgresql.version>42.7.2</postgresql.version>
+        <postgresql.version>42.7.4</postgresql.version>
         <log4j.version>2.17.1</log4j.version>
         <springframework.version>6.2.2</springframework.version>
-        <springsecurity.version>6.0.4</springsecurity.version>
+        <springsecurity.version>6.4.2</springsecurity.version>
         <testContainersVersion>1.15.3</testContainersVersion>
     </properties>
     <dependencies>

--- a/src/main/java/org/openelisglobal/security/SecurityConfig.java
+++ b/src/main/java/org/openelisglobal/security/SecurityConfig.java
@@ -145,8 +145,8 @@ public class SecurityConfig {
                         .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.INCLUDE, DispatcherType.ERROR)
                         .permitAll().anyRequest().permitAll())
                 // disable csrf as it is not needed for open pages
-                .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers.frameOptions().sameOrigin().contentSecurityPolicy(CONTENT_SECURITY_POLICY));
+                .csrf(csrf -> csrf.disable()).headers(headers -> headers.frameOptions(frame -> frame.sameOrigin())
+                        .contentSecurityPolicy(csp -> csp.policyDirectives(CONTENT_SECURITY_POLICY)));
         return http.build();
     }
 
@@ -174,7 +174,8 @@ public class SecurityConfig {
 
                 .addFilterAt(SpringContext.getBean(BasicAuthFilter.class), BasicAuthenticationFilter.class)
                 // add security headers
-                .headers(headers -> headers.frameOptions().sameOrigin().contentSecurityPolicy(CONTENT_SECURITY_POLICY));
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin())
+                        .contentSecurityPolicy(csp -> csp.policyDirectives(CONTENT_SECURITY_POLICY)));
         return http.build();
     }
 
@@ -346,7 +347,8 @@ public class SecurityConfig {
                         .successHandler(customOAuthAuthenticationSuccessHandler())) //
                 .logout(logout -> logout.logoutSuccessHandler(oidcLogoutSuccessHandler()))
                 // add security headers
-                .headers(headers -> headers.frameOptions().sameOrigin().contentSecurityPolicy(CONTENT_SECURITY_POLICY));
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin())
+                        .contentSecurityPolicy(csp -> csp.policyDirectives(CONTENT_SECURITY_POLICY)));
         return http.build();
     }
 
@@ -421,7 +423,8 @@ public class SecurityConfig {
                         .sessionFixation().migrateSession())
                 .csrf(csrf -> csrf.ignoringRequestMatchers("/ValidateLogin"))
                 // add security headers
-                .headers(headers -> headers.frameOptions().sameOrigin().contentSecurityPolicy(CONTENT_SECURITY_POLICY));
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin())
+                        .contentSecurityPolicy(csp -> csp.policyDirectives(CONTENT_SECURITY_POLICY)));
         return http.build();
     }
 

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/MethodRenameEntryRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/MethodRenameEntryRestController.java
@@ -1,7 +1,7 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.hibernate.HibernateException;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.log.LogEvent;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/PanelCreateRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/PanelCreateRestController.java
@@ -1,11 +1,11 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import javax.validation.Valid;
 import org.openelisglobal.common.constants.Constants;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.exception.LIMSRuntimeException;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/PanelOrderRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/PanelOrderRestController.java
@@ -1,11 +1,11 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import javax.validation.Valid;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/PanelRenameEntryRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/PanelRenameEntryRestController.java
@@ -1,7 +1,7 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.common.log.LogEvent;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/PanelTestAssignRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/PanelTestAssignRestController.java
@@ -1,11 +1,11 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import javax.validation.Valid;
 import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.exception.LIMSRuntimeException;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/SampleTypeCreateRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/SampleTypeCreateRestController.java
@@ -1,9 +1,9 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Locale;
-import javax.validation.Valid;
 import org.openelisglobal.common.constants.Constants;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.exception.LIMSRuntimeException;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/SampleTypeOrderRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/SampleTypeOrderRestController.java
@@ -1,9 +1,9 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.Valid;
 import org.hibernate.HibernateException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/SampleTypeRenameEntryRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/SampleTypeRenameEntryRestController.java
@@ -1,7 +1,7 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.hibernate.HibernateException;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.log.LogEvent;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/SampleTypeTestAssignRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/SampleTypeTestAssignRestController.java
@@ -1,11 +1,11 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.validation.Valid;
 import org.hibernate.HibernateException;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.log.LogEvent;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestActivationRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestActivationRestController.java
@@ -1,11 +1,11 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import javax.validation.Valid;
 import org.apache.commons.lang.math.NumberUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestAddRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestAddRestController.java
@@ -1,12 +1,12 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import javax.validation.Valid;
 import org.hibernate.HibernateException;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestModifyEntryRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestModifyEntryRestController.java
@@ -1,13 +1,13 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
-import javax.validation.Valid;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.validator.GenericValidator;
 import org.hibernate.HibernateException;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestOrderabilityRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestOrderabilityRestController.java
@@ -1,11 +1,11 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import javax.validation.Valid;
 import org.apache.commons.lang.math.NumberUtils;
 import org.hibernate.HibernateException;
 import org.json.simple.JSONArray;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestRenameEntryRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestRenameEntryRestController.java
@@ -1,7 +1,7 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.common.log.LogEvent;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestSectionCreateRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestSectionCreateRestController.java
@@ -1,9 +1,9 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Locale;
-import javax.validation.Valid;
 import org.openelisglobal.common.constants.Constants;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.exception.LIMSRuntimeException;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestSectionOrderRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestSectionOrderRestController.java
@@ -1,9 +1,9 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.Valid;
 import org.hibernate.HibernateException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestSectionRenameEntryRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestSectionRenameEntryRestController.java
@@ -1,7 +1,7 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.hibernate.HibernateException;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.log.LogEvent;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestSectionTestAssignRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/TestSectionTestAssignRestController.java
@@ -1,10 +1,10 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import javax.validation.Valid;
 import org.hibernate.HibernateException;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.log.LogEvent;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/UomCreateRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/UomCreateRestController.java
@@ -1,9 +1,9 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Locale;
-import javax.validation.Valid;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.common.log.LogEvent;

--- a/src/main/java/org/openelisglobal/testconfiguration/controller/rest/UomRenameEntryRestController.java
+++ b/src/main/java/org/openelisglobal/testconfiguration/controller/rest/UomRenameEntryRestController.java
@@ -1,7 +1,7 @@
 package org.openelisglobal.testconfiguration.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.hibernate.HibernateException;
 import org.openelisglobal.common.controller.BaseController;
 import org.openelisglobal.common.log.LogEvent;


### PR DESCRIPTION
## Summary
Updates Spring Security from 6.0.4 (EOL Dec 31, 2024) to 6.4.2 (supported until Nov 2026) and PostgreSQL JDBC driver to 42.7.4.

## Changes
- Updated Spring Security version from 6.0.4 to 6.4.2 in pom.xml
- Updated PostgreSQL driver from 42.7.2 to 42.7.4
- Fixed deprecated Spring Security API calls in SecurityConfig.java (migrated to lambda-based configuration)
