### PR TITLE
Fix(Reflex): Prevent invalid chars in numeric field (Fixes #1981)

### DIFF
--- a/frontend/src/components/admin/reflexTests/ReflexRuleForm.js
+++ b/frontend/src/components/admin/reflexTests/ReflexRuleForm.js
@@ -454,6 +454,12 @@ function ReflexRule() {
     }
     return false;
   };
+  const blockInvalidChars = (e) => {
+    const invalidChars = ["e", "E", "+", "-", "."];
+    if (invalidChars.includes(e.key)) {
+      e.preventDefault();
+    }
+  };
 
   return (
     <>
@@ -751,6 +757,7 @@ function ReflexRule() {
                                             ? "number"
                                             : "text"
                                         }
+                                        onKeyDown={blockInvalidChars}
                                         id={
                                           index +
                                           "_" +
@@ -806,7 +813,8 @@ function ReflexRule() {
                                 <>
                                   <TextInput
                                     name="value"
-                                    type="text"
+                                    type="number"
+                                    onKeyDown={blockInvalidChars}
                                     id={
                                       index + "_" + condition_index + "_value"
                                     }


### PR DESCRIPTION

### **Summary**

- This pull request fixes issue #1981 by preventing invalid characters from being entered in the "Numeric value" fields on the Reflex Test Configuration page.

### **The Problem:**

-  The initial "Numeric value" field was correctly set to type="number". However, when a user clicks the + (Add) button to add a new condition, the new input field was incorrectly rendered as a plain type="text". This allowed invalid data, such as letters and symbols, to be entered (e.g., "&q38ysJd").

### **The Solution:** 

- This fix is implemented in frontend/src/components/admin/reflexTests/ReflexRuleForm.js and has two parts:

**Corrected the Input Type:** 
The fallback TextInput (which renders for new conditions) has been changed from type="text" to type="number". This immediately fixes the bug and restores the browser's native up/down arrows for the number field.

**Added Key-Press Validation:**
 A new onKeyDown handler (blockInvalidChars) was added to all numeric inputs in this form. This function blocks non-numeric keys that type="number" still allows (like e, +, -, and .), ensuring only valid integers can be typed.

### Screenshots
![WhatsApp Image 2025-11-08 at 16 26 52_3e38b807](https://github.com/user-attachments/assets/abe1f2db-044b-42a1-b2af-ae7a51715190)


Related Issue
Fixes #1981