### PR TITLE
Fix ci failures and ensure success

### DIFF
--- a/src/test/java/org/openelisglobal/storage/controller/StorageDashboardRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/storage/controller/StorageDashboardRestControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

This PR fixes a CI failure by adding the missing `com.fasterxml.jackson.databind.JsonNode` import to `StorageDashboardRestControllerTest.java`. This compilation error was preventing the test suite from running successfully in CI.

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

Fixes CI failure on PR #2391: [https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/19992045735/job/57334146794?pr=2391](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/19992045735/job/57334146794?pr=2391)

## Other

During local replication, `SampleTrackingServiceTest` failed due to a missing Docker daemon. This is expected to pass in CI environments where Docker is available. `mvn test-compile` and `mvn spotless:apply` were run successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9984798-cc0e-4c46-b07c-358c5fa1d206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9984798-cc0e-4c46-b07c-358c5fa1d206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

