### PR TITLE
docs: clarify E2E network stubbing and fixture strategy

### DIFF
--- a/.specify/guides/cypress-best-practices.md
+++ b/.specify/guides/cypress-best-practices.md
@@ -101,6 +101,14 @@ cy.visit("/storage");
 cy.wait("@getRooms");
 ```
 
+**Important clarification**:
+
+- In `frontend/cypress/e2e/`, `cy.intercept()` is **spy-first**.
+- Do **not** stub the mutation endpoint under test (`PUT|POST|PATCH|DELETE`)
+  with fabricated success responses.
+- If backend responses are stubbed for the workflow you are validating, that
+  test is a mocked-backend UI test (not real E2E).
+
 **Cleanup**:
 
 ```javascript
@@ -204,6 +212,8 @@ cy.intercept("GET", "/rest/rooms", { fixture: "rooms.json" }).as("getRooms");
 
 **DO NOT**:
 
+- ❌ Stub mutation endpoints (`PUT|POST|PATCH|DELETE`) under test — makes it a
+  mocked-backend UI test, not E2E
 - ❌ Use CSS selectors (use data-testid)
 - ❌ Use `cy.wait(5000)` (use `.should()`)
 - ❌ Set up intercepts after actions

--- a/.specify/guides/e2e-fixtures-readme.md
+++ b/.specify/guides/e2e-fixtures-readme.md
@@ -1,0 +1,36 @@
+# E2E Fixtures Quick Reference (Cypress)
+
+**Audience**: Cypress test authors (humans + AI agents)  
+**Purpose**: Make the “real backend + real DB” E2E fixture workflow easy and
+consistent.
+
+## Canonical fixture loader
+
+- **Unified loader**: `./src/test/resources/load-test-fixtures.sh`
+- **Overview**: `src/test/resources/FIXTURE_LOADER_README.md`
+
+This loader is the preferred way to ensure baseline E2E data exists (patients,
+samples, storage hierarchy, etc.).
+
+## Cypress usage
+
+### Preferred: use the Cypress helper
+
+Most storage-related Cypress specs should call:
+
+- `cy.loadStorageFixtures()`
+
+This is wired to the unified loader and is designed to be “smart” about skipping
+reloads for faster iteration.
+
+### Environment variables
+
+- `CYPRESS_SKIP_FIXTURES=true` – skip loading (assumes fixtures already exist)
+- `CYPRESS_FORCE_FIXTURES=true` – force reload even if fixtures exist
+- `CYPRESS_CLEANUP_FIXTURES=true` – cleanup after tests (default false)
+
+## Key rule: fixtures are not a substitute for real E2E
+
+In `frontend/cypress/e2e/`, avoid stubbing backend success responses for the
+workflow you are validating. Use fixtures/API setup to create baseline data,
+then let the real backend handle the requests.

--- a/.specify/guides/test-data-strategy.md
+++ b/.specify/guides/test-data-strategy.md
@@ -1,0 +1,53 @@
+# Test Data Strategy Guide
+
+**Audience**: AI Agents and Human Developers  
+**Purpose**: Define the canonical test data/fixture approach across unit,
+integration, and E2E tests in OpenELIS Global 2.
+
+## Canonical sources of truth
+
+- **Unified fixture loader (canonical entry point)**:
+  - Script: `src/test/resources/load-test-fixtures.sh`
+  - Overview: `src/test/resources/FIXTURE_LOADER_README.md`
+- **DBUnit datasets** (for DB-backed tests and E2E baseline data):
+  - Location: `src/test/resources/testdata/*.xml`
+  - Loader: `org.openelisglobal.testutils.DbUnitFixtureLoader` (invoked by
+    `load-test-fixtures.sh`)
+
+## Principles
+
+- **Prefer real data paths**: If you are validating persistence/integration
+  behavior, use real backend + DB fixtures rather than stubbing network
+  responses.
+- **Separate “fixtures” from “test-created” data**:
+  - Fixtures: stable baseline rows required for many tests.
+  - Test-created: rows created during a test run; must be cleaned up (or created
+    with safe prefixes/ID ranges).
+- **Use the same baseline across test types**:
+  - Manual testing, Cypress E2E, and backend integration tests should share the
+    same fixture loader where possible.
+
+## When to use what
+
+- **Unit tests**:
+
+  - Use builders/factories (in-memory objects).
+  - Mock external dependencies as needed.
+
+- **Backend integration tests**:
+
+  - Prefer DBUnit datasets for setup and deterministic cleanup via
+    `executeDataSetWithStateManagement("testdata/<file>.xml")`.
+  - If inserting rows outside DBUnit, perform targeted cleanup in `@After`.
+
+- **Cypress E2E tests**:
+  - Prefer the unified fixture loader via `cy.loadStorageFixtures()` (see
+    `e2e-fixtures-readme.md`).
+  - Prefer API-based setup (`cy.request()`) for per-test setup that must be
+    unique.
+
+## Related docs
+
+- `.specify/guides/testing-roadmap.md` (authoritative testing guide)
+- `.specify/guides/e2e-fixtures-readme.md` (Cypress fixture usage quick
+  reference)

--- a/.specify/templates/agent-file-template.md
+++ b/.specify/templates/agent-file-template.md
@@ -11,10 +11,12 @@ development principles.
 
 **OpenELIS Global Stack**:
 
-- Backend: Java 21 + Spring Boot 3.x + Hibernate 6.x + JPA + PostgreSQL 14+
+- Backend: Java 21 + Spring Framework 6.2.x (Traditional Spring MVC) +
+  Hibernate + JPA + PostgreSQL 14+
 - Frontend: React 17 + **Carbon Design System v1.15** (OFFICIAL UI framework)
 - FHIR: HAPI FHIR R4 v6.6.2 + IHE mCSD profile
-- Testing: JUnit 5 + Mockito (backend), Jest + RTL + Cypress (frontend)
+- Testing: JUnit 4 + Mockito (backend), Jest + React Testing Library (frontend
+  unit), Cypress (frontend E2E)
 - Build: Maven 3.8+ (backend), npm (frontend), Docker Compose (deployment)
 
 ## Project Structure
@@ -45,7 +47,7 @@ cd frontend && npm run format && npm start
 cd frontend && npm run cy:run
 
 # Hot reload backend (rebuild + restart container)
-mvn clean install -DskipTests && docker compose -f dev.docker-compose.yml up -d --no-deps --force-recreate oe.openelis.org
+mvn clean install -DskipTests -Dmaven.test.skip=true && docker compose -f dev.docker-compose.yml up -d --no-deps --force-recreate oe.openelis.org
 ```
 
 ## Code Style
@@ -61,8 +63,8 @@ mvn clean install -DskipTests && docker compose -f dev.docker-compose.yml up -d 
 - **FHIR**: Extend `FhirTransformService` for entity↔FHIR conversion, sync via
   `FhirPersistanceService`
 - **Database**: Liquibase changesets ONLY (NO direct DDL/DML)
-- **Tests**: JUnit 5 for backend, Jest + Cypress for frontend, >70% coverage
-  goal
+- **Tests**: JUnit 4 for backend, Jest + Cypress for frontend, >80% backend
+  coverage goal, >70% frontend coverage goal
 
 ## Recent Changes
 

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -282,7 +282,14 @@ Document how test data will be created and cleaned up:
   - **E2E Tests (Cypress)**:
     - [ ] Use API-based setup via `cy.request()` (NOT slow UI interactions) -
           10x faster
-    - [ ] Use fixtures with `cy.intercept()` for consistent test data
+    - [ ] Prefer the unified fixture loader for stable baseline data:
+          `./src/test/resources/load-test-fixtures.sh` (see
+          `src/test/resources/FIXTURE_LOADER_README.md`)
+    - [ ] Use `cy.intercept()` as **spy-first** (alias + assertions). Avoid
+          stubbing backend responses in real E2E tests.
+    - [ ] **DO NOT** stub the mutation endpoint under test
+          (`PUT|POST|PATCH|DELETE`) in `frontend/cypress/e2e/` (if backend is
+          stubbed, it is not E2E).
     - [ ] Use `cy.session()` for login state (10-20x faster than per-test login)
 
 ### Checkpoint Validations


### PR DESCRIPTION
## Summary
- Clarifies test type contracts (unit vs controller vs integration vs E2E) to prevent "tests that test nothing".
- Tightens Cypress guidance: `cy.intercept()` is spy-first in real E2E; do not stub mutation endpoints under test.
- Adds missing fixture docs and points to the canonical fixture loader (`load-test-fixtures.sh`).
- Updates templates so new plans/agent guidance don’t propagate ambiguous mocking patterns.

## Screenshots
N/A (documentation-only changes)

## Related Issue
N/A

## Other
- This PR is intentionally docs-only. A follow-up PR can add CI guardrails to enforce the no-mutation-stubbing rule in `frontend/cypress/e2e/`.