### PR TITLE
feat: Add role-based access control for notebooks

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -345,7 +345,6 @@ export default function App() {
                   path="/NoteBookDashboard"
                   exact
                   component={() => <NoteBookDashBoard />}
-                  role={[Roles.RECEPTION, Roles.RESULTS, Roles.VALIDATION]}
                 />
                 <SecureRoute
                   path="/NoteBookEntryForm/:notebookid"
@@ -363,25 +362,21 @@ export default function App() {
                   path="/NoteBookInstanceEntryForm/:notebookid"
                   exact
                   component={() => <NoteBookInstanceEntryForm />}
-                  role={Roles.RESULTS}
                 />
                 <SecureRoute
                   path="/NoteBookInstanceEditForm/:notebookentryid"
                   exact
                   component={() => <NoteBookInstanceEntryForm />}
-                  role={Roles.RESULTS}
                 />
                 <SecureRoute
                   path="/NotebookSampleOrder/:notebookId/:notebookEntryId"
                   exact
                   component={() => <NotebookSampleOrder />}
-                  role={Roles.RESULTS}
                 />
                 <SecureRoute
                   path="/NotebookSampleOrder/:notebookId"
                   exact
                   component={() => <NotebookSampleOrder />}
-                  role={Roles.RESULTS}
                 />
                 <SecureRoute
                   path="/CytologyCaseView/:cytologySampleId"

--- a/frontend/src/components/notebook/NoteBookDashBoard.js
+++ b/frontend/src/components/notebook/NoteBookDashBoard.js
@@ -27,6 +27,9 @@ import { AlertDialog } from "../common/CustomNotification";
 import { FormattedMessage, useIntl } from "react-intl";
 import "../pathology/PathologyDashboard.css";
 import PageBreadCrumb from "../common/PageBreadCrumb";
+import { PermissionGate } from "../security";
+import { Permissions } from "../../constants/roles";
+import { usePermissions } from "../../hooks/usePermissions";
 import CustomDatePicker from "../common/CustomDatePicker";
 import {
   UserAvatar,
@@ -51,6 +54,8 @@ function NoteBookDashBoard() {
 
   const { notificationVisible } = useContext(NotificationContext);
   const { userSessionDetails } = useContext(UserSessionDetailsContext);
+  const { hasRoleForCurrentLabUnit } = usePermissions();
+
   const [statuses, setStatuses] = useState([]);
   const [noteBookEntries, setNoteBookEntries] = useState([]);
   const [noteBooks, setNoteBooks] = useState([]);
@@ -296,16 +301,25 @@ function NoteBookDashBoard() {
       return (
         <TableCell key={cell.id}>
           <div style={{ display: "flex", alignItems: "center" }}>
-            <Button
-              kind="ghost"
-              hasIconOnly
-              renderIcon={Edit}
-              iconDescription={intl.formatMessage({
-                id: "notebook.icon.edit",
+            <PermissionGate
+              roles={Permissions.CREATE_OR_EDIT_NOTEBOOK}
+              disabledTooltip={intl.formatMessage({
+                id: "notebook.permission.edit.required",
+                defaultMessage:
+                  "You need Notebook Administrator role to edit templates",
               })}
-              size="sm"
-              onClick={() => openNoteBookView(row.id)}
-            ></Button>
+            >
+              <Button
+                kind="ghost"
+                hasIconOnly
+                renderIcon={Edit}
+                iconDescription={intl.formatMessage({
+                  id: "notebook.icon.edit",
+                })}
+                size="sm"
+                onClick={() => openNoteBookView(row.id)}
+              ></Button>
+            </PermissionGate>
             {cell.value}
           </div>
         </TableCell>
@@ -344,16 +358,25 @@ function NoteBookDashBoard() {
               <br />
             </Column>
             <Column lg={16} md={8} sm={4}>
-              <Button
-                style={{ width: "70%" }}
-                size="sm"
-                onClick={() => {
-                  openNoteBookEntryForm();
-                }}
+              <PermissionGate
+                roles={Permissions.CREATE_OR_EDIT_NOTEBOOK}
+                disabledTooltip={intl.formatMessage({
+                  id: "notebook.permission.admin.required",
+                  defaultMessage:
+                    "You need Notebook Administrator role to create templates",
+                })}
               >
-                <Add />
-                <FormattedMessage id="notebook.button.newLabNotebook" />
-              </Button>
+                <Button
+                  style={{ width: "70%" }}
+                  size="sm"
+                  onClick={() => {
+                    openNoteBookEntryForm();
+                  }}
+                >
+                  <Add />
+                  <FormattedMessage id="notebook.button.newLabNotebook" />
+                </Button>
+              </PermissionGate>
             </Column>
             <Column lg={16} md={8} sm={4}>
               <br />
@@ -509,10 +532,30 @@ function NoteBookDashBoard() {
                     <Button
                       size="sm"
                       disabled={
-                        selectedNoteBook.technicianId != null &&
-                        userSessionDetails.userId !=
-                          selectedNoteBook.technicianId
+                        // Check if user has any of the notebook's specific allowedRoles
+                        // If no allowedRoles defined, anyone can access (empty = no restriction)
+                        (() => {
+                          const roles = selectedNoteBook?.allowedRoles
+                            ? Array.from(selectedNoteBook.allowedRoles)
+                            : [];
+                          // No roles = no restriction = enabled
+                          if (roles.length === 0) return false;
+                          return !hasRoleForCurrentLabUnit(roles);
+                        })()
                       }
+                      title={(() => {
+                        const roles = selectedNoteBook?.allowedRoles
+                          ? Array.from(selectedNoteBook.allowedRoles)
+                          : [];
+                        if (roles.length === 0) return undefined;
+                        return !hasRoleForCurrentLabUnit(roles)
+                          ? intl.formatMessage({
+                              id: "notebook.permission.entry.edit.required",
+                              defaultMessage:
+                                "You need permission to create or edit notebook entries",
+                            })
+                          : undefined;
+                      })()}
                       onClick={() => {
                         openNoteBookInstanceEntryForm();
                       }}
@@ -692,10 +735,31 @@ function NoteBookDashBoard() {
                             <Button
                               kind="secondary"
                               size="sm"
-                              disabled={
-                                entry.technicianId != null &&
-                                userSessionDetails.userId != entry.technicianId
-                              }
+                              disabled={(() => {
+                                // Check if user has any of the entry's allowedRoles (from template)
+                                const entryRoles = entry.allowedRoles
+                                  ? Array.isArray(entry.allowedRoles)
+                                    ? entry.allowedRoles
+                                    : Array.from(entry.allowedRoles)
+                                  : [];
+                                // User has required role = enabled
+                                if (
+                                  entryRoles.length === 0 ||
+                                  hasRoleForCurrentLabUnit(entryRoles)
+                                ) {
+                                  return false;
+                                }
+                                // User is the assigned technician = enabled
+                                if (
+                                  entry.technicianId != null &&
+                                  userSessionDetails.userId ==
+                                    entry.technicianId
+                                ) {
+                                  return false;
+                                }
+                                // Otherwise disabled
+                                return true;
+                              })()}
                               onClick={() => openNoteBookInstanceView(entry.id)}
                             >
                               <View size={13} />
@@ -707,11 +771,56 @@ function NoteBookDashBoard() {
                               <Button
                                 kind="primary"
                                 size="sm"
-                                disabled={
-                                  entry.technicianId != null &&
-                                  userSessionDetails.userId !=
-                                    entry.technicianId
-                                }
+                                disabled={(() => {
+                                  // Check if user has any of the entry's allowedRoles (from template)
+                                  const entryRoles = entry.allowedRoles
+                                    ? Array.isArray(entry.allowedRoles)
+                                      ? entry.allowedRoles
+                                      : Array.from(entry.allowedRoles)
+                                    : [];
+                                  // User has required role = enabled
+                                  if (
+                                    entryRoles.length === 0 ||
+                                    hasRoleForCurrentLabUnit(entryRoles)
+                                  ) {
+                                    return false;
+                                  }
+                                  // User is the assigned technician = enabled
+                                  if (
+                                    entry.technicianId != null &&
+                                    userSessionDetails.userId ==
+                                      entry.technicianId
+                                  ) {
+                                    return false;
+                                  }
+                                  // Otherwise disabled
+                                  return true;
+                                })()}
+                                title={(() => {
+                                  const entryRoles = entry.allowedRoles
+                                    ? Array.isArray(entry.allowedRoles)
+                                      ? entry.allowedRoles
+                                      : Array.from(entry.allowedRoles)
+                                    : [];
+                                  if (
+                                    entryRoles.length === 0 ||
+                                    hasRoleForCurrentLabUnit(entryRoles)
+                                  ) {
+                                    return undefined;
+                                  }
+                                  if (
+                                    entry.technicianId != null &&
+                                    userSessionDetails.userId ==
+                                      entry.technicianId
+                                  ) {
+                                    return undefined;
+                                  }
+                                  return intl.formatMessage({
+                                    id: "notebook.permission.entry.edit.required",
+                                    defaultMessage:
+                                      "You need permission to create or edit notebook entries",
+                                  });
+                                })()}
                                 onClick={() =>
                                   openNoteBookInstanceEdit(entry.id)
                                 }

--- a/frontend/src/components/notebook/NoteBookEntryForm.js
+++ b/frontend/src/components/notebook/NoteBookEntryForm.js
@@ -348,9 +348,10 @@ const NoteBookEntryForm = () => {
     });
     // Set selected roles for the multiselect
     const existingRoles = page.allowedRoles || [];
-    setPageSelectedRoles(
-      availableRoles.filter((role) => existingRoles.includes(role.id)),
+    const matchedRoles = availableRoles.filter((role) =>
+      existingRoles.includes(role.id),
     );
+    setPageSelectedRoles(matchedRoles);
     // If page has sampleTypeId, fetch the tests for that sample type
     if (page.sampleTypeId) {
       getFromOpenElisServer(
@@ -1085,44 +1086,25 @@ const NoteBookEntryForm = () => {
                 <br />
               </Column>
               <Column lg={8} md={8} sm={4}>
-                <Select
+                <FilterableMultiSelect
+                  key={`departments-${selectedOrganizations.map((o) => o.id).join(",")}`}
                   id="organizations"
-                  labelText={intl.formatMessage({
+                  titleText={intl.formatMessage({
                     id: "notebook.label.organizations",
-                    defaultMessage: "Department",
+                    defaultMessage: "Locations/Organizations",
                   })}
-                  value={
-                    selectedOrganizations.length > 0
-                      ? selectedOrganizations[0].id
-                      : ""
-                  }
-                  onChange={(event) => {
-                    const selectedId = event.target.value;
-                    if (selectedId) {
-                      const selectedOrg = organizations.find(
-                        (org) => String(org.id) === String(selectedId),
-                      );
-                      setSelectedOrganizations(
-                        selectedOrg ? [selectedOrg] : [],
-                      );
-                      setDepartmentsLoaded(true);
-                    } else {
-                      setSelectedOrganizations([]);
-                      setDepartmentsLoaded(true);
-                    }
+                  placeholder={intl.formatMessage({
+                    id: "notebook.label.selectDepartments",
+                    defaultMessage: "Select departments/units",
+                  })}
+                  items={organizations}
+                  itemToString={(item) => (item ? item.label : "")}
+                  initialSelectedItems={selectedOrganizations}
+                  onChange={({ selectedItems }) => {
+                    setSelectedOrganizations(selectedItems);
+                    setDepartmentsLoaded(true);
                   }}
-                >
-                  <SelectItem
-                    text={intl.formatMessage({
-                      id: "label.button.select",
-                      defaultMessage: "Select department",
-                    })}
-                    value=""
-                  />
-                  {organizations.map((org) => (
-                    <SelectItem key={org.id} text={org.label} value={org.id} />
-                  ))}
-                </Select>
+                />
               </Column>
               <Column lg={8} md={8} sm={4}>
                 <FilterableMultiSelect
@@ -1534,6 +1516,35 @@ const NoteBookEntryForm = () => {
                                         <></>
                                       );
                                     })}
+                                  </div>
+                                </Column>
+                              </>
+                            )}
+                          {page.allowedRoles &&
+                            Array.isArray(page.allowedRoles) &&
+                            page.allowedRoles.length > 0 && (
+                              <>
+                                <Column lg={2} md={8} sm={4}>
+                                  <h6>
+                                    {intl.formatMessage({
+                                      id: "notebook.page.allowedRoles",
+                                      defaultMessage: "Access Roles",
+                                    })}
+                                  </h6>
+                                </Column>
+                                <Column lg={14} md={8} sm={4}>
+                                  <div>
+                                    {page.allowedRoles.map(
+                                      (roleName, roleIndex) => (
+                                        <Tag
+                                          key={roleIndex}
+                                          type="purple"
+                                          size="sm"
+                                        >
+                                          {roleName}
+                                        </Tag>
+                                      ),
+                                    )}
                                   </div>
                                 </Column>
                               </>
@@ -2094,6 +2105,7 @@ const NoteBookEntryForm = () => {
           required
         />
         <FilterableMultiSelect
+          key={`pageRoles-${pageSelectedRoles.map((r) => r.id).join(",")}`}
           id="pageAllowedRoles"
           titleText={intl.formatMessage({
             id: "notebook.page.modal.roles.label",
@@ -2105,7 +2117,7 @@ const NoteBookEntryForm = () => {
           })}
           items={availableRoles}
           itemToString={(item) => (item ? item.label : "")}
-          selectedItems={pageSelectedRoles}
+          initialSelectedItems={pageSelectedRoles}
           onChange={({ selectedItems }) => setPageSelectedRoles(selectedItems)}
           helperText={intl.formatMessage({
             id: "notebook.page.modal.roles.helper",

--- a/frontend/src/components/notebook/NoteBookEntryForm.js
+++ b/frontend/src/components/notebook/NoteBookEntryForm.js
@@ -54,6 +54,8 @@ import UserSessionDetailsContext from "../../UserSessionDetailsContext";
 import { NotificationContext } from "../layout/Layout";
 import { AlertDialog, NotificationKinds } from "../common/CustomNotification";
 import { FormattedMessage, useIntl } from "react-intl";
+import { usePermissions } from "../../hooks/usePermissions";
+import { Permissions } from "../../constants/roles";
 import {
   NoteBookFormValues,
   NoteBookInitialData,
@@ -95,6 +97,11 @@ const NoteBookEntryForm = () => {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
   const { userSessionDetails } = useContext(UserSessionDetailsContext);
+  const { hasAnyRole } = usePermissions();
+
+  // Check if user can create/edit notebook templates
+  const canEditTemplate = hasAnyRole(Permissions.CREATE_OR_EDIT_NOTEBOOK);
+
   const [statuses, setStatuses] = useState([]);
   const [types, setTypes] = useState([]);
   const [technicianUsers, setTechnicianUsers] = useState([]);
@@ -134,14 +141,7 @@ const NoteBookEntryForm = () => {
   const [selectedAllowedRoles, setSelectedAllowedRoles] = useState([]);
   const [rolesLoaded, setRolesLoaded] = useState(false);
   const [pendingSelectedRoleIds, setPendingSelectedRoleIds] = useState(null);
-  const [availableRoles] = useState([
-    { id: "Technician", label: "Technician" },
-    { id: "Supervisor", label: "Supervisor" },
-    { id: "Results", label: "Results" },
-    { id: "Validation", label: "Validation" },
-    { id: "Reception", label: "Reception" },
-    { id: "Reports", label: "Reports" },
-  ]);
+  const [availableRoles, setAvailableRoles] = useState([]);
 
   const isFormValid = () => {
     return (
@@ -276,7 +276,9 @@ const NoteBookEntryForm = () => {
     sampleTypeId: null,
     panels: [],
     tests: [],
+    allowedRoles: [],
   });
+  const [pageSelectedRoles, setPageSelectedRoles] = useState([]);
   const [newTag, setNewTag] = useState("");
   const [pageError, setPageError] = useState("");
   const [tagError, setTagError] = useState("");
@@ -297,9 +299,11 @@ const NoteBookEntryForm = () => {
       sampleTypeId: null,
       panels: [],
       tests: [],
+      allowedRoles: [],
     });
     setPageSelectedTests([]);
     setPageSelectedPanels([]);
+    setPageSelectedRoles([]);
     setPageSampleTypeTests(sampleTypeTestsStructure);
     setPageTestSearchTerm("");
     setPagePanelSearchTerm("");
@@ -340,7 +344,13 @@ const NoteBookEntryForm = () => {
       sampleTypeId: page.sampleTypeId || null,
       panels: page.panels || [],
       tests: page.tests || [],
+      allowedRoles: page.allowedRoles || [],
     });
+    // Set selected roles for the multiselect
+    const existingRoles = page.allowedRoles || [];
+    setPageSelectedRoles(
+      availableRoles.filter((role) => existingRoles.includes(role.id)),
+    );
     // If page has sampleTypeId, fetch the tests for that sample type
     if (page.sampleTypeId) {
       getFromOpenElisServer(
@@ -407,11 +417,12 @@ const NoteBookEntryForm = () => {
       );
       return;
     }
-    // Update newPage with selected tests and panels
+    // Update newPage with selected tests, panels, and allowed roles
     const updatedPage = {
       ...newPage,
       tests: pageSelectedTests.map((test) => test.id),
       panels: pageSelectedPanels.map((panel) => parseInt(panel.id)),
+      allowedRoles: pageSelectedRoles.map((role) => role.id),
     };
     if (editingPageIndex !== null) {
       // Update existing page
@@ -685,7 +696,6 @@ const NoteBookEntryForm = () => {
             `/rest/notebook/${data.id}/allowed-roles`,
             (rolesResponse) => {
               if (Array.isArray(rolesResponse)) {
-                // Store role IDs to match against availableRoles
                 setPendingSelectedRoleIds(rolesResponse);
                 setRolesLoaded(true);
               }
@@ -778,12 +788,19 @@ const NoteBookEntryForm = () => {
     getFromOpenElisServer("/rest/user-sample-types", setSampleTypes);
     getFromOpenElisServer("/rest/notebook/questionnaires", setQuestionnaires);
     getFromOpenElisServer("/rest/notebook/departments", (depts) => {
+      console.log("Departments API response:", depts);
       if (Array.isArray(depts)) {
-        setOrganizations(
-          depts.map((dept) => ({
-            id: dept.id,
-            label: dept.name || dept.shortName,
-          })),
+        const mappedOrgs = depts.map((dept) => ({
+          id: dept.id,
+          label: dept.name || dept.shortName,
+        }));
+        console.log("Mapped organizations:", mappedOrgs);
+        setOrganizations(mappedOrgs);
+      } else {
+        console.warn(
+          "Departments response was not an array:",
+          typeof depts,
+          depts,
         );
       }
     });
@@ -798,10 +815,31 @@ const NoteBookEntryForm = () => {
         }
       },
     );
+    // Fetch available roles dynamically from backend
+    // Using /rest/systemroles which returns {label: description, value: name}
+    getFromOpenElisServer("/rest/systemroles", (roles) => {
+      console.log("System roles API response:", roles);
+      if (Array.isArray(roles)) {
+        const mappedRoles = roles.map((role) => ({
+          id: role.value?.trim(), // role name is the ID we store (trim whitespace)
+          label: role.value?.trim(), // show role name as label
+        }));
+        console.log("Mapped available roles:", mappedRoles);
+        setAvailableRoles(mappedRoles);
+      } else {
+        console.warn(
+          "System roles response was not an array:",
+          typeof roles,
+          roles,
+        );
+      }
+    });
     return () => {
       componentMounted.current = false;
     };
   }, []);
+
+  console.log({ organizations });
 
   // Match pending selected department IDs to actual organization objects once both are loaded
   useEffect(() => {
@@ -837,23 +875,11 @@ const NoteBookEntryForm = () => {
       availableRoles.length > 0 &&
       pendingSelectedRoleIds.length > 0
     ) {
-      // Convert IDs to strings for comparison
-      const pendingRolesAsStrings = pendingSelectedRoleIds.map((id) =>
-        String(id),
-      );
       const matchedRoles = availableRoles.filter((role) =>
-        pendingRolesAsStrings.includes(String(role.id)),
-      );
-      console.log(
-        "Matching roles - pending:",
-        pendingRolesAsStrings,
-        "available:",
-        availableRoles.map((r) => r.id),
-        "matched:",
-        matchedRoles,
+        pendingSelectedRoleIds.includes(role.id),
       );
       setSelectedAllowedRoles(matchedRoles);
-      setPendingSelectedRoleIds(null); // Clear pending to avoid re-running
+      setPendingSelectedRoleIds(null);
     }
   }, [pendingSelectedRoleIds, availableRoles]);
 
@@ -1100,6 +1126,7 @@ const NoteBookEntryForm = () => {
               </Column>
               <Column lg={8} md={8} sm={4}>
                 <FilterableMultiSelect
+                  key={`roles-${selectedAllowedRoles.map((r) => r.id).join(",")}`}
                   id="allowedRoles"
                   titleText={intl.formatMessage({
                     id: "notebook.label.allowedRoles",
@@ -1111,7 +1138,7 @@ const NoteBookEntryForm = () => {
                   })}
                   items={availableRoles}
                   itemToString={(item) => (item ? item.label : "")}
-                  selectedItems={selectedAllowedRoles}
+                  initialSelectedItems={selectedAllowedRoles}
                   onChange={({ selectedItems }) => {
                     setSelectedAllowedRoles(selectedItems || []);
                   }}
@@ -1176,8 +1203,9 @@ const NoteBookEntryForm = () => {
                   noteBookData.analyzers.map((item, index) => (
                     <Tag
                       key={index}
-                      filter
+                      filter={canEditTemplate}
                       onClose={() => {
+                        if (!canEditTemplate) return;
                         var info = { ...noteBookData };
                         info["analyzers"].splice(index, 1);
                         setNoteBookData(info);
@@ -1197,7 +1225,21 @@ const NoteBookEntryForm = () => {
                 </h5>
               </Column>
               <Column lg={8} md={8} sm={4}>
-                <Button onClick={openTagModal} kind="primary" size="sm">
+                <Button
+                  onClick={openTagModal}
+                  kind="primary"
+                  size="sm"
+                  disabled={!canEditTemplate}
+                  title={
+                    !canEditTemplate
+                      ? intl.formatMessage({
+                          id: "notebook.permission.edit.required",
+                          defaultMessage:
+                            "You need Notebook Administrator role to edit templates",
+                        })
+                      : undefined
+                  }
+                >
                   <Add />
                   <FormattedMessage id="notebook.tags.add" />
                 </Button>
@@ -1209,8 +1251,9 @@ const NoteBookEntryForm = () => {
                 {noteBookData.tags.map((tag, index) => (
                   <Tag
                     key={index}
-                    filter
+                    filter={canEditTemplate}
                     onClose={() => {
+                      if (!canEditTemplate) return;
                       handleRemoveTag(index);
                     }}
                   >
@@ -1232,6 +1275,7 @@ const NoteBookEntryForm = () => {
                   multiple
                   onAddFiles={handleAddFiles}
                   accept={[".pdf", ".png", ".jpg", ".txt"]}
+                  disabled={!canEditTemplate}
                 />
                 {uploadedFiles.map((fileObj, index) => (
                   <FileUploaderItem
@@ -1270,6 +1314,16 @@ const NoteBookEntryForm = () => {
                             kind="danger--tertiary"
                             size="sm"
                             onClick={() => handleRemoveFile(index)}
+                            disabled={!canEditTemplate}
+                            title={
+                              !canEditTemplate
+                                ? intl.formatMessage({
+                                    id: "notebook.permission.edit.required",
+                                    defaultMessage:
+                                      "You need Notebook Administrator role to edit templates",
+                                  })
+                                : undefined
+                            }
                           >
                             <FormattedMessage id="label.button.remove" />
                           </Button>
@@ -1292,7 +1346,21 @@ const NoteBookEntryForm = () => {
                 </h5>
               </Column>
               <Column lg={2} md={2} sm={4}>
-                <Button onClick={openPageModal} size="sm" kind="primary">
+                <Button
+                  onClick={openPageModal}
+                  size="sm"
+                  kind="primary"
+                  disabled={!canEditTemplate}
+                  title={
+                    !canEditTemplate
+                      ? intl.formatMessage({
+                          id: "notebook.permission.edit.required",
+                          defaultMessage:
+                            "You need Notebook Administrator role to edit templates",
+                        })
+                      : undefined
+                  }
+                >
                   <Add /> <FormattedMessage id="notebook.label.addpage" />
                 </Button>
               </Column>
@@ -1477,6 +1545,16 @@ const NoteBookEntryForm = () => {
                               size="sm"
                               onClick={() => openEditPageModal(index)}
                               style={{ marginRight: "0.5rem" }}
+                              disabled={!canEditTemplate}
+                              title={
+                                !canEditTemplate
+                                  ? intl.formatMessage({
+                                      id: "notebook.permission.edit.required",
+                                      defaultMessage:
+                                        "You need Notebook Administrator role to edit templates",
+                                    })
+                                  : undefined
+                              }
                             >
                               <FormattedMessage id="label.button.edit" />
                             </Button>
@@ -1484,6 +1562,16 @@ const NoteBookEntryForm = () => {
                               kind="danger--tertiary"
                               size="sm"
                               onClick={() => handleRemovePage(index)}
+                              disabled={!canEditTemplate}
+                              title={
+                                !canEditTemplate
+                                  ? intl.formatMessage({
+                                      id: "notebook.permission.edit.required",
+                                      defaultMessage:
+                                        "You need Notebook Administrator role to edit templates",
+                                    })
+                                  : undefined
+                              }
                             >
                               <FormattedMessage id="label.button.remove" />
                             </Button>
@@ -2005,6 +2093,26 @@ const NoteBookEntryForm = () => {
           onChange={handlePageChange}
           required
         />
+        <FilterableMultiSelect
+          id="pageAllowedRoles"
+          titleText={intl.formatMessage({
+            id: "notebook.page.modal.roles.label",
+            defaultMessage: "Page Access Roles (Optional)",
+          })}
+          placeholder={intl.formatMessage({
+            id: "notebook.page.modal.roles.placeholder",
+            defaultMessage: "Select roles that can view this page",
+          })}
+          items={availableRoles}
+          itemToString={(item) => (item ? item.label : "")}
+          selectedItems={pageSelectedRoles}
+          onChange={({ selectedItems }) => setPageSelectedRoles(selectedItems)}
+          helperText={intl.formatMessage({
+            id: "notebook.page.modal.roles.helper",
+            defaultMessage:
+              "Leave empty to allow all users. Selected roles restrict page access.",
+          })}
+        />
       </Modal>
       <Modal
         open={showTagModal}
@@ -2104,7 +2212,18 @@ const NoteBookEntryForm = () => {
               <Button
                 kind="primary"
                 disabled={
-                  isSubmitting || (mode === MODES.CREATE && !isFormValid())
+                  !canEditTemplate ||
+                  isSubmitting ||
+                  (mode === MODES.CREATE && !isFormValid())
+                }
+                title={
+                  !canEditTemplate
+                    ? intl.formatMessage({
+                        id: "notebook.permission.edit.required",
+                        defaultMessage:
+                          "You need Notebook Administrator role to edit templates",
+                      })
+                    : undefined
                 }
                 onClick={() => handleSubmit()}
               >

--- a/frontend/src/components/notebook/NoteBookInstanceEntryForm.js
+++ b/frontend/src/components/notebook/NoteBookInstanceEntryForm.js
@@ -1152,6 +1152,20 @@ const NoteBookInstanceEntryForm = () => {
           <Column lg={16} md={8} sm={4}>
             {/* Use enhanced workflow view for notebook instances (non-templates) */}
             {/* Detect workflow type based on notebook title */}
+            {/*
+              IMPORTANT: Do NOT pass entryId to workflow tabs.
+
+              The notebookentryid from URL params is a NoteBook ID (from notebook table),
+              NOT a NotebookEntry ID (from notebook_entry table). These are different entities.
+
+              The workflow tabs have their own logic to:
+              1. Load notebook data using notebookId
+              2. Check for existing NotebookEntry via /rest/notebook-entry/by-notebook/{notebookId}
+              3. Create a new NotebookEntry if needed
+
+              Passing notebookentryid as entryId would cause 404 errors because the workflow
+              tabs would try to fetch /rest/notebook-entry/{notebookId} which doesn't exist.
+            */}
             {noteBookData?.isTemplate !== true &&
               noteBookData?.id &&
               noteBookData?.title
@@ -1215,7 +1229,13 @@ const NoteBookInstanceEntryForm = () => {
                     <Accordion>
                       {noteBookData.pages
                         .filter((page) => {
-                          // Check page-level access control
+                          // During entry creation (CREATE mode), show ALL pages - no restrictions
+                          // Page-level role restrictions only apply when viewing/editing existing entries
+                          if (mode === MODES.CREATE) {
+                            return true;
+                          }
+
+                          // Check page-level access control for existing entries
                           const pageRoles = page.allowedRoles
                             ? Array.isArray(page.allowedRoles)
                               ? page.allowedRoles

--- a/frontend/src/components/notebook/NoteBookInstanceEntryForm.js
+++ b/frontend/src/components/notebook/NoteBookInstanceEntryForm.js
@@ -59,6 +59,8 @@ import {
   hasRole,
   toBase64,
 } from "../utils/Utils";
+import { usePermissions } from "../../hooks/usePermissions";
+import { Permissions } from "../../constants/roles";
 import NotebookWorkflowTab from "./workflow/NotebookWorkflowTab";
 import MNTDWorkflowTab from "./workflow/MNTDWorkflowTab";
 import TBWorkflowTab from "./workflow/TBWorkflowTab";
@@ -98,6 +100,19 @@ const NoteBookInstanceEntryForm = () => {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
   const { userSessionDetails } = useContext(UserSessionDetailsContext);
+  const { hasRoleForCurrentLabUnit } = usePermissions();
+
+  // Template's allowed roles - will be set when template data is loaded
+  const [templateAllowedRoles, setTemplateAllowedRoles] = useState([]);
+
+  // Check if user can create/edit notebook entries for this specific template
+  // Uses the template's allowedRoles if available, otherwise falls back to generic permissions
+  const canEditEntry = hasRoleForCurrentLabUnit(
+    templateAllowedRoles.length > 0
+      ? templateAllowedRoles
+      : Permissions.CREATE_OR_EDIT_NOTEBOOK_ENTRY,
+  );
+
   const [statuses, setStatuses] = useState([]);
   const [types, setTypes] = useState([]);
   const [technicianUsers, setTechnicianUsers] = useState([]);
@@ -377,15 +392,34 @@ const NoteBookInstanceEntryForm = () => {
     }
   }, []);
 
-  // Check if user is authorized to access this notebook
-  const checkAuthorization = (technicianId) => {
-    if (technicianId && userSessionDetails.userId != technicianId) {
+  // Check if user is authorized to create entries for this notebook
+  // Uses role-based permission checking: Global Roles → AllLabUnits → Specific Lab Unit
+  // @param {Set|Array} allowedRoles - The template's specific allowedRoles
+  const checkAuthorization = (allowedRoles) => {
+    // Convert Set to Array if needed
+    const rolesArray = allowedRoles
+      ? Array.isArray(allowedRoles)
+        ? allowedRoles
+        : Array.from(allowedRoles)
+      : [];
+
+    // Check if user has any of the notebook's specific allowedRoles
+    // hasRoleForCurrentLabUnit checks:
+    // 1. Global Admin (always allowed)
+    // 2. Global roles (userSessionDetails.roles)
+    // 3. AllLabUnits roles (userSessionDetails.userLabRolesMap["AllLabUnits"])
+    // 4. Specific lab unit roles (userSessionDetails.userLabRolesMap[loginLabUnit])
+    const hasAccess =
+      rolesArray.length === 0 || hasRoleForCurrentLabUnit(rolesArray);
+
+    if (!hasAccess) {
       addNotification({
         kind: NotificationKinds.error,
         title: intl.formatMessage({ id: "notification.title" }),
         message: intl.formatMessage({
-          id: "notebook.error.notAssigned",
-          defaultMessage: "You are not assigned to this project",
+          id: "notebook.permission.entry.edit.required",
+          defaultMessage:
+            "You need permission to create or edit notebook entries",
         }),
       });
       setNotificationVisible(true);
@@ -401,8 +435,14 @@ const NoteBookInstanceEntryForm = () => {
   const loadInitialProjectData = (data) => {
     if (componentMounted.current) {
       if (data && data.id) {
-        // Check authorization
-        if (!checkAuthorization(data.technicianId)) {
+        // Store template's allowedRoles for permission checking
+        const allowedRoles = data.allowedRoles || [];
+        setTemplateAllowedRoles(
+          Array.isArray(allowedRoles) ? allowedRoles : Array.from(allowedRoles),
+        );
+
+        // Check authorization using template's specific allowedRoles
+        if (!checkAuthorization(allowedRoles)) {
           setLoading(false);
           return;
         }
@@ -434,18 +474,26 @@ const NoteBookInstanceEntryForm = () => {
   const loadInitialData = (data) => {
     if (componentMounted.current) {
       if (data && data.id) {
-        // Check authorization
-        if (!checkAuthorization(data.technicianId)) {
-          setLoading(false);
-          return;
-        }
-
         // If this is an instance (isTemplate=false) and we have templateId from backend,
         // fetch the latest parent template properties to ensure we always display the most up-to-date template data
         if (data.isTemplate === false && data.templateId) {
           getFromOpenElisServer(
             "/rest/notebook/view/" + data.templateId,
             (templateData) => {
+              // Store template's allowedRoles for permission checking
+              const allowedRoles = templateData.allowedRoles || [];
+              setTemplateAllowedRoles(
+                Array.isArray(allowedRoles)
+                  ? allowedRoles
+                  : Array.from(allowedRoles),
+              );
+
+              // Check authorization using template's specific allowedRoles
+              if (!checkAuthorization(allowedRoles)) {
+                setLoading(false);
+                return;
+              }
+
               // Merge pages: Keep existing instance pages, add new template pages that don't exist
               const instancePages = data.pages || [];
               const templatePages = templateData.pages || [];
@@ -509,6 +557,21 @@ const NoteBookInstanceEntryForm = () => {
             },
           );
         } else {
+          // This is either a template or an entry without parent templateId
+          // For templates, use allowedRoles from the data itself if available
+          const allowedRoles = data.allowedRoles || [];
+          setTemplateAllowedRoles(
+            Array.isArray(allowedRoles)
+              ? allowedRoles
+              : Array.from(allowedRoles),
+          );
+
+          // Check authorization - if no allowedRoles, fall back to generic permissions
+          if (allowedRoles.length > 0 && !checkAuthorization(allowedRoles)) {
+            setLoading(false);
+            return;
+          }
+
           setNoteBookData(data);
         }
 
@@ -1150,200 +1213,219 @@ const NoteBookInstanceEntryForm = () => {
                   )}
                   {noteBookData?.pages?.length > 0 && (
                     <Accordion>
-                      {noteBookData.pages.map((page, index) => (
-                        <AccordionItem
-                          key={index}
-                          style={{ marginBottom: "1rem" }}
-                          title={
-                            <span
-                              style={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "0.5rem",
-                              }}
-                            >
-                              {intl.formatMessage(
-                                { id: "pagination.page" },
-                                { page: page.order || index + 1 },
-                              )}
-                              :{" "}
-                              <h5 style={{ margin: 0, display: "inline" }}>
-                                {page.title}
-                              </h5>
-                              {page.completed && (
-                                <Tag type="green" size="sm">
-                                  <FormattedMessage id="notebook.page.completed" />
-                                </Tag>
-                              )}
-                            </span>
-                          }
-                        >
-                          <Grid>
-                            <Column lg={2} md={8} sm={4}>
-                              <h6>
-                                {intl.formatMessage({
-                                  id: "notebook.page.instructions",
-                                })}
-                              </h6>
-                            </Column>
-                            <Column lg={14} md={8} sm={4}>
-                              {page.instructions}
-                            </Column>
-                            <Column lg={2} md={8} sm={4}>
-                              <h6>
-                                {intl.formatMessage({
-                                  id: "notebook.page.content",
-                                })}
-                              </h6>
-                            </Column>
-                            <Column lg={14} md={8} sm={4}>
-                              {page.content}
-                            </Column>
-                            {page.sampleTypeId && (
-                              <>
-                                <Column lg={2} md={8} sm={4}>
-                                  <h6>
-                                    {intl.formatMessage({
-                                      id: "sample.type",
-                                    })}
-                                  </h6>
-                                </Column>
-                                <Column lg={14} md={8} sm={4}>
-                                  <div>
-                                    <span style={{ marginRight: "0.5rem" }}>
-                                      {intl.formatMessage({
-                                        id: "sample.type",
-                                      })}
-                                      :{" "}
-                                    </span>
-                                    {(() => {
-                                      const sampleType = sampleTypes.find(
-                                        (st) => st.id == page.sampleTypeId,
-                                      );
-                                      return sampleType ? (
-                                        <Tag type="blue" size="sm">
-                                          {sampleType.value}
-                                        </Tag>
-                                      ) : (
-                                        <></>
-                                      );
-                                    })()}
-                                  </div>
-                                </Column>
-                              </>
-                            )}
-                            {page.panels &&
-                              Array.isArray(page.panels) &&
-                              page.panels.length > 0 && (
+                      {noteBookData.pages
+                        .filter((page) => {
+                          // Check page-level access control
+                          const pageRoles = page.allowedRoles
+                            ? Array.isArray(page.allowedRoles)
+                              ? page.allowedRoles
+                              : Array.from(page.allowedRoles)
+                            : [];
+                          // No roles = no restriction = show page
+                          if (pageRoles.length === 0) return true;
+                          // Check if user has any of the page's required roles
+                          return hasRoleForCurrentLabUnit(pageRoles);
+                        })
+                        .map((page, index) => (
+                          <AccordionItem
+                            key={index}
+                            style={{ marginBottom: "1rem" }}
+                            title={
+                              <span
+                                style={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: "0.5rem",
+                                }}
+                              >
+                                {intl.formatMessage(
+                                  { id: "pagination.page" },
+                                  { page: page.order || index + 1 },
+                                )}
+                                :{" "}
+                                <h5 style={{ margin: 0, display: "inline" }}>
+                                  {page.title}
+                                </h5>
+                                {page.completed && (
+                                  <Tag type="green" size="sm">
+                                    <FormattedMessage id="notebook.page.completed" />
+                                  </Tag>
+                                )}
+                              </span>
+                            }
+                          >
+                            <Grid>
+                              <Column lg={2} md={8} sm={4}>
+                                <h6>
+                                  {intl.formatMessage({
+                                    id: "notebook.page.instructions",
+                                  })}
+                                </h6>
+                              </Column>
+                              <Column lg={14} md={8} sm={4}>
+                                {page.instructions}
+                              </Column>
+                              <Column lg={2} md={8} sm={4}>
+                                <h6>
+                                  {intl.formatMessage({
+                                    id: "notebook.page.content",
+                                  })}
+                                </h6>
+                              </Column>
+                              <Column lg={14} md={8} sm={4}>
+                                {page.content}
+                              </Column>
+                              {page.sampleTypeId && (
                                 <>
                                   <Column lg={2} md={8} sm={4}>
                                     <h6>
-                                      <FormattedMessage id="sample.label.orderpanel" />
+                                      {intl.formatMessage({
+                                        id: "sample.type",
+                                      })}
                                     </h6>
                                   </Column>
                                   <Column lg={14} md={8} sm={4}>
                                     <div>
                                       <span style={{ marginRight: "0.5rem" }}>
-                                        <FormattedMessage id="sample.label.orderpanel" />
+                                        {intl.formatMessage({
+                                          id: "sample.type",
+                                        })}
                                         :{" "}
                                       </span>
-                                      {page.panels
-                                        .filter((panelId) => panelId != null)
-                                        .map((panelId, panelIndex) => {
-                                          // Try to find panel by ID (handle both string and number)
-                                          const panel = allPanels.find((p) => {
-                                            if (!p || p.id == null)
-                                              return false;
-                                            // Normalize both to strings for comparison
-                                            const pId = String(p.id).trim();
-                                            const pagePanelId =
-                                              String(panelId).trim();
-                                            // Compare as both string and number
-                                            return (
-                                              pId === pagePanelId ||
-                                              Number(p.id) ===
-                                                Number(panelId) ||
-                                              p.id == panelId
-                                            );
-                                          });
-                                          // Only show panel if found (don't show ID fallback)
-                                          return panel ? (
-                                            <Tag
-                                              key={panelIndex}
-                                              type="green"
-                                              size="sm"
-                                              style={{ marginRight: "0.5rem" }}
-                                            >
-                                              {panel.value}
-                                            </Tag>
-                                          ) : null;
-                                        })
-                                        .filter((tag) => tag !== null)}
-                                    </div>
-                                  </Column>
-                                </>
-                              )}
-                            {page.tests &&
-                              Array.isArray(page.tests) &&
-                              page.tests.length > 0 && (
-                                <>
-                                  <Column lg={2} md={8} sm={4}>
-                                    <h6>
-                                      {intl.formatMessage({
-                                        id: "barcode.label.info.tests",
-                                      })}
-                                    </h6>
-                                  </Column>
-                                  <Column lg={14} md={8} sm={4}>
-                                    <div>
-                                      {page.tests.map((testId, testIndex) => {
-                                        const test = allTests.find(
-                                          (t) => t.id == testId,
+                                      {(() => {
+                                        const sampleType = sampleTypes.find(
+                                          (st) => st.id == page.sampleTypeId,
                                         );
-                                        return test ? (
-                                          <Tag
-                                            key={testIndex}
-                                            type="blue"
-                                            size="sm"
-                                          >
-                                            {test.value}
+                                        return sampleType ? (
+                                          <Tag type="blue" size="sm">
+                                            {sampleType.value}
                                           </Tag>
                                         ) : (
                                           <></>
                                         );
-                                      })}
+                                      })()}
                                     </div>
                                   </Column>
                                 </>
                               )}
-                            <Column lg={16} md={8} sm={4}>
-                              <br />
-                              {!page.completed ? (
-                                <Button
-                                  kind="primary"
-                                  size="sm"
-                                  onClick={() => handleMarkPageComplete(index)}
-                                  style={{ marginRight: "0.5rem" }}
-                                  hasIconOnly
-                                  renderIcon={Checkmark}
-                                  iconDescription={intl.formatMessage({
-                                    id: "notebook.page.markComplete",
-                                  })}
-                                  disabled={isViewMode}
-                                />
-                              ) : (
-                                <Tag
-                                  type="green"
-                                  size="sm"
-                                  style={{ marginRight: "0.5rem" }}
-                                >
-                                  <FormattedMessage id="notebook.page.completed" />
-                                </Tag>
-                              )}
-                            </Column>
-                          </Grid>
-                        </AccordionItem>
-                      ))}
+                              {page.panels &&
+                                Array.isArray(page.panels) &&
+                                page.panels.length > 0 && (
+                                  <>
+                                    <Column lg={2} md={8} sm={4}>
+                                      <h6>
+                                        <FormattedMessage id="sample.label.orderpanel" />
+                                      </h6>
+                                    </Column>
+                                    <Column lg={14} md={8} sm={4}>
+                                      <div>
+                                        <span style={{ marginRight: "0.5rem" }}>
+                                          <FormattedMessage id="sample.label.orderpanel" />
+                                          :{" "}
+                                        </span>
+                                        {page.panels
+                                          .filter((panelId) => panelId != null)
+                                          .map((panelId, panelIndex) => {
+                                            // Try to find panel by ID (handle both string and number)
+                                            const panel = allPanels.find(
+                                              (p) => {
+                                                if (!p || p.id == null)
+                                                  return false;
+                                                // Normalize both to strings for comparison
+                                                const pId = String(p.id).trim();
+                                                const pagePanelId =
+                                                  String(panelId).trim();
+                                                // Compare as both string and number
+                                                return (
+                                                  pId === pagePanelId ||
+                                                  Number(p.id) ===
+                                                    Number(panelId) ||
+                                                  p.id == panelId
+                                                );
+                                              },
+                                            );
+                                            // Only show panel if found (don't show ID fallback)
+                                            return panel ? (
+                                              <Tag
+                                                key={panelIndex}
+                                                type="green"
+                                                size="sm"
+                                                style={{
+                                                  marginRight: "0.5rem",
+                                                }}
+                                              >
+                                                {panel.value}
+                                              </Tag>
+                                            ) : null;
+                                          })
+                                          .filter((tag) => tag !== null)}
+                                      </div>
+                                    </Column>
+                                  </>
+                                )}
+                              {page.tests &&
+                                Array.isArray(page.tests) &&
+                                page.tests.length > 0 && (
+                                  <>
+                                    <Column lg={2} md={8} sm={4}>
+                                      <h6>
+                                        {intl.formatMessage({
+                                          id: "barcode.label.info.tests",
+                                        })}
+                                      </h6>
+                                    </Column>
+                                    <Column lg={14} md={8} sm={4}>
+                                      <div>
+                                        {page.tests.map((testId, testIndex) => {
+                                          const test = allTests.find(
+                                            (t) => t.id == testId,
+                                          );
+                                          return test ? (
+                                            <Tag
+                                              key={testIndex}
+                                              type="blue"
+                                              size="sm"
+                                            >
+                                              {test.value}
+                                            </Tag>
+                                          ) : (
+                                            <></>
+                                          );
+                                        })}
+                                      </div>
+                                    </Column>
+                                  </>
+                                )}
+                              <Column lg={16} md={8} sm={4}>
+                                <br />
+                                {!page.completed ? (
+                                  <Button
+                                    kind="primary"
+                                    size="sm"
+                                    onClick={() =>
+                                      handleMarkPageComplete(index)
+                                    }
+                                    style={{ marginRight: "0.5rem" }}
+                                    hasIconOnly
+                                    renderIcon={Checkmark}
+                                    iconDescription={intl.formatMessage({
+                                      id: "notebook.page.markComplete",
+                                    })}
+                                    disabled={isViewMode}
+                                  />
+                                ) : (
+                                  <Tag
+                                    type="green"
+                                    size="sm"
+                                    style={{ marginRight: "0.5rem" }}
+                                  >
+                                    <FormattedMessage id="notebook.page.completed" />
+                                  </Tag>
+                                )}
+                              </Column>
+                            </Grid>
+                          </AccordionItem>
+                        ))}
                     </Accordion>
                   )}
                 </Column>
@@ -1644,7 +1726,16 @@ const NoteBookInstanceEntryForm = () => {
             <Column lg={8} md={8} sm={4}>
               <Button
                 kind="primary"
-                disabled={isSubmitting || isViewMode}
+                disabled={!canEditEntry || isSubmitting || isViewMode}
+                title={
+                  !canEditEntry
+                    ? intl.formatMessage({
+                        id: "notebook.permission.entry.edit.required",
+                        defaultMessage:
+                          "You need permission to create or edit notebook entries",
+                      })
+                    : undefined
+                }
                 onClick={() => handleSubmit()}
               >
                 <FormattedMessage id="label.button.save" />

--- a/frontend/src/components/notebook/workflow/BacteriologyWorkflowTab.js
+++ b/frontend/src/components/notebook/workflow/BacteriologyWorkflowTab.js
@@ -4,7 +4,6 @@ import React, {
   useEffect,
   useRef,
   useCallback,
-  useMemo,
 } from "react";
 import {
   Loading,
@@ -17,6 +16,7 @@ import {
 import { Renew } from "@carbon/react/icons";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../../utils/Utils";
+import { usePageAccessControl } from "../../../hooks/usePageAccessControl";
 import config from "../../../config.json";
 import { NotificationContext } from "../../layout/Layout";
 import PageNavigation from "./PageNavigation";
@@ -80,19 +80,21 @@ function BacteriologyWorkflowTab({ notebookId, entryId: propEntryId }) {
   const [entryId, setEntryId] = useState(propEntryId);
   const [pages, setPages] = useState([]);
   const [pageProgress, setPageProgress] = useState({});
-  const [activePage, setActivePage] = useState(0);
   const [samples, setSamples] = useState([]);
   const [errorMessage, setErrorMessage] = useState(null);
   const [syncing, setSyncing] = useState(false);
   const [syncMessage, setSyncMessage] = useState(null);
+  // Track whether we're creating a new entry vs viewing/editing existing
+  // This is determined after checking if an entry exists for the notebook
+  const [isCreatingEntry, setIsCreatingEntry] = useState(!propEntryId);
 
-  // Use actual pages if available, otherwise use default Bacteriology workflow pages
-  const effectivePages = useMemo(() => {
-    if (pages && pages.length > 0) {
-      return pages;
-    }
-    return DEFAULT_BACTERIOLOGY_WORKFLOW_PAGES;
-  }, [pages]);
+  // Use shared hook for page access control
+  // isCreating: true when creating a new entry (bypasses page-level role restrictions)
+  // isCreating: false when viewing/editing existing entry (applies role restrictions)
+  const { effectivePages, activePage, setActivePage, handlePageChange } =
+    usePageAccessControl(pages, DEFAULT_BACTERIOLOGY_WORKFLOW_PAGES, 0, {
+      isCreating: isCreatingEntry,
+    });
 
   useEffect(() => {
     componentMounted.current = true;
@@ -169,9 +171,12 @@ function BacteriologyWorkflowTab({ notebookId, entryId: propEntryId }) {
                 Array.isArray(entriesResponse) &&
                 entriesResponse.length > 0
               ) {
+                // Use the first/most recent entry - this is an EXISTING entry
+                // so page-level role restrictions should apply
                 const existingEntry = entriesResponse[0];
                 setEntry(existingEntry);
                 setEntryId(existingEntry.id);
+                setIsCreatingEntry(false); // Viewing/editing existing entry
 
                 getFromOpenElisServer(
                   `/rest/notebook-entry/${existingEntry.id}/samples`,
@@ -185,6 +190,9 @@ function BacteriologyWorkflowTab({ notebookId, entryId: propEntryId }) {
                   },
                 );
               } else {
+                // No entry exists - create one automatically
+                // This is a NEW entry, so page-level restrictions should NOT apply
+                setIsCreatingEntry(true); // Creating new entry
                 createEntryForNotebook(nbId);
               }
             }
@@ -229,6 +237,7 @@ function BacteriologyWorkflowTab({ notebookId, entryId: propEntryId }) {
             setEntry(data);
             setEntryId(data.id);
             setSamples([]);
+            setIsCreatingEntry(false); // Entry created - apply page restrictions
           } else if (data && data.error) {
             console.error("Entry creation error:", data.error);
           }
@@ -242,10 +251,6 @@ function BacteriologyWorkflowTab({ notebookId, entryId: propEntryId }) {
           setLoading(false);
         }
       });
-  };
-
-  const handlePageChange = (pageIndex) => {
-    setActivePage(pageIndex);
   };
 
   const getProgressForPage = (pageId) => {
@@ -570,38 +575,64 @@ function BacteriologyWorkflowTab({ notebookId, entryId: propEntryId }) {
 
         <Column lg={12} md={6} sm={4}>
           <div className="workflow-page-content">
-            {effectivePages.length > 0 && effectivePages[activePage] && (
-              <div className="page-panel">
-                <div className="page-header">
-                  <h3>{effectivePages[activePage].title}</h3>
-                  <div className="page-progress">
-                    {(() => {
-                      const progress = getProgressForPage(
-                        effectivePages[activePage].id,
-                      );
-                      return (
-                        <span>
-                          {progress.completed}/{progress.total}{" "}
-                          <FormattedMessage id="notebook.workflow.samplesCompleted" />
-                        </span>
-                      );
-                    })()}
-                  </div>
-                </div>
-
-                <div className="page-content">
-                  {effectivePages[activePage].instructions && (
-                    <div className="page-instructions">
-                      {effectivePages[activePage].instructions}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              effectivePages[activePage].hasAccess && (
+                <div className="page-panel">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <div className="page-progress">
+                      {(() => {
+                        const progress = getProgressForPage(
+                          effectivePages[activePage].id,
+                        );
+                        return (
+                          <span>
+                            {progress.completed}/{progress.total}{" "}
+                            <FormattedMessage id="notebook.workflow.samplesCompleted" />
+                          </span>
+                        );
+                      })()}
                     </div>
-                  )}
+                  </div>
 
-                  <div key={`page-content-${effectivePages[activePage].id}`}>
-                    {renderPageContent(effectivePages[activePage])}
+                  <div className="page-content">
+                    {effectivePages[activePage].instructions && (
+                      <div className="page-instructions">
+                        {effectivePages[activePage].instructions}
+                      </div>
+                    )}
+
+                    <div key={`page-content-${effectivePages[activePage].id}`}>
+                      {renderPageContent(effectivePages[activePage])}
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            {/* Show access denied message if current page is restricted */}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              !effectivePages[activePage].hasAccess && (
+                <div className="page-panel access-denied">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <Tag type="red">
+                      <FormattedMessage
+                        id="notebook.page.restricted"
+                        defaultMessage="Restricted"
+                      />
+                    </Tag>
+                  </div>
+                  <div className="page-content">
+                    <p>
+                      <FormattedMessage
+                        id="notebook.page.accessDeniedMessage"
+                        defaultMessage="You do not have the required role to access this page."
+                      />
+                    </p>
+                  </div>
+                </div>
+              )}
           </div>
         </Column>
       </Grid>

--- a/frontend/src/components/notebook/workflow/MNTDWorkflowTab.js
+++ b/frontend/src/components/notebook/workflow/MNTDWorkflowTab.js
@@ -4,7 +4,6 @@ import React, {
   useEffect,
   useRef,
   useCallback,
-  useMemo,
 } from "react";
 import {
   Loading,
@@ -17,6 +16,7 @@ import {
 import { Renew } from "@carbon/react/icons";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../../utils/Utils";
+import { usePageAccessControl } from "../../../hooks/usePageAccessControl";
 import config from "../../../config.json";
 import { NotificationContext } from "../../layout/Layout";
 import PageNavigation from "./PageNavigation";
@@ -80,19 +80,21 @@ function MNTDWorkflowTab({ notebookId, entryId: propEntryId }) {
   const [entryId, setEntryId] = useState(propEntryId);
   const [pages, setPages] = useState([]);
   const [pageProgress, setPageProgress] = useState({});
-  const [activePage, setActivePage] = useState(0);
   const [samples, setSamples] = useState([]);
   const [errorMessage, setErrorMessage] = useState(null);
   const [syncing, setSyncing] = useState(false);
   const [syncMessage, setSyncMessage] = useState(null);
+  // Track whether we're creating a new entry vs viewing/editing existing
+  // This is determined after checking if an entry exists for the notebook
+  const [isCreatingEntry, setIsCreatingEntry] = useState(!propEntryId);
 
-  // Use actual pages if available, otherwise use default MNTD workflow pages
-  const effectivePages = useMemo(() => {
-    if (pages && pages.length > 0) {
-      return pages;
-    }
-    return DEFAULT_MNTD_WORKFLOW_PAGES;
-  }, [pages]);
+  // Use shared hook for page access control
+  // isCreating: true when creating a new entry (bypasses page-level role restrictions)
+  // isCreating: false when viewing/editing existing entry (applies role restrictions)
+  const { effectivePages, activePage, setActivePage, handlePageChange } =
+    usePageAccessControl(pages, DEFAULT_MNTD_WORKFLOW_PAGES, 0, {
+      isCreating: isCreatingEntry,
+    });
 
   useEffect(() => {
     componentMounted.current = true;
@@ -169,9 +171,12 @@ function MNTDWorkflowTab({ notebookId, entryId: propEntryId }) {
                 Array.isArray(entriesResponse) &&
                 entriesResponse.length > 0
               ) {
+                // Use the first/most recent entry - this is an EXISTING entry
+                // so page-level role restrictions should apply
                 const existingEntry = entriesResponse[0];
                 setEntry(existingEntry);
                 setEntryId(existingEntry.id);
+                setIsCreatingEntry(false); // Viewing/editing existing entry
 
                 getFromOpenElisServer(
                   `/rest/notebook-entry/${existingEntry.id}/samples`,
@@ -185,6 +190,9 @@ function MNTDWorkflowTab({ notebookId, entryId: propEntryId }) {
                   },
                 );
               } else {
+                // No entry exists - create one automatically
+                // This is a NEW entry, so page-level restrictions should NOT apply
+                setIsCreatingEntry(true); // Creating new entry
                 createEntryForNotebook(nbId);
               }
             }
@@ -229,6 +237,7 @@ function MNTDWorkflowTab({ notebookId, entryId: propEntryId }) {
             setEntry(data);
             setEntryId(data.id);
             setSamples([]);
+            setIsCreatingEntry(false); // Entry created - apply page restrictions
           } else if (data && data.error) {
             console.error("Entry creation error:", data.error);
           }
@@ -242,10 +251,6 @@ function MNTDWorkflowTab({ notebookId, entryId: propEntryId }) {
           setLoading(false);
         }
       });
-  };
-
-  const handlePageChange = (pageIndex) => {
-    setActivePage(pageIndex);
   };
 
   const getProgressForPage = (pageId) => {
@@ -593,38 +598,64 @@ function MNTDWorkflowTab({ notebookId, entryId: propEntryId }) {
 
         <Column lg={12} md={6} sm={4}>
           <div className="workflow-page-content">
-            {effectivePages.length > 0 && effectivePages[activePage] && (
-              <div className="page-panel">
-                <div className="page-header">
-                  <h3>{effectivePages[activePage].title}</h3>
-                  <div className="page-progress">
-                    {(() => {
-                      const progress = getProgressForPage(
-                        effectivePages[activePage].id,
-                      );
-                      return (
-                        <span>
-                          {progress.completed}/{progress.total}{" "}
-                          <FormattedMessage id="notebook.workflow.samplesCompleted" />
-                        </span>
-                      );
-                    })()}
-                  </div>
-                </div>
-
-                <div className="page-content">
-                  {effectivePages[activePage].instructions && (
-                    <div className="page-instructions">
-                      {effectivePages[activePage].instructions}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              effectivePages[activePage].hasAccess && (
+                <div className="page-panel">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <div className="page-progress">
+                      {(() => {
+                        const progress = getProgressForPage(
+                          effectivePages[activePage].id,
+                        );
+                        return (
+                          <span>
+                            {progress.completed}/{progress.total}{" "}
+                            <FormattedMessage id="notebook.workflow.samplesCompleted" />
+                          </span>
+                        );
+                      })()}
                     </div>
-                  )}
+                  </div>
 
-                  <div key={`page-content-${effectivePages[activePage].id}`}>
-                    {renderPageContent(effectivePages[activePage])}
+                  <div className="page-content">
+                    {effectivePages[activePage].instructions && (
+                      <div className="page-instructions">
+                        {effectivePages[activePage].instructions}
+                      </div>
+                    )}
+
+                    <div key={`page-content-${effectivePages[activePage].id}`}>
+                      {renderPageContent(effectivePages[activePage])}
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            {/* Show access denied message if current page is restricted */}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              !effectivePages[activePage].hasAccess && (
+                <div className="page-panel access-denied">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <Tag type="red">
+                      <FormattedMessage
+                        id="notebook.page.restricted"
+                        defaultMessage="Restricted"
+                      />
+                    </Tag>
+                  </div>
+                  <div className="page-content">
+                    <p>
+                      <FormattedMessage
+                        id="notebook.page.accessDeniedMessage"
+                        defaultMessage="You do not have the required role to access this page."
+                      />
+                    </p>
+                  </div>
+                </div>
+              )}
           </div>
         </Column>
       </Grid>

--- a/frontend/src/components/notebook/workflow/NotebookWorkflowTab.js
+++ b/frontend/src/components/notebook/workflow/NotebookWorkflowTab.js
@@ -20,6 +20,7 @@ import {
 } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer, postToOpenElisServer } from "../../utils/Utils";
+import { usePermissions } from "../../../hooks/usePermissions";
 import config from "../../../config.json";
 import { NotificationContext } from "../../layout/Layout";
 import PageNavigation from "./PageNavigation";
@@ -72,6 +73,7 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
   const intl = useIntl();
   const { notificationVisible, setNotificationVisible } =
     useContext(NotificationContext);
+  const { hasRoleForCurrentLabUnit } = usePermissions();
 
   const [loading, setLoading] = useState(true);
   const [notebook, setNotebook] = useState(null);
@@ -84,12 +86,31 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
   const [errorMessage, setErrorMessage] = useState(null);
 
   // Use actual pages if available, otherwise use default workflow pages
+  // Filter pages based on user's role access (page-level RBAC)
   const effectivePages = useMemo(() => {
+    let pagesToUse = DEFAULT_WORKFLOW_PAGES;
     if (pages && pages.length > 0) {
-      return pages;
+      pagesToUse = pages;
     }
-    return DEFAULT_WORKFLOW_PAGES;
-  }, [pages]);
+
+    // Filter pages based on allowedRoles (page-level access control)
+    return pagesToUse.filter((page) => {
+      // Get allowedRoles, handling null/undefined and Set/Array types
+      const pageRoles = page.allowedRoles
+        ? Array.isArray(page.allowedRoles)
+          ? page.allowedRoles
+          : Array.from(page.allowedRoles)
+        : [];
+
+      // No roles defined = no restriction = show page to everyone
+      if (pageRoles.length === 0) {
+        return true;
+      }
+
+      // Check if user has any of the page's required roles
+      return hasRoleForCurrentLabUnit(pageRoles);
+    });
+  }, [pages, hasRoleForCurrentLabUnit]);
 
   useEffect(() => {
     componentMounted.current = true;

--- a/frontend/src/components/notebook/workflow/NotebookWorkflowTab.js
+++ b/frontend/src/components/notebook/workflow/NotebookWorkflowTab.js
@@ -4,23 +4,11 @@ import React, {
   useEffect,
   useRef,
   useCallback,
-  useMemo,
 } from "react";
-import {
-  Tabs,
-  TabList,
-  Tab,
-  TabPanels,
-  TabPanel,
-  Loading,
-  Grid,
-  Column,
-  Button,
-  Tag,
-} from "@carbon/react";
+import { Loading, Grid, Column, Tag } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { getFromOpenElisServer, postToOpenElisServer } from "../../utils/Utils";
-import { usePermissions } from "../../../hooks/usePermissions";
+import { getFromOpenElisServer } from "../../utils/Utils";
+import { usePageAccessControl } from "../../../hooks/usePageAccessControl";
 import config from "../../../config.json";
 import { NotificationContext } from "../../layout/Layout";
 import PageNavigation from "./PageNavigation";
@@ -73,7 +61,6 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
   const intl = useIntl();
   const { notificationVisible, setNotificationVisible } =
     useContext(NotificationContext);
-  const { hasRoleForCurrentLabUnit } = usePermissions();
 
   const [loading, setLoading] = useState(true);
   const [notebook, setNotebook] = useState(null);
@@ -81,44 +68,19 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
   const [entryId, setEntryId] = useState(propEntryId);
   const [pages, setPages] = useState([]);
   const [pageProgress, setPageProgress] = useState({});
-  const [activePage, setActivePage] = useState(0);
   const [samples, setSamples] = useState([]);
   const [errorMessage, setErrorMessage] = useState(null);
+  // Track whether we're creating a new entry vs viewing/editing existing
+  // This is determined after checking if an entry exists for the notebook
+  const [isCreatingEntry, setIsCreatingEntry] = useState(!propEntryId);
 
-  // Helper function to check if user has access to a page
-  const hasPageAccess = useCallback(
-    (page) => {
-      const pageRoles = page.allowedRoles
-        ? Array.isArray(page.allowedRoles)
-          ? page.allowedRoles
-          : Array.from(page.allowedRoles)
-        : [];
-
-      // No roles defined = no restriction = allow everyone
-      if (pageRoles.length === 0) {
-        return true;
-      }
-
-      // Check if user has any of the page's required roles
-      return hasRoleForCurrentLabUnit(pageRoles);
-    },
-    [hasRoleForCurrentLabUnit],
-  );
-
-  // Use actual pages if available, otherwise use default workflow pages
-  // Include access info for each page (for disabling in navigation)
-  const effectivePages = useMemo(() => {
-    let pagesToUse = DEFAULT_WORKFLOW_PAGES;
-    if (pages && pages.length > 0) {
-      pagesToUse = pages;
-    }
-
-    // Add hasAccess property to each page for navigation
-    return pagesToUse.map((page) => ({
-      ...page,
-      hasAccess: hasPageAccess(page),
-    }));
-  }, [pages, hasPageAccess]);
+  // Use shared hook for page access control
+  // isCreating: true when creating a new entry (bypasses page-level role restrictions)
+  // isCreating: false when viewing/editing existing entry (applies role restrictions)
+  const { effectivePages, activePage, setActivePage, handlePageChange } =
+    usePageAccessControl(pages, DEFAULT_WORKFLOW_PAGES, 0, {
+      isCreating: isCreatingEntry,
+    });
 
   useEffect(() => {
     componentMounted.current = true;
@@ -204,10 +166,12 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
                 Array.isArray(entriesResponse) &&
                 entriesResponse.length > 0
               ) {
-                // Use the first/most recent entry
+                // Use the first/most recent entry - this is an EXISTING entry
+                // so page-level role restrictions should apply
                 const existingEntry = entriesResponse[0];
                 setEntry(existingEntry);
                 setEntryId(existingEntry.id);
+                setIsCreatingEntry(false); // Viewing/editing existing entry
 
                 // Load samples for this entry
                 getFromOpenElisServer(
@@ -223,11 +187,13 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
                 );
               } else {
                 // No entry exists or got error - create one automatically
+                // This is a NEW entry, so page-level restrictions should NOT apply
                 console.log(
                   "No existing entries found for notebook",
                   nbId,
                   "- creating new entry",
                 );
+                setIsCreatingEntry(true); // Creating new entry
                 createEntryForNotebook(nbId);
               }
             }
@@ -283,6 +249,7 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
             setEntry(data);
             setEntryId(data.id);
             setSamples([]);
+            setIsCreatingEntry(false); // Entry created - apply page restrictions
             console.log("Entry created successfully with ID:", data.id);
           } else if (data && data.error) {
             console.error("Entry creation error:", data.error);
@@ -299,14 +266,6 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
           setLoading(false);
         }
       });
-  };
-
-  const handlePageChange = (pageIndex) => {
-    // Don't navigate to pages the user doesn't have access to
-    if (effectivePages[pageIndex] && !effectivePages[pageIndex].hasAccess) {
-      return;
-    }
-    setActivePage(pageIndex);
   };
 
   const getProgressForPage = (pageId) => {
@@ -579,43 +538,69 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
 
         <Column lg={12} md={6} sm={4}>
           <div className="workflow-page-content">
-            {effectivePages.length > 0 && effectivePages[activePage] && (
-              <div className="page-panel">
-                <div className="page-header">
-                  <h3>{effectivePages[activePage].title}</h3>
-                  <div className="page-progress">
-                    {(() => {
-                      const progress = getProgressForPage(
-                        effectivePages[activePage].id,
-                      );
-                      return (
-                        <span>
-                          {progress.completed}/{progress.total}{" "}
-                          <FormattedMessage id="notebook.workflow.samplesCompleted" />
-                        </span>
-                      );
-                    })()}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              effectivePages[activePage].hasAccess && (
+                <div className="page-panel">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <div className="page-progress">
+                      {(() => {
+                        const progress = getProgressForPage(
+                          effectivePages[activePage].id,
+                        );
+                        return (
+                          <span>
+                            {progress.completed}/{progress.total}{" "}
+                            <FormattedMessage id="notebook.workflow.samplesCompleted" />
+                          </span>
+                        );
+                      })()}
+                    </div>
+                  </div>
+
+                  <div className="page-content">
+                    {effectivePages[activePage].content && (
+                      <div
+                        className="page-instructions"
+                        dangerouslySetInnerHTML={{
+                          __html: effectivePages[activePage].content,
+                        }}
+                      />
+                    )}
+
+                    {/* Page-specific content rendered based on page order */}
+                    {/* Key forces React to unmount/remount when switching pages to reset state */}
+                    <div key={`page-content-${effectivePages[activePage].id}`}>
+                      {renderPageContent(effectivePages[activePage])}
+                    </div>
                   </div>
                 </div>
-
-                <div className="page-content">
-                  {effectivePages[activePage].content && (
-                    <div
-                      className="page-instructions"
-                      dangerouslySetInnerHTML={{
-                        __html: effectivePages[activePage].content,
-                      }}
-                    />
-                  )}
-
-                  {/* Page-specific content rendered based on page order */}
-                  {/* Key forces React to unmount/remount when switching pages to reset state */}
-                  <div key={`page-content-${effectivePages[activePage].id}`}>
-                    {renderPageContent(effectivePages[activePage])}
+              )}
+            {/* Show access denied message if current page is restricted */}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              !effectivePages[activePage].hasAccess && (
+                <div className="page-panel access-denied">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <Tag type="red">
+                      <FormattedMessage
+                        id="notebook.page.restricted"
+                        defaultMessage="Restricted"
+                      />
+                    </Tag>
+                  </div>
+                  <div className="page-content">
+                    <p>
+                      <FormattedMessage
+                        id="notebook.page.accessDeniedMessage"
+                        defaultMessage="You do not have the required role to access this page."
+                      />
+                    </p>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
           </div>
         </Column>
       </Grid>

--- a/frontend/src/components/notebook/workflow/NotebookWorkflowTab.js
+++ b/frontend/src/components/notebook/workflow/NotebookWorkflowTab.js
@@ -85,32 +85,40 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
   const [samples, setSamples] = useState([]);
   const [errorMessage, setErrorMessage] = useState(null);
 
-  // Use actual pages if available, otherwise use default workflow pages
-  // Filter pages based on user's role access (page-level RBAC)
-  const effectivePages = useMemo(() => {
-    let pagesToUse = DEFAULT_WORKFLOW_PAGES;
-    if (pages && pages.length > 0) {
-      pagesToUse = pages;
-    }
-
-    // Filter pages based on allowedRoles (page-level access control)
-    return pagesToUse.filter((page) => {
-      // Get allowedRoles, handling null/undefined and Set/Array types
+  // Helper function to check if user has access to a page
+  const hasPageAccess = useCallback(
+    (page) => {
       const pageRoles = page.allowedRoles
         ? Array.isArray(page.allowedRoles)
           ? page.allowedRoles
           : Array.from(page.allowedRoles)
         : [];
 
-      // No roles defined = no restriction = show page to everyone
+      // No roles defined = no restriction = allow everyone
       if (pageRoles.length === 0) {
         return true;
       }
 
       // Check if user has any of the page's required roles
       return hasRoleForCurrentLabUnit(pageRoles);
-    });
-  }, [pages, hasRoleForCurrentLabUnit]);
+    },
+    [hasRoleForCurrentLabUnit],
+  );
+
+  // Use actual pages if available, otherwise use default workflow pages
+  // Include access info for each page (for disabling in navigation)
+  const effectivePages = useMemo(() => {
+    let pagesToUse = DEFAULT_WORKFLOW_PAGES;
+    if (pages && pages.length > 0) {
+      pagesToUse = pages;
+    }
+
+    // Add hasAccess property to each page for navigation
+    return pagesToUse.map((page) => ({
+      ...page,
+      hasAccess: hasPageAccess(page),
+    }));
+  }, [pages, hasPageAccess]);
 
   useEffect(() => {
     componentMounted.current = true;
@@ -294,6 +302,10 @@ function NotebookWorkflowTab({ notebookId, entryId: propEntryId }) {
   };
 
   const handlePageChange = (pageIndex) => {
+    // Don't navigate to pages the user doesn't have access to
+    if (effectivePages[pageIndex] && !effectivePages[pageIndex].hasAccess) {
+      return;
+    }
     setActivePage(pageIndex);
   };
 

--- a/frontend/src/components/notebook/workflow/PageNavigation.js
+++ b/frontend/src/components/notebook/workflow/PageNavigation.js
@@ -1,19 +1,61 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 import { Tag, Tooltip } from "@carbon/react";
 import { Checkmark, InProgress, CircleDash, Locked } from "@carbon/react/icons";
+import { usePermissions } from "../../../hooks/usePermissions";
 import "./NotebookWorkflow.css";
 
 /**
- * PageNavigation - Displays the 9 workflow pages with progress indicators.
+ * PageNavigation - Displays the workflow pages with progress indicators and access control.
+ *
+ * Access control is handled internally - pages with allowedRoles will be disabled
+ * if the current user doesn't have the required roles.
  *
  * @param {Object} props
- * @param {Array} props.pages - Array of notebook pages
+ * @param {Array} props.pages - Array of notebook pages (may include allowedRoles property)
  * @param {number} props.activePage - Currently active page index
  * @param {function} props.onPageChange - Callback when page is selected
  * @param {Object} props.pageProgress - Map of page ID to progress object
  */
 function PageNavigation({ pages, activePage, onPageChange, pageProgress }) {
+  const { hasRoleForCurrentLabUnit } = usePermissions();
+
+  /**
+   * Check if user has access to a specific page based on its allowedRoles
+   * If no roles are defined, access is granted to everyone.
+   */
+  const checkPageAccess = useCallback(
+    (page) => {
+      // If page already has hasAccess computed (from parent), respect it
+      if (page.hasAccess !== undefined) {
+        return page.hasAccess;
+      }
+
+      const pageRoles = page.allowedRoles
+        ? Array.isArray(page.allowedRoles)
+          ? page.allowedRoles
+          : Array.from(page.allowedRoles)
+        : [];
+
+      // No roles defined = no restriction = allow everyone
+      if (pageRoles.length === 0) {
+        return true;
+      }
+
+      // Check if user has any of the page's required roles
+      return hasRoleForCurrentLabUnit(pageRoles);
+    },
+    [hasRoleForCurrentLabUnit],
+  );
+
+  // Compute pages with access info
+  const pagesWithAccess = useMemo(() => {
+    return pages.map((page) => ({
+      ...page,
+      hasAccess: checkPageAccess(page),
+    }));
+  }, [pages, checkPageAccess]);
+
   const getProgressStatus = (pageId) => {
     const progress = pageProgress[pageId];
     if (!progress) {
@@ -90,11 +132,11 @@ function PageNavigation({ pages, activePage, onPageChange, pageProgress }) {
       </h4>
 
       <div className="page-list">
-        {pages.map((page, index) => {
+        {pagesWithAccess.map((page, index) => {
           const status = getProgressStatus(page.id);
           const percentage = getProgressPercentage(page.id);
           const isActive = index === activePage;
-          const hasAccess = page.hasAccess !== false; // Default to true if not specified
+          const hasAccess = page.hasAccess;
           const isDisabled = !hasAccess;
 
           const pageItem = (
@@ -163,10 +205,10 @@ function PageNavigation({ pages, activePage, onPageChange, pageProgress }) {
           id="notebook.workflow.pagesCompleted"
           defaultMessage="{completed} of {total} pages completed"
           values={{
-            completed: pages.filter(
+            completed: pagesWithAccess.filter(
               (p) => getProgressStatus(p.id) === "complete",
             ).length,
-            total: pages.length,
+            total: pagesWithAccess.length,
           }}
         />
       </div>

--- a/frontend/src/components/notebook/workflow/PageNavigation.js
+++ b/frontend/src/components/notebook/workflow/PageNavigation.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import { Tag } from "@carbon/react";
-import { Checkmark, InProgress, CircleDash } from "@carbon/react/icons";
+import { Tag, Tooltip } from "@carbon/react";
+import { Checkmark, InProgress, CircleDash, Locked } from "@carbon/react/icons";
 import "./NotebookWorkflow.css";
 
 /**
@@ -36,7 +36,10 @@ function PageNavigation({ pages, activePage, onPageChange, pageProgress }) {
     return Math.round((progress.completed / progress.total) * 100);
   };
 
-  const getStatusIcon = (status) => {
+  const getStatusIcon = (status, hasAccess = true) => {
+    if (!hasAccess) {
+      return <Locked size={16} className="status-icon locked" />;
+    }
     switch (status) {
       case "complete":
         return <Checkmark size={16} className="status-icon complete" />;
@@ -91,32 +94,67 @@ function PageNavigation({ pages, activePage, onPageChange, pageProgress }) {
           const status = getProgressStatus(page.id);
           const percentage = getProgressPercentage(page.id);
           const isActive = index === activePage;
+          const hasAccess = page.hasAccess !== false; // Default to true if not specified
+          const isDisabled = !hasAccess;
 
-          return (
+          const pageItem = (
             <div
               key={page.id}
               role="button"
               aria-pressed={isActive}
-              className={`page-item ${isActive ? "active" : ""} ${status}`}
-              onClick={() => handlePageClick(index)}
+              aria-disabled={isDisabled}
+              className={`page-item ${isActive ? "active" : ""} ${status} ${isDisabled ? "disabled" : ""}`}
+              onClick={() => !isDisabled && handlePageClick(index)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
+                if (!isDisabled && (e.key === "Enter" || e.key === " ")) {
                   e.preventDefault();
                   handlePageClick(index);
                 }
               }}
-              tabIndex={0}
+              tabIndex={isDisabled ? -1 : 0}
+              style={isDisabled ? { opacity: 0.5, cursor: "not-allowed" } : {}}
             >
-              <div className="page-status-cell">{getStatusIcon(status)}</div>
+              <div className="page-status-cell">
+                {getStatusIcon(status, hasAccess)}
+              </div>
               <div className="page-title-cell">
                 <span className="page-number">{index + 1}.</span>
                 <span className="page-title">{page.title}</span>
               </div>
               <div className="page-progress-cell">
-                {getStatusTag(status, percentage)}
+                {isDisabled ? (
+                  <Tag type="gray">
+                    <FormattedMessage
+                      id="notebook.page.restricted"
+                      defaultMessage="Restricted"
+                    />
+                  </Tag>
+                ) : (
+                  getStatusTag(status, percentage)
+                )}
               </div>
             </div>
           );
+
+          // Wrap disabled pages in Tooltip to explain why
+          if (isDisabled) {
+            return (
+              <Tooltip
+                key={page.id}
+                label={
+                  <FormattedMessage
+                    id="notebook.page.accessDenied"
+                    defaultMessage="You don't have the required role to access this page"
+                  />
+                }
+                align="right"
+              >
+                {pageItem}
+              </Tooltip>
+            );
+          }
+
+          return pageItem;
         })}
       </div>
 

--- a/frontend/src/components/notebook/workflow/PharmaceuticalWorkflowTab.js
+++ b/frontend/src/components/notebook/workflow/PharmaceuticalWorkflowTab.js
@@ -4,11 +4,11 @@ import React, {
   useEffect,
   useRef,
   useCallback,
-  useMemo,
 } from "react";
 import { Loading, Grid, Column, Tag } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../../utils/Utils";
+import { usePageAccessControl } from "../../../hooks/usePageAccessControl";
 import config from "../../../config.json";
 import { NotificationContext } from "../../layout/Layout";
 import PageNavigation from "./PageNavigation";
@@ -67,22 +67,19 @@ function PharmaceuticalWorkflowTab({ notebookId, entryId: propEntryId }) {
   const [entryId, setEntryId] = useState(propEntryId);
   const [pages, setPages] = useState([]);
   const [pageProgress, setPageProgress] = useState({});
-  const [activePage, setActivePage] = useState(0);
   const [samples, setSamples] = useState([]);
   const [errorMessage, setErrorMessage] = useState(null);
+  // Track whether we're creating a new entry vs viewing/editing existing
+  // This is determined after checking if an entry exists for the notebook
+  const [isCreatingEntry, setIsCreatingEntry] = useState(!propEntryId);
 
-  // Use actual pages if available, otherwise use default pharma workflow pages
-  // Sort by page_order or order to ensure correct display sequence
-  const effectivePages = useMemo(() => {
-    if (pages && pages.length > 0) {
-      return [...pages].sort((a, b) => {
-        const orderA = a.pageOrder ?? a.order ?? 0;
-        const orderB = b.pageOrder ?? b.order ?? 0;
-        return orderA - orderB;
-      });
-    }
-    return DEFAULT_PHARMA_WORKFLOW_PAGES;
-  }, [pages]);
+  // Use shared hook for page access control
+  // isCreating: true when creating a new entry (bypasses page-level role restrictions)
+  // isCreating: false when viewing/editing existing entry (applies role restrictions)
+  const { effectivePages, activePage, setActivePage, handlePageChange } =
+    usePageAccessControl(pages, DEFAULT_PHARMA_WORKFLOW_PAGES, 0, {
+      isCreating: isCreatingEntry,
+    });
 
   useEffect(() => {
     componentMounted.current = true;
@@ -160,9 +157,12 @@ function PharmaceuticalWorkflowTab({ notebookId, entryId: propEntryId }) {
                 Array.isArray(entriesResponse) &&
                 entriesResponse.length > 0
               ) {
+                // Use the first/most recent entry - this is an EXISTING entry
+                // so page-level role restrictions should apply
                 const existingEntry = entriesResponse[0];
                 setEntry(existingEntry);
                 setEntryId(existingEntry.id);
+                setIsCreatingEntry(false); // Viewing/editing existing entry
 
                 getFromOpenElisServer(
                   `/rest/notebook-entry/${existingEntry.id}/samples`,
@@ -176,6 +176,9 @@ function PharmaceuticalWorkflowTab({ notebookId, entryId: propEntryId }) {
                   },
                 );
               } else {
+                // No entry exists - create one automatically
+                // This is a NEW entry, so page-level restrictions should NOT apply
+                setIsCreatingEntry(true); // Creating new entry
                 createEntryForNotebook(nbId);
               }
             }
@@ -220,6 +223,7 @@ function PharmaceuticalWorkflowTab({ notebookId, entryId: propEntryId }) {
             setEntry(data);
             setEntryId(data.id);
             setSamples([]);
+            setIsCreatingEntry(false); // Entry created - apply page restrictions
           } else if (data && data.error) {
             console.error("Entry creation error:", data.error);
           }
@@ -233,10 +237,6 @@ function PharmaceuticalWorkflowTab({ notebookId, entryId: propEntryId }) {
           setLoading(false);
         }
       });
-  };
-
-  const handlePageChange = (pageIndex) => {
-    setActivePage(pageIndex);
   };
 
   const getProgressForPage = (pageId) => {
@@ -445,38 +445,64 @@ function PharmaceuticalWorkflowTab({ notebookId, entryId: propEntryId }) {
 
         <Column lg={12} md={6} sm={4}>
           <div className="workflow-page-content">
-            {effectivePages.length > 0 && effectivePages[activePage] && (
-              <div className="page-panel">
-                <div className="page-header">
-                  <h3>{effectivePages[activePage].title}</h3>
-                  <div className="page-progress">
-                    {(() => {
-                      const progress = getProgressForPage(
-                        effectivePages[activePage].id,
-                      );
-                      return (
-                        <span>
-                          {progress.completed}/{progress.total}{" "}
-                          <FormattedMessage id="notebook.workflow.samplesCompleted" />
-                        </span>
-                      );
-                    })()}
-                  </div>
-                </div>
-
-                <div className="page-content">
-                  {effectivePages[activePage].instructions && (
-                    <div className="page-instructions">
-                      {effectivePages[activePage].instructions}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              effectivePages[activePage].hasAccess && (
+                <div className="page-panel">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <div className="page-progress">
+                      {(() => {
+                        const progress = getProgressForPage(
+                          effectivePages[activePage].id,
+                        );
+                        return (
+                          <span>
+                            {progress.completed}/{progress.total}{" "}
+                            <FormattedMessage id="notebook.workflow.samplesCompleted" />
+                          </span>
+                        );
+                      })()}
                     </div>
-                  )}
+                  </div>
 
-                  <div key={`page-content-${effectivePages[activePage].id}`}>
-                    {renderPageContent(effectivePages[activePage])}
+                  <div className="page-content">
+                    {effectivePages[activePage].instructions && (
+                      <div className="page-instructions">
+                        {effectivePages[activePage].instructions}
+                      </div>
+                    )}
+
+                    <div key={`page-content-${effectivePages[activePage].id}`}>
+                      {renderPageContent(effectivePages[activePage])}
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            {/* Show access denied message if current page is restricted */}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              !effectivePages[activePage].hasAccess && (
+                <div className="page-panel access-denied">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <Tag type="red">
+                      <FormattedMessage
+                        id="notebook.page.restricted"
+                        defaultMessage="Restricted"
+                      />
+                    </Tag>
+                  </div>
+                  <div className="page-content">
+                    <p>
+                      <FormattedMessage
+                        id="notebook.page.accessDeniedMessage"
+                        defaultMessage="You do not have the required role to access this page."
+                      />
+                    </p>
+                  </div>
+                </div>
+              )}
           </div>
         </Column>
       </Grid>

--- a/frontend/src/components/notebook/workflow/TBWorkflowTab.js
+++ b/frontend/src/components/notebook/workflow/TBWorkflowTab.js
@@ -4,11 +4,11 @@ import React, {
   useEffect,
   useRef,
   useCallback,
-  useMemo,
 } from "react";
 import { Loading, Grid, Column, Tag } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../../utils/Utils";
+import { usePageAccessControl } from "../../../hooks/usePageAccessControl";
 import config from "../../../config.json";
 import { NotificationContext } from "../../layout/Layout";
 import PageNavigation from "./PageNavigation";
@@ -61,17 +61,19 @@ function TBWorkflowTab({ notebookId, entryId: propEntryId }) {
   const [entryId, setEntryId] = useState(propEntryId);
   const [pages, setPages] = useState([]);
   const [pageProgress, setPageProgress] = useState({});
-  const [activePage, setActivePage] = useState(0);
   const [samples, setSamples] = useState([]);
   const [errorMessage, setErrorMessage] = useState(null);
+  // Track whether we're creating a new entry vs viewing/editing existing
+  // This is determined after checking if an entry exists for the notebook
+  const [isCreatingEntry, setIsCreatingEntry] = useState(!propEntryId);
 
-  // Use actual pages if available, otherwise use default TB workflow pages
-  const effectivePages = useMemo(() => {
-    if (pages && pages.length > 0) {
-      return pages;
-    }
-    return DEFAULT_TB_WORKFLOW_PAGES;
-  }, [pages]);
+  // Use shared hook for page access control
+  // isCreating: true when creating a new entry (bypasses page-level role restrictions)
+  // isCreating: false when viewing/editing existing entry (applies role restrictions)
+  const { effectivePages, activePage, setActivePage, handlePageChange } =
+    usePageAccessControl(pages, DEFAULT_TB_WORKFLOW_PAGES, 0, {
+      isCreating: isCreatingEntry,
+    });
 
   useEffect(() => {
     componentMounted.current = true;
@@ -148,9 +150,12 @@ function TBWorkflowTab({ notebookId, entryId: propEntryId }) {
                 Array.isArray(entriesResponse) &&
                 entriesResponse.length > 0
               ) {
+                // Use the first/most recent entry - this is an EXISTING entry
+                // so page-level role restrictions should apply
                 const existingEntry = entriesResponse[0];
                 setEntry(existingEntry);
                 setEntryId(existingEntry.id);
+                setIsCreatingEntry(false); // Viewing/editing existing entry
 
                 getFromOpenElisServer(
                   `/rest/notebook-entry/${existingEntry.id}/samples`,
@@ -164,6 +169,9 @@ function TBWorkflowTab({ notebookId, entryId: propEntryId }) {
                   },
                 );
               } else {
+                // No entry exists - create one automatically
+                // This is a NEW entry, so page-level restrictions should NOT apply
+                setIsCreatingEntry(true); // Creating new entry
                 createEntryForNotebook(nbId);
               }
             }
@@ -208,6 +216,7 @@ function TBWorkflowTab({ notebookId, entryId: propEntryId }) {
             setEntry(data);
             setEntryId(data.id);
             setSamples([]);
+            setIsCreatingEntry(false); // Entry created - apply page restrictions
           } else if (data && data.error) {
             console.error("Entry creation error:", data.error);
           }
@@ -221,10 +230,6 @@ function TBWorkflowTab({ notebookId, entryId: propEntryId }) {
           setLoading(false);
         }
       });
-  };
-
-  const handlePageChange = (pageIndex) => {
-    setActivePage(pageIndex);
   };
 
   const getProgressForPage = (pageId) => {
@@ -420,38 +425,64 @@ function TBWorkflowTab({ notebookId, entryId: propEntryId }) {
 
         <Column lg={12} md={6} sm={4}>
           <div className="workflow-page-content">
-            {effectivePages.length > 0 && effectivePages[activePage] && (
-              <div className="page-panel">
-                <div className="page-header">
-                  <h3>{effectivePages[activePage].title}</h3>
-                  <div className="page-progress">
-                    {(() => {
-                      const progress = getProgressForPage(
-                        effectivePages[activePage].id,
-                      );
-                      return (
-                        <span>
-                          {progress.completed}/{progress.total}{" "}
-                          <FormattedMessage id="notebook.workflow.samplesCompleted" />
-                        </span>
-                      );
-                    })()}
-                  </div>
-                </div>
-
-                <div className="page-content">
-                  {effectivePages[activePage].instructions && (
-                    <div className="page-instructions">
-                      {effectivePages[activePage].instructions}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              effectivePages[activePage].hasAccess && (
+                <div className="page-panel">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <div className="page-progress">
+                      {(() => {
+                        const progress = getProgressForPage(
+                          effectivePages[activePage].id,
+                        );
+                        return (
+                          <span>
+                            {progress.completed}/{progress.total}{" "}
+                            <FormattedMessage id="notebook.workflow.samplesCompleted" />
+                          </span>
+                        );
+                      })()}
                     </div>
-                  )}
+                  </div>
 
-                  <div key={`page-content-${effectivePages[activePage].id}`}>
-                    {renderPageContent(effectivePages[activePage])}
+                  <div className="page-content">
+                    {effectivePages[activePage].instructions && (
+                      <div className="page-instructions">
+                        {effectivePages[activePage].instructions}
+                      </div>
+                    )}
+
+                    <div key={`page-content-${effectivePages[activePage].id}`}>
+                      {renderPageContent(effectivePages[activePage])}
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            {/* Show access denied message if current page is restricted */}
+            {effectivePages.length > 0 &&
+              effectivePages[activePage] &&
+              !effectivePages[activePage].hasAccess && (
+                <div className="page-panel access-denied">
+                  <div className="page-header">
+                    <h3>{effectivePages[activePage].title}</h3>
+                    <Tag type="red">
+                      <FormattedMessage
+                        id="notebook.page.restricted"
+                        defaultMessage="Restricted"
+                      />
+                    </Tag>
+                  </div>
+                  <div className="page-content">
+                    <p>
+                      <FormattedMessage
+                        id="notebook.page.accessDeniedMessage"
+                        defaultMessage="You do not have the required role to access this page."
+                      />
+                    </p>
+                  </div>
+                </div>
+              )}
           </div>
         </Column>
       </Grid>

--- a/frontend/src/components/security/PermissionGate.js
+++ b/frontend/src/components/security/PermissionGate.js
@@ -1,0 +1,169 @@
+import React, { cloneElement, Children } from "react";
+import PropTypes from "prop-types";
+import { Tooltip } from "@carbon/react";
+import { usePermissions } from "../../hooks/usePermissions";
+
+/**
+ * PermissionGate - Declarative permission checking component
+ *
+ * Wraps children and controls their rendering based on user permissions.
+ * By default (per design decision 4B), shows disabled state with tooltip
+ * when user lacks permission. Can be configured to hide completely.
+ *
+ * @example
+ * // Basic usage - disable with tooltip if no access
+ * <PermissionGate
+ *   roles={[Roles.GLOBAL_ADMIN, Roles.NOTEBOOK_ADMIN]}
+ *   disabledTooltip="You need admin access to perform this action"
+ * >
+ *   <Button>Add Notebook</Button>
+ * </PermissionGate>
+ *
+ * @example
+ * // Hide completely if no access
+ * <PermissionGate
+ *   roles={[Roles.GLOBAL_ADMIN]}
+ *   hideCompletely
+ * >
+ *   <AdminPanel />
+ * </PermissionGate>
+ *
+ * @example
+ * // Lab-unit specific role check
+ * <PermissionGate
+ *   labUnitRoles={{ "Cytology": [Roles.TECHNICIAN, Roles.SUPERVISOR] }}
+ *   disabledTooltip="You need Cytology access"
+ * >
+ *   <CytologyWorkflow />
+ * </PermissionGate>
+ *
+ * @example
+ * // Require all roles (AND logic)
+ * <PermissionGate
+ *   roles={[Roles.RESULTS, Roles.VALIDATION]}
+ *   requireAll
+ *   disabledTooltip="You need both Results and Validation roles"
+ * >
+ *   <ApproveButton />
+ * </PermissionGate>
+ */
+const PermissionGate = ({
+  children,
+  roles = [],
+  labUnitRoles = {},
+  requireAll = false,
+  disabledTooltip = "You do not have permission to access this feature",
+  hideCompletely = false,
+  fallback = null,
+}) => {
+  const { hasRole, hasAnyRole, hasAllRoles, hasLabUnitRole } = usePermissions();
+
+  /**
+   * Check if user has required global roles
+   */
+  const checkGlobalRoles = () => {
+    if (!roles || roles.length === 0) {
+      return true; // No global role requirement
+    }
+    return requireAll ? hasAllRoles(roles) : hasAnyRole(roles);
+  };
+
+  /**
+   * Check if user has required lab-unit specific roles
+   */
+  const checkLabUnitRoles = () => {
+    if (!labUnitRoles || Object.keys(labUnitRoles).length === 0) {
+      return true; // No lab unit role requirement
+    }
+
+    // Check each lab unit's role requirements
+    const results = Object.entries(labUnitRoles).map(([labUnit, unitRoles]) => {
+      if (!unitRoles || unitRoles.length === 0) {
+        return true;
+      }
+      // Check if user has any of the required roles for this lab unit
+      return unitRoles.some((role) => hasLabUnitRole(labUnit, role));
+    });
+
+    // If requireAll, all lab units must have at least one matching role
+    // Otherwise, at least one lab unit must match
+    return requireAll ? results.every(Boolean) : results.some(Boolean);
+  };
+
+  /**
+   * Determine if user has permission
+   */
+  const hasPermission = checkGlobalRoles() && checkLabUnitRoles();
+
+  // If user has permission, render children normally
+  if (hasPermission) {
+    return <>{children}</>;
+  }
+
+  // If configured to hide completely, render fallback or nothing
+  if (hideCompletely) {
+    return fallback;
+  }
+
+  // Default behavior: show disabled state with tooltip
+  // Clone children and add disabled prop
+  const disabledChildren = Children.map(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return child;
+    }
+
+    // Clone the child with disabled prop
+    const clonedChild = cloneElement(child, {
+      disabled: true,
+      className: `${child.props.className || ""} permission-denied`.trim(),
+      "aria-disabled": true,
+      onClick: (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      },
+    });
+
+    return clonedChild;
+  });
+
+  // Wrap with tooltip explaining why it's disabled
+  return (
+    <Tooltip
+      label={disabledTooltip}
+      align="bottom"
+      className="permission-gate-tooltip"
+    >
+      <span
+        style={{ display: "inline-block", cursor: "not-allowed" }}
+        className="permission-gate-wrapper"
+      >
+        {disabledChildren}
+      </span>
+    </Tooltip>
+  );
+};
+
+PermissionGate.propTypes = {
+  /** Child components to render/control */
+  children: PropTypes.node.isRequired,
+
+  /** Global roles required (checked with OR logic by default) */
+  roles: PropTypes.arrayOf(PropTypes.string),
+
+  /** Lab-unit specific roles: { labUnitName: [roleNames] } */
+  labUnitRoles: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)),
+
+  /** If true, require ALL roles instead of ANY role */
+  requireAll: PropTypes.bool,
+
+  /** Tooltip text shown when user lacks permission (used when not hiding) */
+  disabledTooltip: PropTypes.string,
+
+  /** If true, hide completely instead of showing disabled state */
+  hideCompletely: PropTypes.bool,
+
+  /** Element to render when hideCompletely is true and user lacks permission */
+  fallback: PropTypes.node,
+};
+
+export default PermissionGate;

--- a/frontend/src/components/security/index.js
+++ b/frontend/src/components/security/index.js
@@ -1,1 +1,2 @@
 export { default as SecureRoute } from "./SecureRoute";
+export { default as PermissionGate } from "./PermissionGate";

--- a/frontend/src/constants/roles.js
+++ b/frontend/src/constants/roles.js
@@ -1,0 +1,151 @@
+/**
+ * Centralized role and permission definitions for OpenELIS-Global
+ *
+ * This file defines:
+ * 1. Roles - Base system roles (must match backend role names)
+ * 2. Permissions - Permission-based groups for feature access control
+ *
+ * Usage:
+ *   import { Roles, Permissions } from "../constants/roles";
+ *   <PermissionGate roles={Permissions.CREATE_OR_EDIT_NOTEBOOK}>
+ *     <AddButton />
+ *   </PermissionGate>
+ */
+
+/**
+ * Base system roles - must match backend role names exactly
+ * These are the actual role names stored in the database
+ */
+export const Roles = {
+  // System/Global Roles
+  GLOBAL_ADMIN: "Global Administrator",
+  USER_ACCOUNT_ADMIN: "User Account Administrator",
+  AUDIT_TRAIL: "Audit Trail",
+
+  // Core Lab Roles
+  TECHNICIAN: "Technician",
+  SUPERVISOR: "Supervisor",
+  RESULTS: "Results",
+  VALIDATION: "Validation",
+  RECEPTION: "Reception",
+  REPORTS: "Reports",
+  PATHOLOGIST: "Pathologist",
+  CYTOPATHOLOGIST: "Cytopathologist",
+
+  // Notebook-specific role
+  NOTEBOOK_ADMIN: "Notebook Administrator",
+};
+
+/**
+ * Permission-based role groups for feature access control
+ *
+ * Define permissions by what action they allow, not by organization.
+ * This keeps the code generic and reusable across deployments.
+ *
+ * Usage:
+ *   <PermissionGate roles={Permissions.CREATE_OR_EDIT_NOTEBOOK}>
+ *     <CreateButton />
+ *   </PermissionGate>
+ */
+export const Permissions = {
+  // ========== Notebook Permissions ==========
+
+  // Can create or edit notebook templates
+  CREATE_OR_EDIT_NOTEBOOK: [Roles.GLOBAL_ADMIN, Roles.NOTEBOOK_ADMIN],
+
+  // Can view notebook templates
+  VIEW_NOTEBOOK: [
+    Roles.GLOBAL_ADMIN,
+    Roles.NOTEBOOK_ADMIN,
+    Roles.SUPERVISOR,
+    Roles.TECHNICIAN,
+  ],
+
+  // Can create or edit notebook entries (instances)
+  CREATE_OR_EDIT_NOTEBOOK_ENTRY: [
+    Roles.GLOBAL_ADMIN,
+    Roles.NOTEBOOK_ADMIN,
+    Roles.SUPERVISOR,
+    Roles.TECHNICIAN,
+    Roles.RESULTS,
+  ],
+
+  // @deprecated Use CREATE_OR_EDIT_NOTEBOOK_ENTRY instead
+  CREATE_NOTEBOOK_ENTRY: [
+    Roles.GLOBAL_ADMIN,
+    Roles.NOTEBOOK_ADMIN,
+    Roles.SUPERVISOR,
+    Roles.TECHNICIAN,
+    Roles.RESULTS,
+  ],
+
+  // Can approve/lock/finalize notebook entries
+  APPROVE_NOTEBOOK_ENTRY: [
+    Roles.GLOBAL_ADMIN,
+    Roles.NOTEBOOK_ADMIN,
+    Roles.SUPERVISOR,
+  ],
+
+  // ========== Results Permissions ==========
+
+  // Can enter results
+  ENTER_RESULTS: [Roles.RESULTS, Roles.TECHNICIAN, Roles.SUPERVISOR],
+
+  // Can validate results
+  VALIDATE_RESULTS: [Roles.VALIDATION, Roles.SUPERVISOR, Roles.PATHOLOGIST],
+
+  // Can view results
+  VIEW_RESULTS: [
+    Roles.RESULTS,
+    Roles.VALIDATION,
+    Roles.PATHOLOGIST,
+    Roles.CYTOPATHOLOGIST,
+    Roles.SUPERVISOR,
+    Roles.REPORTS,
+  ],
+
+  // ========== Sample Permissions ==========
+
+  // Can receive/register samples
+  RECEIVE_SAMPLES: [Roles.RECEPTION, Roles.TECHNICIAN, Roles.SUPERVISOR],
+
+  // Can process samples
+  PROCESS_SAMPLES: [Roles.TECHNICIAN, Roles.SUPERVISOR],
+
+  // ========== Report Permissions ==========
+
+  // Can generate reports
+  GENERATE_REPORTS: [Roles.REPORTS, Roles.SUPERVISOR, Roles.GLOBAL_ADMIN],
+
+  // ========== Admin Permissions ==========
+
+  // Can manage users
+  MANAGE_USERS: [Roles.GLOBAL_ADMIN, Roles.USER_ACCOUNT_ADMIN],
+
+  // Can view audit trail
+  VIEW_AUDIT_TRAIL: [Roles.GLOBAL_ADMIN, Roles.AUDIT_TRAIL],
+
+  // Full system administration
+  SYSTEM_ADMIN: [Roles.GLOBAL_ADMIN],
+};
+
+/**
+ * @deprecated Use Permissions instead. RoleGroups kept for backwards compatibility.
+ */
+export const RoleGroups = {
+  // Backwards compatibility - maps to new Permissions
+  NOTEBOOK_ADMINS: Permissions.CREATE_OR_EDIT_NOTEBOOK,
+  ADMIN_ROLES: Permissions.MANAGE_USERS,
+  RESULTS_VIEWERS: Permissions.VIEW_RESULTS,
+  LAB_ROLES: [
+    Roles.TECHNICIAN,
+    Roles.SUPERVISOR,
+    Roles.RESULTS,
+    Roles.VALIDATION,
+    Roles.RECEPTION,
+    Roles.REPORTS,
+  ],
+  PATHOLOGY_ROLES: [Roles.PATHOLOGIST, Roles.CYTOPATHOLOGIST],
+};
+
+export default Roles;

--- a/frontend/src/hooks/usePageAccessControl.js
+++ b/frontend/src/hooks/usePageAccessControl.js
@@ -1,0 +1,141 @@
+import { useCallback, useMemo, useEffect, useState } from "react";
+import { usePermissions } from "./usePermissions";
+
+/**
+ * Custom hook for page-level access control in notebook workflows.
+ *
+ * Handles:
+ * - Checking if user has access to individual pages based on allowedRoles
+ * - Adding hasAccess property to each page
+ * - Auto-navigating to first accessible page if current page is restricted
+ * - Preventing navigation to restricted pages
+ *
+ * @param {Array} pages - Array of page objects (may include allowedRoles property)
+ * @param {Array} defaultPages - Default pages to use if no pages provided
+ * @param {number} initialActivePage - Initial active page index (default: 0)
+ * @param {Object} options - Optional configuration
+ * @param {boolean} options.isCreating - If true, bypasses page-level role restrictions
+ *                                       (used during new entry creation to show all pages)
+ * @returns {Object} - { effectivePages, activePage, setActivePage, handlePageChange }
+ *
+ * @example
+ * // During entry creation - show all pages
+ * const { effectivePages } = usePageAccessControl(pages, DEFAULT_PAGES, 0, { isCreating: true });
+ *
+ * // When viewing/editing existing entry - apply role restrictions
+ * const { effectivePages } = usePageAccessControl(pages, DEFAULT_PAGES, 0, { isCreating: false });
+ */
+export const usePageAccessControl = (
+  pages,
+  defaultPages = [],
+  initialActivePage = 0,
+  options = {},
+) => {
+  const { isCreating = false } = options;
+  const { hasRoleForCurrentLabUnit } = usePermissions();
+  const [activePage, setActivePage] = useState(initialActivePage);
+
+  /**
+   * Check if user has access to a specific page based on its allowedRoles.
+   * If no roles are defined, access is granted to everyone.
+   * If isCreating is true, access is always granted (show all pages during entry creation).
+   */
+  const hasPageAccess = useCallback(
+    (page) => {
+      // During entry creation, show all pages - no restrictions
+      if (isCreating) {
+        return true;
+      }
+
+      const pageRoles = page.allowedRoles
+        ? Array.isArray(page.allowedRoles)
+          ? page.allowedRoles
+          : Array.from(page.allowedRoles)
+        : [];
+
+      // No roles defined = no restriction = allow everyone
+      if (pageRoles.length === 0) {
+        return true;
+      }
+
+      // Check if user has any of the page's required roles
+      return hasRoleForCurrentLabUnit(pageRoles);
+    },
+    [hasRoleForCurrentLabUnit, isCreating],
+  );
+
+  /**
+   * Pages with access info computed.
+   * Uses provided pages if available, otherwise falls back to defaultPages.
+   */
+  const effectivePages = useMemo(() => {
+    let pagesToUse = defaultPages;
+    if (pages && pages.length > 0) {
+      pagesToUse = pages;
+    }
+
+    // Add hasAccess property to each page for navigation
+    return pagesToUse.map((page) => ({
+      ...page,
+      hasAccess: hasPageAccess(page),
+    }));
+  }, [pages, defaultPages, hasPageAccess]);
+
+  /**
+   * Auto-navigate to first accessible page if current page is restricted.
+   */
+  useEffect(() => {
+    if (effectivePages.length > 0) {
+      const currentPage = effectivePages[activePage];
+      // If current page is not accessible, find and navigate to first accessible page
+      if (!currentPage || !currentPage.hasAccess) {
+        const firstAccessibleIndex = effectivePages.findIndex(
+          (page) => page.hasAccess,
+        );
+        if (firstAccessibleIndex >= 0 && firstAccessibleIndex !== activePage) {
+          setActivePage(firstAccessibleIndex);
+        }
+      }
+    }
+  }, [effectivePages, activePage]);
+
+  /**
+   * Handle page change with access control.
+   * Prevents navigation to pages the user doesn't have access to.
+   */
+  const handlePageChange = useCallback(
+    (pageIndex) => {
+      if (effectivePages[pageIndex] && !effectivePages[pageIndex].hasAccess) {
+        return; // Don't navigate to restricted pages
+      }
+      setActivePage(pageIndex);
+    },
+    [effectivePages],
+  );
+
+  /**
+   * Check if any page is accessible to the user.
+   */
+  const hasAnyAccessiblePage = useMemo(() => {
+    return effectivePages.some((page) => page.hasAccess);
+  }, [effectivePages]);
+
+  /**
+   * Get the first accessible page index.
+   */
+  const firstAccessiblePageIndex = useMemo(() => {
+    return effectivePages.findIndex((page) => page.hasAccess);
+  }, [effectivePages]);
+
+  return {
+    effectivePages,
+    activePage,
+    setActivePage,
+    handlePageChange,
+    hasPageAccess,
+    hasAnyAccessiblePage,
+    firstAccessiblePageIndex,
+  };
+};
+
+export default usePageAccessControl;

--- a/frontend/src/hooks/usePermissions.js
+++ b/frontend/src/hooks/usePermissions.js
@@ -172,6 +172,10 @@ export const usePermissions = () => {
    */
   const hasRoleForCurrentLabUnit = useCallback(
     (roles) => {
+      const globalRoles = userSessionDetails?.roles || [];
+      const allLabUnitsRoles =
+        userSessionDetails?.userLabRolesMap?.["AllLabUnits"] || [];
+
       // Global Admins are super users - bypass all location restrictions
       if (isGlobalAdminUser()) {
         return true;
@@ -182,14 +186,11 @@ export const usePermissions = () => {
       }
 
       // Check global roles first (userSessionDetails.roles)
-      const globalRoles = userSessionDetails?.roles || [];
       if (roles.some((role) => globalRoles.includes(role))) {
         return true;
       }
 
       // Then check "AllLabUnits" (global lab access)
-      const allLabUnitsRoles =
-        userSessionDetails?.userLabRolesMap?.["AllLabUnits"] || [];
       if (roles.some((role) => allLabUnitsRoles.includes(role))) {
         return true;
       }

--- a/frontend/src/hooks/usePermissions.js
+++ b/frontend/src/hooks/usePermissions.js
@@ -1,0 +1,244 @@
+import { useContext, useCallback, useMemo } from "react";
+import UserSessionDetailsContext from "../UserSessionDetailsContext";
+import { Roles, RoleGroups } from "../constants/roles";
+
+/**
+ * Custom hook for permission checking
+ *
+ * Provides utilities to check user roles (both global and lab-unit specific)
+ * and determine access to various features.
+ *
+ * @example
+ * const { hasRole, hasAnyRole, hasLabUnitRole, canManageNotebookTemplates } = usePermissions();
+ *
+ * // Check single global role
+ * if (hasRole(Roles.GLOBAL_ADMIN)) { ... }
+ *
+ * // Check if user has any of multiple roles
+ * if (hasAnyRole([Roles.TECHNICIAN, Roles.SUPERVISOR])) { ... }
+ *
+ * // Check lab-unit specific role
+ * if (hasLabUnitRole("Cytology", Roles.TECHNICIAN)) { ... }
+ *
+ * // Check notebook template management permission
+ * if (canManageNotebookTemplates()) { ... }
+ */
+export const usePermissions = () => {
+  const { userSessionDetails } = useContext(UserSessionDetailsContext);
+
+  /**
+   * Check if user has a specific global role
+   * @param {string} role - Role name to check
+   * @returns {boolean}
+   */
+  const hasRole = useCallback(
+    (role) => {
+      if (
+        !userSessionDetails?.roles ||
+        !Array.isArray(userSessionDetails.roles)
+      ) {
+        return false;
+      }
+      return userSessionDetails.roles.includes(role);
+    },
+    [userSessionDetails?.roles],
+  );
+
+  /**
+   * Check if user has any of the specified global roles
+   * @param {string[]} roles - Array of role names to check
+   * @returns {boolean}
+   */
+  const hasAnyRole = useCallback(
+    (roles) => {
+      if (!roles || !Array.isArray(roles)) {
+        return false;
+      }
+      return roles.some((role) => hasRole(role));
+    },
+    [hasRole],
+  );
+
+  /**
+   * Check if user has all of the specified global roles
+   * @param {string[]} roles - Array of role names to check
+   * @returns {boolean}
+   */
+  const hasAllRoles = useCallback(
+    (roles) => {
+      if (!roles || !Array.isArray(roles)) {
+        return false;
+      }
+      return roles.every((role) => hasRole(role));
+    },
+    [hasRole],
+  );
+
+  /**
+   * Check if user is a global administrator (super user)
+   * Global Admins bypass all location/lab unit restrictions
+   * @returns {boolean}
+   */
+  const isGlobalAdminUser = useCallback(() => {
+    if (
+      !userSessionDetails?.roles ||
+      !Array.isArray(userSessionDetails.roles)
+    ) {
+      return false;
+    }
+    return userSessionDetails.roles.includes(Roles.GLOBAL_ADMIN);
+  }, [userSessionDetails?.roles]);
+
+  /**
+   * Check if user has a specific role for a given lab unit
+   * Also checks "AllLabUnits" for users with global lab access
+   * Global Admins bypass all lab unit restrictions (super users)
+   * @param {string} labUnit - Lab unit name or ID
+   * @param {string} role - Role name to check
+   * @returns {boolean}
+   */
+  const hasLabUnitRole = useCallback(
+    (labUnit, role) => {
+      // Global Admins are super users - bypass all location restrictions
+      if (isGlobalAdminUser()) {
+        return true;
+      }
+
+      if (!userSessionDetails?.userLabRolesMap) {
+        return false;
+      }
+
+      // First check "AllLabUnits" for global lab access
+      const allLabUnitsRoles =
+        userSessionDetails.userLabRolesMap["AllLabUnits"] || [];
+      if (allLabUnitsRoles.includes(role)) {
+        return true;
+      }
+
+      // Then check specific lab unit
+      const labUnitRoles = userSessionDetails.userLabRolesMap[labUnit] || [];
+      return labUnitRoles.includes(role);
+    },
+    [userSessionDetails?.userLabRolesMap, isGlobalAdminUser],
+  );
+
+  /**
+   * Check if user has any of the specified roles for a given lab unit
+   * @param {string} labUnit - Lab unit name or ID
+   * @param {string[]} roles - Array of role names to check
+   * @returns {boolean}
+   */
+  const hasAnyLabUnitRole = useCallback(
+    (labUnit, roles) => {
+      if (!roles || !Array.isArray(roles)) {
+        return false;
+      }
+      return roles.some((role) => hasLabUnitRole(labUnit, role));
+    },
+    [hasLabUnitRole],
+  );
+
+  /**
+   * Check if user is a global administrator (super user)
+   * @returns {boolean}
+   */
+  const isGlobalAdmin = useMemo(() => isGlobalAdminUser(), [isGlobalAdminUser]);
+
+  /**
+   * Check if user can manage notebook templates (create/edit/delete)
+   * Requires Global Admin or Notebook Administrator role
+   * @returns {boolean}
+   */
+  const canManageNotebookTemplates = useMemo(
+    () => hasAnyRole(RoleGroups.NOTEBOOK_ADMINS),
+    [hasAnyRole],
+  );
+
+  /**
+   * Get the user's current login lab unit
+   * @returns {string|null}
+   */
+  const loginLabUnit = useMemo(
+    () => userSessionDetails?.loginLabUnit || null,
+    [userSessionDetails?.loginLabUnit],
+  );
+
+  /**
+   * Check if user has any role for their current login lab unit
+   * Global Admins bypass all lab unit restrictions (super users)
+   * Also checks global roles and "AllLabUnits" for users with global lab access
+   * @param {string[]} roles - Array of role names to check
+   * @returns {boolean}
+   */
+  const hasRoleForCurrentLabUnit = useCallback(
+    (roles) => {
+      // Global Admins are super users - bypass all location restrictions
+      if (isGlobalAdminUser()) {
+        return true;
+      }
+
+      if (!roles || !Array.isArray(roles)) {
+        return false;
+      }
+
+      // Check global roles first (userSessionDetails.roles)
+      const globalRoles = userSessionDetails?.roles || [];
+      if (roles.some((role) => globalRoles.includes(role))) {
+        return true;
+      }
+
+      // Then check "AllLabUnits" (global lab access)
+      const allLabUnitsRoles =
+        userSessionDetails?.userLabRolesMap?.["AllLabUnits"] || [];
+      if (roles.some((role) => allLabUnitsRoles.includes(role))) {
+        return true;
+      }
+
+      // If loginLabUnit is set, also check that specific lab unit
+      if (loginLabUnit) {
+        return hasAnyLabUnitRole(loginLabUnit, roles);
+      }
+
+      return false;
+    },
+    [
+      loginLabUnit,
+      hasAnyLabUnitRole,
+      isGlobalAdminUser,
+      userSessionDetails?.roles,
+      userSessionDetails?.userLabRolesMap,
+    ],
+  );
+
+  /**
+   * Check if user is authenticated
+   * @returns {boolean}
+   */
+  const isAuthenticated = useMemo(
+    () => userSessionDetails?.authenticated === true,
+    [userSessionDetails?.authenticated],
+  );
+
+  return {
+    // Core utilities
+    hasRole,
+    hasAnyRole,
+    hasAllRoles,
+    hasLabUnitRole,
+    hasAnyLabUnitRole,
+    hasRoleForCurrentLabUnit,
+
+    // Convenience flags
+    isGlobalAdmin,
+    isAuthenticated,
+    loginLabUnit,
+
+    // Feature-specific permissions
+    canManageNotebookTemplates,
+
+    // Raw session data (for advanced use cases)
+    userSessionDetails,
+  };
+};
+
+export default usePermissions;

--- a/src/main/java/org/openelisglobal/common/constants/Constants.java
+++ b/src/main/java/org/openelisglobal/common/constants/Constants.java
@@ -20,6 +20,8 @@ public class Constants {
     public static final String ROLE_VALIDATION = "Validation";
     public static final String ROLE_REPORTS = "Reports";
     public static final String ROLE_PATHOLOGIST = "Pathologist";
+    public static final String ROLE_NOTEBOOK_ADMIN = "Notebook Administrator";
+
     // roles groups
     public static final String GLOBAL_ROLES_GROUP = "Global Roles";
     public static final String LAB_ROLES_GROUP = "Lab Unit Roles";

--- a/src/main/java/org/openelisglobal/notebook/bean/NoteBookDisplayBean.java
+++ b/src/main/java/org/openelisglobal/notebook/bean/NoteBookDisplayBean.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.notebook.bean;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.openelisglobal.notebook.valueholder.NoteBook.NoteBookStatus;
 
@@ -121,6 +122,16 @@ public class NoteBookDisplayBean {
 
     public void setNotebookName(String notebookName) {
         this.notebookName = notebookName;
+    }
+
+    private Set<String> allowedRoles;
+
+    public Set<String> getAllowedRoles() {
+        return allowedRoles;
+    }
+
+    public void setAllowedRoles(Set<String> allowedRoles) {
+        this.allowedRoles = allowedRoles;
     }
 
 }

--- a/src/main/java/org/openelisglobal/notebook/controller/rest/NoteBookRestController.java
+++ b/src/main/java/org/openelisglobal/notebook/controller/rest/NoteBookRestController.java
@@ -41,6 +41,8 @@ import org.openelisglobal.notebook.valueholder.NoteBook.NoteBookStatus;
 import org.openelisglobal.notebook.valueholder.WorkflowPageTemplate;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.role.service.RoleService;
+import org.openelisglobal.role.valueholder.Role;
 import org.openelisglobal.test.service.TestSectionService;
 import org.openelisglobal.test.valueholder.TestSection;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -97,6 +99,9 @@ public class NoteBookRestController extends BaseRestController {
 
     @Autowired
     private NotebookPageSampleService notebookPageSampleService;
+
+    @Autowired
+    private RoleService roleService;
 
     @GetMapping(value = "/dashboard/entries", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
@@ -686,6 +691,29 @@ public class NoteBookRestController extends BaseRestController {
         noteBookService.updateTemplateDepartments(noteBookId, departmentIds, sysUserId);
 
         return ResponseEntity.ok(Map.of("id", noteBookId, "success", true));
+    }
+
+    /**
+     * Get all available roles for assignment to notebook templates and pages.
+     * Returns all active roles from the system that can be used for access control.
+     *
+     * @return list of roles with id (name), name, and displayKey
+     */
+    @GetMapping(value = "/available-roles", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity<List<Map<String, String>>> getAvailableRoles() {
+        List<Role> roles = roleService.getAllActiveRoles();
+
+        List<Map<String, String>> result = roles.stream().filter(role -> !Boolean.TRUE.equals(role.getGroupingRole())) // Exclude
+                                                                                                                       // grouping
+                                                                                                                       // roles
+                .map(role -> Map.of("id", role.getName() != null ? role.getName().trim() : "", "name",
+                        role.getName() != null ? role.getName().trim() : "", "description",
+                        role.getDescription() != null ? role.getDescription() : "", "displayKey",
+                        role.getDisplayKey() != null ? role.getDisplayKey() : ""))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/org/openelisglobal/notebook/service/NoteBookServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NoteBookServiceImpl.java
@@ -205,25 +205,12 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
     @Override
     @Transactional
     protected NoteBook update(NoteBook noteBook, String auditTrailType) {
-        // CRITICAL: Evict the modified object from the session cache BEFORE loading the
-        // old object.
-        // This ensures that when we load the old object, we get a fresh copy from the
-        // database
-        // with the original values, not the modified instance from the session cache.
-        if (auditTrailLog && noteBook.getId() != null) {
-            // Evict the modified object so that get() will return a fresh copy from DB
-            baseObjectDAO.evict(noteBook);
-
-            // Now load the old object - this will get a fresh copy from the database
-            Optional<NoteBook> oldNoteBook = baseObjectDAO.get(noteBook.getId());
-            if (oldNoteBook.isPresent()) {
-                NoteBook oldObject = oldNoteBook.get();
-                // Initialize all lazy collections before the parent evicts the object
-                initializeLazyCollections(oldObject);
-            }
-        }
-        // Let the parent handle the audit trail logic normally
-        // The parent will re-attach the modified object and persist it
+        // Note: Do NOT evict the modified noteBook - it would cause
+        // "collection no longer referenced" errors with orphanRemoval collections.
+        // The parent class handles getting the old object for audit trail comparison.
+        // We just need to ensure lazy collections are initialized on the entity being
+        // saved.
+        initializeLazyCollections(noteBook);
         return super.update(noteBook, auditTrailType);
     }
 
@@ -285,6 +272,7 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
             displayBean.setQuestionnaireFhirUuid(noteBook.getQuestionnaireFhirUuid());
 
             // For non-template entries, find and set entry number and parent notebook name
+            // Also inherit allowedRoles from parent template
             if (noteBook.getIsTemplate() != null && !noteBook.getIsTemplate()) {
                 NoteBook parentTemplate = baseObjectDAO.findParentTemplate(noteBook.getId());
                 if (parentTemplate != null) {
@@ -313,7 +301,14 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
                             }
                         }
                     }
+                    // Entries inherit allowedRoles from their parent template
+                    Hibernate.initialize(parentTemplate.getAllowedRoles());
+                    displayBean.setAllowedRoles(new HashSet<>(parentTemplate.getAllowedRoles()));
                 }
+            } else {
+                // For templates, use their own allowedRoles
+                Hibernate.initialize(noteBook.getAllowedRoles());
+                displayBean.setAllowedRoles(new HashSet<>(noteBook.getAllowedRoles()));
             }
         }
         return displayBean;
@@ -330,12 +325,17 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
             Hibernate.initialize(noteBook.getSamples());
             Hibernate.initialize(noteBook.getPages());
 
-            // Initialize panels and tests for each page (panels is LAZY to avoid
+            // Initialize panels, tests, and allowedRoles for each page (LAZY to avoid
             // MultipleBagFetchException)
+            // Also explicitly copy allowedRoles to ensure proper JSON serialization
             if (noteBook.getPages() != null) {
                 for (NoteBookPage page : noteBook.getPages()) {
                     Hibernate.initialize(page.getPanels());
                     Hibernate.initialize(page.getTests());
+                    Hibernate.initialize(page.getAllowedRoles());
+                    // Ensure allowedRoles is a regular HashSet (not Hibernate proxy) for JSON
+                    // serialization
+                    page.setAllowedRoles(new HashSet<>(page.getAllowedRoles()));
                 }
             }
             Hibernate.initialize(noteBook.getFiles());

--- a/src/main/java/org/openelisglobal/notebook/service/NoteBookServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NoteBookServiceImpl.java
@@ -746,10 +746,15 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
         // Copy pages
         if (template.getPages() != null) {
             for (NoteBookPage templatePage : template.getPages()) {
+                // Initialize lazy collections for this page
+                Hibernate.initialize(templatePage.getAllowedRoles());
+
                 NoteBookPage instancePage = new NoteBookPage();
                 instancePage.setTitle(templatePage.getTitle());
                 instancePage.setOrder(templatePage.getOrder());
                 instancePage.setContent(templatePage.getContent());
+                instancePage.setInstructions(templatePage.getInstructions());
+                instancePage.setSampleTypeId(templatePage.getSampleTypeId());
                 instancePage.setNotebook(instance);
 
                 // Copy panels and tests references
@@ -758,6 +763,11 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
                 }
                 if (templatePage.getTests() != null) {
                     instancePage.getTests().addAll(templatePage.getTests());
+                }
+
+                // Copy allowed roles for page-level access control
+                if (templatePage.getAllowedRoles() != null && !templatePage.getAllowedRoles().isEmpty()) {
+                    instancePage.getAllowedRoles().addAll(templatePage.getAllowedRoles());
                 }
 
                 instance.getPages().add(instancePage);
@@ -1067,11 +1077,16 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
             }
 
             if (!existingOrders.contains(templateOrder)) {
+                // Initialize lazy collections for this page
+                Hibernate.initialize(templatePage.getAllowedRoles());
+
                 // This page is in template but not in instance - add it
                 NoteBookPage newPage = new NoteBookPage();
                 newPage.setTitle(templatePage.getTitle());
                 newPage.setOrder(templatePage.getOrder());
                 newPage.setContent(templatePage.getContent());
+                newPage.setInstructions(templatePage.getInstructions());
+                newPage.setSampleTypeId(templatePage.getSampleTypeId());
                 newPage.setNotebook(instance);
                 newPage.setCompleted(false);
 
@@ -1081,6 +1096,11 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
                 }
                 if (templatePage.getTests() != null) {
                     newPage.getTests().addAll(templatePage.getTests());
+                }
+
+                // Copy allowed roles for page-level access control
+                if (templatePage.getAllowedRoles() != null && !templatePage.getAllowedRoles().isEmpty()) {
+                    newPage.getAllowedRoles().addAll(templatePage.getAllowedRoles());
                 }
 
                 instance.getPages().add(newPage);

--- a/src/main/java/org/openelisglobal/notebook/service/NotebookSecurityService.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NotebookSecurityService.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.notebook.service;
 
 import org.openelisglobal.notebook.valueholder.NoteBook;
+import org.openelisglobal.notebook.valueholder.NoteBookPage;
 import org.openelisglobal.notebook.valueholder.NotebookEntry;
 import org.openelisglobal.organization.valueholder.Organization;
 import org.openelisglobal.test.valueholder.TestSection;
@@ -111,6 +112,29 @@ public interface NotebookSecurityService {
      * @return true if user can edit the entry
      */
     boolean canEditEntry(Integer entryId, String sysUserId, String loginLabUnit);
+
+    // ========== PAGE ACCESS (Role Based) ==========
+
+    /**
+     * Check if user can view a specific notebook page. User must have one of the
+     * page's allowed roles, or the page has no role restrictions.
+     *
+     * @param page         the notebook page
+     * @param sysUserId    the system user ID
+     * @param loginLabUnit the user's login lab unit
+     * @return true if user can view the page
+     */
+    boolean canViewPage(NoteBookPage page, String sysUserId, String loginLabUnit);
+
+    /**
+     * Check if user can view a specific notebook page by ID.
+     *
+     * @param pageId       the notebook page ID
+     * @param sysUserId    the system user ID
+     * @param loginLabUnit the user's login lab unit
+     * @return true if user can view the page
+     */
+    boolean canViewPage(Integer pageId, String sysUserId, String loginLabUnit);
 
     // ========== HELPER METHODS ==========
 

--- a/src/main/java/org/openelisglobal/notebook/service/NotebookSecurityServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NotebookSecurityServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.openelisglobal.common.constants.Constants;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.notebook.valueholder.NoteBook;
+import org.openelisglobal.notebook.valueholder.NoteBookPage;
 import org.openelisglobal.notebook.valueholder.NotebookEntry;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
@@ -45,13 +46,17 @@ public class NotebookSecurityServiceImpl implements NotebookSecurityService {
     private NotebookEntryService notebookEntryService;
 
     @Autowired
+    private NoteBookPageService noteBookPageService;
+
+    @Autowired
     private RoleService roleService;
 
     // ========== TEMPLATE ACCESS (Admin Only for Edit) ==========
 
     @Override
     public boolean canEditTemplate(String sysUserId) {
-        return hasGlobalAdminRole(sysUserId);
+        // Allow Global Administrator or Notebook Administrator to manage templates
+        return hasGlobalAdminRole(sysUserId) || userRoleService.userInRole(sysUserId, Constants.ROLE_NOTEBOOK_ADMIN);
     }
 
     @Override
@@ -334,6 +339,41 @@ public class NotebookSecurityServiceImpl implements NotebookSecurityService {
         return canEditEntry(entry, sysUserId, loginLabUnit);
     }
 
+    // ========== PAGE ACCESS (Role Based) ==========
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean canViewPage(NoteBookPage page, String sysUserId, String loginLabUnit) {
+        // Admin can view any page
+        if (hasGlobalAdminRole(sysUserId)) {
+            return true;
+        }
+
+        // Notebook Admin can view any page (for template management)
+        if (userRoleService.userInRole(sysUserId, Constants.ROLE_NOTEBOOK_ADMIN)) {
+            return true;
+        }
+
+        // If page has no role restrictions, anyone can view it
+        Set<String> allowedRoles = page.getAllowedRoles();
+        if (allowedRoles == null || allowedRoles.isEmpty()) {
+            return true;
+        }
+
+        // Check if user has one of the allowed roles for their lab unit
+        return hasRequiredRoleForLabUnit(sysUserId, loginLabUnit, allowedRoles);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean canViewPage(Integer pageId, String sysUserId, String loginLabUnit) {
+        NoteBookPage page = noteBookPageService.get(pageId);
+        if (page == null) {
+            return false;
+        }
+        return canViewPage(page, sysUserId, loginLabUnit);
+    }
+
     // ========== HELPER METHODS ==========
 
     @Override
@@ -419,6 +459,14 @@ public class NotebookSecurityServiceImpl implements NotebookSecurityService {
             return false;
         }
 
+        // First check global roles (not lab-unit specific)
+        if (userRoleService.userInRole(sysUserId, requiredRoles)) {
+            LogEvent.logInfo(this.getClass().getSimpleName(), "hasRequiredRoleForLabUnit",
+                    "User has global role matching requiredRoles=" + requiredRoles);
+            return true;
+        }
+
+        // Then check lab unit specific roles
         UserLabUnitRoles userLabRoles = userRoleService.getUserLabUnitRoles(sysUserId);
         if (userLabRoles == null || userLabRoles.getLabUnitRoleMap() == null) {
             LogEvent.logInfo(this.getClass().getSimpleName(), "hasRequiredRoleForLabUnit",

--- a/src/main/java/org/openelisglobal/notebook/valueholder/NoteBook.java
+++ b/src/main/java/org/openelisglobal/notebook/valueholder/NoteBook.java
@@ -101,11 +101,11 @@ public class NoteBook extends BaseObject<Integer> {
 
     @OneToMany
     @JoinTable(name = "notebook_samples_list", joinColumns = @JoinColumn(name = "notebook_id"), inverseJoinColumns = @JoinColumn(name = "sample_item_id"))
-    private List<SampleItem> samples;
+    private List<SampleItem> samples = new ArrayList<>();
 
     @OneToMany
     @JoinTable(name = "notebook_analysers", joinColumns = @JoinColumn(name = "notebook_id"), inverseJoinColumns = @JoinColumn(name = "analyser_id"))
-    private List<Analyzer> analysers;
+    private List<Analyzer> analysers = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(name = "notebook_inventory_instruments", joinColumns = @JoinColumn(name = "notebook_id"))
@@ -115,21 +115,21 @@ public class NoteBook extends BaseObject<Integer> {
     @ElementCollection
     @CollectionTable(name = "notebook_tags", joinColumns = @JoinColumn(name = "notebook_id"))
     @Column(name = "tag")
-    private List<String> tags;
+    private List<String> tags = new ArrayList<>();
 
     @OneToMany(mappedBy = "notebook", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("order ASC")
-    private List<NoteBookPage> pages;
+    private List<NoteBookPage> pages = new ArrayList<>();
 
     @OneToMany(mappedBy = "notebook", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<NoteBookFile> files;
+    private List<NoteBookFile> files = new ArrayList<>();
 
     @OneToMany(mappedBy = "notebook", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<NoteBookComment> comments;
+    private List<NoteBookComment> comments = new ArrayList<>();
 
     @OneToMany
     @JoinTable(name = "notebook_entries", joinColumns = @JoinColumn(name = "notebook_id"), inverseJoinColumns = @JoinColumn(name = "entry_id"))
-    private List<NoteBook> entries;
+    private List<NoteBook> entries = new ArrayList<>();
 
     @Column(name = "questionnaire_fhir_uuid", columnDefinition = "uuid")
     private UUID questionnaireFhirUuid;
@@ -198,9 +198,6 @@ public class NoteBook extends BaseObject<Integer> {
     }
 
     public List<SampleItem> getSamples() {
-        if (samples == null) {
-            samples = new ArrayList<>();
-        }
         return samples;
     }
 
@@ -209,9 +206,6 @@ public class NoteBook extends BaseObject<Integer> {
     }
 
     public List<NoteBookPage> getPages() {
-        if (pages == null) {
-            pages = new ArrayList<>();
-        }
         return pages;
     }
 
@@ -220,9 +214,6 @@ public class NoteBook extends BaseObject<Integer> {
     }
 
     public List<Analyzer> getAnalysers() {
-        if (analysers == null) {
-            analysers = new ArrayList<>();
-        }
         return analysers;
     }
 
@@ -242,9 +233,6 @@ public class NoteBook extends BaseObject<Integer> {
     }
 
     public List<String> getTags() {
-        if (tags == null) {
-            tags = new ArrayList<>();
-        }
         return tags;
     }
 
@@ -269,9 +257,6 @@ public class NoteBook extends BaseObject<Integer> {
     }
 
     public List<NoteBookFile> getFiles() {
-        if (files == null) {
-            files = new ArrayList<>();
-        }
         return files;
     }
 
@@ -280,9 +265,6 @@ public class NoteBook extends BaseObject<Integer> {
     }
 
     public List<NoteBookComment> getComments() {
-        if (comments == null) {
-            comments = new ArrayList<>();
-        }
         return comments;
     }
 
@@ -299,9 +281,6 @@ public class NoteBook extends BaseObject<Integer> {
     }
 
     public List<NoteBook> getEntries() {
-        if (entries == null) {
-            entries = new ArrayList<>();
-        }
         return entries;
     }
 

--- a/src/main/java/org/openelisglobal/notebook/valueholder/NoteBookPage.java
+++ b/src/main/java/org/openelisglobal/notebook/valueholder/NoteBookPage.java
@@ -14,8 +14,10 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.openelisglobal.common.valueholder.BaseObject;
@@ -72,6 +74,11 @@ public class NoteBookPage extends BaseObject<Integer> {
     @Type(type = "jsonb-map")
     @Column(name = "data", columnDefinition = "jsonb")
     private Map<String, Object> data;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "notebook_page_allowed_roles", joinColumns = @JoinColumn(name = "notebook_page_id"))
+    @Column(name = "role")
+    private Set<String> allowedRoles = new HashSet<>();
 
     public Integer getId() {
         return id;
@@ -165,6 +172,17 @@ public class NoteBookPage extends BaseObject<Integer> {
 
     public void setData(Map<String, Object> data) {
         this.data = data;
+    }
+
+    public Set<String> getAllowedRoles() {
+        if (allowedRoles == null) {
+            allowedRoles = new HashSet<>();
+        }
+        return allowedRoles;
+    }
+
+    public void setAllowedRoles(Set<String> allowedRoles) {
+        this.allowedRoles = allowedRoles;
     }
 
 }

--- a/src/main/java/org/openelisglobal/systemuser/service/UserServiceImpl.java
+++ b/src/main/java/org/openelisglobal/systemuser/service/UserServiceImpl.java
@@ -142,6 +142,12 @@ public class UserServiceImpl implements UserService {
             Boolean isLabRole) {
         List<String> currentUserRoles = userRoleService.getRoleIdsForUser(systemUser.getId());
         List<UserRole> deletedUserRoles = new ArrayList<>();
+
+        // Handle null selectedRoles - treat as empty list
+        if (selectedRoles == null) {
+            selectedRoles = new ArrayList<>();
+        }
+
         if (isLabRole) {
             for (String role : currentUserRoles) {
                 selectedRoles.add(role);

--- a/src/main/resources/liquibase/3.4.x.x/012-notebook-access-control.xml
+++ b/src/main/resources/liquibase/3.4.x.x/012-notebook-access-control.xml
@@ -357,4 +357,48 @@
         </sql>
     </changeSet>
 
+    <!-- ======================================================== -->
+    <!-- 10. NOTEBOOK_PAGE_ALLOWED_ROLES table -->
+    <!-- Defines which roles can view/edit specific pages within a notebook -->
+    <!-- Enables page-level access control for workflow steps -->
+    <!-- ======================================================== -->
+    <changeSet id="create-notebook-page-allowed-roles-table" author="openelis-access-control">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="notebook_page_allowed_roles" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <comment>Creating NOTEBOOK_PAGE_ALLOWED_ROLES table for page-level role restrictions.</comment>
+        <createTable tableName="notebook_page_allowed_roles">
+            <column name="notebook_page_id" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey
+            tableName="notebook_page_allowed_roles"
+            columnNames="notebook_page_id, role"
+            constraintName="pk_notebook_page_allowed_roles"/>
+        <addForeignKeyConstraint
+            baseTableName="notebook_page_allowed_roles"
+            baseColumnNames="notebook_page_id"
+            referencedTableName="notebook_page"
+            referencedColumnNames="id"
+            constraintName="fk_npar_notebook_page"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+    <!-- Index for querying roles by notebook page -->
+    <changeSet id="add-notebook-page-allowed-roles-index" author="openelis-access-control">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="notebook_page_allowed_roles" schemaName="clinlims"/>
+        </preConditions>
+        <comment>Creating index for notebook_page_allowed_roles table.</comment>
+        <createIndex tableName="notebook_page_allowed_roles" indexName="idx_npar_notebook_page">
+            <column name="notebook_page_id"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/notebook/service/NotebookSecurityServiceImplTest.java
+++ b/src/test/java/org/openelisglobal/notebook/service/NotebookSecurityServiceImplTest.java
@@ -1,0 +1,421 @@
+package org.openelisglobal.notebook.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.common.constants.Constants;
+import org.openelisglobal.notebook.valueholder.NoteBook;
+import org.openelisglobal.organization.service.OrganizationService;
+import org.openelisglobal.role.service.RoleService;
+import org.openelisglobal.role.valueholder.Role;
+import org.openelisglobal.test.service.TestSectionService;
+import org.openelisglobal.test.valueholder.TestSection;
+import org.openelisglobal.userrole.service.UserRoleService;
+import org.openelisglobal.userrole.valueholder.LabUnitRoleMap;
+import org.openelisglobal.userrole.valueholder.UserLabUnitRoles;
+
+/**
+ * Unit tests for NotebookSecurityServiceImpl role checking hierarchy.
+ *
+ * Role checking priority (from hasRequiredRoleForLabUnit): 1. Global Roles -
+ * checked via userRoleService.userInRole(sysUserId, requiredRoles) 2. Lab Unit
+ * Roles - AllLabUnits - checked via userLabRoles with labUnit="AllLabUnits" 3.
+ * Lab Unit Roles - Specific Units - checked via userLabRoles with specific
+ * labUnit ID
+ *
+ * These tests validate that the role checking hierarchy is correctly
+ * implemented.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+@SuppressWarnings("unchecked")
+public class NotebookSecurityServiceImplTest {
+
+    @Mock
+    private UserRoleService userRoleService;
+
+    @Mock
+    private OrganizationService organizationService;
+
+    @Mock
+    private TestSectionService testSectionService;
+
+    @Mock
+    private NoteBookService noteBookService;
+
+    @Mock
+    private NotebookEntryService notebookEntryService;
+
+    @Mock
+    private NoteBookPageService noteBookPageService;
+
+    @Mock
+    private RoleService roleService;
+
+    @InjectMocks
+    private NotebookSecurityServiceImpl securityService;
+
+    // Test constants
+    private static final String GLOBAL_ADMIN_USER_ID = "10";
+    private static final String GLOBAL_TECH_USER_ID = "11";
+    private static final String GLOBAL_PATHOLOGIST_USER_ID = "12";
+    private static final String ALL_LAB_UNITS_TECH_USER_ID = "13";
+    private static final String CYTOLOGY_TECH_USER_ID = "14";
+    private static final String HEMATOLOGY_TECH_USER_ID = "15";
+    private static final String NO_ROLES_USER_ID = "16";
+
+    private static final String CYTOLOGY_LAB_UNIT = "Cytology";
+    private static final String HEMATOLOGY_LAB_UNIT = "Hematology";
+    private static final String BIOCHEMISTRY_LAB_UNIT = "Biochemistry";
+
+    private static final String ROLE_TECHNICIAN = "Technician";
+    private static final String ROLE_PATHOLOGIST = "Pathologist";
+
+    private static final String TECHNICIAN_ROLE_ID = "2";
+    private static final String PATHOLOGIST_ROLE_ID = "4";
+
+    private static final String CYTOLOGY_TEST_SECTION_ID = "100";
+    private static final String HEMATOLOGY_TEST_SECTION_ID = "101";
+
+    private NoteBook templateWithAllowedRoles;
+    private NoteBook templateWithNoRoleRestrictions;
+
+    @Before
+    public void setUp() {
+        // Setup template with role restrictions (requires Technician or Pathologist)
+        templateWithAllowedRoles = new NoteBook();
+        templateWithAllowedRoles.setId(100);
+        templateWithAllowedRoles.setIsTemplate(true);
+        Set<String> allowedRoles = new HashSet<>();
+        allowedRoles.add(ROLE_TECHNICIAN);
+        allowedRoles.add(ROLE_PATHOLOGIST);
+        templateWithAllowedRoles.setAllowedRoles(allowedRoles);
+
+        // Setup template with no role restrictions
+        templateWithNoRoleRestrictions = new NoteBook();
+        templateWithNoRoleRestrictions.setId(101);
+        templateWithNoRoleRestrictions.setIsTemplate(true);
+        templateWithNoRoleRestrictions.setAllowedRoles(new HashSet<>());
+
+        // Setup test sections using mocked objects to avoid SpringContext dependency
+        TestSection cytologySection = Mockito.mock(TestSection.class);
+        when(cytologySection.getId()).thenReturn(CYTOLOGY_TEST_SECTION_ID);
+        when(cytologySection.getTestSectionName()).thenReturn(CYTOLOGY_LAB_UNIT);
+        when(cytologySection.getLocalizedName()).thenReturn(CYTOLOGY_LAB_UNIT);
+
+        TestSection hematologySection = Mockito.mock(TestSection.class);
+        when(hematologySection.getId()).thenReturn(HEMATOLOGY_TEST_SECTION_ID);
+        when(hematologySection.getTestSectionName()).thenReturn(HEMATOLOGY_LAB_UNIT);
+        when(hematologySection.getLocalizedName()).thenReturn(HEMATOLOGY_LAB_UNIT);
+
+        when(testSectionService.get(CYTOLOGY_TEST_SECTION_ID)).thenReturn(cytologySection);
+        when(testSectionService.get(HEMATOLOGY_TEST_SECTION_ID)).thenReturn(hematologySection);
+
+        // Setup roles
+        Role technicianRole = new Role();
+        technicianRole.setId(TECHNICIAN_ROLE_ID);
+        technicianRole.setName(ROLE_TECHNICIAN);
+
+        Role pathologistRole = new Role();
+        pathologistRole.setId(PATHOLOGIST_ROLE_ID);
+        pathologistRole.setName(ROLE_PATHOLOGIST);
+
+        when(roleService.getRoleById(TECHNICIAN_ROLE_ID)).thenReturn(technicianRole);
+        when(roleService.getRoleById(PATHOLOGIST_ROLE_ID)).thenReturn(pathologistRole);
+    }
+
+    // ========== TEST: GLOBAL ADMIN BYPASS ==========
+
+    @Test
+    public void canCreateEntry_globalAdmin_alwaysAllowed() {
+        // Setup: User is Global Administrator
+        when(userRoleService.userInRole(eq(GLOBAL_ADMIN_USER_ID), eq(Constants.ROLE_GLOBAL_ADMIN))).thenReturn(true);
+
+        // Test: Global Admin can create entry regardless of allowed roles
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, GLOBAL_ADMIN_USER_ID, CYTOLOGY_LAB_UNIT);
+
+        assertTrue("Global Admin should always be able to create entries", result);
+    }
+
+    // ========== TEST: GLOBAL ROLES (Priority 1) ==========
+
+    @Test
+    public void canCreateEntry_userWithGlobalTechnicianRole_allowedWhenTechnicianInAllowedRoles() {
+        // Setup: User has global Technician role (not lab-unit specific)
+        setupNonAdminUser(GLOBAL_TECH_USER_ID);
+        setupCanViewTemplate(GLOBAL_TECH_USER_ID, CYTOLOGY_LAB_UNIT);
+
+        // User has global Technician role
+        when(userRoleService.userInRole(eq(GLOBAL_TECH_USER_ID), any(Collection.class))).thenAnswer(invocation -> {
+            Collection<String> roles = invocation.getArgument(1);
+            return roles.contains(ROLE_TECHNICIAN);
+        });
+
+        // Test: User with global Technician role can create entry
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, GLOBAL_TECH_USER_ID,
+                CYTOLOGY_LAB_UNIT);
+
+        assertTrue("User with global Technician role should be allowed when Technician is in allowedRoles", result);
+    }
+
+    @Test
+    public void canCreateEntry_userWithGlobalPathologistRole_allowedWhenPathologistInAllowedRoles() {
+        // Setup: User has global Pathologist role
+        setupNonAdminUser(GLOBAL_PATHOLOGIST_USER_ID);
+        setupCanViewTemplate(GLOBAL_PATHOLOGIST_USER_ID, CYTOLOGY_LAB_UNIT);
+
+        // User has global Pathologist role
+        when(userRoleService.userInRole(eq(GLOBAL_PATHOLOGIST_USER_ID), any(Collection.class)))
+                .thenAnswer(invocation -> {
+                    Collection<String> roles = invocation.getArgument(1);
+                    return roles.contains(ROLE_PATHOLOGIST);
+                });
+
+        // Test: User with global Pathologist role can create entry
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, GLOBAL_PATHOLOGIST_USER_ID,
+                CYTOLOGY_LAB_UNIT);
+
+        assertTrue("User with global Pathologist role should be allowed when Pathologist is in allowedRoles", result);
+    }
+
+    // ========== TEST: ALL LAB UNITS ROLES (Priority 2) ==========
+
+    @Test
+    public void canCreateEntry_userWithAllLabUnitsTechnicianRole_allowedWhenTechnicianInAllowedRoles() {
+        // Setup: User has Technician role for AllLabUnits (not global, but lab-unit
+        // level)
+        setupNonAdminUser(ALL_LAB_UNITS_TECH_USER_ID);
+        setupCanViewTemplate(ALL_LAB_UNITS_TECH_USER_ID, CYTOLOGY_LAB_UNIT);
+
+        // User does NOT have global roles
+        when(userRoleService.userInRole(eq(ALL_LAB_UNITS_TECH_USER_ID), any(Collection.class))).thenReturn(false);
+
+        // User has AllLabUnits Technician role
+        UserLabUnitRoles labRoles = createUserLabUnitRoles("AllLabUnits", TECHNICIAN_ROLE_ID);
+        when(userRoleService.getUserLabUnitRoles(ALL_LAB_UNITS_TECH_USER_ID)).thenReturn(labRoles);
+
+        // Test: User with AllLabUnits Technician role can create entry
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, ALL_LAB_UNITS_TECH_USER_ID,
+                CYTOLOGY_LAB_UNIT);
+
+        assertTrue("User with AllLabUnits Technician role should be allowed when Technician is in allowedRoles",
+                result);
+    }
+
+    @Test
+    public void canCreateEntry_userWithAllLabUnitsTechnicianRole_allowedForAnyLabUnit() {
+        // Setup: User has Technician role for AllLabUnits
+        setupNonAdminUser(ALL_LAB_UNITS_TECH_USER_ID);
+        setupCanViewTemplate(ALL_LAB_UNITS_TECH_USER_ID, HEMATOLOGY_LAB_UNIT);
+
+        when(userRoleService.userInRole(eq(ALL_LAB_UNITS_TECH_USER_ID), any(Collection.class))).thenReturn(false);
+
+        UserLabUnitRoles labRoles = createUserLabUnitRoles("AllLabUnits", TECHNICIAN_ROLE_ID);
+        when(userRoleService.getUserLabUnitRoles(ALL_LAB_UNITS_TECH_USER_ID)).thenReturn(labRoles);
+
+        // Test: AllLabUnits role works for any lab unit (Hematology in this case)
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, ALL_LAB_UNITS_TECH_USER_ID,
+                HEMATOLOGY_LAB_UNIT);
+
+        assertTrue("User with AllLabUnits role should be allowed for any lab unit", result);
+    }
+
+    // ========== TEST: SPECIFIC LAB UNIT ROLES (Priority 3) ==========
+
+    @Test
+    public void canCreateEntry_userWithCytologyTechnicianRole_allowedForCytologyLabUnit() {
+        // Setup: User has Technician role only for Cytology
+        setupNonAdminUser(CYTOLOGY_TECH_USER_ID);
+        setupCanViewTemplate(CYTOLOGY_TECH_USER_ID, CYTOLOGY_LAB_UNIT);
+
+        when(userRoleService.userInRole(eq(CYTOLOGY_TECH_USER_ID), any(Collection.class))).thenReturn(false);
+
+        // Specific lab unit role (Cytology = test section ID 100)
+        UserLabUnitRoles labRoles = createUserLabUnitRoles(CYTOLOGY_TEST_SECTION_ID, TECHNICIAN_ROLE_ID);
+        when(userRoleService.getUserLabUnitRoles(CYTOLOGY_TECH_USER_ID)).thenReturn(labRoles);
+
+        // Test: User with Cytology Technician role can create entry for Cytology
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, CYTOLOGY_TECH_USER_ID,
+                CYTOLOGY_LAB_UNIT);
+
+        assertTrue("User with Cytology Technician role should be allowed for Cytology lab unit", result);
+    }
+
+    @Test
+    public void canCreateEntry_userWithCytologyTechnicianRole_deniedForHematologyLabUnit() {
+        // Setup: User has Technician role only for Cytology, but tries to access
+        // Hematology
+        setupNonAdminUser(CYTOLOGY_TECH_USER_ID);
+        setupCanViewTemplate(CYTOLOGY_TECH_USER_ID, HEMATOLOGY_LAB_UNIT);
+
+        when(userRoleService.userInRole(eq(CYTOLOGY_TECH_USER_ID), any(Collection.class))).thenReturn(false);
+
+        // Specific lab unit role (Cytology = test section ID 100)
+        UserLabUnitRoles labRoles = createUserLabUnitRoles(CYTOLOGY_TEST_SECTION_ID, TECHNICIAN_ROLE_ID);
+        when(userRoleService.getUserLabUnitRoles(CYTOLOGY_TECH_USER_ID)).thenReturn(labRoles);
+
+        // Test: User with Cytology role should NOT be allowed for Hematology
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, CYTOLOGY_TECH_USER_ID,
+                HEMATOLOGY_LAB_UNIT);
+
+        assertFalse("User with Cytology Technician role should NOT be allowed for Hematology lab unit", result);
+    }
+
+    @Test
+    public void canCreateEntry_userWithHematologyTechnicianRole_allowedForHematologyLabUnit() {
+        // Setup: User has Technician role only for Hematology
+        setupNonAdminUser(HEMATOLOGY_TECH_USER_ID);
+        setupCanViewTemplate(HEMATOLOGY_TECH_USER_ID, HEMATOLOGY_LAB_UNIT);
+
+        when(userRoleService.userInRole(eq(HEMATOLOGY_TECH_USER_ID), any(Collection.class))).thenReturn(false);
+
+        UserLabUnitRoles labRoles = createUserLabUnitRoles(HEMATOLOGY_TEST_SECTION_ID, TECHNICIAN_ROLE_ID);
+        when(userRoleService.getUserLabUnitRoles(HEMATOLOGY_TECH_USER_ID)).thenReturn(labRoles);
+
+        // Test: User with Hematology Technician role can create entry for Hematology
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, HEMATOLOGY_TECH_USER_ID,
+                HEMATOLOGY_LAB_UNIT);
+
+        assertTrue("User with Hematology Technician role should be allowed for Hematology lab unit", result);
+    }
+
+    // ========== TEST: NO MATCHING ROLES ==========
+
+    @Test
+    public void canCreateEntry_userWithNoMatchingRoles_denied() {
+        // Setup: User has no roles that match the template's allowedRoles
+        setupNonAdminUser(NO_ROLES_USER_ID);
+        setupCanViewTemplate(NO_ROLES_USER_ID, CYTOLOGY_LAB_UNIT);
+
+        when(userRoleService.userInRole(eq(NO_ROLES_USER_ID), any(Collection.class))).thenReturn(false);
+        when(userRoleService.getUserLabUnitRoles(NO_ROLES_USER_ID)).thenReturn(null);
+
+        // Test: User with no matching roles should be denied
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, NO_ROLES_USER_ID, CYTOLOGY_LAB_UNIT);
+
+        assertFalse("User with no matching roles should be denied", result);
+    }
+
+    @Test
+    public void canCreateEntry_userWithNoMatchingRoles_butNoRoleRestrictions_allowed() {
+        // Setup: User has no roles, but template has no role restrictions
+        setupNonAdminUser(NO_ROLES_USER_ID);
+        setupCanViewTemplateNoRestrictions(NO_ROLES_USER_ID, CYTOLOGY_LAB_UNIT);
+
+        // Test: Template with no role restrictions allows any user
+        boolean result = securityService.canCreateEntry(templateWithNoRoleRestrictions, NO_ROLES_USER_ID,
+                CYTOLOGY_LAB_UNIT);
+
+        assertTrue("User should be allowed when template has no role restrictions", result);
+    }
+
+    // ========== TEST: ROLE HIERARCHY PRIORITY ==========
+
+    @Test
+    public void canCreateEntry_globalRolesCheckedBeforeLabUnitRoles() {
+        // This test verifies that global roles are checked first (priority 1)
+        // If the user has a matching global role, lab unit roles should not matter
+        setupNonAdminUser(GLOBAL_TECH_USER_ID);
+        setupCanViewTemplate(GLOBAL_TECH_USER_ID, BIOCHEMISTRY_LAB_UNIT);
+
+        // User has global Technician role
+        when(userRoleService.userInRole(eq(GLOBAL_TECH_USER_ID), any(Collection.class))).thenAnswer(invocation -> {
+            Collection<String> roles = invocation.getArgument(1);
+            return roles.contains(ROLE_TECHNICIAN);
+        });
+
+        // Even though user has NO lab unit roles for Biochemistry, global role should
+        // suffice
+        when(userRoleService.getUserLabUnitRoles(GLOBAL_TECH_USER_ID)).thenReturn(null);
+
+        // Test: Global role should allow access even without lab unit role
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, GLOBAL_TECH_USER_ID,
+                BIOCHEMISTRY_LAB_UNIT);
+
+        assertTrue("Global Technician role should allow access regardless of lab unit roles", result);
+    }
+
+    @Test
+    public void canCreateEntry_allLabUnitsCheckedBeforeSpecificLabUnits() {
+        // This test verifies that AllLabUnits is checked before specific lab units
+        // (priority 2)
+        setupNonAdminUser(ALL_LAB_UNITS_TECH_USER_ID);
+        setupCanViewTemplate(ALL_LAB_UNITS_TECH_USER_ID, BIOCHEMISTRY_LAB_UNIT);
+
+        when(userRoleService.userInRole(eq(ALL_LAB_UNITS_TECH_USER_ID), any(Collection.class))).thenReturn(false);
+
+        // User has AllLabUnits role (no specific Biochemistry role needed)
+        UserLabUnitRoles labRoles = createUserLabUnitRoles("AllLabUnits", TECHNICIAN_ROLE_ID);
+        when(userRoleService.getUserLabUnitRoles(ALL_LAB_UNITS_TECH_USER_ID)).thenReturn(labRoles);
+
+        // Test: AllLabUnits role should allow access to Biochemistry
+        boolean result = securityService.canCreateEntry(templateWithAllowedRoles, ALL_LAB_UNITS_TECH_USER_ID,
+                BIOCHEMISTRY_LAB_UNIT);
+
+        assertTrue("AllLabUnits role should allow access to any lab unit including Biochemistry", result);
+    }
+
+    // ========== HELPER METHODS ==========
+
+    private void setupNonAdminUser(String userId) {
+        // User is NOT Global Administrator
+        when(userRoleService.userInRole(eq(userId), eq(Constants.ROLE_GLOBAL_ADMIN))).thenReturn(false);
+    }
+
+    private void setupCanViewTemplate(String userId, String loginLabUnit) {
+        // Setup so canViewTemplate returns true (user can view template based on
+        // departments)
+        // Use mocked TestSection objects to avoid SpringContext dependency
+        Set<TestSection> departments = new HashSet<>();
+        departments.add(createMockedTestSection(CYTOLOGY_TEST_SECTION_ID, CYTOLOGY_LAB_UNIT));
+        departments.add(createMockedTestSection(HEMATOLOGY_TEST_SECTION_ID, HEMATOLOGY_LAB_UNIT));
+        departments.add(createMockedTestSection("102", BIOCHEMISTRY_LAB_UNIT));
+
+        templateWithAllowedRoles.setDepartments(departments);
+    }
+
+    private void setupCanViewTemplateNoRestrictions(String userId, String loginLabUnit) {
+        // Setup template with no role restrictions and departments
+        Set<TestSection> departments = new HashSet<>();
+        departments.add(createMockedTestSection(CYTOLOGY_TEST_SECTION_ID, CYTOLOGY_LAB_UNIT));
+        templateWithNoRoleRestrictions.setDepartments(departments);
+    }
+
+    private TestSection createMockedTestSection(String id, String name) {
+        TestSection ts = Mockito.mock(TestSection.class);
+        when(ts.getId()).thenReturn(id);
+        when(ts.getTestSectionName()).thenReturn(name);
+        when(ts.getLocalizedName()).thenReturn(name);
+        return ts;
+    }
+
+    private UserLabUnitRoles createUserLabUnitRoles(String labUnit, String... roleIds) {
+        UserLabUnitRoles userLabRoles = new UserLabUnitRoles();
+
+        Set<LabUnitRoleMap> labUnitRoleMaps = new HashSet<>();
+        LabUnitRoleMap roleMap = new LabUnitRoleMap();
+        roleMap.setLabUnit(labUnit);
+
+        Set<String> roles = new HashSet<>();
+        for (String roleId : roleIds) {
+            roles.add(roleId);
+        }
+        roleMap.setRoles(roles);
+        labUnitRoleMaps.add(roleMap);
+
+        userLabRoles.setLabUnitRoleMap(labUnitRoleMaps);
+        return userLabRoles;
+    }
+}

--- a/src/test/resources/testdata/notebook-security-test-data.xml
+++ b/src/test/resources/testdata/notebook-security-test-data.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <!-- Test data for NotebookSecurityServiceImpl role hierarchy tests. Role
+        checking hierarchy: 1. Global Roles (system_user_role) 2. Lab Unit Roles
+        - AllLabUnits (lab_unit_role_map + lab_roles) 3. Lab Unit Roles - Specific
+        Units (lab_unit_role_map + lab_roles) -->
+
+    <!-- ========== SYSTEM ROLES ========== -->
+    <!-- Role IDs match actual system, names must match exactly -->
+    <system_role id="1" name="Global Administrator"
+        description="Super admin" display_key="role.globaladmin" active="Y" />
+    <system_role id="2" name="Technician"
+        description="Lab Technician" display_key="role.technician" active="Y" />
+    <system_role id="3" name="Supervisor"
+        description="Lab Supervisor" display_key="role.supervisor" active="Y" />
+    <system_role id="4" name="Pathologist"
+        description="Pathologist" display_key="role.pathologist" active="Y" />
+    <system_role id="5" name="Results"
+        description="Results entry" display_key="role.results" active="Y" />
+    <system_role id="6" name="Notebook Administrator"
+        description="Notebook Admin" display_key="role.notebookadmin"
+        active="Y" />
+    <system_role id="7" name="Cytopathologist"
+        description="Cytopathologist" display_key="role.cytopathologist"
+        active="Y" />
+
+    <!-- ========== TEST SECTIONS (Lab Units) ========== -->
+    <test_section id="100" name="Cytology"
+        description="Cytology Department" is_active="Y" sort_order="1" />
+    <test_section id="101" name="Hematology"
+        description="Hematology Department" is_active="Y" sort_order="2" />
+    <test_section id="102" name="Biochemistry"
+        description="Biochemistry Department" is_active="Y" sort_order="3" />
+
+    <!-- ========== LOCALIZATION FOR TEST SECTIONS ========== -->
+    <localization id="1000" english="Cytology"
+        french="Cytologie" description="Test section localization"
+        lastupdated="2025-01-01 00:00:00" />
+    <localization id="1001" english="Hematology"
+        french="Hematologie" description="Test section localization"
+        lastupdated="2025-01-01 00:00:00" />
+    <localization id="1002" english="Biochemistry"
+        french="Biochimie" description="Test section localization"
+        lastupdated="2025-01-01 00:00:00" />
+
+    <!-- ========== SYSTEM USERS ========== -->
+    <!-- User 10: Global Admin (has global role) -->
+    <system_user id="10" external_id="EXT010"
+        login_name="globaladmin" last_name="Admin" first_name="Global"
+        initials="GA" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 00:00:00" />
+
+    <!-- User 11: User with global Technician role (not lab-unit specific) -->
+    <system_user id="11" external_id="EXT011"
+        login_name="globaltech" last_name="Technician" first_name="Global"
+        initials="GT" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 00:00:00" />
+
+    <!-- User 12: User with global Pathologist role -->
+    <system_user id="12" external_id="EXT012"
+        login_name="globalpathologist" last_name="Pathologist"
+        first_name="Global" initials="GP" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 00:00:00" />
+
+    <!-- User 13: User with AllLabUnits Technician role -->
+    <system_user id="13" external_id="EXT013"
+        login_name="alllabtech" last_name="Technician" first_name="AllLab"
+        initials="AT" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 00:00:00" />
+
+    <!-- User 14: User with Cytology-specific Technician role -->
+    <system_user id="14" external_id="EXT014"
+        login_name="cytotech" last_name="Technician" first_name="Cytology"
+        initials="CT" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 00:00:00" />
+
+    <!-- User 15: User with Hematology-specific Technician role -->
+    <system_user id="15" external_id="EXT015"
+        login_name="hematech" last_name="Technician" first_name="Hematology"
+        initials="HT" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 00:00:00" />
+
+    <!-- User 16: User with NO matching roles (only has unrelated role) -->
+    <system_user id="16" external_id="EXT016"
+        login_name="noroles" last_name="NoRoles" first_name="User"
+        initials="NR" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 00:00:00" />
+
+    <!-- ========== GLOBAL ROLE ASSIGNMENTS (system_user_role) ========== -->
+    <!-- User 10 has Global Administrator role -->
+    <system_user_role system_user_id="10" role_id="1" />
+
+    <!-- User 11 has global Technician role -->
+    <system_user_role system_user_id="11" role_id="2" />
+
+    <!-- User 12 has global Pathologist role -->
+    <system_user_role system_user_id="12" role_id="4" />
+
+    <!-- User 16 has no relevant roles (just a placeholder role) -->
+    <!-- No entry needed - user has no global roles -->
+
+    <!-- ========== LAB UNIT ROLE MAPPINGS ========== -->
+    <!-- User 13: AllLabUnits with Technician role -->
+    <user_lab_unit_roles system_user_id="13"
+        last_updated="2025-01-01 00:00:00" />
+    <lab_unit_role_map lab_unit_role_map_id="1"
+        lab_unit="AllLabUnits" />
+    <lab_roles lab_unit_role_map_id="1" role="2" />
+    <lab_unit_roles system_user_id="13"
+        lab_unit_role_map_id="1" />
+
+    <!-- User 14: Cytology (test_section id=100) with Technician role -->
+    <user_lab_unit_roles system_user_id="14"
+        last_updated="2025-01-01 00:00:00" />
+    <lab_unit_role_map lab_unit_role_map_id="2"
+        lab_unit="100" />
+    <lab_roles lab_unit_role_map_id="2" role="2" />
+    <lab_unit_roles system_user_id="14"
+        lab_unit_role_map_id="2" />
+
+    <!-- User 15: Hematology (test_section id=101) with Technician role -->
+    <user_lab_unit_roles system_user_id="15"
+        last_updated="2025-01-01 00:00:00" />
+    <lab_unit_role_map lab_unit_role_map_id="3"
+        lab_unit="101" />
+    <lab_roles lab_unit_role_map_id="3" role="2" />
+    <lab_unit_roles system_user_id="15"
+        lab_unit_role_map_id="3" />
+
+    <!-- ========== NOTEBOOK TEMPLATE FOR TESTING ========== -->
+    <!-- Template that requires Technician or Pathologist role -->
+    <notebook id="100" title="Security Test Template" type="100"
+        protocol="Test Protocol" content="Template content"
+        objective="Security Testing" status="DRAFT" is_template="true"
+        technician_id="10" creator_id="10" date_created="2025-01-01 10:00:00"
+        last_updated="2025-01-01 10:00:00" />
+
+    <!-- Allowed roles for the template: Technician, Pathologist -->
+    <notebook_allowed_roles notebook_id="100"
+        role="Technician" />
+    <notebook_allowed_roles notebook_id="100"
+        role="Pathologist" />
+
+    <!-- Template departments (test sections) -->
+    <notebook_departments notebook_id="100"
+        test_section_id="100" />
+    <notebook_departments notebook_id="100"
+        test_section_id="101" />
+
+    <!-- ========== NOTEBOOK PAGES FOR TESTING ========== -->
+    <!-- Page 1: Requires Technician role -->
+    <notebook_page id="200" notebook_id="100" page_order="1"
+        title="Sample Intake" instructions="Intake instructions"
+        content="Sample intake content" completed="false" />
+    <notebook_page_allowed_roles
+        notebook_page_id="200" role="Technician" />
+
+    <!-- Page 2: Requires Pathologist role -->
+    <notebook_page id="201" notebook_id="100" page_order="2"
+        title="Pathology Review" instructions="Review instructions"
+        content="Pathology review content" completed="false" />
+    <notebook_page_allowed_roles
+        notebook_page_id="201" role="Pathologist" />
+
+    <!-- Page 3: Multiple roles (Technician OR Supervisor) -->
+    <notebook_page id="202" notebook_id="100" page_order="3"
+        title="Quality Control" instructions="QC instructions"
+        content="Quality control content" completed="false" />
+    <notebook_page_allowed_roles
+        notebook_page_id="202" role="Technician" />
+    <notebook_page_allowed_roles
+        notebook_page_id="202" role="Supervisor" />
+
+    <!-- Page 4: No role restriction (accessible to all) -->
+    <notebook_page id="203" notebook_id="100" page_order="4"
+        title="General Notes" instructions="General instructions"
+        content="General notes content" completed="false" />
+
+</dataset>

--- a/volume/configuration/backend/roles/example-lab-roles.csv
+++ b/volume/configuration/backend/roles/example-lab-roles.csv
@@ -1,7 +1,13 @@
 name,description,displayKey,active,editable,isGroupingRole,groupingParent
-Lab Staff,Grouping role for all laboratory staff,role.lab.staff,Y,N,Y,
-Lab Technician,Basic laboratory technician role,role.lab.technician,Y,Y,N,Lab Staff
-Results Validator,Can validate and approve test results,role.results.validator,Y,Y,N,Lab Staff
-Sample Collector,Authorized to collect patient samples,role.sample.collector,Y,Y,N,Lab Staff
-Lab Supervisor,Laboratory supervisor with extended permissions,role.lab.supervisor,Y,Y,N,Lab Staff
-Quality Control Officer,Manages quality control and assurance,role.qc.officer,Y,Y,N,
+Notebook Entry Creator,Can create new notebook entries for assigned templates,role.notebook.entry.creator,Y,Y,N,Lab Unit Roles
+Sample Receiver,Can receive and register incoming samples,role.sample.receiver,Y,Y,N,Lab Unit Roles
+Sample Processor,Can perform initial sample processing and preparation,role.sample.processor,Y,Y,N,Lab Unit Roles
+Aliquoting Technician,Can create aliquots and child samples,role.aliquoting.technician,Y,Y,N,Lab Unit Roles
+QC Technician,Can perform quality control checks on samples,role.qc.technician,Y,Y,N,Lab Unit Roles
+Storage Manager,Can manage storage locations and retrieve samples,role.storage.manager,Y,Y,N,Lab Unit Roles
+Test Executor,Can execute tests and capture raw data,role.test.executor,Y,Y,N,Lab Unit Roles
+Analyst,Can perform data analysis on test results,role.analyst,Y,Y,N,Lab Unit Roles
+Results Entry and Validator,Can enter and compile test results,role.results.entry,Y,Y,N,Lab Unit Roles
+Archivist,Can archive samples and manage long-term storage,role.archivist,Y,Y,N,Lab Unit Roles
+Disposal Officer,Can dispose of samples following protocols,role.disposal.officer,Y,Y,N,Lab Unit Roles
+Report Generator,Can generate reports and export data,role.report.generator,Y,Y,N,Lab Unit Roles


### PR DESCRIPTION
- Add allowedRoles field to NoteBookPage entity with ElementCollection mapping
- Create Liquibase migration for notebook_page_allowed_roles table
- Implement page-level access filtering in NotebookWorkflowTab.js
- Fix Hibernate lazy loading issues for allowedRoles collections
- Entries now inherit allowedRoles from parent template
- Add usePermissions hook with role checking hierarchy: Global Admin → Global Roles → AllLabUnits → Specific Lab Unit
- Add PermissionGate component for declarative permission checks
- Update View/Edit buttons to check user roles
- Add NotebookSecurityServiceImplTest with role hierarchy tests
- Add Notebook Administrator role constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
