### PR TITLE
Fixed dev login docs: default admin password violates password policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,14 @@ speeds up the development process
 
 #### The Instances can be accessed at
 
-| Instance     |                   URL                   | credentials (user : password) |
-| ------------ | :-------------------------------------: | ----------------------------: |
-| Legacy UI    | https://localhost/api/OpenELIS-Global/  |            admin: adminADMIN! |
-| New React UI |           https://localhost/            |            admin: adminADMIN! |
+| Instance     |                   URL                   |
+| ------------ | :-------------------------------------: | 
+| Legacy UI    | https://localhost/api/OpenELIS-Global/  | 
+| New React UI |           https://localhost/            |
+
+
+Important: The default admin password must meet the current password complexity requirements.
+If the password does not meet requirements, the admin user will not be created.
 
 **Note:** If your browser indicates that the website is not secure after
 accessing any of these links, simply follow these steps:
@@ -123,6 +127,23 @@ accessing any of these links, simply follow these steps:
 2. Click on the "Advanced" button.
 3. Finally, click on "Proceed to https://localhost" to access the development
    environment.
+
+
+#### Login troubleshooting
+
+Cannot log in as admin?
+
+1. Admin user creation runs only once on first database initialization
+
+2. If the default password does not meet complexity rules, admin creation fails silently
+
+3. Restarting containers or changing DEFAULT_PW will not fix this
+
+Solutions:
+
+1. Reset the database volumes and restart Docker
+
+2. Or manually create the admin user in the database 
 
 #### Formating the Source code after making changes
 


### PR DESCRIPTION


# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
The development documentation currently lists a default admin password (adminADMIN!) that no longer meets OpenELIS password complexity requirements. As a result, the admin bootstrap fails silently during first startup, leaving the system with no users and making login impossible for new contributors.

This PR updates the documentation to reflect the current password requirements and clarifies expected behavior when admin creation fails and troubleshooting.

## Screenshots
<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/62abb0a2-39cf-44f6-84a5-964ebe224aff" />




## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]

https://github.com/user-attachments/assets/4b44169b-568e-4174-a0dc-72131e38b52e

