### PR TITLE
fix: Implement escapeRegexChars in NameValidator

### DIFF
--- a/src/main/java/org/openelisglobal/validation/constraintvalidator/NameValidator.java
+++ b/src/main/java/org/openelisglobal/validation/constraintvalidator/NameValidator.java
@@ -27,8 +27,10 @@ public class NameValidator implements ConstraintValidator<ValidName, String>, Co
     SiteInformationService siteInformationService = SpringContext.getBean(SiteInformationService.class);
 
     private String escapeRegexChars(String regex) {
-        // TODO Auto-generated method stub
-        return regex;
+        if (regex == null) {
+            return "";
+        }
+        return regex.replaceAll("([\\\\\\^\\$\\.\\|\\?\\*\\+\\(\\)\\[\\]\\{\\}])", "\\\\$1");
     }
 
     @PostConstruct


### PR DESCRIPTION
## Description
Implemented the [escapeRegexChars](cci:1://file:///C:/Users/airaj/OneDrive/Desktop/gsoc/openelis/src/main/java/org/openelisglobal/validation/constraintvalidator/NameValidator.java:28:4-33:5) method in [NameValidator.java](cci:7://file:///C:/Users/airaj/OneDrive/Desktop/gsoc/openelis/src/main/java/org/openelisglobal/validation/constraintvalidator/NameValidator.java:0:0-0:0) which previously had a TODO stub that just returned the input unchanged.

## Changes
- Added null check with empty string fallback
- Escape special regex characters: \ ^ $ . | ? * + ( ) [ ] { }

## Why
The method is used to build regex patterns for name validation. Without proper escaping, special characters in the charset configuration could cause regex parsing errors or unintended pattern matching.