### PR TITLE
feat: Add manifest description field to MNTD import

### DIFF
--- a/frontend/src/components/notebook/pages/mntd/MNTDSampleIntakePage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDSampleIntakePage.js
@@ -12,8 +12,11 @@ import {
   Tile,
   InlineNotification,
   Tag,
+  ExpandableTile,
+  TileAboveTheFoldContent,
+  TileBelowTheFoldContent,
 } from "@carbon/react";
-import { Upload, Checkmark, Printer } from "@carbon/react/icons";
+import { Upload, Checkmark, Printer, Document } from "@carbon/react/icons";
 import { FormattedMessage, useIntl } from "react-intl";
 import {
   getFromOpenElisServer,
@@ -57,13 +60,28 @@ function MNTDSampleIntakePage({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  // State for manifest description
+  const [manifestDescription, setManifestDescription] = useState(null);
+
   // Modal state for import
   const [importModalOpen, setImportModalOpen] = useState(false);
+
+  // Load entry data to get manifest description
+  const loadEntryData = useCallback(() => {
+    if (!entryId) return;
+
+    getFromOpenElisServer(`/rest/notebook-entry/${entryId}`, (response) => {
+      if (componentMounted.current && response) {
+        setManifestDescription(response.manifestDescription || null);
+      }
+    });
+  }, [entryId]);
 
   // Load samples for this page
   useEffect(() => {
     componentMounted.current = true;
     loadPageSamples();
+    loadEntryData();
 
     return () => {
       componentMounted.current = false;
@@ -116,11 +134,12 @@ function MNTDSampleIntakePage({
   const handleImportSuccess = useCallback(
     (result) => {
       loadPageSamples();
+      loadEntryData(); // Reload to get updated manifest description
       if (onProgressUpdate) {
         onProgressUpdate();
       }
     },
-    [loadPageSamples, onProgressUpdate],
+    [loadPageSamples, loadEntryData, onProgressUpdate],
   );
 
   // Handle bulk mark as registered
@@ -228,6 +247,24 @@ function MNTDSampleIntakePage({
         </Column>
       </Grid>
 
+      {/* Manifest Description Display */}
+      {manifestDescription && (
+        <div className="manifest-description-display">
+          <Tile className="manifest-info-tile">
+            <div className="manifest-info-header">
+              <Document size={16} />
+              <span className="manifest-info-label">
+                <FormattedMessage
+                  id="notebook.page.mntd.manifestDescription.label"
+                  defaultMessage="Manifest Notes"
+                />
+              </span>
+            </div>
+            <p className="manifest-info-text">{manifestDescription}</p>
+          </Tile>
+        </div>
+      )}
+
       {/* Action Buttons */}
       <div className="page-actions-bar">
         <Button
@@ -312,7 +349,7 @@ function MNTDSampleIntakePage({
                     id: "notebook.sample.sampleType",
                     defaultMessage: "Sample Type",
                   }),
-                  render: (sample) => sample.sampleType || "-",
+                  render: (value, sample) => sample?.sampleType || value || "-",
                 },
                 {
                   key: "projectName",
@@ -320,7 +357,8 @@ function MNTDSampleIntakePage({
                     id: "notebook.sample.projectName",
                     defaultMessage: "Project",
                   }),
-                  render: (sample) => sample.projectName || "-",
+                  render: (value, sample) =>
+                    sample?.projectName || value || "-",
                 },
                 {
                   key: "sampleSourceLocation",
@@ -328,7 +366,8 @@ function MNTDSampleIntakePage({
                     id: "notebook.sample.sourceLocation",
                     defaultMessage: "Source Location",
                   }),
-                  render: (sample) => sample.sampleSourceLocation || "-",
+                  render: (value, sample) =>
+                    sample?.sampleSourceLocation || value || "-",
                 },
                 {
                   key: "broughtBy",
@@ -336,7 +375,7 @@ function MNTDSampleIntakePage({
                     id: "notebook.sample.broughtBy",
                     defaultMessage: "Brought By",
                   }),
-                  render: (sample) => sample.broughtBy || "-",
+                  render: (value, sample) => sample?.broughtBy || value || "-",
                 },
               ]}
             />
@@ -386,7 +425,7 @@ function MNTDSampleIntakePage({
                     id: "notebook.sample.sampleType",
                     defaultMessage: "Sample Type",
                   }),
-                  render: (sample) => sample.sampleType || "-",
+                  render: (value, sample) => sample?.sampleType || value || "-",
                 },
                 {
                   key: "projectName",
@@ -394,7 +433,8 @@ function MNTDSampleIntakePage({
                     id: "notebook.sample.projectName",
                     defaultMessage: "Project",
                   }),
-                  render: (sample) => sample.projectName || "-",
+                  render: (value, sample) =>
+                    sample?.projectName || value || "-",
                 },
                 {
                   key: "sampleSourceLocation",
@@ -402,7 +442,8 @@ function MNTDSampleIntakePage({
                     id: "notebook.sample.sourceLocation",
                     defaultMessage: "Source Location",
                   }),
-                  render: (sample) => sample.sampleSourceLocation || "-",
+                  render: (value, sample) =>
+                    sample?.sampleSourceLocation || value || "-",
                 },
                 {
                   key: "broughtBy",
@@ -410,7 +451,7 @@ function MNTDSampleIntakePage({
                     id: "notebook.sample.broughtBy",
                     defaultMessage: "Brought By",
                   }),
-                  render: (sample) => sample.broughtBy || "-",
+                  render: (value, sample) => sample?.broughtBy || value || "-",
                 },
               ]}
             />

--- a/frontend/src/components/notebook/workflow/MNTDManifestImportModal.js
+++ b/frontend/src/components/notebook/workflow/MNTDManifestImportModal.js
@@ -25,6 +25,7 @@ import {
   TableHeader,
   TableBody,
   TableCell,
+  TextArea,
 } from "@carbon/react";
 import {
   Upload,
@@ -192,6 +193,7 @@ function MNTDManifestImportModal({ open, onClose, entryId, onImportSuccess }) {
   });
 
   const [step, setStep] = useState(1);
+  const [manifestDescription, setManifestDescription] = useState("");
   const [previewData, setPreviewData] = useState(null);
   const [previewErrors, setPreviewErrors] = useState([]);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
@@ -363,6 +365,7 @@ function MNTDManifestImportModal({ open, onClose, entryId, onImportSuccess }) {
       specimenConditionColumn: "",
       remarksColumn: "",
     });
+    setManifestDescription("");
     setPreviewData(null);
     setPreviewErrors([]);
     setStep(1);
@@ -402,6 +405,7 @@ function MNTDManifestImportModal({ open, onClose, entryId, onImportSuccess }) {
       "mapping",
       new Blob([JSON.stringify(columnMapping)], { type: "application/json" }),
     );
+    formData.append("manifestDescription", manifestDescription);
 
     fetch(
       `${config.serverBaseUrl}/rest/notebook/mntd/entry/${entryId}/samples/preview-manifest`,
@@ -435,7 +439,7 @@ function MNTDManifestImportModal({ open, onClose, entryId, onImportSuccess }) {
           { rowNumber: 0, column: "system", message: error.message },
         ]);
       });
-  }, [file, entryId, columnMapping]);
+  }, [file, entryId, columnMapping, manifestDescription]);
 
   // Execute import
   const handleImport = useCallback(() => {
@@ -449,6 +453,7 @@ function MNTDManifestImportModal({ open, onClose, entryId, onImportSuccess }) {
       "mapping",
       new Blob([JSON.stringify(columnMapping)], { type: "application/json" }),
     );
+    formData.append("manifestDescription", manifestDescription);
 
     fetch(
       `${config.serverBaseUrl}/rest/notebook/mntd/entry/${entryId}/samples/create-from-manifest`,
@@ -485,7 +490,7 @@ function MNTDManifestImportModal({ open, onClose, entryId, onImportSuccess }) {
           { rowNumber: 0, column: "system", message: error.message },
         ]);
       });
-  }, [file, entryId, columnMapping, onImportSuccess]);
+  }, [file, entryId, columnMapping, manifestDescription, onImportSuccess]);
 
   // Close modal and reset
   const handleClose = useCallback(() => {
@@ -846,6 +851,26 @@ function MNTDManifestImportModal({ open, onClose, entryId, onImportSuccess }) {
                 onDelete={handleRemoveFile}
               />
             )}
+
+            {/* Manifest Description */}
+            <div className="manifest-description-section">
+              <TextArea
+                id="manifestDescription"
+                labelText={intl.formatMessage({
+                  id: "notebook.mntd.manifest.description",
+                  defaultMessage: "Manifest Description / Notes",
+                })}
+                placeholder={intl.formatMessage({
+                  id: "notebook.mntd.manifest.description.placeholder",
+                  defaultMessage:
+                    "Enter any additional information about this manifest import...",
+                })}
+                value={manifestDescription}
+                onChange={(e) => setManifestDescription(e.target.value)}
+                rows={3}
+                maxCount={500}
+              />
+            </div>
 
             {/* Required Fields Mapping */}
             <div className="mapping-section">

--- a/frontend/src/components/notebook/workflow/NotebookWorkflow.css
+++ b/frontend/src/components/notebook/workflow/NotebookWorkflow.css
@@ -1407,3 +1407,40 @@
     font-size: 0.8125rem;
   }
 }
+
+/* ========================================== */
+/* Manifest Description Display Styles        */
+/* ========================================== */
+
+.manifest-description-display {
+  margin: 1rem 0;
+}
+
+.manifest-info-tile {
+  background-color: var(--cds-layer-02);
+  border-left: 3px solid var(--cds-support-info);
+  padding: 0.75rem 1rem;
+}
+
+.manifest-info-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--cds-text-secondary);
+}
+
+.manifest-info-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.32px;
+}
+
+.manifest-info-text {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--cds-text-primary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}

--- a/src/main/java/org/openelisglobal/notebook/controller/rest/MNTDManifestImportController.java
+++ b/src/main/java/org/openelisglobal/notebook/controller/rest/MNTDManifestImportController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -119,16 +120,19 @@ public class MNTDManifestImportController extends BaseRestController {
      * Create MNTD samples from manifest CSV for a notebook entry. POST
      * /rest/notebook/mntd/entry/{entryId}/samples/create-from-manifest
      *
-     * @param entryId     the notebook entry ID
-     * @param file        the CSV file
-     * @param form        MNTD column mapping configuration
-     * @param httpRequest for getting user session
+     * @param entryId             the notebook entry ID
+     * @param file                the CSV file
+     * @param form                MNTD column mapping configuration
+     * @param manifestDescription optional description/notes about this manifest
+     *                            import
+     * @param httpRequest         for getting user session
      * @return creation result with created sample count and accession numbers
      */
     @PostMapping(value = "/entry/{entryId}/samples/create-from-manifest", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Map<String, Object>> createSamplesForEntry(@PathVariable("entryId") Integer entryId,
             @RequestPart("file") MultipartFile file, @RequestPart("mapping") MNTDManifestImportForm form,
+            @RequestParam(value = "manifestDescription", required = false) String manifestDescription,
             HttpServletRequest httpRequest) {
 
         // Verify entry exists
@@ -182,7 +186,7 @@ public class MNTDManifestImportController extends BaseRestController {
 
             // Create samples for the entry
             MNTDManifestImportResult result = mntdManifestImportService.createSamplesForEntry(entryId, parsed,
-                    sysUserId);
+                    sysUserId, manifestDescription);
 
             // Build response
             Map<String, Object> response = new HashMap<>();

--- a/src/main/java/org/openelisglobal/notebook/controller/rest/NotebookEntryRestController.java
+++ b/src/main/java/org/openelisglobal/notebook/controller/rest/NotebookEntryRestController.java
@@ -620,6 +620,8 @@ public class NotebookEntryRestController extends BaseRestController {
         map.put("status", entry.getStatus() != null ? entry.getStatus().name() : null);
         map.put("dateCreated", entry.getDateCreated());
         map.put("dateCompleted", entry.getDateCompleted());
+        map.put("notes", entry.getNotes());
+        map.put("manifestDescription", entry.getManifestDescription());
 
         if (entry.getNotebook() != null) {
             Map<String, Object> notebookMap = new HashMap<>();

--- a/src/main/java/org/openelisglobal/notebook/service/MNTDManifestImportService.java
+++ b/src/main/java/org/openelisglobal/notebook/service/MNTDManifestImportService.java
@@ -61,12 +61,15 @@ public interface MNTDManifestImportService {
      * row with numOfSamples > 1 creates multiple SampleItem records. MNTD-specific
      * data is stored in sample metadata.
      *
-     * @param entryId   the notebook entry to link samples to
-     * @param manifest  the parsed and validated manifest
-     * @param sysUserId the user creating the samples
+     * @param entryId             the notebook entry to link samples to
+     * @param manifest            the parsed and validated manifest
+     * @param sysUserId           the user creating the samples
+     * @param manifestDescription optional description/notes about this manifest
+     *                            import
      * @return result containing created samples, accession numbers, and any errors
      */
-    MNTDManifestImportResult createSamplesForEntry(Integer entryId, ParsedManifest manifest, String sysUserId);
+    MNTDManifestImportResult createSamplesForEntry(Integer entryId, ParsedManifest manifest, String sysUserId,
+            String manifestDescription);
 
     /**
      * Generate external ID for an MNTD sample based on sample ID and sequence

--- a/src/main/java/org/openelisglobal/notebook/service/MNTDManifestImportServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/MNTDManifestImportServiceImpl.java
@@ -167,7 +167,8 @@ public class MNTDManifestImportServiceImpl implements MNTDManifestImportService 
 
     @Override
     @Transactional
-    public MNTDManifestImportResult createSamplesForEntry(Integer entryId, ParsedManifest manifest, String sysUserId) {
+    public MNTDManifestImportResult createSamplesForEntry(Integer entryId, ParsedManifest manifest, String sysUserId,
+            String manifestDescription) {
         List<SampleItem> createdSamples = new ArrayList<>();
         List<String> createdAccessionNumbers = new ArrayList<>();
         List<ParseError> errors = new ArrayList<>();
@@ -180,6 +181,13 @@ public class MNTDManifestImportServiceImpl implements MNTDManifestImportService 
         }
 
         NotebookEntry entry = optEntry.get();
+
+        // Store manifest description if provided
+        if (manifestDescription != null && !manifestDescription.isBlank()) {
+            entry.setManifestDescription(manifestDescription.trim());
+            entry.setSysUserId(sysUserId);
+            notebookEntryService.update(entry);
+        }
         int totalRequested = 0;
 
         for (MNTDManifestRow row : manifest.rows()) {

--- a/src/main/java/org/openelisglobal/notebook/valueholder/NotebookEntry.java
+++ b/src/main/java/org/openelisglobal/notebook/valueholder/NotebookEntry.java
@@ -79,6 +79,10 @@ public class NotebookEntry extends BaseObject<Integer> {
     @SafeHtml(level = SafeHtml.SafeListLevel.NONE)
     private String notes;
 
+    @Column(name = "manifest_description")
+    @SafeHtml(level = SafeHtml.SafeListLevel.NONE)
+    private String manifestDescription;
+
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "notebook_entry_sample", joinColumns = @JoinColumn(name = "notebook_entry_id"), inverseJoinColumns = @JoinColumn(name = "sample_item_id"))
     private List<SampleItem> samples = new ArrayList<>();
@@ -181,6 +185,14 @@ public class NotebookEntry extends BaseObject<Integer> {
 
     public void setNotes(String notes) {
         this.notes = notes;
+    }
+
+    public String getManifestDescription() {
+        return manifestDescription;
+    }
+
+    public void setManifestDescription(String manifestDescription) {
+        this.manifestDescription = manifestDescription;
     }
 
     public List<SampleItem> getSamples() {

--- a/src/main/resources/liquibase/3.4.x.x/035-notebook-entry-manifest-description.xml
+++ b/src/main/resources/liquibase/3.4.x.x/035-notebook-entry-manifest-description.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!-- ======================================================== -->
+    <!-- ADD MANIFEST DESCRIPTION COLUMN TO NOTEBOOK_ENTRY -->
+    <!-- Stores description/notes entered during manifest import -->
+    <!-- ======================================================== -->
+    <changeSet id="add-manifest-description-to-notebook-entry" author="openelis-mntd">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="notebook_entry" schemaName="clinlims"/>
+            <not>
+                <columnExists tableName="notebook_entry" columnName="manifest_description" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <comment>Add manifest_description column to notebook_entry table for storing import notes</comment>
+        <addColumn tableName="notebook_entry">
+            <column name="manifest_description" type="TEXT">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.4.x.x/base.xml
+++ b/src/main/resources/liquibase/3.4.x.x/base.xml
@@ -50,5 +50,6 @@
     <include file="liquibase/3.4.x.x/031-mntd-environmental-monitoring-page.xml"/>
     <include file="liquibase/3.4.x.x/033-notebook-hierarchy.xml"/>
     <include file="liquibase/3.4.x.x/034-notebook-project-metadata.xml"/>
+    <include file="liquibase/3.4.x.x/035-notebook-entry-manifest-description.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
- Add manifest_description column to notebook_entry table via Liquibase migration
- Add TextArea field in MNTD manifest import modal (Step 2) for entering description
- Store description on NotebookEntry entity when importing samples
- Display manifest notes on Sample Intake page after import
- Fix SampleGrid render function signature bug in MNTDSampleIntakePage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
