### PR TITLE
Fixed #2036: radio button

### DIFF
--- a/frontend/src/components/admin/userManagement/UserManagement.js
+++ b/frontend/src/components/admin/userManagement/UserManagement.js
@@ -22,6 +22,7 @@ import {
   Select,
   SelectItem,
   Stack,
+  RadioButton,
 } from "@carbon/react";
 import {
   getFromOpenElisServer,
@@ -271,24 +272,19 @@ function UserManagement() {
   const renderCell = (cell, row) => {
     if (cell.info.header === "select") {
       return (
-        <TableSelectRow
-          key={cell.id}
-          id={cell.id}
-          checked={selectedRowIds.includes(row.id)}
-          name="selectRowCheckbox"
-          ariaLabel="selectRows"
-          onSelect={() => {
-            const isActiveCell = row.cells.find((cell) =>
-              cell.id.endsWith(":active"),
-            );
-
-            if (selectedRowIds.includes(row.id)) {
-              setSelectedRowIds(selectedRowIds.filter((id) => id !== row.id));
-            } else {
-              setSelectedRowIds([...selectedRowIds, row.id]);
-            }
-          }}
-        />
+        <TableCell key={cell.id}>
+          <RadioButton
+            id={row.id}
+            name="select-user-radio"
+            labelText=""
+            hideLabel
+            checked={selectedRowIds.includes(row.id)}
+            onChange={() => {
+              // This ensures only one ID is in the array at a time
+              setSelectedRowIds([row.id]);
+            }}
+          />
+        </TableCell>
       );
     } else {
       return <TableCell key={cell.id}>{cell.value}</TableCell>;
@@ -554,21 +550,7 @@ function UserManagement() {
                             {rows.map((row) => (
                               <TableRow
                                 key={row.id}
-                                onClick={() => {
-                                  const id = row.id;
-                                  const CombinedUserID = row.combinedUserID;
-                                  const isSelected =
-                                    selectedRowIds.includes(id);
-                                  if (isSelected) {
-                                    setSelectedRowIds(
-                                      selectedRowIds.filter(
-                                        (selectedId) => selectedId !== id,
-                                      ),
-                                    );
-                                  } else {
-                                    setSelectedRowIds([...selectedRowIds, id]);
-                                  }
-                                }}
+                                onClick={() => setSelectedRowIds([row.id])}
                               >
                                 {row.cells.map((cell) => renderCell(cell, row))}
                               </TableRow>


### PR DESCRIPTION
# Pull Requests Requirements
FIxed issue #2036 
Description : 
      This PR addresses issue #2036 by replacing the multi-select checkboxes with single-select Radio buttons. This ensures that only one user can be selected at a time for modification or deactivation, as requested in the issue requirements.
      
      Proof of Fix:
      previous behavior :
![f1010935-c36e-4369-913b-ed4e400ec6f3](https://github.com/user-attachments/assets/af175381-1ce1-46cd-a1b0-ea0aec08ee57)

![848a1e71-5f18-4704-8b40-2453c101838d](https://github.com/user-attachments/assets/9e1b7981-b4d7-4ec7-995a-b371400eb745)
fixed behaviour : 

https://github.com/user-attachments/assets/be4b013a-a0c4-4f25-bdf1-f025697678f0


      
- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Replaced TableSelectRow (checkbox) with RadioButton in the UserManagement component to enforce single-user selection for admin actions. This implementation ensures that only one user ID is stored in the selectedRowIds state array at any time, preventing bulk deactivation or modification. I have also resolved potential runtime errors by initializing the selection state as an empty array."
## Screenshots

screenshots and recording added above 

## Related Issue
Closes #2036



## Other
Validated on local Docker environment. Verified that selection persists correctly during pagination and search.
[Add any additional information or notes here]
