### PR TITLE
Fixes (#2521): Clicking on cross icon, Clearing the search input results in error.

### DIFF
--- a/frontend/src/components/layout/search/searchService.js
+++ b/frontend/src/components/layout/search/searchService.js
@@ -163,5 +163,6 @@ export const useAutocomplete = (props) => {
     onClick,
     onKeyDown,
     onDelete,
+    setTextValue,
   };
 };


### PR DESCRIPTION

# Pull Requests Requirements
closes #2521 
- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
This PR contains the fix of frontend bug where :
1. Go to homepage.
2. Click on search icon.
3. Notice a Input box will appear, Fill some words.
4. Then Cross icon will appear ( for clearing the input box )
5. Click on that cross icon.

## Screenshots

<img width="1920" height="1003" alt="image" src="https://github.com/user-attachments/assets/6a58e346-bd13-4a9d-9c22-804bd697d0cf" />

[Screencast from 2026-01-05 17-33-05.webm](https://github.com/user-attachments/assets/afd6ffd2-6df2-42aa-8477-2f89fb27fed1)

[Add relevant screenshots here if applicable]

## Related Issue
#2521 
[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
