### PR TITLE
solved #2532 by Store errors and warnings under correct request attributes 

### DIFF
--- a/frontend/src/components/layout/search/searchBar.js
+++ b/frontend/src/components/layout/search/searchBar.js
@@ -37,13 +37,10 @@ const SearchBar = (props) => {
 
   const handleClearSearch = () => {
     setSearchInput("");
-   // setTextValue("");
-
+  
    if (typeof setTextValue === "function") {
     setTextValue("");
   }
-
-    
 
     setPatientData([]);
   };

--- a/frontend/src/components/layout/search/searchBar.js
+++ b/frontend/src/components/layout/search/searchBar.js
@@ -43,7 +43,7 @@ const SearchBar = (props) => {
     setTextValue("");
   }
 
-    console.log("setTextValue: jai shree", setTextValue);
+    
 
     setPatientData([]);
   };

--- a/frontend/src/components/layout/search/searchBar.js
+++ b/frontend/src/components/layout/search/searchBar.js
@@ -37,7 +37,14 @@ const SearchBar = (props) => {
 
   const handleClearSearch = () => {
     setSearchInput("");
+   // setTextValue("");
+
+   if (typeof setTextValue === "function") {
     setTextValue("");
+  }
+
+    console.log("setTextValue: jai shree", setTextValue);
+
     setPatientData([]);
   };
 

--- a/src/main/java/org/openelisglobal/common/controller/BaseController.java
+++ b/src/main/java/org/openelisglobal/common/controller/BaseController.java
@@ -298,7 +298,7 @@ public abstract class BaseController extends ControllerUtills implements IAction
 
         Errors errors = (Errors) inputFlashMap.get(Constants.REQUEST_ERRORS);
         if (errors != null) {
-            request.setAttribute(Constants.REQUEST_ERRORS, errors); // ✅ fixed
+            request.setAttribute(Constants.REQUEST_ERRORS, errors);
         }
 
         List<String> messages =

--- a/src/main/java/org/openelisglobal/common/controller/BaseController.java
+++ b/src/main/java/org/openelisglobal/common/controller/BaseController.java
@@ -281,25 +281,40 @@ public abstract class BaseController extends ControllerUtills implements IAction
     }
 
     // move flash attributes into request
-    protected void addFlashMsgsToRequest(HttpServletRequest request) {
-        Map<String, ?> inputFlashMap = RequestContextUtils.getInputFlashMap(request);
-        if (inputFlashMap != null) {
-            Boolean success = (Boolean) inputFlashMap.get(FWD_SUCCESS);
+  protected void addFlashMsgsToRequest(HttpServletRequest request) {
+    Map<String, ?> inputFlashMap = RequestContextUtils.getInputFlashMap(request);
+
+    if (inputFlashMap != null) {
+
+        Boolean success = (Boolean) inputFlashMap.get(FWD_SUCCESS);
+        if (success != null) {
             request.setAttribute(FWD_SUCCESS, success);
+        }
 
-            String successMessage = (String) inputFlashMap.get(Constants.SUCCESS_MSG);
+        String successMessage = (String) inputFlashMap.get(Constants.SUCCESS_MSG);
+        if (successMessage != null) {
             request.setAttribute(Constants.SUCCESS_MSG, successMessage);
+        }
 
-            Errors errors = (Errors) inputFlashMap.get(Constants.REQUEST_ERRORS);
-            request.setAttribute(Constants.SUCCESS_MSG, errors);
+        Errors errors = (Errors) inputFlashMap.get(Constants.REQUEST_ERRORS);
+        if (errors != null) {
+            request.setAttribute(Constants.REQUEST_ERRORS, errors); // ✅ fixed
+        }
 
-            List<String> messages = (List<String>) inputFlashMap.get(Constants.REQUEST_MESSAGES);
+        List<String> messages =
+                (List<String>) inputFlashMap.get(Constants.REQUEST_MESSAGES);
+        if (messages != null) {
             request.setAttribute(Constants.REQUEST_MESSAGES, messages);
+        }
 
-            List<String> warnings = (List<String>) inputFlashMap.get(Constants.REQUEST_WARNINGS);
-            request.setAttribute(Constants.SUCCESS_MSG, warnings);
+        List<String> warnings =
+                (List<String>) inputFlashMap.get(Constants.REQUEST_WARNINGS);
+        if (warnings != null) {
+            request.setAttribute(Constants.REQUEST_WARNINGS, warnings);
         }
     }
+}
+
 
     // re-initialize form object in the request
     protected <T extends BaseForm> T resetFormSessionObject(String objectName, T form) {


### PR DESCRIPTION

### Demo video
https://github.com/user-attachments/assets/c7bf600e-4b6e-4eb5-ac43-5210925c1b93

### What I fixed

While reviewing BaseController, I noticed that errors and warnings were being stored using the success message request key.
This could cause error and warning messages to overwrite success messages or be displayed incorrectly in the UI.


### What I changed

Updated the request attribute mapping so that:
Errors are stored under REQUEST_ERRORS
Warnings are stored under REQUEST_WARNINGS
Success messages continue to use SUCCESS_MSG

### Why this change

Using the success message key for errors and warnings is semantically incorrect and breaks the expected controller–view contract.
This fix ensures that each message type is handled and displayed correctly.


### Testing
Submitted forms that trigger:
Success messages
Error messages
Warning messages
Verified that each message is displayed correctly without overriding the others.
