### PR TITLE
Fix (#2503): patients born on the current date cannot be registered in OpenELIS Global.

### DIFF
--- a/src/main/java/org/openelisglobal/common/util/validator/CustomDateValidator.java
+++ b/src/main/java/org/openelisglobal/common/util/validator/CustomDateValidator.java
@@ -141,15 +141,17 @@ public class CustomDateValidator extends DateValidator {
         calendarDate.set(Calendar.MILLISECOND, 0);
         date = calendarDate.getTime();
 
-        int dateDiff = date.compareTo(today);
+        long diffInMillis = date.getTime() - today.getTime();
+        // Allow 24 hours buffer for timezone differences
+        long buffer = 24 * 60 * 60 * 1000;
 
-        if (relative.equals(DateRelation.PAST) && dateDiff > 0) {
+        if (relative.equals(DateRelation.PAST) && diffInMillis > buffer) {
             result = IActionConstants.INVALID_TO_LARGE;
-        } else if (relative.equals(DateRelation.FUTURE) && dateDiff < 0) {
+        } else if (relative.equals(DateRelation.FUTURE) && diffInMillis < -buffer) {
             result = IActionConstants.INVALID_TO_SMALL;
-        } else if (relative.equals(DateRelation.TODAY) && dateDiff > 0) {
+        } else if (relative.equals(DateRelation.TODAY) && diffInMillis > buffer) {
             result = IActionConstants.INVALID_TO_SMALL;
-        } else if (relative.equals(DateRelation.TODAY) && dateDiff < 0) {
+        } else if (relative.equals(DateRelation.TODAY) && diffInMillis < -buffer) {
             result = IActionConstants.INVALID_TO_SMALL;
         }
 

--- a/src/test/java/org/openelisglobal/common/util/validator/CustomDateValidatorTest.java
+++ b/src/test/java/org/openelisglobal/common/util/validator/CustomDateValidatorTest.java
@@ -1,0 +1,43 @@
+package org.openelisglobal.common.util.validator;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import org.junit.Test;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.common.util.validator.CustomDateValidator.DateRelation;
+
+public class CustomDateValidatorTest {
+
+    @Test
+    public void testValidateDate_Past_TomorrowAllowed() {
+        CustomDateValidator validator = CustomDateValidator.getInstance();
+
+        Calendar cal = new GregorianCalendar();
+        cal.add(Calendar.DAY_OF_MONTH, 1); // Tomorrow
+        Date tomorrow = cal.getTime();
+
+        // This effectively simulates a user in a timezone ahead of the server
+        // selecting "Today", which the server sees as "Tomorrow"
+        String result = validator.validateDate(tomorrow, DateRelation.PAST);
+
+        // This validates that "Tomorrow" (up to 24h) is accepted as PAST
+        // to handle timezone discrepancies (User ahead of Server)
+        assertEquals(IActionConstants.VALID, result);
+    }
+
+    @Test
+    public void testValidateDate_Past_DayAfterTomorrowRejected() {
+        CustomDateValidator validator = CustomDateValidator.getInstance();
+
+        Calendar cal = new GregorianCalendar();
+        cal.add(Calendar.DAY_OF_MONTH, 2); // 2 days in future
+        Date dayAfterTomorrow = cal.getTime();
+
+        String result = validator.validateDate(dayAfterTomorrow, DateRelation.PAST);
+
+        assertEquals(IActionConstants.INVALID_TO_LARGE, result);
+    }
+}


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
- The issue was If user is in different timezone for example : tokyo japan, and server is in different timezone. So that there is a difference of one day then server fails to fulfill the request.
- Added Test case for the same.

## Screenshots
[Screencast from 2026-01-11 00-54-35.webm](https://github.com/user-attachments/assets/4c6df7ef-eb0f-44d8-a6e6-82463c1044a9)

[Add relevant screenshots here if applicable]

## Related Issue
closes #2503 

## Other

[Add any additional information or notes here]
