### PR TITLE
Solved #2546 : header notification bell icon alignment

### DIFF
--- a/frontend/src/components/layout/Header.js
+++ b/frontend/src/components/layout/Header.js
@@ -487,7 +487,7 @@ function OEHeader(props) {
                               display: "flex",
                               alignItems: "center",
                               justifyContent: "center",
-                              height: "100%"
+                              height: "100%",
                             }}
                           >
                             {!notificationsOpen ? (

--- a/frontend/src/components/layout/Header.js
+++ b/frontend/src/components/layout/Header.js
@@ -484,7 +484,10 @@ function OEHeader(props) {
                           <div
                             style={{
                               position: "relative",
-                              display: "inline-block",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              height: "100%"
                             }}
                           >
                             {!notificationsOpen ? (


### PR DESCRIPTION

Fixes #2546

**_DESCRIPTION_**
The notification bell icon in the dashboard header was misaligned vertically compared to other icons because it used `display: inline-block`.

**_CHANGES_**
- Updated `Header.js` to use `display: flex` with `alignItems: center` and `justifyContent: 'center'`.
- Ran `npm run format` to ensure code style compliance.

**_SCREENSHOTS_**

before:
<img width="892" height="51" alt="Screenshot 2026-01-13 at 2 34 46 AM" src="https://github.com/user-attachments/assets/e9e52e2a-3a48-4fc8-9a70-256d3c474e29" />


after:
<img width="890" height="53" alt="Screenshot 2026-01-13 at 3 28 57 AM" src="https://github.com/user-attachments/assets/973bded6-1a4b-4a9e-bfb6-6b0314f699d6" />
