### PR TITLE
issue-2532: Fix incorrect flash message attribute handling in BaseController

### DIFF
--- a/src/main/java/org/openelisglobal/common/controller/BaseController.java
+++ b/src/main/java/org/openelisglobal/common/controller/BaseController.java
@@ -291,13 +291,13 @@ public abstract class BaseController extends ControllerUtills implements IAction
             request.setAttribute(Constants.SUCCESS_MSG, successMessage);
 
             Errors errors = (Errors) inputFlashMap.get(Constants.REQUEST_ERRORS);
-            request.setAttribute(Constants.SUCCESS_MSG, errors);
+            request.setAttribute(Constants.REQUEST_ERRORS, errors);
 
             List<String> messages = (List<String>) inputFlashMap.get(Constants.REQUEST_MESSAGES);
             request.setAttribute(Constants.REQUEST_MESSAGES, messages);
 
             List<String> warnings = (List<String>) inputFlashMap.get(Constants.REQUEST_WARNINGS);
-            request.setAttribute(Constants.SUCCESS_MSG, warnings);
+            request.setAttribute(Constants.REQUEST_WARNINGS, warnings);
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #2532 - Corrected the incorrect usage of request attribute keys in BaseController.addFlashMsgsToRequest()

## Bug Description
The [addFlashMsgsToRequest](cci:1://file:///c:/Users/airaj/OneDrive/Desktop/gsoc/openelis/src/main/java/org/openelisglobal/common/controller/BaseController.java:282:4-301:5) method was incorrectly storing errors and warnings under the `SUCCESS_MSG` key:
- Line 294: `request.setAttribute(Constants.SUCCESS_MSG, errors)` - errors stored as success
- Line 300: `request.setAttribute(Constants.SUCCESS_MSG, warnings)` - warnings stored as success

This caused:
1. Errors to overwrite success messages
2. Warnings to then overwrite errors
3. All error and warning information to be lost
4. Semantically incorrect attribute mapping

## Changes
- Changed line 294: `Constants.SUCCESS_MSG` → `Constants.REQUEST_ERRORS`
- Changed line 300: `Constants.SUCCESS_MSG` → `Constants.REQUEST_WARNINGS`

## Impact
Errors and warnings will now be correctly displayed in the UI instead of being lost or misclassified as success messages.