### PR TITLE
Util integration test

### DIFF
--- a/src/test/java/org/openelisglobal/common/util/IntegerUtilTest.java
+++ b/src/test/java/org/openelisglobal/common/util/IntegerUtilTest.java
@@ -1,0 +1,44 @@
+package org.openelisglobal.common.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class IntegerUtilTest {
+    
+    @Test
+    public void toStringBase27_and_parseIntBase27_roundTrip_variousValues() {
+        int[] values = {0, 1, -1, 27, 12345, -12345, Integer.MAX_VALUE, Integer.MIN_VALUE + 1}; 
+        for (int v : values) {
+            String s = IntegerUtil.toStringBase27(v);
+            int parsed = IntegerUtil.parseIntBase27(s);
+            assertEquals("Round trip failed for value: " + v, v, parsed);
+        }
+    }
+
+    @Test
+    public void toStringBase27_negativeStartsWithMinus() {
+        String s = IntegerUtil.toStringBase27(-42);
+        // negative representation includes '-' char
+        org.junit.Assert.assertTrue("Expected negative representation to contain '-'", s.indexOf('-') >= 0);
+    }
+
+    @Test
+    public void parseIntBase27_invalidInput_throwsNumberFormatException() {
+        try {
+            IntegerUtil.parseIntBase27("!!invalid!!");
+            fail("Expected NumberFormatException for invalid input");
+        } catch (NumberFormatException e) {
+            // expected
+        }
+
+        try {
+            IntegerUtil.parseIntBase27(null);
+            fail("Expected NumberFormatException for null");
+        } catch (NumberFormatException e) {
+            // expected
+        }
+    }
+}
+

--- a/src/test/java/org/openelisglobal/common/util/UtilIntegrationTestIT.java
+++ b/src/test/java/org/openelisglobal/common/util/UtilIntegrationTestIT.java
@@ -1,0 +1,37 @@
+package org.openelisglobal.common.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class UtilIntegrationTestIT {
+    @Test
+    public void integerAndXml_integrationProducesWellFormedEncodedXml() {
+        int original = 12345;
+        String base27 = IntegerUtil.toStringBase27(original);
+        int parsed = IntegerUtil.parseIntBase27(base27);
+        assertEquals("hi", original, parsed);
+
+
+        StringBuilder xml = new StringBuilder();
+        xml.append("<person ");
+        xml.append(XMLUtil.createAttributeKeyValue("id", base27));
+        xml.append(">");
+
+        XMLUtil.appendKeyTextValue("name", "<John & Jane>", xml);
+        XMLUtil.appendKeyXmlValue("bio", "<p>Test</p>", xml);
+
+        xml.append(XMLUtil.makeEndTag("person"));
+
+        String out = xml.toString();
+
+        assertTrue("Output should start with person start tag", out.startsWith("<person "));
+        assertTrue("Output should end with person end tag", out.endsWith("</person>"));
+        assertTrue("Output should contain id attribute", out.contains("id=\""));
+
+        assertTrue("Text content should be encoded", out.contains("&lt;John") || out.contains("&amp;"));
+
+        assertTrue("XML content should be preserved", out.contains("<p>Test</p>"));
+    }
+}


### PR DESCRIPTION
PR title: test: add dependency-free integration test for IntegerUtil and XMLUtil

The PR title follows conventional commit label standards.
The changes conform to the OpenElis Global x3 [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide) documentation.
- Notes: Test code follows the project’s existing style and JUnit 4 usage.
The changes include tests or are validated by existing tests.

## Summary

This PR adds a small, dependency-free integration test that exercises IntegerUtil and XMLUtil together to:

Verify IntegerUtil.toStringBase27 / parseIntBase27 round-trip behavior.
Validate XMLUtil attribute creation, text encoding (appendKeyTextValue), and preserved XML insertion (appendKeyXmlValue).
The test intentionally avoids DateUtil and other classes that trigger static initialization of ConfigurationProperties, so it is safe to run in isolation.

Added file: src/test/java/org/openelisglobal/common/util/UtilIntegrationTestIT.java

Why:

Adds coverage for low-dependency utility logic without needing Spring/App context or a DB.
Provides an integration-level assertion that small utility pieces work together correctly.
Serves as a safe first PR and a pattern for future tests.

Screenshots: Not applicable — no UI changes.

[Add relevant screenshots here if applicable]
