### PR TITLE
fix(postgres): resolve type mismatch in ReferenceTables duplicate check

### DIFF
--- a/src/main/java/org/openelisglobal/referencetables/daoimpl/ReferenceTablesDAOImpl.java
+++ b/src/main/java/org/openelisglobal/referencetables/daoimpl/ReferenceTablesDAOImpl.java
@@ -156,7 +156,7 @@ public class ReferenceTablesDAOImpl extends BaseDAOImpl<ReferenceTables, String>
             }
 
             if (!isNew) {
-                query.setParameter("param2", referenceTablesId);
+                query.setParameter("param2", Integer.parseInt(referenceTablesId));
             }
             list = query.list();
             if (list.size() > 0) {


### PR DESCRIPTION
Fixes #2606

This PR resolves the PostgreSQL error operator does not exist: numeric <> character varying in ReferenceTablesServiceTest.

Root Cause:  
The test duplicateReferenceTable_shouldThrowException() creates a  ReferenceTables  object without an ID. In duplicateReferenceTablesExists() , this causes the code to default to using "0"  (a String) as the ID value. This string is then passed directly into a Hibernate query that compares it against the  id  column — which is  numeric  in PostgreSQL. Unlike MySQL, PostgreSQL does not allow implicit type conversion between string and numeric types, so the query fails.

Fix:  
Parse the ID as an `Integer` before setting it as a query parameter:

query.setParameter("param2", Integer.parseInt(referenceTablesId));
