### PR TITLE
docs(011): align spec/tasks/data-model after analysis

### DIFF
--- a/specs/011-madagascar-analyzer-integration/data-model.md
+++ b/specs/011-madagascar-analyzer-integration/data-model.md
@@ -842,11 +842,11 @@ All schema changes will be placed in `src/main/resources/liquibase/3.8.x.x/`
 
 | Entity                    | Table                       | Purpose                | Milestone     |
 | ------------------------- | --------------------------- | ---------------------- | ------------- |
-| InstrumentMetadata        | instrument_metadata         | Extended analyzer info | M15           |
-| InstrumentLocationHistory | instrument_location_history | Location audit trail   | M15           |
+| InstrumentMetadata        | instrument_metadata         | Extended analyzer info | M16           |
+| InstrumentLocationHistory | instrument_location_history | Location audit trail   | M16           |
 | SerialPortConfiguration   | serial_port_configuration   | RS232 settings         | M2            |
 | FileImportConfiguration   | file_import_configuration   | File import settings   | M3            |
-| OrderExport               | order_export                | Order tracking         | M14           |
+| OrderExport               | order_export                | Order tracking         | M15           |
 | GeneXpertModule           | genexpert_module            | Module tracking        | Post-deadline |
 | MaintenanceEvent          | maintenance_event           | Maintenance records    | Post-deadline |
 

--- a/specs/011-madagascar-analyzer-integration/spec.md
+++ b/specs/011-madagascar-analyzer-integration/spec.md
@@ -439,6 +439,20 @@ the simulated messages.
   ASTM header parsing, HL7 MSH segment sender ID, client IP address, or serial
   port assignment.
 
+  **Identification precedence (deterministic)**:
+
+  1. **Protocol-native identity**:
+     - HL7: MSH sender fields (MSH-3/MSH-4)
+     - ASTM: H-segment identity fields (sender / instrument ID)
+     - File: import configuration for the watched directory + file pattern
+  2. **Transport identity**:
+     - Network client IP (when protocol-native identity is missing/blank)
+     - Serial port assignment (when receiving via RS232 bridge)
+  3. **Conflict handling**:
+     - If multiple analyzers match, the message MUST NOT be processed.
+     - An error record MUST be created with the raw message and matching
+       candidates for operator resolution.
+
 #### Analyzer Coverage (Contract Critical - Deadline: 2026-02-28)
 
 - **FR-006**: System MUST support all 12 contract-required analyzers with
@@ -527,13 +541,24 @@ Ordered by implementation priority (Romain's deployment list):
 - **FR-016**: System MUST track order export status: pending, sent,
   acknowledged, results received, expired.
 
+  **Acknowledgment semantics (by protocol)**:
+
+  - HL7: `ACKNOWLEDGED` means OpenELIS received a valid HL7 ACK for the exported
+    ORM^O01 message (or vendor middleware ACK if middleware is used).
+  - ASTM: `ACKNOWLEDGED` is supported only when the analyzer/bridge provides an
+    explicit acknowledgment signal; otherwise the highest state is `SENT` until
+    results are received.
+  - For the contract deadline, lack of an acknowledgment mechanism MUST NOT
+    block order export; status MUST still progress to `SENT` and eventually to
+    `RESULTS_RECEIVED` when matching results arrive.
+
 - **FR-017**: System MUST support order cancellation with notification to
   analyzers that support cancel messages.
 
 - **FR-018**: System MUST automatically match incoming results to exported
   orders using sample/accession identifiers.
 
-#### GeneXpert Module Management (Post-Deadline)
+#### GeneXpert Module Management (Post-Deadline; Out of Scope for 2026-02-28)
 
 - **FR-019**: System MUST track GeneXpert module status
   (enabled/disabled/replaced) with automatic detection polling.
@@ -544,7 +569,7 @@ Ordered by implementation priority (Romain's deployment list):
 - **FR-021**: System MUST generate alerts when module failure rate exceeds
   configurable thresholds.
 
-#### Maintenance Tracking (Post-Deadline)
+#### Maintenance Tracking (Post-Deadline; Out of Scope for 2026-02-28)
 
 - **FR-022**: System MUST record maintenance events (calibration, preventative,
   curative) with: event type, date, performer, results, and next scheduled date.

--- a/specs/011-madagascar-analyzer-integration/tasks.md
+++ b/specs/011-madagascar-analyzer-integration/tasks.md
@@ -772,7 +772,7 @@ Adapt QuantStudio3 plugin for QuantStudio 7 Flex **User Stories**: US-4, US-6
 
 ---
 
-## [P] M9: Horiba Pentra 60 Plugin (2 days) ✅ **COMPLETED**
+## [P] M9: Horiba Pentra 60 Plugin (2 days)
 
 **Branch**: `feat/011-madagascar-analyzer-integration-m9-m10-horiba` (combined
 with M10) **Goal**: Build new Horiba Pentra 60 plugin **User Stories**: US-3
@@ -814,7 +814,7 @@ Plugin built, committed (b93e04b), documented (59d454d), PR created (#33)
 
 ---
 
-## [P] M10: Horiba Micros 60 Plugin (2 days) ✅ **COMPLETED**
+## [P] M10: Horiba Micros 60 Plugin (2 days)
 
 **Branch**: `feat/011-madagascar-analyzer-integration-m9-m10-horiba` (combined
 with M9) **Goal**: Build new Horiba Micros 60 plugin **User Stories**: US-3
@@ -1293,6 +1293,12 @@ All **Depends On**: M15, M16, M17 **Workstream**: All
 - [ ] T304 [M18] Performance test: 5+ concurrent analyzers via simulator
 - [ ] T305 [M18] Stress test: 1000+ messages through system
 - [ ] T306 [M18] Verify message routing with multiple simultaneous analyzers
+- [ ] T306a [M18] RS232 reliability soak test (8+ hours) using RS232 bridge +
+      simulator (or virtual serial ports) and verify no message loss (SC-007)
+- [ ] T306b [M18] Validate analyzer communication service uptime measurement and
+      monitoring approach for lab operating hours (SC-010)
+- [ ] T306c [M18] Verify timestamps are stored in UTC and rendered correctly for
+      analyzer results and order export workflows (Edge Case: time zones)
 
 ### Documentation for M18
 
@@ -1473,6 +1479,8 @@ M14). Plugin tasks added to respective milestones.
 - **M0 only blocks M7** - GeneXpert Multi requires M0 for ASTM variant
 - Tests are MANDATORY per Constitution Principle V
 - Each milestone = 1 PR per Constitution Principle IX
+- **Plugins submodule prerequisite** (M5-M13): ensure `plugins/` is initialized
+  before starting plugin milestone work (`git submodule update --init plugins`).
 - Run `mvn spotless:apply` and `cd frontend && npm run format` before every PR
 - Use BOTH flags when skipping tests: `-DskipTests -Dmaven.test.skip=true`
 - Run E2E tests individually during development:


### PR DESCRIPTION
## Summary
- clarify deterministic analyzer identification precedence + conflict handling (FR-005)
- clarify order export acknowledgement semantics per protocol (FR-016)
- explicitly mark post-deadline requirement sections as out-of-scope for 2026-02-28
- align `data-model.md` milestone ownership with `plan.md`/`tasks.md`
- add explicit M18 validation tasks for RS232 soak, uptime, and UTC timestamps

## Notes
- No runtime code changes.