### PR TITLE
feat(analyzer): Enhance HL7 endpoint with Universal Bridge header support (M2b)

### DIFF
--- a/src/main/java/org/openelisglobal/analyzerimport/action/AnalyzerImportController.java
+++ b/src/main/java/org/openelisglobal/analyzerimport/action/AnalyzerImportController.java
@@ -26,6 +26,7 @@ import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerReaderFactory;
 import org.openelisglobal.analyzerimport.analyzerreaders.HL7AnalyzerReader;
 import org.openelisglobal.analyzerimport.util.AnalyzerTestNameCache;
 import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.PluginAnalyzerService;
 import org.openelisglobal.internationalization.MessageUtil;
 import org.openelisglobal.login.service.LoginUserService;
@@ -121,11 +122,39 @@ public class AnalyzerImportController implements IActionConstants {
 
     /**
      * HTTP endpoint for HL7 ORU^R01 messages (e.g. from mock server or HL7 bridge).
-     * Body is raw HL7 message; analyzer is identified from MSH segment.
+     * Body is raw HL7 message; analyzer is identified from MSH segment or bridge
+     * headers.
+     *
+     * <p>
+     * Supports headers from Universal Bridge (M2a MLLP transport):
+     * <ul>
+     * <li>X-Source-Analyzer-IP: Source IP address (for fallback identification and
+     * audit)</li>
+     * <li>X-Source-Protocol: Protocol used (HL7)</li>
+     * <li>X-Source-Transport: Transport method (MLLP, SERIAL, FILE, HTTP)</li>
+     * <li>X-Analyzer-Id: Pre-identified analyzer ID from bridge</li>
+     * </ul>
      */
     @PostMapping("/analyzer/hl7")
     public void doPostHl7(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
+
+        // Extract bridge headers for audit trail and fallback identification
+        String sourceIp = request.getHeader("X-Source-Analyzer-IP");
+        String sourceProtocol = request.getHeader("X-Source-Protocol");
+        String sourceTransport = request.getHeader("X-Source-Transport");
+        String analyzerId = request.getHeader("X-Analyzer-Id");
+
+        // Fallback to direct connection IP if header not present
+        if (sourceIp == null || sourceIp.isEmpty()) {
+            sourceIp = request.getRemoteAddr();
+        }
+
+        LogEvent.logInfo(this.getClass().getSimpleName(), "doPostHl7",
+                "Received HL7 message from " + sourceIp + " (protocol: "
+                        + (sourceProtocol != null ? sourceProtocol : "unknown") + ", transport: "
+                        + (sourceTransport != null ? sourceTransport : "direct") + ", analyzer: "
+                        + (analyzerId != null ? analyzerId : "auto-detect") + ")");
 
         response.setContentType("text/plain;charset=UTF-8");
         HL7AnalyzerReader reader = (HL7AnalyzerReader) AnalyzerReaderFactory.getReaderFor("hl7");
@@ -133,6 +162,11 @@ public class AnalyzerImportController implements IActionConstants {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "HL7 reader not available");
             return;
         }
+
+        // Pass source IP to reader for fallback identification
+        reader.setSourceIp(sourceIp);
+        reader.setBridgeAnalyzerId(analyzerId);
+
         boolean read = reader.readStream(request.getInputStream());
         if (!read) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST,

--- a/src/main/java/org/openelisglobal/analyzerimport/analyzerreaders/HL7AnalyzerReader.java
+++ b/src/main/java/org/openelisglobal/analyzerimport/analyzerreaders/HL7AnalyzerReader.java
@@ -41,6 +41,8 @@ public class HL7AnalyzerReader extends AnalyzerReader {
 
     private List<String> lines;
     private String error;
+    private String sourceIp;
+    private String bridgeAnalyzerId;
 
     @Override
     public boolean readStream(InputStream stream) {
@@ -95,6 +97,26 @@ public class HL7AnalyzerReader extends AnalyzerReader {
         return error;
     }
 
+    /**
+     * Sets the source IP address from the bridge (via X-Source-Analyzer-IP header).
+     * Used for fallback analyzer identification and audit logging.
+     *
+     * @param sourceIp the source IP address
+     */
+    public void setSourceIp(String sourceIp) {
+        this.sourceIp = sourceIp;
+    }
+
+    /**
+     * Sets the analyzer ID pre-identified by the bridge (via X-Analyzer-Id header).
+     * Used as a hint for analyzer identification.
+     *
+     * @param bridgeAnalyzerId the analyzer ID from the bridge
+     */
+    public void setBridgeAnalyzerId(String bridgeAnalyzerId) {
+        this.bridgeAnalyzerId = bridgeAnalyzerId;
+    }
+
     private AnalyzerLineInserter wrapInserterIfMappingsExist(AnalyzerLineInserter originalInserter, Analyzer analyzer) {
         try {
             MappingApplicationService mappingSvc = SpringContext.getBean(MappingApplicationService.class);
@@ -111,31 +133,71 @@ public class HL7AnalyzerReader extends AnalyzerReader {
         if (lines == null || lines.isEmpty()) {
             return Optional.empty();
         }
+
+        org.openelisglobal.analyzer.service.AnalyzerConfigurationService configService = SpringContext
+                .getBean(org.openelisglobal.analyzer.service.AnalyzerConfigurationService.class);
+
+        // Strategy 1: Try bridge-provided analyzer ID first
+        if (StringUtils.isNotBlank(bridgeAnalyzerId)) {
+            LogEvent.logTrace("HL7AnalyzerReader", "identifyAnalyzerFromMessage",
+                    "Trying bridge analyzer ID: " + bridgeAnalyzerId);
+            Optional<AnalyzerConfiguration> config = configService.getByAnalyzerName(bridgeAnalyzerId.trim());
+            if (config.isPresent() && config.get().getAnalyzer() != null) {
+                LogEvent.logInfo("HL7AnalyzerReader", "identifyAnalyzerFromMessage",
+                        "Identified analyzer from bridge ID: " + bridgeAnalyzerId);
+                return Optional.of(config.get().getAnalyzer());
+            }
+        }
+
+        // Strategy 2: Extract from MSH segment (HL7 standard way)
         try {
             HL7MessageService svc = SpringContext.getBean(HL7MessageService.class);
             String raw = String.join("\r", lines);
             HL7MessageService.MshInfo msh = svc.extractMshInfo(raw);
             String app = msh.getSendingApplication();
             String fac = msh.getSendingFacility();
-            if (StringUtils.isBlank(app) && StringUtils.isBlank(fac)) {
-                return Optional.empty();
-            }
-            org.openelisglobal.analyzer.service.AnalyzerConfigurationService configService = SpringContext
-                    .getBean(org.openelisglobal.analyzer.service.AnalyzerConfigurationService.class);
-            String name = StringUtils.isNotBlank(app) ? app : fac;
-            Optional<AnalyzerConfiguration> config = configService.getByAnalyzerName(name.trim());
-            if (config.isPresent() && config.get().getAnalyzer() != null) {
-                return Optional.of(config.get().getAnalyzer());
-            }
-            if (StringUtils.isNotBlank(app) && StringUtils.isNotBlank(fac)) {
-                config = configService.getByAnalyzerName((app + " " + fac).trim());
+
+            if (StringUtils.isNotBlank(app) || StringUtils.isNotBlank(fac)) {
+                // Try sending application first
+                String name = StringUtils.isNotBlank(app) ? app : fac;
+                LogEvent.logTrace("HL7AnalyzerReader", "identifyAnalyzerFromMessage", "Trying MSH sender: " + name);
+                Optional<AnalyzerConfiguration> config = configService.getByAnalyzerName(name.trim());
                 if (config.isPresent() && config.get().getAnalyzer() != null) {
+                    LogEvent.logInfo("HL7AnalyzerReader", "identifyAnalyzerFromMessage",
+                            "Identified analyzer from MSH: " + name);
                     return Optional.of(config.get().getAnalyzer());
+                }
+
+                // Try combined application + facility
+                if (StringUtils.isNotBlank(app) && StringUtils.isNotBlank(fac)) {
+                    String combined = (app + " " + fac).trim();
+                    LogEvent.logTrace("HL7AnalyzerReader", "identifyAnalyzerFromMessage",
+                            "Trying combined MSH: " + combined);
+                    config = configService.getByAnalyzerName(combined);
+                    if (config.isPresent() && config.get().getAnalyzer() != null) {
+                        LogEvent.logInfo("HL7AnalyzerReader", "identifyAnalyzerFromMessage",
+                                "Identified analyzer from combined MSH: " + combined);
+                        return Optional.of(config.get().getAnalyzer());
+                    }
                 }
             }
         } catch (Exception e) {
-            LogEvent.logError("Error identifying HL7 analyzer: " + e.getMessage(), e);
+            LogEvent.logError("Error extracting MSH info: " + e.getMessage(), e);
         }
+
+        // Strategy 3: Try source IP as fallback
+        if (StringUtils.isNotBlank(sourceIp)) {
+            LogEvent.logTrace("HL7AnalyzerReader", "identifyAnalyzerFromMessage", "Trying source IP: " + sourceIp);
+            Optional<AnalyzerConfiguration> config = configService.getByAnalyzerName(sourceIp.trim());
+            if (config.isPresent() && config.get().getAnalyzer() != null) {
+                LogEvent.logInfo("HL7AnalyzerReader", "identifyAnalyzerFromMessage",
+                        "Identified analyzer from source IP: " + sourceIp);
+                return Optional.of(config.get().getAnalyzer());
+            }
+        }
+
+        LogEvent.logWarn("HL7AnalyzerReader", "identifyAnalyzerFromMessage",
+                "Failed to identify analyzer using all strategies (bridge ID, MSH, source IP)");
         return Optional.empty();
     }
 }


### PR DESCRIPTION
## Summary

Enhances the existing `/analyzer/hl7` endpoint to support headers from the **Universal Bridge MLLP transport (M2a)**, completing the M2 milestone for HL7/MLLP support.

## Background

The `/analyzer/hl7` endpoint was previously implemented but didn't utilize headers sent by the bridge. This PR adds **bridge header support** while maintaining **full backward compatibility** with direct HL7 submissions.

## Changes

### AnalyzerImportController
**Enhanced `/analyzer/hl7` endpoint:**
- ✅ Reads bridge headers:
  - `X-Source-Analyzer-IP`: Source IP for identification/audit
  - `X-Source-Protocol`: Protocol type (HL7)
  - `X-Source-Transport`: Transport method (MLLP, SERIAL, FILE, HTTP)
  - `X-Analyzer-Id`: Pre-identified analyzer from bridge
- ✅ Passes sourceIp and bridgeAnalyzerId to HL7AnalyzerReader
- ✅ Adds audit logging with source information
- ✅ Fallback to `request.getRemoteAddr()` if headers not present

### HL7AnalyzerReader
**3-tier analyzer identification strategy:**
1. **Bridge analyzer ID** (from X-Analyzer-Id header) - highest priority
2. **MSH segment extraction** (from MSH-3/MSH-4) - standard HL7 way
3. **Source IP fallback** (from X-Source-Analyzer-IP header) - last resort

**Enhanced logging:**
- TRACE: Each identification attempt
- INFO: Successful identification with method used
- WARN: All strategies failed

## Example Flow

### From MLLP Bridge:
```http
POST /api/OpenELIS-Global/analyzer/hl7
X-Source-Analyzer-IP: 192.168.1.50
X-Source-Protocol: HL7
X-Source-Transport: MLLP
X-Analyzer-Id: SYSMEX-XN
Content-Type: text/plain

MSH|^~\&|SYSMEX|LAB1|||||ORU^R01|12345|P|2.5.1\r
PID|1||12345^^^MRN||Doe^John||19800101|M\r
OBX|1|NM|WBC||7.5|10^3/uL|4.0-10.0|N|||F\r
```

**Identification flow:**
1. ✅ Try X-Analyzer-Id: "SYSMEX-XN" → matches configured analyzer
2. ⏭️ Skip MSH (already found)
3. ⏭️ Skip source IP (already found)

### Direct HL7 (Backward Compatible):
```http
POST /api/OpenELIS-Global/analyzer/hl7
Content-Type: text/plain

MSH|^~\&|SYSMEX|LAB1|||||ORU^R01|12345|P|2.5.1\r
...
```

**Identification flow:**
1. ⏭️ Skip bridge ID (not provided)
2. ✅ Try MSH-3/MSH-4: "SYSMEX" or "LAB1" → matches configured analyzer
3. ⏭️ Skip source IP (already found)

## Testing

✅ **All existing tests pass** (4 HL7AnalyzerReader tests)
- Valid HL7 message parsing
- Invalid message handling
- MSH-based identification
- Error scenarios

**Backward Compatibility:**
- Existing HL7 submissions without headers work unchanged
- MSH-based identification still primary method
- Headers are optional enhancements

## Benefits

| Aspect | Before | After |
|--------|--------|-------|
| **Identification** | MSH only | Bridge ID → MSH → Source IP |
| **Audit Trail** | None | Full source tracking |
| **Bridge Support** | None | Full M2a MLLP integration |
| **Fallback** | Fails if MSH wrong | Multiple strategies |
| **Compatibility** | HL7 only | HL7 + bridge headers |

## Architecture Alignment

This completes the **M2 milestone** (HL7/MLLP Support):
- ✅ **M2a** (Bridge): MLLP listener - https://github.com/DIGI-UW/astm-http-bridge/pull/7
- ✅ **M2b** (OpenELIS): HL7 endpoint enhancement - **this PR**

**Integration flow:**
```
Analyzer → MLLP → Bridge → HTTP (with headers) → OpenELIS → HL7AnalyzerReader → TestResult
         (VT/FS/CR)      (M2a)    (with audit info)    (M2b)      (parse/save)
```

## Configuration

No configuration changes needed - endpoint works with existing setup.

Analyzers can be identified by:
- Bridge-provided ID (recommended)
- MSH sending application/facility (standard)
- Source IP address (fallback)

## Related

- **Plan**: `~/.claude/plans/universal-analyzer-bridge.md` § M2b
- **Bridge PR**: https://github.com/DIGI-UW/astm-http-bridge/pull/7 (M2a)
- **Submodule PR**: https://github.com/DIGI-UW/OpenELIS-Global-2/pull/2715
- **Base Branch**: `demo/madagascar`

## Checklist

- [x] Header reading implemented
- [x] 3-tier identification strategy
- [x] Audit logging added
- [x] All existing tests pass
- [x] Backward compatible
- [x] Code formatted (Spotless)
- [x] Documentation in code comments

---

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>