### PR TITLE
feat: M7 Message Normalizer — unified routing pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,9 @@ LETSENCRYPT_DOMAIN=localhost
 
 # Email for Let's Encrypt certificate notifications (required for real certs)
 LETSENCRYPT_EMAIL=admin@example.com
+
+# --- E2E Test Credentials (Playwright) ---
+# Required for: npm run pw:test (Playwright auth setup)
+# Use the admin user created by e2e-foundational-data.sql
+TEST_USER=admin
+TEST_PASS=adminADMIN!

--- a/.github/workflows/frontend-qa.yml
+++ b/.github/workflows/frontend-qa.yml
@@ -109,8 +109,9 @@ jobs:
         working-directory: frontend
         env:
           CI: true
-          TEST_USER: admin
-          TEST_PASS: adminADMIN!
+          # Use vars/secrets when configured; defaults allow workflow to run out of the box
+          TEST_USER: ${{ vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ secrets.TEST_PASS || 'adminADMIN!' }}
 
       - name: Upload Playwright report on failure
         if: failure()
@@ -175,6 +176,9 @@ jobs:
           CYPRESS_BASE_URL: https://localhost
           LC_ALL: en_US.UTF-8  # Fix locale so date formats are deterministic (MM/DD/YYYY)
           LANG: en_US.UTF-8
+          # Use vars/secrets when configured; defaults allow workflow to run out of the box
+          TEST_USER: ${{ vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ secrets.TEST_PASS || 'adminADMIN!' }}
 
       - name: Upload Cypress screenshots on failure
         if: failure()

--- a/.github/workflows/frontend-qa.yml
+++ b/.github/workflows/frontend-qa.yml
@@ -109,6 +109,8 @@ jobs:
         working-directory: frontend
         env:
           CI: true
+          TEST_USER: admin
+          TEST_PASS: adminADMIN!
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -72,6 +72,12 @@ module.exports = defineConfig({
   // Stop on first spec failure when E2E_FAIL_FAST is set (e.g. in CI)
   bail: process.env.E2E_FAIL_FAST === "true" ? 1 : false,
   env: {
+    // E2E test credentials - use env vars in CI, fallback for local dev
+    // Set CYPRESS_USERNAME/CYPRESS_PASSWORD or TEST_USER/TEST_PASS for CI
+    USERNAME: process.env.CYPRESS_USERNAME || process.env.TEST_USER || "admin",
+    PASSWORD:
+      process.env.CYPRESS_PASSWORD || process.env.TEST_PASS || "adminADMIN!",
+
     // Env-controlled fail-fast using cypress-fail-fast plugin
     // Set E2E_FAIL_FAST=true to stop on first failure (saves CI time)
     // Set E2E_FAIL_FAST=false or unset to run all tests (default)
@@ -109,6 +115,54 @@ module.exports = defineConfig({
       // Register all Cypress tasks in ONE handler (Cypress does not merge task handlers).
       // This keeps logging/diagnostics and fixture utilities available across specs.
       on("task", {
+        // Poll backend until it responds (retries on connection errors - CI reliability)
+        // cy.request() fails immediately on ECONNREFUSED; this task retries with backoff
+        waitForBackendReady({ path }) {
+          const baseUrl = config.baseUrl || "https://localhost";
+          const url = new URL(path, baseUrl).href;
+          const maxAttempts = 15;
+          const delayMs = 2000;
+
+          const attempt = (attemptNum) =>
+            new Promise((resolve, reject) => {
+              const lib = url.startsWith("https")
+                ? require("https")
+                : require("http");
+              const req = lib.get(url, (res) => {
+                if (typeof res.statusCode === "number") {
+                  console.log(
+                    `Backend ready: ${path} responded with status ${res.statusCode}`,
+                  );
+                  resolve(true);
+                } else {
+                  reject(new Error("No status code in response"));
+                }
+              });
+              req.on("error", (err) => {
+                if (attemptNum >= maxAttempts) {
+                  reject(
+                    new Error(
+                      `Backend did not become ready after ${maxAttempts} attempts: ${err.message}`,
+                    ),
+                  );
+                } else {
+                  console.log(
+                    `Backend not ready (attempt ${attemptNum}/${maxAttempts}), retrying in ${delayMs}ms...`,
+                  );
+                  setTimeout(
+                    () =>
+                      attempt(attemptNum + 1)
+                        .then(resolve)
+                        .catch(reject),
+                    delayMs,
+                  );
+                }
+              });
+            });
+
+          return attempt(1);
+        },
+
         // Log messages to the Node process stdout (captured by CI/tee logs)
         log(message, options = {}) {
           if (options.log !== false) {

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -61,6 +61,24 @@ function detectBaseUrl() {
   return "https://localhost";
 }
 
+// E2E credentials: in CI require env vars (fail fast); locally allow fallbacks
+const isCI = process.env.CI === "true";
+let cypressUsername, cypressPassword;
+if (isCI) {
+  cypressUsername = process.env.CYPRESS_USERNAME || process.env.TEST_USER;
+  cypressPassword = process.env.CYPRESS_PASSWORD || process.env.TEST_PASS;
+  if (!cypressUsername || !cypressPassword) {
+    throw new Error(
+      "In CI, CYPRESS_USERNAME/CYPRESS_PASSWORD or TEST_USER/TEST_PASS must be set for E2E tests.",
+    );
+  }
+} else {
+  cypressUsername =
+    process.env.CYPRESS_USERNAME || process.env.TEST_USER || "admin";
+  cypressPassword =
+    process.env.CYPRESS_PASSWORD || process.env.TEST_PASS || "adminADMIN!";
+}
+
 module.exports = defineConfig({
   defaultCommandTimeout: 3000, // 3 seconds - use Cypress retry-ability instead of long timeouts
   pageLoadTimeout: 180000, // 3 minutes - analyzer mappings page loads 3.4MB bundle.js (takes >2min in CI)
@@ -72,11 +90,9 @@ module.exports = defineConfig({
   // Stop on first spec failure when E2E_FAIL_FAST is set (e.g. in CI)
   bail: process.env.E2E_FAIL_FAST === "true" ? 1 : false,
   env: {
-    // E2E test credentials - use env vars in CI, fallback for local dev
-    // Set CYPRESS_USERNAME/CYPRESS_PASSWORD or TEST_USER/TEST_PASS for CI
-    USERNAME: process.env.CYPRESS_USERNAME || process.env.TEST_USER || "admin",
-    PASSWORD:
-      process.env.CYPRESS_PASSWORD || process.env.TEST_PASS || "adminADMIN!",
+    // E2E test credentials - CI: required via env; local: fallback to admin/adminADMIN!
+    USERNAME: cypressUsername,
+    PASSWORD: cypressPassword,
 
     // Env-controlled fail-fast using cypress-fail-fast plugin
     // Set E2E_FAIL_FAST=true to stop on first failure (saves CI time)
@@ -128,7 +144,16 @@ module.exports = defineConfig({
               const lib = url.startsWith("https")
                 ? require("https")
                 : require("http");
-              const req = lib.get(url, (res) => {
+              const parsed = new URL(url);
+              const isLocalhost = ["localhost", "127.0.0.1"].includes(
+                parsed.hostname,
+              );
+              const opts =
+                url.startsWith("https") && isLocalhost
+                  ? { rejectUnauthorized: false }
+                  : {};
+              const req = lib.get(url, opts, (res) => {
+                res.resume(); // drain response to avoid socket leaks
                 if (typeof res.statusCode === "number") {
                   console.log(
                     `Backend ready: ${path} responded with status ${res.statusCode}`,

--- a/frontend/cypress/ENVIRONMENT-DETECTION.md
+++ b/frontend/cypress/ENVIRONMENT-DETECTION.md
@@ -198,6 +198,15 @@ curl -k -I https://analyzers.openelis-global.org/ 2>&1 | head -1
 
 ---
 
+## Platform Notes
+
+**Windows**: The Cypress npm scripts use `unset ELECTRON_RUN_AS_NODE` (POSIX shell).
+This fails on Windows cmd/PowerShell. Use WSL, Git Bash, or a Unix-like environment
+for local Cypress runs. CI uses Linux. If Windows contributor support is needed,
+consider `cross-env` or a Node-based wrapper to clear env vars cross-platform.
+
+---
+
 ## Feature Testing Checklist
 
 When creating E2E tests for new features:

--- a/frontend/cypress/e2e/analyzerConfiguration.cy.js
+++ b/frontend/cypress/e2e/analyzerConfiguration.cy.js
@@ -20,11 +20,6 @@
 
 let testAnalyzerId = null;
 
-const auth = () => ({
-  username: Cypress.env("USERNAME"),
-  password: Cypress.env("PASSWORD"),
-});
-
 /**
  * Setup: Create test analyzer via API and VERIFY it exists
  * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
@@ -41,7 +36,7 @@ before("Setup test analyzer", () => {
     cy.request({
       method: "GET",
       url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-      auth: auth(),
+      auth: Cypress.getBasicAuth(),
       failOnStatusCode: false,
     });
   });
@@ -50,7 +45,7 @@ before("Setup test analyzer", () => {
   cy.request({
     method: "POST",
     url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-    auth: auth(),
+    auth: Cypress.getBasicAuth(),
     body: {
       name: "E2E-Config-Test-Analyzer",
       analyzerType: "CHEMISTRY",
@@ -86,7 +81,7 @@ before("Setup test analyzer", () => {
   cy.request({
     method: "GET",
     url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-    auth: auth(),
+    auth: Cypress.getBasicAuth(),
   }).then((response) => {
     expect(response.status).to.eq(200);
     expect(response.body).to.be.an("array");
@@ -115,7 +110,7 @@ after("Cleanup test analyzer", () => {
     cy.request({
       method: "DELETE",
       url: `/api/OpenELIS-Global/rest/analyzer/analyzers/${testAnalyzerId}`,
-      auth: auth(),
+      auth: Cypress.getBasicAuth(),
       failOnStatusCode: false,
     });
   }
@@ -124,7 +119,7 @@ after("Cleanup test analyzer", () => {
 describe("Analyzer Configuration - User Story 1", function () {
   beforeEach(() => {
     cy.viewport(1025, 900);
-    cy.visit("/", { auth: auth() });
+    cy.visit("/", { auth: Cypress.getBasicAuth() });
 
     // Set up intercepts before actions
     cy.intercept("GET", "**/rest/analyzer/analyzers**").as("getAnalyzers");
@@ -149,7 +144,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    */
   it("should configure analyzer with field mappings", function () {
     // Navigate to analyzers page
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );
@@ -182,7 +177,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    */
   it("should validate IP address format", function () {
     // Navigate to analyzers page
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );
@@ -222,7 +217,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       }
 
       // Navigate to analyzers page
-      cy.visit("/analyzers", { auth: auth() });
+      cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
         "be.visible",
       );
@@ -272,7 +267,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       // Navigate directly to mappings page
       // Use longer timeout and wait for element (not page load event)
       cy.visit(`/analyzers/${id}/mappings`, {
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         timeout: 180000, // 3 minutes for CI
       });
       // Wait for the element to be visible (page is functional even if load event hasn't fired)
@@ -308,7 +303,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       }
 
       cy.visit(`/analyzers/${id}/mappings`, {
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         timeout: 180000, // 3 min for CI - page load event doesn't fire consistently
       });
       cy.get('[data-testid="field-mapping"]', { timeout: 30000 }).should(
@@ -342,7 +337,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       }
 
       cy.visit(`/analyzers/${id}/mappings`, {
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         timeout: 180000, // 3 min for CI - page load event doesn't fire consistently
       });
       cy.get('[data-testid="field-mapping"]', { timeout: 30000 }).should(
@@ -375,7 +370,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       }
 
       // Step 1: Navigate to analyzers list
-      cy.visit("/analyzers", { auth: auth() });
+      cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
       // Step 2: Navigate to mappings for our analyzer
@@ -396,7 +391,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Step 4: Navigate back to analyzers
-      cy.visit("/analyzers", { auth: auth() });
+      cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
       cy.log(
@@ -417,7 +412,7 @@ describe("Analyzer Configuration - User Story 1", function () {
         return;
       }
 
-      cy.visit(`/analyzers/${id}/mappings`, { auth: auth() });
+      cy.visit(`/analyzers/${id}/mappings`, { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="field-mapping"]', { timeout: 10000 }).should(
         "be.visible",
       );
@@ -442,7 +437,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    */
   it("should configure new analyzer", function () {
     // Navigate to analyzers page
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );
@@ -457,7 +452,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    * Test: Display analyzer list with existing analyzers
    */
   it("should display analyzer list with existing analyzers", function () {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );
@@ -480,7 +475,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    * Test: Display analyzer statistics
    */
   it("should display analyzer statistics", function () {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );

--- a/frontend/cypress/e2e/analyzerConfiguration.cy.js
+++ b/frontend/cypress/e2e/analyzerConfiguration.cy.js
@@ -20,14 +20,14 @@
 
 let testAnalyzerId = null;
 
-// Basic auth credentials
-const AUTH = {
-  username: "admin",
-  password: "adminADMIN!",
-};
+const auth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
 
 /**
  * Setup: Create test analyzer via API and VERIFY it exists
+ * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  * Uses cy.session() for auth caching + correct API path pattern
  * NOTE: /api/OpenELIS-Global/rest/... is the CORRECT pattern (like storage tests)
  *       /rest/... returns HTML, not JSON - other analyzer tests are broken
@@ -41,7 +41,7 @@ before("Setup test analyzer", () => {
     cy.request({
       method: "GET",
       url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-      auth: AUTH,
+      auth: auth(),
       failOnStatusCode: false,
     });
   });
@@ -50,7 +50,7 @@ before("Setup test analyzer", () => {
   cy.request({
     method: "POST",
     url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-    auth: AUTH,
+    auth: auth(),
     body: {
       name: "E2E-Config-Test-Analyzer",
       analyzerType: "CHEMISTRY",
@@ -86,7 +86,7 @@ before("Setup test analyzer", () => {
   cy.request({
     method: "GET",
     url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-    auth: AUTH,
+    auth: auth(),
   }).then((response) => {
     expect(response.status).to.eq(200);
     expect(response.body).to.be.an("array");
@@ -115,7 +115,7 @@ after("Cleanup test analyzer", () => {
     cy.request({
       method: "DELETE",
       url: `/api/OpenELIS-Global/rest/analyzer/analyzers/${testAnalyzerId}`,
-      auth: AUTH,
+      auth: auth(),
       failOnStatusCode: false,
     });
   }
@@ -124,7 +124,7 @@ after("Cleanup test analyzer", () => {
 describe("Analyzer Configuration - User Story 1", function () {
   beforeEach(() => {
     cy.viewport(1025, 900);
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/`);
+    cy.visit("/", { auth: auth() });
 
     // Set up intercepts before actions
     cy.intercept("GET", "**/rest/analyzer/analyzers**").as("getAnalyzers");
@@ -149,7 +149,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    */
   it("should configure analyzer with field mappings", function () {
     // Navigate to analyzers page
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );
@@ -182,7 +182,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    */
   it("should validate IP address format", function () {
     // Navigate to analyzers page
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );
@@ -222,7 +222,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       }
 
       // Navigate to analyzers page
-      cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+      cy.visit("/analyzers", { auth: auth() });
       cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
         "be.visible",
       );
@@ -271,10 +271,10 @@ describe("Analyzer Configuration - User Story 1", function () {
 
       // Navigate directly to mappings page
       // Use longer timeout and wait for element (not page load event)
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${id}/mappings`,
-        { timeout: 180000 }, // 3 minutes for CI
-      );
+      cy.visit(`/analyzers/${id}/mappings`, {
+        auth: auth(),
+        timeout: 180000, // 3 minutes for CI
+      });
       // Wait for the element to be visible (page is functional even if load event hasn't fired)
       cy.get('[data-testid="field-mapping"]', { timeout: 30000 }).should(
         "be.visible",
@@ -307,10 +307,10 @@ describe("Analyzer Configuration - User Story 1", function () {
         return;
       }
 
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${id}/mappings`,
-        { timeout: 180000 }, // 3 min for CI - page load event doesn't fire consistently
-      );
+      cy.visit(`/analyzers/${id}/mappings`, {
+        auth: auth(),
+        timeout: 180000, // 3 min for CI - page load event doesn't fire consistently
+      });
       cy.get('[data-testid="field-mapping"]', { timeout: 30000 }).should(
         "be.visible",
       );
@@ -341,10 +341,10 @@ describe("Analyzer Configuration - User Story 1", function () {
         return;
       }
 
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${id}/mappings`,
-        { timeout: 180000 }, // 3 min for CI - page load event doesn't fire consistently
-      );
+      cy.visit(`/analyzers/${id}/mappings`, {
+        auth: auth(),
+        timeout: 180000, // 3 min for CI - page load event doesn't fire consistently
+      });
       cy.get('[data-testid="field-mapping"]', { timeout: 30000 }).should(
         "be.visible",
       );
@@ -375,7 +375,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       }
 
       // Step 1: Navigate to analyzers list
-      cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+      cy.visit("/analyzers", { auth: auth() });
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
       // Step 2: Navigate to mappings for our analyzer
@@ -396,7 +396,7 @@ describe("Analyzer Configuration - User Story 1", function () {
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Step 4: Navigate back to analyzers
-      cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+      cy.visit("/analyzers", { auth: auth() });
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
       cy.log(
@@ -417,9 +417,7 @@ describe("Analyzer Configuration - User Story 1", function () {
         return;
       }
 
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${id}/mappings`,
-      );
+      cy.visit(`/analyzers/${id}/mappings`, { auth: auth() });
       cy.get('[data-testid="field-mapping"]', { timeout: 10000 }).should(
         "be.visible",
       );
@@ -444,7 +442,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    */
   it("should configure new analyzer", function () {
     // Navigate to analyzers page
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );
@@ -459,7 +457,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    * Test: Display analyzer list with existing analyzers
    */
   it("should display analyzer list with existing analyzers", function () {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );
@@ -482,7 +480,7 @@ describe("Analyzer Configuration - User Story 1", function () {
    * Test: Display analyzer statistics
    */
   it("should display analyzer statistics", function () {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]', { timeout: 10000 }).should(
       "be.visible",
     );

--- a/frontend/cypress/e2e/analyzerFieldMappingsDisplay.cy.js
+++ b/frontend/cypress/e2e/analyzerFieldMappingsDisplay.cy.js
@@ -7,11 +7,6 @@
  * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  */
 
-const auth = () => ({
-  username: Cypress.env("USERNAME"),
-  password: Cypress.env("PASSWORD"),
-});
-
 describe("Analyzer Field Mappings Display", () => {
   before("Setup authentication", () => {
     // Wait for backend API to be available
@@ -23,7 +18,7 @@ describe("Analyzer Field Mappings Display", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         failOnStatusCode: false,
       });
     });
@@ -35,7 +30,7 @@ describe("Analyzer Field Mappings Display", () => {
 
   it("should open field mappings page and display mappings when available", () => {
     // Navigate to analyzers list with basic auth (credentials from env, not in URL)
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
     cy.get('[data-testid="analyzers-table-container"]', {
       timeout: 10000,

--- a/frontend/cypress/e2e/analyzerFieldMappingsDisplay.cy.js
+++ b/frontend/cypress/e2e/analyzerFieldMappingsDisplay.cy.js
@@ -3,13 +3,14 @@
  *
  * Verifies that the field mappings page opens and displays mappings correctly.
  * Simple test to ensure mappings appear on the page.
+ *
+ * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  */
 
-// Basic auth credentials
-const AUTH = {
-  username: "admin",
-  password: "adminADMIN!",
-};
+const auth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
 
 describe("Analyzer Field Mappings Display", () => {
   before("Setup authentication", () => {
@@ -22,7 +23,7 @@ describe("Analyzer Field Mappings Display", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: AUTH,
+        auth: auth(),
         failOnStatusCode: false,
       });
     });
@@ -33,8 +34,8 @@ describe("Analyzer Field Mappings Display", () => {
   });
 
   it("should open field mappings page and display mappings when available", () => {
-    // Navigate to analyzers list with basic auth
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    // Navigate to analyzers list with basic auth (credentials from env, not in URL)
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
     cy.get('[data-testid="analyzers-table-container"]', {
       timeout: 10000,

--- a/frontend/cypress/e2e/analyzerHappyPathUserStories.cy.js
+++ b/frontend/cypress/e2e/analyzerHappyPathUserStories.cy.js
@@ -16,11 +16,6 @@
 
 let testAnalyzerId = null;
 
-const auth = () => ({
-  username: Cypress.env("USERNAME"),
-  password: Cypress.env("PASSWORD"),
-});
-
 /**
  * Setup: Wait for backend and create test analyzer via API with basic auth
  * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
@@ -35,7 +30,7 @@ before("Setup test analyzer", () => {
     cy.request({
       method: "GET",
       url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-      auth: auth(),
+      auth: Cypress.getBasicAuth(),
       failOnStatusCode: false,
     });
   });
@@ -44,7 +39,7 @@ before("Setup test analyzer", () => {
   cy.request({
     method: "POST",
     url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-    auth: auth(),
+    auth: Cypress.getBasicAuth(),
     body: {
       name: "E2E-Test-Analyzer-HappyPath",
       analyzerType: "CHEMISTRY",
@@ -105,7 +100,7 @@ after("Cleanup test analyzer", () => {
     cy.request({
       method: "DELETE",
       url: `/api/OpenELIS-Global/rest/analyzer/analyzers/${testAnalyzerId}`,
-      auth: auth(),
+      auth: Cypress.getBasicAuth(),
       failOnStatusCode: false,
     });
   }
@@ -115,7 +110,7 @@ describe("User Story 1: Configure field mappings for a new ASTM analyzer (P1)", 
   beforeEach(() => {
     cy.viewport(1025, 900);
     // Visit with basic auth in URL format
-    cy.visit("/", { auth: auth() });
+    cy.visit("/", { auth: Cypress.getBasicAuth() });
   });
 
   it("should allow administrator to configure field mappings for a new analyzer", () => {
@@ -128,7 +123,7 @@ describe("User Story 1: Configure field mappings for a new ASTM analyzer (P1)", 
       }
 
       // Navigate to analyzers list
-      cy.visit("/analyzers", { auth: auth() });
+      cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
 
       // Find and click on the test analyzer
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
@@ -171,7 +166,7 @@ describe("User Story 1: Configure field mappings for a new ASTM analyzer (P1)", 
         cy.log("Skipping test - analyzer ID not available");
         return;
       }
-      cy.visit(`/analyzers/${id}/mappings`, { auth: auth() });
+      cy.visit(`/analyzers/${id}/mappings`, { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Check if there are unmapped fields to map
@@ -204,7 +199,7 @@ describe("User Story 1: Configure field mappings for a new ASTM analyzer (P1)", 
 describe("User Story 2: Maintain mappings as instruments and test menus change (P2)", () => {
   beforeEach(() => {
     cy.viewport(1025, 900);
-    cy.visit("/", { auth: auth() });
+    cy.visit("/", { auth: Cypress.getBasicAuth() });
   });
 
   it("should allow updating existing mappings when analyzer configuration changes", () => {
@@ -215,7 +210,7 @@ describe("User Story 2: Maintain mappings as instruments and test menus change (
         cy.log("Skipping test - analyzer ID not available");
         return;
       }
-      cy.visit(`/analyzers/${id}/mappings`, { auth: auth() });
+      cy.visit(`/analyzers/${id}/mappings`, { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Check if there are existing mappings to update
@@ -249,7 +244,7 @@ describe("User Story 2: Maintain mappings as instruments and test menus change (
         cy.log("Skipping test - analyzer ID not available");
         return;
       }
-      cy.visit(`/analyzers/${id}/mappings`, { auth: auth() });
+      cy.visit(`/analyzers/${id}/mappings`, { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Verify statistics cards are displayed
@@ -265,12 +260,12 @@ describe("User Story 2: Maintain mappings as instruments and test menus change (
 describe("User Story 3: Resolve unmapped or failed analyzer messages (P3)", () => {
   beforeEach(() => {
     cy.viewport(1025, 900);
-    cy.visit("/", { auth: auth() });
+    cy.visit("/", { auth: Cypress.getBasicAuth() });
   });
 
   it("should display unmapped messages in Error Dashboard", () => {
     // Navigate to Error Dashboard
-    cy.visit("/analyzers/errors", { auth: auth() });
+    cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Verify Error Dashboard components are visible
@@ -282,7 +277,7 @@ describe("User Story 3: Resolve unmapped or failed analyzer messages (P3)", () =
 
   it("should allow viewing error details with context for mapping", () => {
     // Navigate to Error Dashboard
-    cy.visit("/analyzers/errors", { auth: auth() });
+    cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Check if there are errors to view
@@ -348,7 +343,7 @@ describe("User Story 3: Resolve unmapped or failed analyzer messages (P3)", () =
 
   it("should allow creating mappings from error context", () => {
     // Navigate to Error Dashboard
-    cy.visit("/analyzers/errors", { auth: auth() });
+    cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Check if there are errors with mapping options
@@ -393,7 +388,7 @@ describe("User Story 3: Resolve unmapped or failed analyzer messages (P3)", () =
 describe("Cross-Story: End-to-End Happy Path Flow", () => {
   beforeEach(() => {
     cy.viewport(1025, 900);
-    cy.visit("/", { auth: auth() });
+    cy.visit("/", { auth: Cypress.getBasicAuth() });
   });
 
   it("should complete full workflow: configure analyzer → view mappings → check errors", () => {
@@ -406,7 +401,7 @@ describe("Cross-Story: End-to-End Happy Path Flow", () => {
       }
 
       // Step 1: Navigate to analyzers list
-      cy.visit("/analyzers", { auth: auth() });
+      cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
       // Step 2: Open mappings for test analyzer
@@ -426,11 +421,11 @@ describe("Cross-Story: End-to-End Happy Path Flow", () => {
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Step 4: Navigate to Error Dashboard
-      cy.visit("/analyzers/errors", { auth: auth() });
+      cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
       // Step 5: Navigate back to analyzers list
-      cy.visit("/analyzers", { auth: auth() });
+      cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
       cy.log(

--- a/frontend/cypress/e2e/analyzerHappyPathUserStories.cy.js
+++ b/frontend/cypress/e2e/analyzerHappyPathUserStories.cy.js
@@ -16,14 +16,14 @@
 
 let testAnalyzerId = null;
 
-// Basic auth credentials
-const AUTH = {
-  username: "admin",
-  password: "adminADMIN!",
-};
+const auth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
 
 /**
  * Setup: Wait for backend and create test analyzer via API with basic auth
+ * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  */
 before("Setup test analyzer", () => {
   // Wait for backend API to be available
@@ -35,7 +35,7 @@ before("Setup test analyzer", () => {
     cy.request({
       method: "GET",
       url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-      auth: AUTH,
+      auth: auth(),
       failOnStatusCode: false,
     });
   });
@@ -44,7 +44,7 @@ before("Setup test analyzer", () => {
   cy.request({
     method: "POST",
     url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-    auth: AUTH,
+    auth: auth(),
     body: {
       name: "E2E-Test-Analyzer-HappyPath",
       analyzerType: "CHEMISTRY",
@@ -105,7 +105,7 @@ after("Cleanup test analyzer", () => {
     cy.request({
       method: "DELETE",
       url: `/api/OpenELIS-Global/rest/analyzer/analyzers/${testAnalyzerId}`,
-      auth: AUTH,
+      auth: auth(),
       failOnStatusCode: false,
     });
   }
@@ -115,7 +115,7 @@ describe("User Story 1: Configure field mappings for a new ASTM analyzer (P1)", 
   beforeEach(() => {
     cy.viewport(1025, 900);
     // Visit with basic auth in URL format
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/`);
+    cy.visit("/", { auth: auth() });
   });
 
   it("should allow administrator to configure field mappings for a new analyzer", () => {
@@ -128,7 +128,7 @@ describe("User Story 1: Configure field mappings for a new ASTM analyzer (P1)", 
       }
 
       // Navigate to analyzers list
-      cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+      cy.visit("/analyzers", { auth: auth() });
 
       // Find and click on the test analyzer
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
@@ -171,9 +171,7 @@ describe("User Story 1: Configure field mappings for a new ASTM analyzer (P1)", 
         cy.log("Skipping test - analyzer ID not available");
         return;
       }
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${id}/mappings`,
-      );
+      cy.visit(`/analyzers/${id}/mappings`, { auth: auth() });
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Check if there are unmapped fields to map
@@ -206,7 +204,7 @@ describe("User Story 1: Configure field mappings for a new ASTM analyzer (P1)", 
 describe("User Story 2: Maintain mappings as instruments and test menus change (P2)", () => {
   beforeEach(() => {
     cy.viewport(1025, 900);
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/`);
+    cy.visit("/", { auth: auth() });
   });
 
   it("should allow updating existing mappings when analyzer configuration changes", () => {
@@ -217,9 +215,7 @@ describe("User Story 2: Maintain mappings as instruments and test menus change (
         cy.log("Skipping test - analyzer ID not available");
         return;
       }
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${id}/mappings`,
-      );
+      cy.visit(`/analyzers/${id}/mappings`, { auth: auth() });
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Check if there are existing mappings to update
@@ -253,9 +249,7 @@ describe("User Story 2: Maintain mappings as instruments and test menus change (
         cy.log("Skipping test - analyzer ID not available");
         return;
       }
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${id}/mappings`,
-      );
+      cy.visit(`/analyzers/${id}/mappings`, { auth: auth() });
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Verify statistics cards are displayed
@@ -271,14 +265,12 @@ describe("User Story 2: Maintain mappings as instruments and test menus change (
 describe("User Story 3: Resolve unmapped or failed analyzer messages (P3)", () => {
   beforeEach(() => {
     cy.viewport(1025, 900);
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/`);
+    cy.visit("/", { auth: auth() });
   });
 
   it("should display unmapped messages in Error Dashboard", () => {
     // Navigate to Error Dashboard
-    cy.visit(
-      `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-    );
+    cy.visit("/analyzers/errors", { auth: auth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Verify Error Dashboard components are visible
@@ -290,9 +282,7 @@ describe("User Story 3: Resolve unmapped or failed analyzer messages (P3)", () =
 
   it("should allow viewing error details with context for mapping", () => {
     // Navigate to Error Dashboard
-    cy.visit(
-      `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-    );
+    cy.visit("/analyzers/errors", { auth: auth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Check if there are errors to view
@@ -358,9 +348,7 @@ describe("User Story 3: Resolve unmapped or failed analyzer messages (P3)", () =
 
   it("should allow creating mappings from error context", () => {
     // Navigate to Error Dashboard
-    cy.visit(
-      `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-    );
+    cy.visit("/analyzers/errors", { auth: auth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Check if there are errors with mapping options
@@ -405,7 +393,7 @@ describe("User Story 3: Resolve unmapped or failed analyzer messages (P3)", () =
 describe("Cross-Story: End-to-End Happy Path Flow", () => {
   beforeEach(() => {
     cy.viewport(1025, 900);
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/`);
+    cy.visit("/", { auth: auth() });
   });
 
   it("should complete full workflow: configure analyzer → view mappings → check errors", () => {
@@ -418,7 +406,7 @@ describe("Cross-Story: End-to-End Happy Path Flow", () => {
       }
 
       // Step 1: Navigate to analyzers list
-      cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+      cy.visit("/analyzers", { auth: auth() });
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
       // Step 2: Open mappings for test analyzer
@@ -438,13 +426,11 @@ describe("Cross-Story: End-to-End Happy Path Flow", () => {
       cy.get('[data-testid="field-mapping"]').should("be.visible");
 
       // Step 4: Navigate to Error Dashboard
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-      );
+      cy.visit("/analyzers/errors", { auth: auth() });
       cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
       // Step 5: Navigate back to analyzers list
-      cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+      cy.visit("/analyzers", { auth: auth() });
       cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
       cy.log(

--- a/frontend/cypress/e2e/analyzerMaintenance.cy.js
+++ b/frontend/cypress/e2e/analyzerMaintenance.cy.js
@@ -28,11 +28,6 @@
 let testAnalyzerId = null;
 let testMappingId = null;
 
-const auth = () => ({
-  username: Cypress.env("USERNAME"),
-  password: Cypress.env("PASSWORD"),
-});
-
 /**
  * Setup: Wait for backend and create test analyzer with mappings via API with basic auth
  * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
@@ -47,7 +42,7 @@ before("Login and setup test analyzer with mappings", () => {
     cy.request({
       method: "GET",
       url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-      auth: auth(),
+      auth: Cypress.getBasicAuth(),
       failOnStatusCode: false,
     });
   });
@@ -57,7 +52,7 @@ before("Login and setup test analyzer with mappings", () => {
   cy.request({
     method: "POST",
     url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-    auth: auth(),
+    auth: Cypress.getBasicAuth(),
     body: {
       name: "TEST-Maintenance-Analyzer-E2E",
       analyzerType: "HEMATOLOGY",
@@ -78,7 +73,7 @@ before("Login and setup test analyzer with mappings", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers/1001",
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         failOnStatusCode: false,
       }).then((checkResponse) => {
         if (checkResponse.status === 200) {
@@ -91,7 +86,7 @@ before("Login and setup test analyzer with mappings", () => {
           cy.request({
             method: "GET",
             url: "/api/OpenELIS-Global/rest/analyzer/analyzers/1001/fields",
-            auth: auth(),
+            auth: Cypress.getBasicAuth(),
             failOnStatusCode: false,
           }).then((fieldsResponse) => {
             if (
@@ -108,7 +103,7 @@ before("Login and setup test analyzer with mappings", () => {
                 cy.request({
                   method: "POST",
                   url: `/api/OpenELIS-Global/rest/analyzer/analyzers/1001/mappings`,
-                  auth: auth(),
+                  auth: Cypress.getBasicAuth(),
                   body: {
                     analyzerFieldId: fieldId,
                     openelisFieldId: "TEST-001",
@@ -147,7 +142,7 @@ after("Cleanup test analyzer", () => {
     cy.request({
       method: "DELETE",
       url: `/api/OpenELIS-Global/rest/analyzer/analyzers/${testAnalyzerId}`,
-      auth: auth(),
+      auth: Cypress.getBasicAuth(),
       failOnStatusCode: false,
     });
   }
@@ -197,7 +192,9 @@ describe("Analyzer Maintenance - User Story 2", function () {
       }
 
       // Arrange: Navigate to field mappings page (credentials from env, not in URL)
-      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, { auth: auth() });
+      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, {
+        auth: Cypress.getBasicAuth(),
+      });
 
       // Wait for page to load
       cy.get('[data-testid="field-mapping"]').should("be.visible");
@@ -293,7 +290,9 @@ describe("Analyzer Maintenance - User Story 2", function () {
       }
 
       // Arrange: Navigate to field mappings page (credentials from env, not in URL)
-      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, { auth: auth() });
+      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, {
+        auth: Cypress.getBasicAuth(),
+      });
 
       // Wait for page to load
       cy.get('[data-testid="field-mapping"]').should("be.visible");
@@ -391,7 +390,9 @@ describe("Analyzer Maintenance - User Story 2", function () {
       }
 
       // Arrange: Navigate to field mappings page (credentials from env, not in URL)
-      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, { auth: auth() });
+      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, {
+        auth: Cypress.getBasicAuth(),
+      });
 
       // Wait for page to load
       cy.get('[data-testid="field-mapping"]').should("be.visible");

--- a/frontend/cypress/e2e/analyzerMaintenance.cy.js
+++ b/frontend/cypress/e2e/analyzerMaintenance.cy.js
@@ -28,14 +28,14 @@
 let testAnalyzerId = null;
 let testMappingId = null;
 
-// Basic auth credentials
-const AUTH = {
-  username: "admin",
-  password: "adminADMIN!",
-};
+const auth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
 
 /**
  * Setup: Wait for backend and create test analyzer with mappings via API with basic auth
+ * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  */
 before("Login and setup test analyzer with mappings", () => {
   // Wait for backend API to be available
@@ -47,7 +47,7 @@ before("Login and setup test analyzer with mappings", () => {
     cy.request({
       method: "GET",
       url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-      auth: AUTH,
+      auth: auth(),
       failOnStatusCode: false,
     });
   });
@@ -57,7 +57,7 @@ before("Login and setup test analyzer with mappings", () => {
   cy.request({
     method: "POST",
     url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-    auth: AUTH,
+    auth: auth(),
     body: {
       name: "TEST-Maintenance-Analyzer-E2E",
       analyzerType: "HEMATOLOGY",
@@ -78,7 +78,7 @@ before("Login and setup test analyzer with mappings", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers/1001",
-        auth: AUTH,
+        auth: auth(),
         failOnStatusCode: false,
       }).then((checkResponse) => {
         if (checkResponse.status === 200) {
@@ -91,7 +91,7 @@ before("Login and setup test analyzer with mappings", () => {
           cy.request({
             method: "GET",
             url: "/api/OpenELIS-Global/rest/analyzer/analyzers/1001/fields",
-            auth: AUTH,
+            auth: auth(),
             failOnStatusCode: false,
           }).then((fieldsResponse) => {
             if (
@@ -108,7 +108,7 @@ before("Login and setup test analyzer with mappings", () => {
                 cy.request({
                   method: "POST",
                   url: `/api/OpenELIS-Global/rest/analyzer/analyzers/1001/mappings`,
-                  auth: AUTH,
+                  auth: auth(),
                   body: {
                     analyzerFieldId: fieldId,
                     openelisFieldId: "TEST-001",
@@ -147,7 +147,7 @@ after("Cleanup test analyzer", () => {
     cy.request({
       method: "DELETE",
       url: `/api/OpenELIS-Global/rest/analyzer/analyzers/${testAnalyzerId}`,
-      auth: AUTH,
+      auth: auth(),
       failOnStatusCode: false,
     });
   }
@@ -196,10 +196,8 @@ describe("Analyzer Maintenance - User Story 2", function () {
         return;
       }
 
-      // Arrange: Navigate to field mappings page with basic auth
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${testAnalyzerId}/mappings`,
-      );
+      // Arrange: Navigate to field mappings page (credentials from env, not in URL)
+      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, { auth: auth() });
 
       // Wait for page to load
       cy.get('[data-testid="field-mapping"]').should("be.visible");
@@ -294,10 +292,8 @@ describe("Analyzer Maintenance - User Story 2", function () {
         return;
       }
 
-      // Arrange: Navigate to field mappings page with basic auth
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${testAnalyzerId}/mappings`,
-      );
+      // Arrange: Navigate to field mappings page (credentials from env, not in URL)
+      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, { auth: auth() });
 
       // Wait for page to load
       cy.get('[data-testid="field-mapping"]').should("be.visible");
@@ -394,10 +390,8 @@ describe("Analyzer Maintenance - User Story 2", function () {
         return;
       }
 
-      // Arrange: Navigate to field mappings page
-      cy.visit(
-        `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/${testAnalyzerId}/mappings`,
-      );
+      // Arrange: Navigate to field mappings page (credentials from env, not in URL)
+      cy.visit(`/analyzers/${testAnalyzerId}/mappings`, { auth: auth() });
 
       // Wait for page to load
       cy.get('[data-testid="field-mapping"]').should("be.visible");

--- a/frontend/cypress/e2e/analyzerModals.cy.js
+++ b/frontend/cypress/e2e/analyzerModals.cy.js
@@ -17,15 +17,16 @@
  * - Uses data-testid selectors (PREFERRED)
  * - Simple happy path test (open/close only)
  *
+ * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
+ *
  * Execution:
  * - Development: npm run cy:single "cypress/e2e/analyzerModals.cy.js"
  */
 
-// Basic auth credentials
-const AUTH = {
-  username: "admin",
-  password: "adminADMIN!",
-};
+const auth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
 
 let testAnalyzerId = null;
 
@@ -40,7 +41,7 @@ describe("Analyzer Modals - Open/Close", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: AUTH,
+        auth: auth(),
         failOnStatusCode: false,
       });
     });
@@ -49,7 +50,7 @@ describe("Analyzer Modals - Open/Close", () => {
     cy.request({
       method: "POST",
       url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-      auth: AUTH,
+      auth: auth(),
       body: {
         name: "TEST-Modal-E2E",
         analyzerType: "HEMATOLOGY",
@@ -71,7 +72,7 @@ describe("Analyzer Modals - Open/Close", () => {
       cy.request({
         method: "DELETE",
         url: `/api/OpenELIS-Global/rest/analyzer/analyzers/${testAnalyzerId}`,
-        auth: AUTH,
+        auth: auth(),
         failOnStatusCode: false,
       });
     }
@@ -83,7 +84,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Add Analyzer modal", () => {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Click Add Analyzer button
@@ -106,7 +107,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Edit Analyzer modal", () => {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Wait for analyzers table to load
@@ -158,7 +159,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Delete Analyzer modal", () => {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Find analyzer row and click overflow menu
@@ -205,7 +206,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Test Connection modal", () => {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Find analyzer row and click overflow menu
@@ -255,7 +256,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Copy Mappings modal", () => {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Find analyzer row and click overflow menu
@@ -302,7 +303,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should navigate to Field Mappings page and verify Test Mapping modal", () => {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Navigate to field mappings via analyzer row
@@ -344,9 +345,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Error Details modal from Error Dashboard", () => {
-    cy.visit(
-      `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-    );
+    cy.visit("/analyzers/errors", { auth: auth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Check if there are any error rows in the table

--- a/frontend/cypress/e2e/analyzerModals.cy.js
+++ b/frontend/cypress/e2e/analyzerModals.cy.js
@@ -23,11 +23,6 @@
  * - Development: npm run cy:single "cypress/e2e/analyzerModals.cy.js"
  */
 
-const auth = () => ({
-  username: Cypress.env("USERNAME"),
-  password: Cypress.env("PASSWORD"),
-});
-
 let testAnalyzerId = null;
 
 describe("Analyzer Modals - Open/Close", () => {
@@ -41,7 +36,7 @@ describe("Analyzer Modals - Open/Close", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         failOnStatusCode: false,
       });
     });
@@ -50,7 +45,7 @@ describe("Analyzer Modals - Open/Close", () => {
     cy.request({
       method: "POST",
       url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-      auth: auth(),
+      auth: Cypress.getBasicAuth(),
       body: {
         name: "TEST-Modal-E2E",
         analyzerType: "HEMATOLOGY",
@@ -72,7 +67,7 @@ describe("Analyzer Modals - Open/Close", () => {
       cy.request({
         method: "DELETE",
         url: `/api/OpenELIS-Global/rest/analyzer/analyzers/${testAnalyzerId}`,
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         failOnStatusCode: false,
       });
     }
@@ -84,7 +79,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Add Analyzer modal", () => {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Click Add Analyzer button
@@ -107,7 +102,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Edit Analyzer modal", () => {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Wait for analyzers table to load
@@ -159,7 +154,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Delete Analyzer modal", () => {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Find analyzer row and click overflow menu
@@ -206,7 +201,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Test Connection modal", () => {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Find analyzer row and click overflow menu
@@ -256,7 +251,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Copy Mappings modal", () => {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Find analyzer row and click overflow menu
@@ -303,7 +298,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should navigate to Field Mappings page and verify Test Mapping modal", () => {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Navigate to field mappings via analyzer row
@@ -345,7 +340,7 @@ describe("Analyzer Modals - Open/Close", () => {
   });
 
   it("should open and close Error Details modal from Error Dashboard", () => {
-    cy.visit("/analyzers/errors", { auth: auth() });
+    cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Check if there are any error rows in the table

--- a/frontend/cypress/e2e/analyzerNavigationQuick.cy.js
+++ b/frontend/cypress/e2e/analyzerNavigationQuick.cy.js
@@ -3,13 +3,14 @@
  *
  * Simple test to verify navigation between analyzer pages works correctly
  * and there are no console errors
+ *
+ * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  */
 
-// Basic auth credentials
-const AUTH = {
-  username: "admin",
-  password: "adminADMIN!",
-};
+const auth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
 
 describe("Quick Analyzer Navigation", () => {
   before("Setup authentication", () => {
@@ -22,7 +23,7 @@ describe("Quick Analyzer Navigation", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: AUTH,
+        auth: auth(),
         failOnStatusCode: false,
       });
     });
@@ -34,21 +35,19 @@ describe("Quick Analyzer Navigation", () => {
   });
 
   it("should navigate between analyzer pages without errors", () => {
-    // 1. Navigate to Analyzers List with basic auth
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    // 1. Navigate to Analyzers List with basic auth (credentials from env, not in URL)
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
     cy.get('[data-testid="page-title"]').should("be.visible");
     cy.get('[data-testid="analyzers-list-stats"]').should("be.visible");
 
     // 2. Navigate to Error Dashboard with basic auth
-    cy.visit(
-      `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-    );
+    cy.visit("/analyzers/errors", { auth: auth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
     cy.get('[data-testid="error-dashboard-stats"]').should("be.visible");
 
     // 3. Navigate back to Analyzers List with basic auth
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // 4. Try to navigate to field mappings if analyzer exists

--- a/frontend/cypress/e2e/analyzerNavigationQuick.cy.js
+++ b/frontend/cypress/e2e/analyzerNavigationQuick.cy.js
@@ -7,11 +7,6 @@
  * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  */
 
-const auth = () => ({
-  username: Cypress.env("USERNAME"),
-  password: Cypress.env("PASSWORD"),
-});
-
 describe("Quick Analyzer Navigation", () => {
   before("Setup authentication", () => {
     // Wait for backend API to be available
@@ -23,7 +18,7 @@ describe("Quick Analyzer Navigation", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         failOnStatusCode: false,
       });
     });
@@ -36,18 +31,18 @@ describe("Quick Analyzer Navigation", () => {
 
   it("should navigate between analyzer pages without errors", () => {
     // 1. Navigate to Analyzers List with basic auth (credentials from env, not in URL)
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
     cy.get('[data-testid="page-title"]').should("be.visible");
     cy.get('[data-testid="analyzers-list-stats"]').should("be.visible");
 
     // 2. Navigate to Error Dashboard with basic auth
-    cy.visit("/analyzers/errors", { auth: auth() });
+    cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
     cy.get('[data-testid="error-dashboard-stats"]').should("be.visible");
 
     // 3. Navigate back to Analyzers List with basic auth
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // 4. Try to navigate to field mappings if analyzer exists

--- a/frontend/cypress/e2e/analyzerPagesLoad.cy.js
+++ b/frontend/cypress/e2e/analyzerPagesLoad.cy.js
@@ -14,11 +14,6 @@
  * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  */
 
-const auth = () => ({
-  username: Cypress.env("USERNAME"),
-  password: Cypress.env("PASSWORD"),
-});
-
 describe("Analyzer Pages Load", () => {
   before("Setup authentication", () => {
     // Wait for backend API to be available
@@ -30,7 +25,7 @@ describe("Analyzer Pages Load", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         failOnStatusCode: false,
       });
     });
@@ -43,7 +38,7 @@ describe("Analyzer Pages Load", () => {
 
   it("should load Analyzers List page without errors", () => {
     // Navigate to analyzers list with basic auth (credentials from env, not in URL)
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
 
     // Verify page loads
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
@@ -61,7 +56,7 @@ describe("Analyzer Pages Load", () => {
 
   it("should load Error Dashboard page without errors", () => {
     // Navigate to error dashboard with basic auth
-    cy.visit("/analyzers/errors", { auth: auth() });
+    cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
 
     // Verify page loads
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
@@ -79,14 +74,14 @@ describe("Analyzer Pages Load", () => {
 
   it("should navigate between analyzer pages with sidebar persistent", () => {
     // Start at analyzers list with basic auth
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Verify sidebar exists (may be collapsed at certain viewport widths per Carbon Design)
     cy.get('nav[aria-label="Side navigation"]').should("exist");
 
     // Navigate to error dashboard with basic auth
-    cy.visit("/analyzers/errors", { auth: auth() });
+    cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Verify sidebar still exists after navigation (may be collapsed per Carbon Design)
@@ -94,7 +89,7 @@ describe("Analyzer Pages Load", () => {
   });
 
   it("should show analyzer menu items in sidebar", () => {
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
 
     // Verify sidebar exists (may be collapsed at certain viewport widths per Carbon Design)
     cy.get('nav[aria-label="Side navigation"]').should("exist");

--- a/frontend/cypress/e2e/analyzerPagesLoad.cy.js
+++ b/frontend/cypress/e2e/analyzerPagesLoad.cy.js
@@ -10,13 +10,14 @@
  * - Navigate to /analyzers/errors - verify page loads, check console logs
  * - Verify sidebar navigation is visible and functional
  * - Verify menu items are clickable and navigate correctly
+ *
+ * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD')
  */
 
-// Basic auth credentials
-const AUTH = {
-  username: "admin",
-  password: "adminADMIN!",
-};
+const auth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
 
 describe("Analyzer Pages Load", () => {
   before("Setup authentication", () => {
@@ -29,7 +30,7 @@ describe("Analyzer Pages Load", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: AUTH,
+        auth: auth(),
         failOnStatusCode: false,
       });
     });
@@ -41,8 +42,8 @@ describe("Analyzer Pages Load", () => {
   });
 
   it("should load Analyzers List page without errors", () => {
-    // Navigate to analyzers list with basic auth
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    // Navigate to analyzers list with basic auth (credentials from env, not in URL)
+    cy.visit("/analyzers", { auth: auth() });
 
     // Verify page loads
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
@@ -60,9 +61,7 @@ describe("Analyzer Pages Load", () => {
 
   it("should load Error Dashboard page without errors", () => {
     // Navigate to error dashboard with basic auth
-    cy.visit(
-      `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-    );
+    cy.visit("/analyzers/errors", { auth: auth() });
 
     // Verify page loads
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
@@ -80,16 +79,14 @@ describe("Analyzer Pages Load", () => {
 
   it("should navigate between analyzer pages with sidebar persistent", () => {
     // Start at analyzers list with basic auth
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Verify sidebar exists (may be collapsed at certain viewport widths per Carbon Design)
     cy.get('nav[aria-label="Side navigation"]').should("exist");
 
     // Navigate to error dashboard with basic auth
-    cy.visit(
-      `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-    );
+    cy.visit("/analyzers/errors", { auth: auth() });
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
 
     // Verify sidebar still exists after navigation (may be collapsed per Carbon Design)
@@ -97,7 +94,7 @@ describe("Analyzer Pages Load", () => {
   });
 
   it("should show analyzer menu items in sidebar", () => {
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
 
     // Verify sidebar exists (may be collapsed at certain viewport widths per Carbon Design)
     cy.get('nav[aria-label="Side navigation"]').should("exist");

--- a/frontend/cypress/e2e/analyzerPagesNavigation.cy.js
+++ b/frontend/cypress/e2e/analyzerPagesNavigation.cy.js
@@ -20,11 +20,6 @@
  * - Development: npm run cy:single "cypress/e2e/analyzerPagesNavigation.cy.js"
  */
 
-const auth = () => ({
-  username: Cypress.env("USERNAME"),
-  password: Cypress.env("PASSWORD"),
-});
-
 describe("Analyzer Pages Navigation", () => {
   before("Setup authentication", () => {
     // Wait for backend API to be available
@@ -36,7 +31,7 @@ describe("Analyzer Pages Navigation", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: auth(),
+        auth: Cypress.getBasicAuth(),
         failOnStatusCode: false,
       });
     });
@@ -49,7 +44,7 @@ describe("Analyzer Pages Navigation", () => {
 
   it("should navigate to analyzers list page", () => {
     // Navigate to analyzers list with basic auth (credentials from env, not in URL)
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
 
     // Verify page loaded
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
@@ -58,7 +53,7 @@ describe("Analyzer Pages Navigation", () => {
 
   it("should navigate to error dashboard page", () => {
     // Navigate to error dashboard with basic auth
-    cy.visit("/analyzers/errors", { auth: auth() });
+    cy.visit("/analyzers/errors", { auth: Cypress.getBasicAuth() });
 
     // Verify page loaded
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
@@ -67,7 +62,7 @@ describe("Analyzer Pages Navigation", () => {
 
   it("should navigate to field mappings page via analyzer row", () => {
     // First go to analyzers list with basic auth
-    cy.visit("/analyzers", { auth: auth() });
+    cy.visit("/analyzers", { auth: Cypress.getBasicAuth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Check if there are any analyzers in the table

--- a/frontend/cypress/e2e/analyzerPagesNavigation.cy.js
+++ b/frontend/cypress/e2e/analyzerPagesNavigation.cy.js
@@ -14,15 +14,16 @@
  * - Uses data-testid selectors (PREFERRED)
  * - Simple happy path test
  *
+ * Credentials: Cypress.env('USERNAME') / Cypress.env('PASSWORD') (set via env or cypress.config.js)
+ *
  * Execution:
  * - Development: npm run cy:single "cypress/e2e/analyzerPagesNavigation.cy.js"
  */
 
-// Basic auth credentials
-const AUTH = {
-  username: "admin",
-  password: "adminADMIN!",
-};
+const auth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
 
 describe("Analyzer Pages Navigation", () => {
   before("Setup authentication", () => {
@@ -35,7 +36,7 @@ describe("Analyzer Pages Navigation", () => {
       cy.request({
         method: "GET",
         url: "/api/OpenELIS-Global/rest/analyzer/analyzers",
-        auth: AUTH,
+        auth: auth(),
         failOnStatusCode: false,
       });
     });
@@ -47,8 +48,8 @@ describe("Analyzer Pages Navigation", () => {
   });
 
   it("should navigate to analyzers list page", () => {
-    // Navigate to analyzers list with basic auth
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    // Navigate to analyzers list with basic auth (credentials from env, not in URL)
+    cy.visit("/analyzers", { auth: auth() });
 
     // Verify page loaded
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
@@ -57,9 +58,7 @@ describe("Analyzer Pages Navigation", () => {
 
   it("should navigate to error dashboard page", () => {
     // Navigate to error dashboard with basic auth
-    cy.visit(
-      `https://${AUTH.username}:${AUTH.password}@localhost/analyzers/errors`,
-    );
+    cy.visit("/analyzers/errors", { auth: auth() });
 
     // Verify page loaded
     cy.get('[data-testid="error-dashboard"]').should("be.visible");
@@ -68,7 +67,7 @@ describe("Analyzer Pages Navigation", () => {
 
   it("should navigate to field mappings page via analyzer row", () => {
     // First go to analyzers list with basic auth
-    cy.visit(`https://${AUTH.username}:${AUTH.password}@localhost/analyzers`);
+    cy.visit("/analyzers", { auth: auth() });
     cy.get('[data-testid="analyzers-list"]').should("be.visible");
 
     // Check if there are any analyzers in the table

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -9,6 +9,16 @@
 // ***********************************************
 
 /**
+ * Returns basic auth object for cy.visit/cy.request when using HTTP basic auth.
+ * Credentials from Cypress.env('USERNAME') / Cypress.env('PASSWORD').
+ * Usage: cy.visit('/path', { auth: Cypress.getBasicAuth() })
+ */
+Cypress.getBasicAuth = () => ({
+  username: Cypress.env("USERNAME"),
+  password: Cypress.env("PASSWORD"),
+});
+
+/**
  * Login command with session caching for faster tests
  * Uses cy.session() to cache login state across tests
  * Usage: cy.login("admin", "password")

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -77,26 +77,17 @@ Cypress.Commands.add("enterText", (selector, value) => {
 
 /**
  * Wait for backend API to be ready before running tests
- * Uses direct cy.request() for reliability (no intercept timing issues)
+ * Uses cy.task with retry loop for CI reliability - cy.request() fails immediately
+ * on connection errors (ECONNREFUSED) when backend is still starting.
+ * Retries with 2s backoff, max 15 attempts (~30s total).
  * Per Constitution V.5: Avoid intercept timing issues by using direct requests
  */
 Cypress.Commands.add("waitForBackend", (restEndpoint = null) => {
-  // Use cy.request() to verify backend is responding (more reliable than intercepts)
-  // This avoids the timing issue where intercepts may be set up after page load starts
   const checkEndpoint = restEndpoint || "/api/OpenELIS-Global/rest/menu";
 
-  cy.request({
-    method: "GET",
-    url: checkEndpoint,
-    failOnStatusCode: false, // Don't fail on 401/403/404 - just verify backend responds
-    timeout: 30000,
-    retryOnStatusCodeFailure: false,
-  }).then((response) => {
-    // Backend is responding if we get any HTTP status code
-    expect(response.status).to.be.a("number");
-    cy.log(
-      `Backend ready: ${checkEndpoint} responded with status ${response.status}`,
-    );
+  cy.task("waitForBackendReady", { path: checkEndpoint }).then((ready) => {
+    expect(ready).to.be.true;
+    cy.log(`Backend ready: ${checkEndpoint} responded`);
   });
 });
 

--- a/frontend/playwright/tests/auth.setup.ts
+++ b/frontend/playwright/tests/auth.setup.ts
@@ -3,8 +3,14 @@ import { test as setup, expect } from "@playwright/test";
 const AUTH_FILE = "playwright/.auth/user.json";
 
 setup("authenticate", async ({ page }) => {
-  const username = process.env.TEST_USER || "admin";
-  const password = process.env.TEST_PASS || "adminADMIN!";
+  const username = process.env.TEST_USER;
+  const password = process.env.TEST_PASS;
+
+  if (!username || !password) {
+    throw new Error(
+      "TEST_USER and TEST_PASS environment variables must be set for Playwright authentication setup.",
+    );
+  }
 
   await page.goto("/");
   await page.getByLabel("Username").fill(username);

--- a/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
+++ b/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
@@ -90,7 +90,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
     setNotification(null);
   }, [analyzer, open]);
 
-  // Clear close timeout on unmount or when modal closes
+  // Clear close timeout on unmount
   useEffect(() => {
     return () => {
       if (closeTimeoutRef.current) {
@@ -99,6 +99,15 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
       }
     };
   }, []);
+
+  // Clear close timeout when modal is closed manually (prevents timer firing after user dismisses)
+  const handleModalClose = () => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+    onClose();
+  };
 
   // Validate IP address format
   const validateIPAddress = (ip) => {
@@ -199,7 +208,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
           kind: "success",
           title: intl.formatMessage({ id: "analyzer.form.success.save" }),
         });
-        // Close modal after short delay; store timer for cleanup on unmount
+        // Close modal after short delay; timer cleared on unmount or when user closes manually
         if (closeTimeoutRef.current) {
           clearTimeout(closeTimeoutRef.current);
         }
@@ -221,7 +230,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
     <>
       <ComposedModal
         open={open}
-        onClose={onClose}
+        onClose={handleModalClose}
         data-testid="analyzer-form"
         className="analyzer-form-modal"
       >

--- a/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
+++ b/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   ComposedModal,
   ModalHeader,
@@ -36,6 +36,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [notification, setNotification] = useState(null);
   const [testConnectionModalOpen, setTestConnectionModalOpen] = useState(false);
+  const closeTimeoutRef = useRef(null);
 
   // Analyzer type options
   const analyzerTypeOptions = [
@@ -88,6 +89,16 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
     setErrors({});
     setNotification(null);
   }, [analyzer, open]);
+
+  // Clear close timeout on unmount or when modal closes
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   // Validate IP address format
   const validateIPAddress = (ip) => {
@@ -188,8 +199,12 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
           kind: "success",
           title: intl.formatMessage({ id: "analyzer.form.success.save" }),
         });
-        // Close modal after short delay
-        setTimeout(() => {
+        // Close modal after short delay; store timer for cleanup on unmount
+        if (closeTimeoutRef.current) {
+          clearTimeout(closeTimeoutRef.current);
+        }
+        closeTimeoutRef.current = setTimeout(() => {
+          closeTimeoutRef.current = null;
           onClose();
         }, 1000);
       }

--- a/frontend/src/components/analyzers/DeleteAnalyzerModal/DeleteAnalyzerModal.jsx
+++ b/frontend/src/components/analyzers/DeleteAnalyzerModal/DeleteAnalyzerModal.jsx
@@ -122,7 +122,7 @@ const DeleteAnalyzerModal = ({ analyzer, open, onClose, onConfirm }) => {
 
 DeleteAnalyzerModal.propTypes = {
   analyzer: PropTypes.shape({
-    id: PropTypes.string.isRequired,
+    id: PropTypes.string, // Optional - component handles null/missing id with error notification
     name: PropTypes.string,
   }),
   open: PropTypes.bool.isRequired,

--- a/frontend/src/components/analyzers/FieldMapping/CopyMappingsModal.test.jsx
+++ b/frontend/src/components/analyzers/FieldMapping/CopyMappingsModal.test.jsx
@@ -135,25 +135,14 @@ describe("CopyMappingsModal", () => {
   });
 
   /**
-   * Test: Copy mappings shows confirmation dialog
+   * Test: Copy mappings modal structure supports confirmation flow
    * Task Reference: T196
    *
-   * When copy button is clicked with target selected, a confirmation dialog should appear.
-   * Note: We test the confirmation dialog logic by simulating the component state.
+   * Verifies modal renders with copy button and warning section. Full confirmation
+   * dialog flow (select target + click copy) requires Carbon dropdown interaction;
+   * covered by E2E tests.
    */
-  test("testCopyMappings_ShowsConfirmationDialog", async () => {
-    // Mock component with target already selected (simulating user selection)
-    const CopyMappingsModalWithTarget = () => {
-      const [targetId, setTargetId] = React.useState("TARGET-001");
-      return (
-        <CopyMappingsModal
-          {...defaultProps}
-          // We can't easily set internal state, so we test the confirmation modal rendering
-          // by verifying the component structure
-        />
-      );
-    };
-
+  test("testCopyMappings_ModalStructure_SupportsConfirmation", async () => {
     renderWithIntl(<CopyMappingsModal {...defaultProps} />);
 
     // Wait for modal to render

--- a/frontend/src/components/analyzers/FieldMapping/FieldMappingPanel.css
+++ b/frontend/src/components/analyzers/FieldMapping/FieldMappingPanel.css
@@ -4,7 +4,7 @@
  */
 
 .field-mapping-panel {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--cds-border-subtle);
   border-radius: 4px;
   padding: 1rem;
   height: 100%;
@@ -25,13 +25,13 @@
 .panel-footer {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--cds-border-subtle);
   font-size: 0.875rem;
-  color: #525252;
+  color: var(--cds-text-secondary);
 }
 
 .selected-row {
-  background-color: #e8f4f8;
+  background-color: var(--cds-layer-accent-01);
 }
 
 .panel-header-controls {
@@ -46,7 +46,7 @@
 }
 
 .unmapped-field-icon {
-  color: #da1e28;
+  color: var(--cds-support-error);
   width: 16px;
   height: 16px;
   flex-shrink: 0;

--- a/frontend/src/components/analyzers/FieldMapping/InlineFieldCreationModal.test.jsx
+++ b/frontend/src/components/analyzers/FieldMapping/InlineFieldCreationModal.test.jsx
@@ -81,15 +81,15 @@ describe("InlineFieldCreationModal", () => {
    */
 
   /**
-   * Test: Validate field name with duplicate shows error
+   * Test: Render modal with duplicate-error mock - smoke test
    * Task Reference: T149
    *
-   * When a duplicate field name is submitted, an error should be displayed.
-   * Note: This test verifies error handling structure. Full form submission
-   * testing may require Carbon-specific test utilities.
+   * Verifies modal renders with form fields when createField mock is configured.
+   * Full duplicate-error flow (submit + assert error display) requires Carbon
+   * dropdown interaction; covered by E2E tests in analyzerConfiguration.cy.js.
    */
-  test("testValidateFieldName_WithDuplicate_ShowsError", async () => {
-    // Arrange: Mock API response with duplicate error
+  test("testRender_WithDuplicateMock_ShowsFormFields", async () => {
+    // Arrange: Mock API response with duplicate error (for when submit is triggered)
     analyzerService.createField.mockImplementation((fieldData, callback) => {
       callback(
         {
@@ -110,7 +110,7 @@ describe("InlineFieldCreationModal", () => {
       />,
     );
 
-    // Assert: Form fields are present
+    // Assert: Form fields are present (render/smoke test)
     const fieldNameInput = await screen.findByTestId("field-name-input");
     const entityTypeDropdown = await screen.findByTestId(
       "entity-type-dropdown",
@@ -118,10 +118,6 @@ describe("InlineFieldCreationModal", () => {
 
     expect(fieldNameInput).not.toBeNull();
     expect(entityTypeDropdown).not.toBeNull();
-
-    // Note: The error handling logic (duplicate detection, error display) is
-    // implemented in the component. Full end-to-end error flow testing would
-    // require proper dropdown interaction which may need Carbon-specific setup.
   });
 
   /**

--- a/frontend/src/components/analyzers/FieldMapping/MappingActivationModal.css
+++ b/frontend/src/components/analyzers/FieldMapping/MappingActivationModal.css
@@ -19,7 +19,7 @@
 }
 
 .warning-icon {
-  color: var(--cds-support-warning);
+  color: var(--cds-support-warning, #f1c21b);
 }
 
 .warning-messages {
@@ -31,5 +31,5 @@
 .mapping-activation-confirmation {
   margin-top: 1.5rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--cds-border-subtle);
+  border-top: 1px solid var(--cds-border-subtle, #e0e0e0);
 }

--- a/frontend/src/components/analyzers/FieldMapping/MappingActivationModal.css
+++ b/frontend/src/components/analyzers/FieldMapping/MappingActivationModal.css
@@ -19,7 +19,7 @@
 }
 
 .warning-icon {
-  color: var(--cds-support-warning, #f1c21b);
+  color: var(--cds-support-warning);
 }
 
 .warning-messages {
@@ -31,5 +31,5 @@
 .mapping-activation-confirmation {
   margin-top: 1.5rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--cds-border-subtle, #e0e0e0);
+  border-top: 1px solid var(--cds-border-subtle);
 }

--- a/frontend/src/components/analyzers/FieldMapping/MappingPanel.css
+++ b/frontend/src/components/analyzers/FieldMapping/MappingPanel.css
@@ -4,7 +4,7 @@
  */
 
 .mapping-panel {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--cds-border-subtle);
   border-radius: 4px;
   padding: 1rem;
   height: 100%;
@@ -28,7 +28,7 @@
 .source-field-card,
 .target-field-card {
   padding: 1rem;
-  background-color: #f4f4f4;
+  background-color: var(--cds-layer-01);
   border-radius: 4px;
   margin-bottom: 1rem;
 }

--- a/specs/011-madagascar-analyzer-integration/plans/m7-pr2726-round2-remediation.md
+++ b/specs/011-madagascar-analyzer-integration/plans/m7-pr2726-round2-remediation.md
@@ -1,0 +1,46 @@
+# PR #2726 Round 2 — New Comments Remediation
+
+All 6 items decided as **Fix** in answer session.
+
+## Decision Summary
+
+| #   | Comment                                    | Decision |
+| --- | ------------------------------------------ | -------- |
+| 1   | AnalyzerForm timer cleanup on modal close  | **Fix**  |
+| 2   | Centralize auth() helper (8 specs)         | **Fix**  |
+| 3   | waitForBackendReady self-signed TLS        | **Fix**  |
+| 4   | Cypress credentials — fail in CI only      | **Fix**  |
+| 5   | frontend-qa.yml vars/secrets with defaults | **Fix**  |
+| 6   | MappingActivationModal.css var fallbacks   | **Fix**  |
+
+## Implementation Details
+
+### 1. AnalyzerForm timer cleanup
+
+- Clear `closeTimeoutRef` when `open` transitions to `false`, not just on
+  unmount
+- Add `open` to cleanup effect deps or clear in onClose handler
+
+### 2. Centralize auth() helper
+
+- Add `Cypress.getBasicAuth` in commands.js
+- Update 8 analyzer specs to use it
+
+### 3. waitForBackendReady TLS + drain
+
+- Add `rejectUnauthorized: false` for localhost HTTPS
+- Call `res.resume()` to drain response
+
+### 4. Cypress credentials — fail in CI only
+
+- When CI: require env vars, throw if missing
+- Local: keep fallbacks
+
+### 5. frontend-qa.yml
+
+- Use `vars.TEST_USER || 'admin'` and `secrets.TEST_PASS || 'adminADMIN!'`
+
+### 6. MappingActivationModal.css
+
+- Add fallbacks: `var(--cds-support-warning, #f1c21b)`,
+  `var(--cds-border-subtle, #e0e0e0)`


### PR DESCRIPTION
## Summary

- Updates `tools/astm-http-bridge` submodule to M7 Message Normalizer milestone (see [openelis-analyzer-bridge#11](https://github.com/DIGI-UW/openelis-analyzer-bridge/pull/11) for full diff)
- Central orchestration layer where all 5 transport listeners (ASTM TCP, MLLP, Serial, File, HTTP Input) route through MessageNormalizer for consistent forwarding, retry/backoff, analyzer identification, and audit logging
- Security hardening: PHI removed from logs, credential handling fixed, defensive validation added

## Test plan

- [x] `mvn clean test` passes in submodule (254+ tests, 0 failures)
- [x] See [openelis-analyzer-bridge#11](https://github.com/DIGI-UW/openelis-analyzer-bridge/pull/11) for detailed test plan


Made with [Cursor](https://cursor.com)