### PR TITLE
docs: M7.1 bridge authentication milestone plan

### DIFF
--- a/specs/011-madagascar-analyzer-integration/plans/m8-implementation-prompt.md
+++ b/specs/011-madagascar-analyzer-integration/plans/m8-implementation-prompt.md
@@ -1,0 +1,182 @@
+# M8: Integration, Testing & Deployment — LLM Implementation Prompt
+
+> Run from: `tools/astm-http-bridge/` (bridge submodule root)  
+> Branch: `feat/universal-bridge-integration` (create from `develop` **after M7
+> is merged**)  
+> Depends on: M7 merged (bridge PR:
+> [openelis-analyzer-bridge#11](https://github.com/DIGI-UW/openelis-analyzer-bridge/pull/11))
+
+---
+
+## Goal
+
+Make the Universal Analyzer Bridge production-ready by adding:
+
+- **Observability**: Prometheus metrics via Micrometer + new health indicators
+- **Docker-based E2E**: exercise all 5 transports end-to-end in a repeatable
+  compose environment
+- **Documentation**: README + configuration reference updates
+
+Tag **v3.0.0** when complete.
+
+---
+
+## Current Reality (What Exists vs What’s Missing)
+
+### Exists already
+
+- `spring-boot-starter-actuator` is present
+- Docker compose files exist (`docker-compose.yml`, `docker-compose.test.yml`,
+  dev variants)
+- One health indicator exists: `health/HTTPForwardServerHealthIndicator.java`
+- M7 unified routing is implemented and tested (see `UnifiedRoutingTest`)
+
+### Missing (M8 scope)
+
+- `micrometer-registry-prometheus` dependency (needed for
+  `/actuator/prometheus`)
+- Metrics instrumentation (recommended single instrumentation point:
+  `MessageNormalizer.process()`)
+- Health indicators for MLLP, Serial, and File Watcher
+- Docker E2E runners that validate:
+  - ASTM TCP → route → HTTP forward
+  - HL7 MLLP → route → HTTP forward
+  - File drop (CSV) → route → HTTP forward
+  - HTTP `/input` → route → HTTP forward
+
+---
+
+## M8 Tasks (T12–T25)
+
+### T12: Add Prometheus Registry
+
+**File**: `pom.xml`
+
+Add:
+
+```xml
+<dependency>
+  <groupId>io.micrometer</groupId>
+  <artifactId>micrometer-registry-prometheus</artifactId>
+</dependency>
+```
+
+Do **not** specify a version (Spring Boot BOM manages it).
+
+---
+
+### T13: Create `MetricsService` + wire into `MessageNormalizer`
+
+**New file**: `src/main/java/org/itech/ahb/metrics/MetricsService.java`
+
+Expose at minimum:
+
+- `bridge.messages.received` (Counter; tags: `protocol`, `transport`)
+- `bridge.messages.routed` (Counter; tags: `protocol`, `transport`, `result`)
+- `bridge.messages.routing.duration` (Timer; tags: `protocol`, `transport`)
+
+**Wire point**: `MessageNormalizer.process(MessageEnvelope)`
+
+Implementation guidance:
+
+- Inject `MetricsService` into `MessageNormalizer` as
+  `@Autowired(required = false)` (so tests/configs that don’t include Micrometer
+  still work).
+- Use `Timer.Sample` to measure end-to-end routing latency inside `process()`.
+
+---
+
+### T14–T16: Add Health Indicators
+
+Create new health indicators (all should degrade gracefully when the listener
+bean is absent):
+
+- **T14**: `health/MLLPHealthIndicator.java` (uses
+  `HapiMLLPListener.isRunning()`)
+- **T15**: `health/SerialHealthIndicator.java` (uses
+  `SerialPortListener.getOpenPorts()` + `getPortStatus()`)
+- **T16**: `health/FileWatcherHealthIndicator.java`
+  - Add `public boolean isRunning()` accessor to `file/FileWatcher.java`
+    (currently `running` is private)
+
+Use `@ConditionalOnEnabledHealthIndicator("<name>")` and
+`@Autowired(required = false)`.
+
+---
+
+### T17–T18: Docker Compose Updates
+
+- **T17** (`docker-compose.yml`): expose MLLP port, add file watcher volumes,
+  document serial device mount placeholder.
+- **T18** (`docker-compose.test.yml`): ensure a repeatable E2E environment
+  exists for all 5 transports.
+
+Pragmatic approach for M8 E2E:
+
+- Use a **capture server** as “OpenELIS” target (already exists) and verify:
+  - HTTP request path (`/analyzer/{hl7|csv|astm|raw}`)
+  - Headers `X-Source-Protocol`, `X-Source-Transport`, `X-Source-Id`, optional
+    `X-Analyzer-Id`
+  - Body contains original payload
+
+If the capture server does not currently provide a query API, enhance it
+minimally (store last N requests and expose via `GET /requests`).
+
+---
+
+### T19–T22: E2E Tests (Docker)
+
+Implement E2E tests that run in Docker (scripts or a small test container):
+
+- **T19**: MLLP HL7 → expect forward to `/analyzer/hl7` with headers
+- **T20**: File drop CSV → expect forward to `/analyzer/csv`
+- **T21**: HTTP `/input` POST → expect forward to `/analyzer/{protocol}`
+- **T22**: ASTM TCP → expect forward to `/analyzer/astm` and include source IP
+  header
+
+---
+
+### T23–T24: README + `configuration.yml`
+
+- Update README with:
+  - architecture diagram (include metrics + health endpoints)
+  - full configuration reference (`bridge.*`, plus legacy `org.itech.ahb.*`
+    where still required)
+  - Docker deployment instructions (ports/volumes)
+  - monitoring section (`/actuator/prometheus`, suggested dashboards)
+- Update `configuration.yml` to:
+  - expose `prometheus` actuator endpoint
+  - enable the new health indicators
+  - document MLLP config keys
+
+---
+
+### T25: Version Bump + Tag
+
+Update versions to `3.0.0` (main + `astm-http-lib`), then tag `v3.0.0` **after
+CI is green**.
+
+---
+
+## Verification Commands
+
+From `tools/astm-http-bridge/`:
+
+```bash
+mvn clean test
+mvn verify
+```
+
+Local actuator sanity check:
+
+```bash
+mvn spring-boot:run
+curl http://localhost:8443/actuator/health
+curl http://localhost:8443/actuator/prometheus | head
+```
+
+Docker E2E:
+
+```bash
+docker compose -f docker-compose.test.yml up --build
+```

--- a/specs/011-madagascar-analyzer-integration/plans/universal-analyzer-bridge-v2.md
+++ b/specs/011-madagascar-analyzer-integration/plans/universal-analyzer-bridge-v2.md
@@ -1,44 +1,39 @@
 # Universal Analyzer Bridge — Updated Implementation Plan v2.0
 
 **Updated**: 2026-02-06 | **Original**: universal-analyzer-bridge.md v1.0
-**Status**: M1-M6 complete (8 PRs merged), M7 in review (PR #11), M7.1-M9 +
-remediation remaining
+**Status**:
+
+- **M1-M6**: ✅ complete (8 PRs merged)
+- **M7**: ⚠️ PR open, **Copilot remediation complete** (tests passing) —
+  awaiting final review/merge:
+  [openelis-analyzer-bridge#11](https://github.com/DIGI-UW/openelis-analyzer-bridge/pull/11)
+- **M7.1 (plan)**: ✅ documented in parent repo PR:
+  [OpenELIS-Global-2#2730](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/2730)
+  (implementation still pending)
+- **M8**: ❌ not started (prompt ready; metrics/health/E2E still missing)
+- **M9 + R-OPENELIS**: ❌ pending
 
 ---
 
-## Immediate Next Steps (Execution Setup)
+## Immediate Next Steps (Current)
 
-### Step 1: Create Worktree from `demo/madagascar`
+### Step 1: Merge M7 after final review
 
-```bash
-# From parent repo root
-cd /Users/pmanko/code/OpenELIS-Global-2
-git worktree add ../OpenELIS-bridge-m7 demo/madagascar
-```
+- **Bridge repo**: M7 is ready for merge once PR #11 review is satisfied.
+- **Validation**: `mvn test` and `mvn verify` both pass on the PR branch.
 
-### Step 2: Create M7 Branch in Bridge Submodule
+### Step 2: Merge the plan update PR (this doc + M7.1 plan)
 
-```bash
-cd ../OpenELIS-bridge-m7/tools/astm-http-bridge
-git fetch origin
-git checkout -b feat/universal-bridge-normalizer origin/develop
-```
+- **Parent repo**: merge
+  [OpenELIS-Global-2#2730](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/2730)
+  so the M7.1 security milestone is captured on `demo/madagascar`.
 
-### Step 3: Generate M7 LLM Implementation Prompt
+### Step 3: Start M8 implementation (after M7 merge)
 
-Write a comprehensive, self-contained prompt to
-`OpenELIS-bridge-m7/tools/astm-http-bridge/M7-PROMPT.md` that includes:
-
-- Full context (architecture, current state, what exists, what's missing)
-- All 11 M7 tasks (T01-T11) with file paths and implementation details
-- The ASTM adapter architecture (T08 detail)
-- R-BRIDGE items folded in (RB-05, RB-06)
-- Existing file contents and patterns to follow
-- Test expectations
-- Verification commands
-
-The prompt should be runnable by any LLM agent (Claude, Cursor, etc.) working in
-the `tools/astm-http-bridge/` directory with no additional context needed.
+- **Bridge repo branch**: create `feat/universal-bridge-integration` from
+  `develop` _after_ M7 merges.
+- **Implementation prompt**: use `m8-implementation-prompt.md` in this same
+  folder.
 
 ---
 
@@ -78,22 +73,24 @@ with remediation tracks that can run in parallel.
 
 ## Section 1: Milestone Status
 
-| ID       | Milestone                | Repo         | Status           | PR      | Notes                                                       |
-| -------- | ------------------------ | ------------ | ---------------- | ------- | ----------------------------------------------------------- |
-| M1       | Foundation               | Bridge       | ✅ MERGED        | #5      | Protocol/Transport enums, MessageEnvelope, ProtocolDetector |
-| M2a      | MLLP Listener            | Bridge       | ✅ MERGED        | #7      | HapiMLLPListener, HapiReceivingApplication                  |
-| M2b      | HL7 Endpoint             | OpenELIS     | ✅ MERGED        | #2718   | `/analyzer/hl7`, HL7AnalyzerReader 3-tier ID                |
-| M3       | Serial Listener          | Bridge       | ✅ MERGED        | #9      | SerialPortListener, SerialFrameBuffer                       |
-| M4a      | File Watcher             | Bridge       | ✅ MERGED        | #8      | FileWatcher, CSVParser, FileMessageHandler                  |
-| M4b      | CSV Endpoint             | OpenELIS     | ✅ MERGED        | #2714   | CSVAnalyzerReader, AnalyzerReaderFactory                    |
-| M5       | HTTP Input               | Bridge       | ✅ MERGED        | #6      | AnalyzerInputController `/input`                            |
-| M6       | ASTM Enhancements        | Bridge       | ✅ MERGED        | #4      | X-Source-Analyzer-IP propagation                            |
-| **M7**   | **Message Normalizer**   | **Bridge**   | **⚠️ IN REVIEW** | **#11** | PR open; addressing Copilot comments                        |
-| **M7.1** | **Bridge Auth/Security** | **Bridge**   | **❌ PLANNED**   | —       | Security gap from M7 review; depends on M7 merge            |
-| **M8**   | **Integration & Deploy** | **Bridge**   | **⚠️ ~70%**      | —       | Docker/README done; E2E tests + metrics missing             |
-| **M9**   | **Spec Documentation**   | **OpenELIS** | **❌ 0%**        | —       | No branch created                                           |
+| ID       | Milestone                | Repo         | Status           | PR      | Notes                                                                                                                                   |
+| -------- | ------------------------ | ------------ | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| M1       | Foundation               | Bridge       | ✅ MERGED        | #5      | Protocol/Transport enums, MessageEnvelope, ProtocolDetector                                                                             |
+| M2a      | MLLP Listener            | Bridge       | ✅ MERGED        | #7      | HapiMLLPListener, HapiReceivingApplication                                                                                              |
+| M2b      | HL7 Endpoint             | OpenELIS     | ✅ MERGED        | #2718   | `/analyzer/hl7`, HL7AnalyzerReader 3-tier ID                                                                                            |
+| M3       | Serial Listener          | Bridge       | ✅ MERGED        | #9      | SerialPortListener, SerialFrameBuffer                                                                                                   |
+| M4a      | File Watcher             | Bridge       | ✅ MERGED        | #8      | FileWatcher, CSVParser, FileMessageHandler                                                                                              |
+| M4b      | CSV Endpoint             | OpenELIS     | ✅ MERGED        | #2714   | CSVAnalyzerReader, AnalyzerReaderFactory                                                                                                |
+| M5       | HTTP Input               | Bridge       | ✅ MERGED        | #6      | AnalyzerInputController `/input`                                                                                                        |
+| M6       | ASTM Enhancements        | Bridge       | ✅ MERGED        | #4      | X-Source-Analyzer-IP propagation                                                                                                        |
+| **M7**   | **Message Normalizer**   | **Bridge**   | **⚠️ IN REVIEW** | **#11** | Copilot remediation complete; `mvn test` + `mvn verify` passing; awaiting merge                                                         |
+| **M7.1** | **Bridge Auth/Security** | **Bridge**   | **❌ PLANNED**   | —       | Plan documented in [OpenELIS-Global-2#2730](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/2730); implementation depends on M7 merge |
+| **M8**   | **Integration & Deploy** | **Bridge**   | **❌ 0%**        | —       | Docker compose scaffolding exists; metrics/health/E2E tests not implemented yet                                                         |
+| **M9**   | **Spec Documentation**   | **OpenELIS** | **❌ 0%**        | —       | No branch created                                                                                                                       |
 
-### Current Routing Fragmentation (the core M7 problem)
+### Routing State
+
+**Before M7** (resolved by PR #11):
 
 ```
 MLLP:    HapiReceivingApplication → MessageRouter → HttpForwardingRouter  ✅ CORRECT
@@ -101,6 +98,12 @@ Serial:  SerialMessageHandler → own forwardMessage() with HttpClient      ❌ 
 File:    FileMessageHandler → own forwardToOpenELIS() with RestTemplate   ❌ BYPASS
 ASTM:    ASTMReceiveThread → ASTMHandlerService → legacy handler chain    ❌ LEGACY
 HTTP:    AnalyzerInputController → creates envelope → DOES NOTHING        ❌ BROKEN
+```
+
+**After M7** (PR #11, verified by `UnifiedRoutingTest`):
+
+```
+MLLP/Serial/File/ASTM/HTTP → MessageNormalizer → HttpForwardingRouter → OpenELIS
 ```
 
 ---
@@ -459,18 +462,18 @@ plugins via `isTargetAnalyzer()`.
 
 ### Success Criteria (Carried from Original Plan)
 
-| #   | Criterion                                                         | Verified By                        | Status   |
-| --- | ----------------------------------------------------------------- | ---------------------------------- | -------- |
-| 1   | Single bridge handles: ASTM/TCP, HL7/MLLP, Serial, File, HTTP     | M8 E2E tests (T19-T22)             | PENDING  |
-| 2   | ALL 5 listeners route through MessageNormalizer (no bypasses)     | M7 integration test (T11)          | PENDING  |
-| 3   | All Madagascar analyzers work through bridge                      | M8 E2E + plugin tests              | PENDING  |
-| 4   | <100ms p95 latency for message forwarding (bridge overhead)       | M8 metrics + load test             | PENDING  |
-| 5   | Auto-reconnection on serial disconnect                            | M3 (done) — verified in deployment | COMPLETE |
-| 6   | Prometheus metrics for all listeners                              | M8 MetricsService (T13)            | PENDING  |
-| 7   | Zero protocol code in OpenELIS (HTTP-only at boundary)            | Architecture review                | COMPLETE |
-| 8   | Spec documentation updated with protocol/transport clarifications | M9 (T27-T31)                       | PENDING  |
-| 9   | No raw exception messages returned to clients                     | R-OPENELIS (RO-01-03)              | PENDING  |
-| 10  | Retry/backoff on all forwarding paths                             | M7 (T04)                           | PENDING  |
+| #   | Criterion                                                         | Verified By                        | Status                      |
+| --- | ----------------------------------------------------------------- | ---------------------------------- | --------------------------- |
+| 1   | Single bridge handles: ASTM/TCP, HL7/MLLP, Serial, File, HTTP     | M8 E2E tests (T19-T22)             | PENDING                     |
+| 2   | ALL 5 listeners route through MessageNormalizer (no bypasses)     | M7 integration test (T11)          | DONE (PR #11; `mvn verify`) |
+| 3   | All Madagascar analyzers work through bridge                      | M8 E2E + plugin tests              | PENDING                     |
+| 4   | <100ms p95 latency for message forwarding (bridge overhead)       | M8 metrics + load test             | PENDING                     |
+| 5   | Auto-reconnection on serial disconnect                            | M3 (done) — verified in deployment | COMPLETE                    |
+| 6   | Prometheus metrics for all listeners                              | M8 MetricsService (T13)            | PENDING                     |
+| 7   | Zero protocol code in OpenELIS (HTTP-only at boundary)            | Architecture review                | COMPLETE                    |
+| 8   | Spec documentation updated with protocol/transport clarifications | M9 (T27-T31)                       | PENDING                     |
+| 9   | No raw exception messages returned to clients                     | R-OPENELIS (RO-01-03)              | PENDING                     |
+| 10  | Retry/backoff on all forwarding paths                             | M7 (T04)                           | DONE (PR #11; `mvn verify`) |
 
 ### Verification Steps
 
@@ -557,7 +560,8 @@ mvn test -pl . -Dtest="HL7AnalyzerReaderTest,CSVAnalyzerReaderTest,AnalyzerImpor
 | M8            | T12-T25           | 4    | After M7, parallel with M7.1  | Bridge   |
 | M9            | T26-T32           | 2    | After M8                      | OpenELIS |
 
-**Remaining: 48 tasks, ~10 days with parallelization**
+**Remaining (post-M7 remediation):** implement M7.1 auth, complete M8, complete
+R-OPENELIS, then M9 docs + submodule update.
 
 ---
 
@@ -565,8 +569,7 @@ mvn test -pl . -Dtest="HL7AnalyzerReaderTest,CSVAnalyzerReaderTest,AnalyzerImpor
 
 The following sections from the original plan (v1.0) remain valid and are NOT
 duplicated here. Refer to
-[universal-analyzer-bridge.md](specs/011-madagascar-analyzer-integration/plans/universal-analyzer-bridge.md)
-for:
+[universal-analyzer-bridge.md](universal-analyzer-bridge.md) for:
 
 | Section                                                    | Original Lines | Notes                                        |
 | ---------------------------------------------------------- | -------------- | -------------------------------------------- |

--- a/specs/011-madagascar-analyzer-integration/plans/universal-analyzer-bridge-v2.md
+++ b/specs/011-madagascar-analyzer-integration/plans/universal-analyzer-bridge-v2.md
@@ -1,0 +1,583 @@
+# Universal Analyzer Bridge — Updated Implementation Plan v2.0
+
+**Updated**: 2026-02-06 | **Original**: universal-analyzer-bridge.md v1.0
+**Status**: M1-M6 complete (8 PRs merged), M7 in review (PR #11), M7.1-M9 +
+remediation remaining
+
+---
+
+## Immediate Next Steps (Execution Setup)
+
+### Step 1: Create Worktree from `demo/madagascar`
+
+```bash
+# From parent repo root
+cd /Users/pmanko/code/OpenELIS-Global-2
+git worktree add ../OpenELIS-bridge-m7 demo/madagascar
+```
+
+### Step 2: Create M7 Branch in Bridge Submodule
+
+```bash
+cd ../OpenELIS-bridge-m7/tools/astm-http-bridge
+git fetch origin
+git checkout -b feat/universal-bridge-normalizer origin/develop
+```
+
+### Step 3: Generate M7 LLM Implementation Prompt
+
+Write a comprehensive, self-contained prompt to
+`OpenELIS-bridge-m7/tools/astm-http-bridge/M7-PROMPT.md` that includes:
+
+- Full context (architecture, current state, what exists, what's missing)
+- All 11 M7 tasks (T01-T11) with file paths and implementation details
+- The ASTM adapter architecture (T08 detail)
+- R-BRIDGE items folded in (RB-05, RB-06)
+- Existing file contents and patterns to follow
+- Test expectations
+- Verification commands
+
+The prompt should be runnable by any LLM agent (Claude, Cursor, etc.) working in
+the `tools/astm-http-bridge/` directory with no additional context needed.
+
+---
+
+## Decisions Confirmed
+
+| Decision          | Choice                       | Rationale                                                                              |
+| ----------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
+| ASTM scope in M7  | **Unify all 5 listeners**    | ASTMBridgeAdapter is ~50 lines, no library changes, zero risk to bidirectional queries |
+| Version tag       | **v3.0.0**                   | Major bump signals breaking handler architecture change                                |
+| R-OPENELIS timing | **Parallel with M7**         | Separate OpenELIS branch, saves calendar time                                          |
+| Plan location     | **Default Claude plan file** | Archive decision deferred to after completion                                          |
+
+---
+
+## Context
+
+The original Universal Analyzer Bridge plan defined 9 milestones across two
+repos to extend the ASTM-HTTP bridge into a multi-protocol bridge handling ASTM,
+HL7, Serial, File, and HTTP input. After completing M1-M6 (all transport
+listeners + OpenELIS endpoints), deep exploration revealed:
+
+1. **Routing fragmentation** — Serial, File, and ASTM handlers bypass the
+   central `HttpForwardingRouter`, each with their own HTTP forwarding logic
+2. **Dead code paths** — HTTP `/input` endpoint creates a `MessageEnvelope` but
+   silently drops it (TODO comment)
+3. **Unwired config** — Retry/backoff properties exist in YAML but aren't
+   connected to any code
+4. **Security gaps** — OpenELIS endpoints return raw exception messages and
+   accept bridge headers without validation
+5. **Test gaps** — HL7 reader has only 4 tests; no controller integration tests
+   exist
+
+This updated plan restructures the remaining work into actionable milestones
+with remediation tracks that can run in parallel.
+
+---
+
+## Section 1: Milestone Status
+
+| ID       | Milestone                | Repo         | Status           | PR      | Notes                                                       |
+| -------- | ------------------------ | ------------ | ---------------- | ------- | ----------------------------------------------------------- |
+| M1       | Foundation               | Bridge       | ✅ MERGED        | #5      | Protocol/Transport enums, MessageEnvelope, ProtocolDetector |
+| M2a      | MLLP Listener            | Bridge       | ✅ MERGED        | #7      | HapiMLLPListener, HapiReceivingApplication                  |
+| M2b      | HL7 Endpoint             | OpenELIS     | ✅ MERGED        | #2718   | `/analyzer/hl7`, HL7AnalyzerReader 3-tier ID                |
+| M3       | Serial Listener          | Bridge       | ✅ MERGED        | #9      | SerialPortListener, SerialFrameBuffer                       |
+| M4a      | File Watcher             | Bridge       | ✅ MERGED        | #8      | FileWatcher, CSVParser, FileMessageHandler                  |
+| M4b      | CSV Endpoint             | OpenELIS     | ✅ MERGED        | #2714   | CSVAnalyzerReader, AnalyzerReaderFactory                    |
+| M5       | HTTP Input               | Bridge       | ✅ MERGED        | #6      | AnalyzerInputController `/input`                            |
+| M6       | ASTM Enhancements        | Bridge       | ✅ MERGED        | #4      | X-Source-Analyzer-IP propagation                            |
+| **M7**   | **Message Normalizer**   | **Bridge**   | **⚠️ IN REVIEW** | **#11** | PR open; addressing Copilot comments                        |
+| **M7.1** | **Bridge Auth/Security** | **Bridge**   | **❌ PLANNED**   | —       | Security gap from M7 review; depends on M7 merge            |
+| **M8**   | **Integration & Deploy** | **Bridge**   | **⚠️ ~70%**      | —       | Docker/README done; E2E tests + metrics missing             |
+| **M9**   | **Spec Documentation**   | **OpenELIS** | **❌ 0%**        | —       | No branch created                                           |
+
+### Current Routing Fragmentation (the core M7 problem)
+
+```
+MLLP:    HapiReceivingApplication → MessageRouter → HttpForwardingRouter  ✅ CORRECT
+Serial:  SerialMessageHandler → own forwardMessage() with HttpClient      ❌ BYPASS
+File:    FileMessageHandler → own forwardToOpenELIS() with RestTemplate   ❌ BYPASS
+ASTM:    ASTMReceiveThread → ASTMHandlerService → legacy handler chain    ❌ LEGACY
+HTTP:    AnalyzerInputController → creates envelope → DOES NOTHING        ❌ BROKEN
+```
+
+---
+
+## Section 2: Repository Workflow
+
+### Repos & Remaining Work
+
+| Repository                    | Purpose                            | Remaining        |
+| ----------------------------- | ---------------------------------- | ---------------- |
+| `DIGI-UW/astm-http-bridge`    | Protocol bridge (Java Spring Boot) | M7, M8, R-BRIDGE |
+| `I-TECH-UW/OpenELIS-Global-2` | Main OpenELIS application          | M9, R-OPENELIS   |
+
+### Branch Naming
+
+| Work Item  | Bridge Branch                       | OpenELIS Branch                        | Notes                  |
+| ---------- | ----------------------------------- | -------------------------------------- | ---------------------- |
+| M7         | `feat/universal-bridge-normalizer`  | N/A                                    | Unify all routing      |
+| M8         | `feat/universal-bridge-integration` | N/A                                    | Tests, metrics, health |
+| M9         | N/A                                 | `docs/universal-bridge-spec-alignment` | Spec updates           |
+| R-BRIDGE   | (fold into M7 PR)                   | N/A                                    | Bridge fixes           |
+| R-OPENELIS | N/A                                 | `fix/011-analyzer-endpoint-hardening`  | OpenELIS hardening     |
+
+### PR Dependency Chain (Remaining Only)
+
+```
+BRIDGE REPO (DIGI-UW/astm-http-bridge):
+
+          Current: develop @ 5a9b12b (M1-M6 merged)
+                              |
+                              v
+                ┌─────────────────────────┐
+                | PR: M7+R-BRIDGE         |
+                | feat/..-normalizer      |
+                | [Unified routing +      |
+                |  config consolidation]  |
+                └────────────┬────────────┘
+                             |  MERGE
+                             v
+                ┌─────────────────────────┐
+                | PR: M8 → develop        |
+                | feat/..-integration     |
+                | [E2E tests, metrics,    |
+                |  health, Docker, docs]  |
+                └────────────┬────────────┘
+                             |  MERGE & TAG v3.0.0
+                             v
+
+OPENELIS REPO (I-TECH-UW/OpenELIS-Global-2):
+
+  ┌──────────────────────┐       ┌──────────────────────────┐
+  | PR: R-OPENELIS       |       | PR: M9                   |
+  | fix/011-analyzer-    |       | docs/universal-bridge-   |
+  | endpoint-hardening   |       | spec-alignment           |
+  | [ANY TIME - parallel]|       | [AFTER M8 tag v3.0.0]    |
+  └──────────────────────┘       └──────────────────────────┘
+```
+
+---
+
+## Section 3: Remaining Milestones
+
+### M7: Message Normalizer — Unify All Routing (4 days)
+
+**Repo**: `DIGI-UW/astm-http-bridge` | **Branch**:
+`feat/universal-bridge-normalizer` **Depends on**: M1-M6 (done)
+
+**Target**: All 5 listeners route through
+`MessageNormalizer → HttpForwardingRouter`.
+
+```
+All listeners → MessageEnvelope → MessageNormalizer → HttpForwardingRouter → OpenELIS
+                                       |
+                                       ├── AnalyzerIdentifier (multi-strategy)
+                                       ├── Retry/backoff (from config)
+                                       └── Audit logging
+```
+
+| Task | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | File(s)                                                                           |
+| ---- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| T01  | CREATE | `MessageNormalizer` service: accepts `MessageEnvelope`, runs `AnalyzerIdentifier`, delegates to `MessageRouter`, logs audit trail                                                                                                                                                                                                                                                                                                                                                                                                                                | `normalizer/MessageNormalizer.java`                                               |
+| T02  | CREATE | `AnalyzerIdentifier` with strategy chain: (1) envelope.analyzerId, (2) IP config lookup, (3) header-based (MSH-3/4, ASTM H-record), (4) serial-port config, (5) file-path pattern                                                                                                                                                                                                                                                                                                                                                                                | `normalizer/AnalyzerIdentifier.java`                                              |
+| T03  | CREATE | `AnalyzerRegistryConfig` — `@ConfigurationProperties("bridge.analyzers")` for IP/serial/file-path → analyzer-ID mappings                                                                                                                                                                                                                                                                                                                                                                                                                                         | `config/AnalyzerRegistryConfig.java`                                              |
+| T04  | WIRE   | Add retry/backoff to `HttpForwardingRouter` using existing `bridge.openelis.retry.*` config. Remove `@ConditionalOnProperty("bridge.file")` from `OpenELISConfig` so retry config is always available                                                                                                                                                                                                                                                                                                                                                            | `routing/HttpForwardingRouter.java`, `config/OpenELISConfig.java`                 |
+| T05  | WIRE   | Refactor `SerialMessageHandler`: remove own `forwardMessage()` + `HttpClient`; inject and delegate to `MessageNormalizer`                                                                                                                                                                                                                                                                                                                                                                                                                                        | `serial/SerialMessageHandler.java`                                                |
+| T06  | WIRE   | Refactor `FileMessageHandler`: remove own `forwardToOpenELIS()` + `RestTemplate`; inject and delegate to `MessageNormalizer`                                                                                                                                                                                                                                                                                                                                                                                                                                     | `file/FileMessageHandler.java`                                                    |
+| T07  | WIRE   | Wire `AnalyzerInputController`: after creating envelope, call `messageNormalizer.process(envelope)`. Remove TODO                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `controller/AnalyzerInputController.java`                                         |
+| T08  | CREATE | `ASTMBridgeAdapter`: implements `ASTMHandler` interface (from `astm-http-lib`). Replaces `DefaultForwardingASTMToHTTPHandler` in the `@Bean` factory at `AstmHttpBridgeApplication.astmHandlerService()`. Converts `ASTMMessage` + `sourceIp` → `MessageEnvelope` with `Protocol.ASTM`, `Transport.TCP`, then delegates to `MessageNormalizer`. ~50 lines. **No library code changes** — only the bean registration in main app changes. Bidirectional queries (HTTP→ASTM via `DefaultForwardingHTTPToASTMHandler`) are a separate handler and remain untouched. | `normalizer/ASTMBridgeAdapter.java`, `AstmHttpBridgeApplication.java` (bean swap) |
+| T09  | CONFIG | Add `bridge.analyzers` section to `configuration.yml` with example IP/serial/file-path mappings                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `configuration.yml`                                                               |
+| T10  | TEST   | Unit tests for `MessageNormalizer`, `AnalyzerIdentifier`, `ASTMBridgeAdapter`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | `test/normalizer/`                                                                |
+| T11  | TEST   | Integration test: verify all 5 listener types route through `MessageNormalizer` to `HttpForwardingRouter`                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `test/integration/UnifiedRoutingTest.java`                                        |
+
+#### T08 Detail: ASTM Adapter Architecture
+
+The ASTM path uses a handler chain from the `astm-http-lib` library module:
+
+```
+TCP Socket → ASTMServlet → ASTMReceiveThread       ← UNTOUCHED (library code)
+                              ├── extractSourceIp()
+                              └── communicator.receiveProtocol()
+                                       ↓
+                              ASTMHandlerService.handle(msg, ip) ← UNTOUCHED (library code)
+                                       ↓
+                              ASTMBridgeAdapter (NEW — main app, replaces DefaultForwarding...)
+                                 ├── Build MessageEnvelope(Protocol.ASTM, Transport.TCP, sourceIp, rawMsg)
+                                 └── messageNormalizer.process(envelope)
+                                       ↓
+                              HttpForwardingRouter → POST /analyzer/astm + all X-* headers + retry
+```
+
+**Why this is safe**: The adapter implements `ASTMHandler` (a library interface)
+and is registered via the existing `@Bean` factory. No library code is modified.
+The bidirectional query path (`DefaultForwardingHTTPToASTMHandler`) is a
+completely separate handler going the opposite direction (HTTP→ASTM) and remains
+untouched. Line contention handling happens in `Communicator` _before_ handler
+dispatch and is unaffected.
+
+**Also resolves these R-BRIDGE items** (folded into M7):
+
+- RB-01: Serial password String exposure (code deleted by T05)
+- RB-02: HTTP `/input` silent message drop (fixed by T07)
+- RB-03: Three different HTTP clients (consolidated by T04-T06)
+- RB-04: Retry config `@ConditionalOnProperty` scoping (fixed by T04)
+
+**Standalone R-BRIDGE items** (add to this PR):
+
+- RB-05: Standardize config prefixes — document in README that `org.itech.ahb.*`
+  is legacy, `bridge.*` is preferred (deferred full migration)
+- RB-06: Consolidate dual OpenELIS base URIs in `configuration.yml`
+
+---
+
+### M7.1: Bridge Authentication & Security (2 days)
+
+**Repo**: `DIGI-UW/astm-http-bridge` | **Branch**: `feat/bridge-authentication`
+**Depends on**: M7 merged (PR #11)
+
+**Context**: Copilot review of PR #11 identified a critical security gap — the
+`/input` HTTP endpoint in `AnalyzerInputController` has no authentication
+requirements. Any client with network access to the bridge can POST arbitrary
+ASTM/HL7/CSV payloads, which are forwarded to OpenELIS under the bridge's
+credentials.
+
+**Security Risk**:
+
+- **Attack scenario**: Attacker on hospital network POSTs fake lab results
+  (e.g., positive HIV test)
+- **Impact**: Unauthorized data injection, tampering with patient records
+- **Scope**: HTTP endpoints that accept analyzer data (`/input`)
+
+**Requirement**: Implement authentication pattern consistent with OpenELIS REST
+API security model.
+
+| Task | Type      | Description                                                                                                                                  | File(s)                                               |
+| ---- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| T7a  | RESEARCH  | Document OpenELIS REST API authentication patterns (Spring Security config, bearer tokens, basic auth, role-based authorization)             | Research findings → this section                      |
+| T7b  | DESIGN    | Select authentication approach: (A) IP whitelist, (B) Bearer token/API key, (C) Mutual TLS, (D) Spring Security integration with OE patterns | `docs/security.md`                                    |
+| T7c  | CONFIG    | Add authentication configuration properties to `bridge.security.*` namespace                                                                 | `config/SecurityConfig.java`, `configuration.yml`     |
+| T7d  | IMPLEMENT | Add Spring Security filter chain for `/input` and analyzer data endpoints                                                                    | `config/SecurityConfig.java`                          |
+| T7e  | IMPLEMENT | Add authentication to `AnalyzerInputController`                                                                                              | `controller/AnalyzerInputController.java`             |
+| T7f  | TEST      | Unit tests for security filter chain, unauthorized request rejection                                                                         | `test/security/SecurityConfigTest.java`               |
+| T7g  | TEST      | Integration test: verify authenticated requests succeed, unauthenticated requests return 401/403                                             | `test/integration/AuthenticationIntegrationTest.java` |
+| T7h  | DOC       | Update README with authentication setup instructions, credential configuration                                                               | `README.md`                                           |
+
+**OpenELIS Auth Pattern Research** (T7a findings):
+
+**Current OE REST API Authentication:**
+
+- **Pattern**: Spring Security with form-based session authentication
+- **Security Config**: `SecurityConfig.java` uses `@EnableWebSecurity` with
+  multiple filter chains
+- **REST Endpoints**: `/rest/**` paths are protected by
+  `ModuleAuthenticationInterceptor` (requires authenticated session)
+- **HTTP Basic Auth**: Available via `BasicAuthFilter` but conditional
+  (`org.itech.login.basic=true`)
+- **RBAC**: Module-based permissions via
+  `ModuleAuthenticationInterceptor.preHandle()` - checks user roles/modules
+
+**Bridge `/input` Endpoint Requirements:**
+
+- **Challenge**: Machine-to-machine communication (not browser sessions)
+- **Current State**: No authentication (security gap identified by Copilot)
+- **Recommended Approach**: HTTP Basic Authentication (aligns with OE's existing
+  `BasicAuthFilter` pattern)
+  - Simple credential management (username/password in bridge config)
+  - Compatible with OE's existing HTTP Basic auth infrastructure
+  - No session management needed (stateless)
+  - Standard protocol (widely supported by analyzers/HTTP clients)
+
+**Alternative Considered**: API key/bearer token - more complex, requires custom
+filter (OE doesn't have this pattern)
+
+**References**:
+
+- PR #11 Copilot Comment #2775830476
+- M7 Implementation: PR #11 `feat/universal-bridge-normalizer`
+
+---
+
+### M8: Integration, Testing & Deployment (4 days)
+
+**Repo**: `DIGI-UW/astm-http-bridge` | **Branch**:
+`feat/universal-bridge-integration` **Depends on**: M7 merged
+
+| Task | Type   | Description                                                                                                                       | File(s)                                       |
+| ---- | ------ | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| T12  | CREATE | Add `micrometer-registry-prometheus` dependency                                                                                   | `pom.xml`                                     |
+| T13  | CREATE | `MetricsService`: counters per protocol/transport, forwarding latency timer, active listener gauge. Wire into `MessageNormalizer` | `config/MetricsService.java`                  |
+| T14  | CREATE | `MLLPHealthIndicator`: checks `HapiMLLPListener.isRunning()`                                                                      | `health/MLLPHealthIndicator.java`             |
+| T15  | CREATE | `SerialHealthIndicator`: reports port connection statuses                                                                         | `health/SerialHealthIndicator.java`           |
+| T16  | CREATE | `FileWatcherHealthIndicator`: reports watched directory status                                                                    | `health/FileWatcherHealthIndicator.java`      |
+| T17  | UPDATE | Docker Compose: expose MLLP port 2575, add file watcher volume, serial device mount placeholder                                   | `docker-compose.yml`                          |
+| T18  | UPDATE | Docker Compose test: add HL7 mock sender, CSV file drop container, verify X-\* header logging                                     | `docker-compose.test.yml`                     |
+| T19  | TEST   | E2E: MLLP HL7 → bridge → HTTP capture verifies `/analyzer/hl7` + headers                                                          | `test/integration/MLLPEndToEndTest.java`      |
+| T20  | TEST   | E2E: File drop CSV → bridge → HTTP capture verifies `/analyzer/csv` + headers                                                     | `test/integration/FileEndToEndTest.java`      |
+| T21  | TEST   | E2E: HTTP `/input` POST → bridge → HTTP capture verifies routing                                                                  | `test/integration/HTTPInputEndToEndTest.java` |
+| T22  | TEST   | E2E: ASTM TCP → bridge → HTTP capture verifies normalizer path                                                                    | `test/integration/ASTMEndToEndTest.java`      |
+| T23  | UPDATE | README: add Universal Bridge config reference (`bridge.*`), all transport sections, architecture diagram update                   | `README.md`                                   |
+| T24  | UPDATE | `configuration.yml`: add MLLP section, analyzer registry examples, Prometheus actuator exposure                                   | `configuration.yml`                           |
+| T25  | TAG    | Tag release `v3.0.0` after all tests pass                                                                                         | `git tag`                                     |
+
+---
+
+### M9: Spec Documentation (2 days)
+
+**Repo**: `I-TECH-UW/OpenELIS-Global-2` | **Branch**:
+`docs/universal-bridge-spec-alignment` **Depends on**: M8 tagged v3.0.0
+
+| Task | Type   | Description                                                                                                                                                                                                 | Target File                                        |
+| ---- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| T26  | UPDATE | Update submodule reference to bridge v3.0.0                                                                                                                                                                 | `tools/astm-http-bridge`                           |
+| T27  | UPDATE | Add "Protocol vs Transport Architecture" section with transport matrix table                                                                                                                                | `specs/011-.../research.md`                        |
+| T28  | UPDATE | Document MLLP architecture decision and bridge requirement for HL7                                                                                                                                          | `specs/011-.../research.md`                        |
+| T29  | UPDATE | Add "Universal Bridge Integration" cross-reference section                                                                                                                                                  | `specs/004-.../research.md`                        |
+| T30  | UPDATE | Cross-reference Universal Bridge from spec 004 plan                                                                                                                                                         | `specs/004-.../plan.md`                            |
+| T31  | UPDATE | Update this plan document with final completion status                                                                                                                                                      | `specs/011-.../plans/universal-analyzer-bridge.md` |
+| T32  | UPDATE | Document plugin architecture and business logic boundaries: 4-layer separation (bridge → reader → plugin → mapping wrapper), HL7 identification inconsistency, and guidelines for future plugin development | `specs/011-.../research.md`                        |
+
+---
+
+## Section 4: R-OPENELIS Remediation (3 days, parallel)
+
+**Repo**: `I-TECH-UW/OpenELIS-Global-2` | **Branch**:
+`fix/011-analyzer-endpoint-hardening` **Depends on**: Nothing — can start
+immediately, parallel with M7/M8
+
+### Priority 1: Security
+
+| Task  | Description                                                                                  | File                                    | Severity |
+| ----- | -------------------------------------------------------------------------------------------- | --------------------------------------- | -------- |
+| RO-01 | Sanitize error responses on `/analyzer/hl7` — don't expose raw exception messages            | `AnalyzerImportController.java:210-224` | HIGH     |
+| RO-02 | Sanitize error responses on `/analyzer/csv` (lines 139, 150)                                 | `AnalyzerImportController.java`         | HIGH     |
+| RO-03 | Sanitize error responses on `/analyzer/astm` (line 113)                                      | `AnalyzerImportController.java`         | HIGH     |
+| RO-04 | Validate bridge headers (X-Source-Analyzer-IP, X-Analyzer-Id) come from trusted bridge IP(s) | `AnalyzerImportController.java`         | MEDIUM   |
+
+### Priority 2: Correctness
+
+| Task  | Description                                                                                                                 | File                                   | Severity |
+| ----- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------- |
+| RO-05 | Add request size limits on analyzer endpoints (Spring `server.tomcat.max-http-form-post-size` or `@RequestBody` annotation) | `application.properties` or controller | MEDIUM   |
+| RO-06 | Make CSV plugin iteration deterministic — add ordering or conflict detection                                                | `CSVAnalyzerReader.java:153`           | LOW      |
+
+### Priority 3: Test Coverage
+
+| Task  | Description                                                                                                                       | File                                      | Severity |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------- |
+| RO-07 | Expand HL7AnalyzerReaderTest: add 3-tier identification tests (bridge ID, MSH, source IP), bridge header tests, fallback behavior | `HL7AnalyzerReaderTest.java`              | MEDIUM   |
+| RO-08 | Add AnalyzerImportController integration tests for all three endpoints                                                            | `AnalyzerImportControllerTest.java` (NEW) | MEDIUM   |
+
+---
+
+## Section 5: Parallelization Strategy
+
+### Dependency Graph
+
+```
+              Current: M1-M6 merged across both repos
+                                |
+          ┌─────────────────────┼────────────────────┐
+          |                     |                     |
+          v                     |                     v
+┌───────────────────┐           |          ┌───────────────────┐
+| M7 + R-BRIDGE     |           |          | R-OPENELIS        |
+| (Bridge repo)     |           |          | (OpenELIS repo)   |
+| [4 days]          |           |          | [3 days]          |
+| PARALLEL TRACK A  |           |          | PARALLEL TRACK B  |
+└────────┬──────────┘           |          └───────────────────┘
+         |                      |               (independent)
+         ├──────────────────┐   |
+         v                  v   |
+┌───────────────────┐  ┌────────────────────┐
+| M8: Integration   |  | M7.1: Auth/Sec     |
+| (Bridge repo)     |  | (Bridge repo)      |
+| [4 days]          |  | [2 days, PARALLEL] |
+└────────┬──────────┘  └────────────────────┘
+         |  TAG v3.0.0
+         v
+┌───────────────────┐
+| M9: Documentation |
+| (OpenELIS repo)   |
+| [2 days]          |
+└───────────────────┘
+```
+
+### Timeline
+
+| Scenario                   | Calendar Days | Notes                                                                                  |
+| -------------------------- | ------------- | -------------------------------------------------------------------------------------- |
+| Sequential                 | 15 days       | M7(4) → M7.1(2) → M8(4) → M9(2) + R-OPENELIS(3)                                        |
+| **Parallel (recommended)** | **10 days**   | Track A: M7(4) → M8(4) + M7.1(2) parallel → M9(2). Track B: R-OPENELIS(3) during M7+M8 |
+
+### Work Order
+
+| Day  | Track A (Bridge)                                                             | Track B (OpenELIS)                                           | Track C (Bridge, parallel)                 |
+| ---- | ---------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------ |
+| 1-4  | **M7**: Create normalizer, wire all listeners, add retry, tests              | **R-OPENELIS**: Sanitize errors, validate headers, add tests | —                                          |
+| 5-8  | **M8**: Prometheus metrics, health indicators, E2E tests, Docker, tag v3.0.0 | (complete)                                                   | **M7.1**: Auth/security (parallel with M8) |
+| 9-10 | —                                                                            | **M9**: Update submodule, spec docs                          | —                                          |
+
+---
+
+## Section 6: Business Logic Separation (Architecture Note)
+
+The Universal Bridge architecture maintains clear layer boundaries:
+
+```
+BRIDGE (transport-only)          OPENELIS (business logic)
+========================         ==============================
+                                 AnalyzerImportController
+TCP/MLLP/Serial/File/HTTP  →      ├── HL7AnalyzerReader (protocol parsing)
+  ↓                                ├── CSVAnalyzerReader (format parsing)
+MessageNormalizer                  ├── ASTMAnalyzerReader (protocol parsing)
+  ↓                                │
+HttpForwardingRouter               ├── PluginAnalyzerService (plugin registry)
+  ↓                                │     └── plugin.isTargetAnalyzer(lines)
+POST /analyzer/{hl7|csv|astm}      │
+  + X-Analyzer-Id (hint)           ├── AnalyzerLineInserter (per-plugin parsing)
+  + X-Source-Analyzer-IP (hint)    │     └── Extract test codes, results, mappings
+  + raw message body               │
+                                   └── MappingAwareAnalyzerLineInserter (optional)
+                                         └── Field transformation overlay
+```
+
+**Key principle**: Bridge knows NOTHING about analyzer-specific parsing. It
+provides transport hints (headers) and raw protocol data. OpenELIS plugins own
+all business logic.
+
+**Known inconsistency** (not blocking, document in M9): HL7AnalyzerReader does
+its own 3-tier analyzer identification (bridge ID → MSH-3 → source IP) before
+plugin delegation, while CSV/ASTM readers delegate identification entirely to
+plugins via `isTargetAnalyzer()`.
+
+---
+
+## Section 7: Verification & Success Criteria
+
+### Success Criteria (Carried from Original Plan)
+
+| #   | Criterion                                                         | Verified By                        | Status   |
+| --- | ----------------------------------------------------------------- | ---------------------------------- | -------- |
+| 1   | Single bridge handles: ASTM/TCP, HL7/MLLP, Serial, File, HTTP     | M8 E2E tests (T19-T22)             | PENDING  |
+| 2   | ALL 5 listeners route through MessageNormalizer (no bypasses)     | M7 integration test (T11)          | PENDING  |
+| 3   | All Madagascar analyzers work through bridge                      | M8 E2E + plugin tests              | PENDING  |
+| 4   | <100ms p95 latency for message forwarding (bridge overhead)       | M8 metrics + load test             | PENDING  |
+| 5   | Auto-reconnection on serial disconnect                            | M3 (done) — verified in deployment | COMPLETE |
+| 6   | Prometheus metrics for all listeners                              | M8 MetricsService (T13)            | PENDING  |
+| 7   | Zero protocol code in OpenELIS (HTTP-only at boundary)            | Architecture review                | COMPLETE |
+| 8   | Spec documentation updated with protocol/transport clarifications | M9 (T27-T31)                       | PENDING  |
+| 9   | No raw exception messages returned to clients                     | R-OPENELIS (RO-01-03)              | PENDING  |
+| 10  | Retry/backoff on all forwarding paths                             | M7 (T04)                           | PENDING  |
+
+### Verification Steps
+
+### How to Verify M7
+
+```bash
+# In bridge repo
+cd tools/astm-http-bridge/
+mvn clean test  # All unit + integration tests pass
+
+# Verify unified routing (T11 test):
+# - Mock OpenELIS HTTP server captures requests
+# - Send MLLP message → verify /analyzer/hl7 received with X-* headers
+# - Send serial message → verify /analyzer/astm received (no bypass)
+# - Drop CSV file → verify /analyzer/csv received (no bypass)
+# - POST to /input → verify message routed (no longer dropped)
+# - Send ASTM TCP → verify routed through MessageNormalizer
+```
+
+### How to Verify M8
+
+```bash
+# Run E2E with Docker
+docker compose -f docker-compose.test.yml up --build
+# Check Prometheus metrics
+curl http://localhost:8443/actuator/prometheus | grep bridge_
+# Check health
+curl http://localhost:8443/actuator/health | jq '.components'
+# Verify all listeners report UP
+```
+
+### How to Verify R-OPENELIS
+
+```bash
+# Run existing + new tests
+cd /Users/pmanko/code/OpenELIS-Global-2
+mvn test -pl . -Dtest="HL7AnalyzerReaderTest,CSVAnalyzerReaderTest,AnalyzerImportControllerTest"
+
+# Manual: POST malformed HL7 → verify generic error (not stack trace)
+# Manual: POST with spoofed X-Source-Analyzer-IP from non-bridge IP → verify rejected/logged
+```
+
+---
+
+## Section 8: Critical Files
+
+### Bridge Repo (to modify)
+
+| File                                      | M7 Action                                                   |
+| ----------------------------------------- | ----------------------------------------------------------- |
+| `routing/HttpForwardingRouter.java`       | Wire retry/backoff from config                              |
+| `serial/SerialMessageHandler.java`        | Replace own HTTP forwarding → delegate to MessageNormalizer |
+| `file/FileMessageHandler.java`            | Replace own HTTP forwarding → delegate to MessageNormalizer |
+| `controller/AnalyzerInputController.java` | Wire envelope to MessageNormalizer (remove TODO)            |
+| `config/OpenELISConfig.java`              | Remove `@ConditionalOnProperty("bridge.file")`              |
+| `configuration.yml`                       | Add `bridge.analyzers` section, consolidate URIs            |
+
+### Bridge Repo (to create)
+
+| File                                 | Purpose                                                   |
+| ------------------------------------ | --------------------------------------------------------- |
+| `normalizer/MessageNormalizer.java`  | Central orchestration service                             |
+| `normalizer/AnalyzerIdentifier.java` | Multi-strategy analyzer ID resolution                     |
+| `normalizer/ASTMBridgeAdapter.java`  | Adapter from legacy ASTM handlers to MessageEnvelope flow |
+| `config/AnalyzerRegistryConfig.java` | `@ConfigurationProperties` for analyzer mappings          |
+
+### OpenELIS Repo (to modify)
+
+| File                                                        | R-OPENELIS Action                        |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `analyzerimport/action/AnalyzerImportController.java`       | Sanitize errors, validate bridge headers |
+| `analyzerimport/analyzerreaders/CSVAnalyzerReader.java`     | Deterministic plugin ordering            |
+| `analyzerimport/analyzerreaders/HL7AnalyzerReaderTest.java` | Expand test coverage                     |
+
+---
+
+## Task Summary
+
+| Work Item     | Tasks             | Days | Parallel?                     | Repo     |
+| ------------- | ----------------- | ---- | ----------------------------- | -------- |
+| M7 + R-BRIDGE | T01-T11, RB-05-06 | 4    | Track A                       | Bridge   |
+| R-OPENELIS    | RO-01-08          | 3    | Track B (parallel with M7/M8) | OpenELIS |
+| M7.1          | T7a-T7h           | 2    | Track C (parallel with M8)    | Bridge   |
+| M8            | T12-T25           | 4    | After M7, parallel with M7.1  | Bridge   |
+| M9            | T26-T32           | 2    | After M8                      | OpenELIS |
+
+**Remaining: 48 tasks, ~10 days with parallelization**
+
+---
+
+## Appendix: Reference to Original Plan
+
+The following sections from the original plan (v1.0) remain valid and are NOT
+duplicated here. Refer to
+[universal-analyzer-bridge.md](specs/011-madagascar-analyzer-integration/plans/universal-analyzer-bridge.md)
+for:
+
+| Section                                                    | Original Lines | Notes                                        |
+| ---------------------------------------------------------- | -------------- | -------------------------------------------- |
+| Architecture Diagram (5 listeners → normalizer → OpenELIS) | 117-158        | Still the target architecture                |
+| Hybrid Architecture (Bridge ↔ OpenELIS message flow)       | 162-225        | HTTP forward format examples unchanged       |
+| Protocol vs Transport Matrix                               | 230-245        | Reference for M9 documentation               |
+| Configuration Schema (full YAML)                           | 636-710        | Add `bridge.analyzers` in M7; rest unchanged |
+| Dependencies (pom.xml)                                     | 714-742        | Already added in M1                          |
+| Git Workflow / Worktree Setup                              | 746-788        | Use for M7/M8 branch work                    |
+| PR Strategy per Repository                                 | 790-828        | Updated chain in Section 2 above             |
+| Submodule Update Workflow                                  | 830-857        | Use after M8 tag                             |
+| Quick Start Commands                                       | 892-909        | Test commands still valid                    |
+
+**In case of conflict**: This updated plan (v2.0) takes precedence over v1.0.

--- a/specs/011-madagascar-analyzer-integration/plans/universal-analyzer-bridge.md
+++ b/specs/011-madagascar-analyzer-integration/plans/universal-analyzer-bridge.md
@@ -1,0 +1,941 @@
+# Universal Analyzer Bridge Implementation Plan
+
+**Goal**: Extend `tools/astm-http-bridge` to become a Universal Analyzer Bridge
+that handles ALL analyzer communication, forwarding normalized messages to
+OpenELIS via HTTP.
+
+**Core Principle**: OpenELIS receives ONE standard HTTP format regardless of how
+the analyzer sent data.
+
+---
+
+## Repository Workflow (CRITICAL - READ FIRST)
+
+### Two Separate Repositories (Updated: Hybrid Approach)
+
+| Repository                                                                  | Purpose                            | Milestones                           |
+| --------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------ |
+| **[DIGI-UW/astm-http-bridge](https://github.com/DIGI-UW/astm-http-bridge)** | Protocol bridge (Java Spring Boot) | **M1-M8** (listeners, routing)       |
+| **[OpenELIS-Global-2](https://github.com/I-TECH-UW/OpenELIS-Global-2)**     | Main OpenELIS application          | **M2, M4, M9** (new endpoints, docs) |
+
+### Branch Naming Convention
+
+| Milestone | Bridge Repo Branch                  | OpenELIS Repo Branch                     | Notes                                     |
+| --------- | ----------------------------------- | ---------------------------------------- | ----------------------------------------- |
+| M1        | `feat/universal-bridge-foundation`  | N/A                                      | Foundation types - ✅ **MERGED**          |
+| M2        | `feat/universal-bridge-mllp`        | `feat/011-universal-bridge-hl7-endpoint` | MLLP listener + HL7 endpoint              |
+| M3        | `feat/universal-bridge-serial`      | N/A                                      | Serial listener (uses ASTM/HL7 endpoints) |
+| M4        | `feat/universal-bridge-file`        | `feat/011-universal-bridge-csv-endpoint` | File watcher + CSV endpoint               |
+| M5        | `feat/universal-bridge-http-input`  | N/A                                      | HTTP input (routes to existing endpoints) |
+| M6        | ✅ **MERGED** (PR #4)               | N/A                                      | ASTM source IP (done)                     |
+| M7        | `feat/universal-bridge-normalizer`  | N/A                                      | Message normalizer/router                 |
+| M8        | `feat/universal-bridge-integration` | N/A                                      | Testing, Docker, README                   |
+| M9        | N/A                                 | `docs/universal-bridge-spec-alignment`   | Update spec docs                          |
+
+### PR Dependency Chain
+
+```
+BRIDGE REPO (DIGI-UW/astm-http-bridge):
+┌──────────────────────────────────────────────────────────────┐
+│ PR #1: M1 → main                                             │
+│   feat/universal-bridge-foundation → main                    │
+│   [Foundation types, enums, DTOs]                            │
+└────────────────────────┬─────────────────────────────────────┘
+                         │ MERGE & TAG v2.0.0-foundation
+                         ▼
+         ┌───────────────┴───────────────┐
+         │                               │
+         ▼                               ▼
+┌──────────────────┐           ┌──────────────────┐
+│ PR #2: M2 → main │           │ PR #3: M3 → main │  (and M4, M5, M6 in parallel)
+│   feat/..-mllp   │           │   feat/..-serial │
+└────────┬─────────┘           └────────┬─────────┘
+         │                               │
+         └───────────────┬───────────────┘
+                         │ ALL MERGE
+                         ▼
+         ┌───────────────────────────────┐
+         │ PR #7: M7 → main              │
+         │   feat/..-normalizer          │
+         └────────────────┬──────────────┘
+                          │
+                          ▼
+         ┌───────────────────────────────┐
+         │ PR #8: M8 → main              │
+         │   feat/..-integration         │
+         │   [FINAL BRIDGE PR]           │
+         └────────────────┬──────────────┘
+                          │ MERGE & TAG v2.0.0
+                          │ UPDATE SUBMODULE IN OPENELIS
+                          ▼
+OPENELIS REPO (I-TECH-UW/OpenELIS-Global-2):
+┌──────────────────────────────────────────────────────────────┐
+│ PR #9: M9 → develop                                          │
+│   docs/universal-bridge-spec-alignment → develop             │
+│   [Update specs 011 & 004 research.md to reference bridge]  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Critical Rules
+
+1. **M1-M8 = Bridge Repo ONLY** - ALL Java code changes go to
+   `DIGI-UW/astm-http-bridge`
+2. **M9 = OpenELIS Repo ONLY** - Documentation updates to spec files
+3. **No OpenELIS code changes** - Bridge handles ALL protocol/transport logic
+4. **Submodule update** - After M8 merges, update `tools/astm-http-bridge`
+   submodule in OpenELIS to v2.0.0
+
+### Working with the Bridge Submodule
+
+**You can work directly in the submodule!**
+`OpenELIS-Global-2/tools/astm-http-bridge/` is a full git repository.
+
+```bash
+# For M1-M8 (Bridge work) - work directly in submodule:
+cd OpenELIS-Global-2/tools/astm-http-bridge/
+git remote -v  # Should show: https://github.com/DIGI-UW/astm-http-bridge.git
+
+# For M9 (OpenELIS docs) - work in parent repo:
+cd OpenELIS-Global-2/
+git remote -v  # Should show: https://github.com/I-TECH-UW/OpenELIS-Global-2.git
+```
+
+**After merging bridge PRs**, update the parent repo's submodule reference:
+
+```bash
+# After PR #1 (M1) merges to bridge repo:
+cd OpenELIS-Global-2/tools/astm-http-bridge/
+git pull origin main  # Pull latest bridge changes
+
+cd ../../  # Back to OpenELIS-Global-2/
+git add tools/astm-http-bridge  # Update submodule reference
+git commit -m "Update bridge submodule after M1 merge"
+git push origin your-branch
+
+# Repeat after each bridge PR merge (M2-M8)
+```
+
+---
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────────────────────────────────┐
+│                UNIVERSAL ANALYZER BRIDGE (Single Java Process)                │
+│                     tools/astm-http-bridge (extended)                         │
+├───────────────────────────────────────────────────────────────────────────────┤
+│                                                                               │
+│  ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐      │
+│  │ ASTM/TCP  │ │ HL7/MLLP  │ │  Serial   │ │   File    │ │   HTTP    │      │
+│  │ Listener  │ │ Listener  │ │ Listener  │ │  Watcher  │ │  Input    │      │
+│  │ :5001     │ │ :2575     │ │ jSerial   │ │ WatchSvc  │ │  :8080    │      │
+│  │ [existing]│ │ [HAPI]    │ │ [NEW]     │ │ [NEW]     │ │  [NEW]    │      │
+│  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘ └─────┬─────┘ └─────┬─────┘      │
+│        │             │             │             │             │             │
+│        │ ASTM/TCP    │ HL7/MLLP    │ ASTM or HL7 │ ASTM/HL7/CSV│ Any/HTTP   │
+│        │             │             │ over RS232  │ from files  │             │
+│        └──────┬──────┴──────┬──────┴──────┬──────┴──────┬──────┴─────┘       │
+│               │             │             │             │                    │
+│               ▼             ▼             ▼             ▼                    │
+│       ┌──────────────────────────────────────────────────────────┐          │
+│       │                  MESSAGE NORMALIZER                       │          │
+│       │  • Detect protocol (ASTM vs HL7 vs CSV)                   │          │
+│       │  • Identify analyzer (IP, serial port, header, file path) │          │
+│       │  • Add metadata (source, timestamp, transport)            │          │
+│       │  • Forward to OpenELIS via HTTP POST                      │          │
+│       └─────────────────────────┬────────────────────────────────┘          │
+│                                 │                                            │
+└─────────────────────────────────┼────────────────────────────────────────────┘
+                                  │ HTTP POST (JSON)
+                                  ▼
+                     ┌──────────────────────────┐
+                     │        OPENELIS          │
+                     │  POST /api/analyzer/     │
+                     │        results           │
+                     │  {                       │
+                     │    "analyzerId": "...",  │
+                     │    "protocol": "ASTM",   │
+                     │    "transport": "TCP",   │
+                     │    "message": "H|...",   │
+                     │    "sourceId": "...",    │
+                     │    "timestamp": "..."    │
+                     │  }                       │
+                     └──────────────────────────┘
+```
+
+---
+
+## Hybrid Architecture (Bridge ↔ OpenELIS Integration)
+
+### Message Flow Pattern
+
+**Bridge Internal:** Uses `NormalizedMessage` DTO for routing **Bridge →
+OpenELIS:** Sends raw message + headers (protocol-specific endpoints)
+
+```
+Analyzer → Bridge Listener → MessageEnvelope (internal)
+                             ↓
+                    Message Normalizer (M7)
+                             ↓
+                    Protocol Router (inspects envelope.protocol)
+                             ↓
+              ┌──────────────┼──────────────┐
+              ↓              ↓              ↓
+        ASTM Protocol   HL7 Protocol   CSV Protocol
+              ↓              ↓              ↓
+   POST /analyzer/astm  POST /analyzer/hl7  POST /analyzer/csv
+   [raw ASTM + headers] [raw HL7 + headers] [CSV + headers]
+              ↓              ↓              ↓
+         OpenELIS        OpenELIS       OpenELIS
+       ASTM Parser     HL7 Parser     CSV Parser
+```
+
+### HTTP Forward Format
+
+**ASTM (existing - unchanged):**
+
+```http
+POST /api/OpenELIS-Global/analyzer/astm
+X-Source-Analyzer-IP: 192.168.1.10
+X-Message-Transport: TCP
+Content-Type: text/plain
+
+H|\^&|||MINDRAY|||...
+```
+
+**HL7 (M2 - new endpoint):**
+
+```http
+POST /api/OpenELIS-Global/analyzer/hl7
+X-Source-Analyzer-IP: 192.168.1.11
+X-Message-Transport: MLLP
+Content-Type: text/plain
+
+MSH|^~\&|SYSMEX|||...
+```
+
+**CSV (M4 - new endpoint):**
+
+```http
+POST /api/OpenELIS-Global/analyzer/csv
+X-Source-Analyzer-IP: 192.168.1.12
+X-Message-Transport: FILE
+Content-Type: text/csv
+
+SampleID,TestCode,Result,Units
+12345,GLU,95,mg/dL
+```
+
+### Why This Approach?
+
+✅ **Backward Compatible** - Existing ASTM workflow unchanged ✅ **Gradual
+Migration** - Add protocols incrementally ✅ **Protocol-Specific Parsing** -
+Each endpoint knows its parser ✅ **Independent Development** - Bridge and
+OpenELIS PRs can be parallel ✅ **Future-Ready** - Can migrate to unified JSON
+endpoint later
+
+---
+
+## Protocol vs Transport Matrix
+
+| Transport                | Protocol     | Example Analyzers                |
+| ------------------------ | ------------ | -------------------------------- |
+| **TCP (raw)**            | ASTM LIS2-A2 | Mindray BC-5380, GeneXpert       |
+| **MLLP (TCP + framing)** | HL7 v2.x     | Sysmex XN, Abbott Architect      |
+| **Serial (RS232)**       | ASTM         | Horiba Pentra 60, Mindray BA-88A |
+| **Serial (RS232)**       | HL7          | Some legacy Siemens analyzers    |
+| **File**                 | ASTM/HL7/CSV | QuantStudio, Hain FluoroCycler   |
+| **HTTP POST**            | ASTM or HL7  | Modern analyzers with REST API   |
+
+**Key Insight**:
+
+- **Protocol** = message format (ASTM, HL7, CSV)
+- **Transport** = delivery method (TCP, MLLP, Serial, File, HTTP)
+- Serial & File listeners auto-detect protocol from content
+
+---
+
+## Milestone Dependency Graph (Parallelizable Work)
+
+```
+                    ┌─────────────────────────────────────────────────┐
+                    │  M1: Foundation (MUST be first - shared types)  │
+                    └────────────────────────┬────────────────────────┘
+                                             │
+              ┌──────────────────────────────┼──────────────────────────────┐
+              │                              │                              │
+              ▼                              ▼                              ▼
+    ┌─────────────────┐           ┌─────────────────┐           ┌─────────────────┐
+    │   M2: MLLP      │           │   M3: Serial    │           │   M4: File      │
+    │   (HL7/TCP)     │           │   (RS232)       │           │   Watcher       │
+    │   [WORKTREE A]  │           │   [WORKTREE B]  │           │   [WORKTREE C]  │
+    └────────┬────────┘           └────────┬────────┘           └────────┬────────┘
+             │                              │                              │
+             │ ┌────────────────────────────┼──────────────────────────────┘
+             │ │                            │
+             ▼ ▼                            ▼
+    ┌─────────────────┐           ┌─────────────────┐
+    │   M5: HTTP      │           │   M6: ASTM      │
+    │   Input         │           │   Enhancements  │
+    │   [WORKTREE D]  │           │   [WORKTREE E]  │
+    └────────┬────────┘           └────────┬────────┘
+             │                              │
+             └──────────────┬───────────────┘
+                            │
+                            ▼
+              ┌─────────────────────────────┐
+              │   M7: Message Normalizer    │
+              │   (integrates all listeners)│
+              └────────────────┬────────────┘
+                               │
+                               ▼
+              ┌─────────────────────────────┐
+              │   M8: Integration & Deploy  │
+              │   (tests, docker, docs)     │
+              └────────────────┬────────────┘
+                               │
+                               ▼
+              ┌─────────────────────────────┐
+              │   M9: Spec Documentation    │
+              │   (update research.md, etc) │
+              └─────────────────────────────┘
+```
+
+### Parallelization Strategy
+
+| Milestone | Repository      | Branch                                 | Worktree   | Depends On | Days |
+| --------- | --------------- | -------------------------------------- | ---------- | ---------- | ---- |
+| M1        | **Bridge**      | `feat/universal-bridge-foundation`     | main       | -          | 2    |
+| M2        | **Bridge**      | `feat/universal-bridge-mllp`           | worktree-a | M1         | 3    |
+| M3        | **Bridge**      | `feat/universal-bridge-serial`         | worktree-b | M1         | 4    |
+| M4        | **Bridge**      | `feat/universal-bridge-file`           | worktree-c | M1         | 3    |
+| M5        | **Bridge**      | `feat/universal-bridge-http-input`     | worktree-d | M2 or M3   | 2    |
+| M6        | **Bridge**      | `feat/universal-bridge-astm-enhance`   | worktree-e | M1         | 2    |
+| M7        | **Bridge**      | `feat/universal-bridge-normalizer`     | main       | M2-M6      | 3    |
+| M8        | **Bridge**      | `feat/universal-bridge-integration`    | main       | M7         | 4    |
+| M9        | **OpenELIS** ⚠️ | `docs/universal-bridge-spec-alignment` | N/A        | M8         | 1    |
+
+**Total**: ~24 days sequential, **~14 days with parallelization**
+
+**Repository Summary**:
+
+- **M1-M8**: `DIGI-UW/astm-http-bridge` (8 milestones, ALL code)
+- **M9**: `I-TECH-UW/OpenELIS-Global-2` (1 milestone, docs only)
+
+---
+
+## Milestones
+
+### M1: Foundation (Days 1-2) — BLOCKING
+
+**Repository**: `DIGI-UW/astm-http-bridge` **Branch**:
+`feat/universal-bridge-foundation` **Worktree**: main (blocking - must complete
+first)
+
+| Task | Description                                              | File                                |
+| ---- | -------------------------------------------------------- | ----------------------------------- |
+| T01  | Add HAPI HL7 v2 + jSerialComm + Commons CSV dependencies | `pom.xml`                           |
+| T02  | Create `Protocol` enum (ASTM, HL7, CSV, UNKNOWN)         | `model/Protocol.java`               |
+| T03  | Create `Transport` enum (TCP, MLLP, SERIAL, FILE, HTTP)  | `model/Transport.java`              |
+| T04  | Create `MessageEnvelope` DTO (internal routing)          | `normalizer/MessageEnvelope.java`   |
+| T05  | Create `NormalizedMessage` DTO (output to OpenELIS)      | `normalizer/NormalizedMessage.java` |
+| T06  | Create `ProtocolDetector` utility                        | `util/ProtocolDetector.java`        |
+| T07  | Unit tests for foundation classes                        | `test/FoundationTest.java`          |
+
+**Protocol Detection**:
+
+```java
+public static Protocol detect(String message) {
+    if (message.charAt(0) == 0x02 || message.startsWith("H|\\^&"))
+        return Protocol.ASTM;
+    if (message.startsWith("MSH|"))
+        return Protocol.HL7;
+    if (message.contains(",") && message.split("\n")[0].split(",").length > 3)
+        return Protocol.CSV;
+    return Protocol.UNKNOWN;
+}
+```
+
+---
+
+### M2: MLLP Listener + HL7 Endpoint (Days 3-5) — PARALLEL REPOS
+
+#### M2a: Bridge - MLLP Listener
+
+**Repository**: `DIGI-UW/astm-http-bridge` **Branch**:
+`feat/universal-bridge-mllp` **Worktree**: bridge-worktree-a **Depends on**: M1
+
+| Task | Description                                     | File                         |
+| ---- | ----------------------------------------------- | ---------------------------- |
+| T08  | Create `MLLPListener` using HAPI `SimpleServer` | `listener/MLLPListener.java` |
+| T09  | Implement `ReceivingApplication` callback       | `listener/MLLPListener.java` |
+| T10  | Extract source IP from MLLP connection          | `listener/MLLPListener.java` |
+| T11  | Add ACK/NAK response generation (HAPI built-in) | `listener/MLLPListener.java` |
+| T12  | Configure MLLP port in `application.yml`        | `application.yml`            |
+| T13  | Unit tests with mock HL7 messages               | `test/MLLPListenerTest.java` |
+
+**HAPI MLLP Server** (handles VT/FS/CR framing automatically):
+
+```java
+@Component
+public class MLLPListener {
+    @PostConstruct
+    public void start() {
+        server = new SimpleServer(2575, false);
+        server.registerApplication("*", "*", (message, metadata) -> {
+            normalizer.process(MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.MLLP)
+                .sourceId((String) metadata.get("SENDING_IP"))
+                .rawMessage(message.encode())
+                .build());
+            return message.generateACK();
+        });
+        server.start();
+    }
+}
+```
+
+#### M2b: OpenELIS - HL7 Endpoint
+
+**Repository**: `I-TECH-UW/OpenELIS-Global-2` **Branch**:
+`feat/011-universal-bridge-hl7-endpoint` (off `demo/madagascar`) **Worktree**:
+openelis-worktree-hl7 **Depends on**: M2a (can develop in parallel)
+
+| Task | Description                                    | File                             |
+| ---- | ---------------------------------------------- | -------------------------------- |
+| T14  | Create HL7 controller endpoint `/analyzer/hl7` | `AnalyzerHL7Controller.java`     |
+| T15  | Create HL7 parser service (using HAPI)         | `HL7ParserService.java`          |
+| T16  | Extract OBX segments → TestResult entities     | `HL7ResultExtractor.java`        |
+| T17  | Handle X-Source-Analyzer-IP header             | `AnalyzerHL7Controller.java`     |
+| T18  | Integration tests with mock HL7 messages       | `AnalyzerHL7ControllerTest.java` |
+
+**Endpoint Implementation**:
+
+```java
+@RestController
+@RequestMapping("/api/OpenELIS-Global/analyzer")
+public class AnalyzerHL7Controller {
+    @PostMapping("/hl7")
+    public ResponseEntity<String> receiveHL7(
+        @RequestBody String hl7Message,
+        @RequestHeader("X-Source-Analyzer-IP") String sourceIp,
+        @RequestHeader(value = "X-Message-Transport", required = false) String transport
+    ) {
+        // Parse HL7, extract results, create TestResult entities
+        hl7ParserService.parseAndSaveResults(hl7Message, sourceIp);
+        return ResponseEntity.ok("ACK");
+    }
+}
+```
+
+---
+
+### M3: Serial Listener (Days 3-6) — BRIDGE ONLY
+
+**Repository**: `DIGI-UW/astm-http-bridge` **Branch**:
+`feat/universal-bridge-serial` **Worktree**: bridge-worktree-b **Depends on**:
+M1
+
+| Task | Description                                            | File                                |
+| ---- | ------------------------------------------------------ | ----------------------------------- |
+| T14  | Create `SerialListener` with jSerialComm               | `listener/SerialListener.java`      |
+| T15  | Implement serial port config (baud, parity, stop bits) | `listener/SerialListener.java`      |
+| T16  | Create `SerialFrameDetector` (ASTM/HL7 framing)        | `listener/SerialFrameDetector.java` |
+| T17  | Integrate `ProtocolDetector` for auto-detection        | `listener/SerialListener.java`      |
+| T18  | Configure serial ports in `application.yml`            | `application.yml`                   |
+| T19  | Add connection status monitoring                       | `listener/SerialListener.java`      |
+| T20  | Handle disconnection/reconnection                      | `listener/SerialListener.java`      |
+| T21  | Unit tests with virtual serial ports (socat)           | `test/SerialListenerTest.java`      |
+
+**Message Framing**:
+
+- ASTM: `<STX>frame<ETX>checksum<CR><LF>` or `<ENQ>`/`<EOT>`
+- HL7: `<VT>message<FS><CR>` (same as MLLP)
+
+---
+
+### M4: File Watcher + CSV Endpoint (Days 3-5) — PARALLEL REPOS
+
+#### M4a: Bridge - File Watcher
+
+**Repository**: `DIGI-UW/astm-http-bridge` **Branch**:
+`feat/universal-bridge-file` **Worktree**: bridge-worktree-c **Depends on**: M1
+
+| Task | Description                                       | File                                |
+| ---- | ------------------------------------------------- | ----------------------------------- |
+| T22  | Create `FileWatcherListener` using `WatchService` | `listener/FileWatcherListener.java` |
+| T23  | Configure watch directories in `application.yml`  | `application.yml`                   |
+| T24  | Implement file type detection (HL7, ASTM, CSV)    | `listener/FileWatcherListener.java` |
+| T25  | Add CSV parsing with Apache Commons CSV           | `listener/FileWatcherListener.java` |
+| T26  | Implement file archival after processing          | `listener/FileWatcherListener.java` |
+| T27  | Implement error directory for failed files        | `listener/FileWatcherListener.java` |
+| T28  | Add duplicate detection (hash-based)              | `listener/FileWatcherListener.java` |
+| T29  | Unit tests with temp directories                  | `test/FileWatcherListenerTest.java` |
+
+#### M4b: OpenELIS - CSV Endpoint
+
+**Repository**: `I-TECH-UW/OpenELIS-Global-2` **Branch**:
+`feat/011-universal-bridge-csv-endpoint` (off `demo/madagascar`) **Worktree**:
+openelis-worktree-csv **Depends on**: M4a (can develop in parallel)
+
+| Task | Description                                    | File                             |
+| ---- | ---------------------------------------------- | -------------------------------- |
+| T30  | Create CSV controller endpoint `/analyzer/csv` | `AnalyzerCSVController.java`     |
+| T31  | Create CSV parser service (using Commons CSV)  | `CSVParserService.java`          |
+| T32  | Map CSV columns → TestResult entities          | `CSVResultExtractor.java`        |
+| T33  | Handle X-Source-Analyzer-IP header             | `AnalyzerCSVController.java`     |
+| T34  | Integration tests with mock CSV data           | `AnalyzerCSVControllerTest.java` |
+
+**Endpoint Implementation**:
+
+```java
+@RestController
+@RequestMapping("/api/OpenELIS-Global/analyzer")
+public class AnalyzerCSVController {
+    @PostMapping("/csv")
+    public ResponseEntity<String> receiveCSV(
+        @RequestBody String csvData,
+        @RequestHeader("X-Source-Analyzer-IP") String sourceIp,
+        @RequestHeader(value = "X-Message-Transport", required = false) String transport
+    ) {
+        // Parse CSV, extract results, create TestResult entities
+        csvParserService.parseAndSaveResults(csvData, sourceIp);
+        return ResponseEntity.ok("OK");
+    }
+}
+```
+
+---
+
+### M5: HTTP Input Listener (Days 7-8) — BRIDGE ONLY
+
+**Repository**: `DIGI-UW/astm-http-bridge` **Branch**:
+`feat/universal-bridge-http-input` **Worktree**: bridge-worktree-d **Depends
+on**: M2 OR M3 (needs normalizer interface pattern)
+
+| Task | Description                            | File                                      |
+| ---- | -------------------------------------- | ----------------------------------------- |
+| T30  | Create HTTP input endpoint `/input`    | `controller/AnalyzerInputController.java` |
+| T31  | Accept raw message body (ASTM/HL7/CSV) | `controller/AnalyzerInputController.java` |
+| T32  | Auto-detect protocol from content      | `controller/AnalyzerInputController.java` |
+| T33  | Extract source IP from HTTP request    | `controller/AnalyzerInputController.java` |
+| T34  | Unit tests for HTTP input              | `test/AnalyzerInputControllerTest.java`   |
+
+---
+
+### M6: ASTM Enhancements (Days 3-4) — WORKTREE E
+
+**Repository**: `DIGI-UW/astm-http-bridge` **Branch**:
+`feat/universal-bridge-astm-enhance` **Worktree**: worktree-e (parallel with M2,
+M3, M4) **Depends on**: M1
+
+| Task | Description                                       | File                                              |
+| ---- | ------------------------------------------------- | ------------------------------------------------- |
+| T35  | Add `X-Source-Analyzer-IP` header to HTTP forward | `handler/DefaultForwardingASTMToHTTPHandler.java` |
+| T36  | Extract source IP from socket in receive thread   | `astm/handling/ASTMReceiveThread.java`            |
+| T37  | Pass source IP through handler chain              | `service/ASTMHandlerService.java`                 |
+| T38  | Unit tests for source IP extraction               | `test/ASTMReceiveThreadTest.java`                 |
+
+---
+
+### M7: Message Normalizer (Days 9-11) — INTEGRATION
+
+**Repository**: `DIGI-UW/astm-http-bridge` **Branch**:
+`feat/universal-bridge-normalizer` **Worktree**: main (integration work after
+all listeners complete) **Depends on**: M2, M3, M4, M5, M6
+
+| Task | Description                                         | File                                 |
+| ---- | --------------------------------------------------- | ------------------------------------ |
+| T39  | Create `MessageNormalizer` service (central router) | `normalizer/MessageNormalizer.java`  |
+| T40  | Create `AnalyzerIdentifier` (multi-strategy)        | `normalizer/AnalyzerIdentifier.java` |
+| T41  | Implement IP-based identification                   | `normalizer/AnalyzerIdentifier.java` |
+| T42  | Implement header-based ID (ASTM H-segment, HL7 MSH) | `normalizer/AnalyzerIdentifier.java` |
+| T43  | Implement serial-port-based identification          | `normalizer/AnalyzerIdentifier.java` |
+| T44  | Implement file-path-pattern identification          | `normalizer/AnalyzerIdentifier.java` |
+| T45  | Create `OpenELISForwarder` HTTP client              | `normalizer/OpenELISForwarder.java`  |
+| T46  | Add retry logic with exponential backoff            | `normalizer/OpenELISForwarder.java`  |
+| T47  | Add audit logging                                   | `normalizer/MessageNormalizer.java`  |
+| T48  | Unit tests for normalizer                           | `test/MessageNormalizerTest.java`    |
+
+---
+
+### M8: Integration & Deployment (Days 12-15)
+
+**Repository**: `DIGI-UW/astm-http-bridge` **Branch**:
+`feat/universal-bridge-integration` **Worktree**: main (final bridge repo work)
+**Depends on**: M7
+
+| Task | Description                                   | File                               |
+| ---- | --------------------------------------------- | ---------------------------------- |
+| T49  | Create unified configuration schema           | `application.yml`                  |
+| T50  | Add health check endpoint (all listeners)     | `controller/HealthController.java` |
+| T51  | Add Prometheus metrics                        | `config/MetricsConfiguration.java` |
+| T52  | Update Dockerfile (expose all ports)          | `Dockerfile`                       |
+| T53  | Create Docker Compose for testing             | `docker-compose-test.yml`          |
+| T54  | Integration tests (all transports → OpenELIS) | `test/integration/`                |
+| T55  | Update bridge README with all transports      | `README.md`                        |
+
+---
+
+### M9: Spec Documentation Updates (Day 16)
+
+**Repository**: `I-TECH-UW/OpenELIS-Global-2` ⚠️ **DIFFERENT REPO** **Branch**:
+`docs/universal-bridge-spec-alignment` **Worktree**: N/A (OpenELIS main repo)
+**Depends on**: M8 (bridge v2.0.0 tagged and submodule updated)
+
+| Task | Description                                                        | Target File                                             |
+| ---- | ------------------------------------------------------------------ | ------------------------------------------------------- |
+| T56  | Update spec 011 research.md with protocol/transport clarifications | `specs/011-madagascar-analyzer-integration/research.md` |
+| T57  | Add "Protocol vs Transport" section to 011 research.md             | `specs/011-madagascar-analyzer-integration/research.md` |
+| T58  | Document MLLP (HL7 transport) architecture decision                | `specs/011-madagascar-analyzer-integration/research.md` |
+| T59  | Update spec 004 research.md to align with Universal Bridge         | `specs/004-astm-analyzer-mapping/research.md`           |
+| T60  | Cross-reference Universal Bridge from spec 004 plan.md             | `specs/004-astm-analyzer-mapping/plan.md`               |
+| T61  | Update tool architecture clarification (bridge ≠ mock server)      | `specs/011-madagascar-analyzer-integration/research.md` |
+
+**Documentation Updates Content**:
+
+For **spec 011 research.md**, add section:
+
+```markdown
+## Protocol vs Transport Architecture (Universal Bridge)
+
+### Key Clarification (Feb 2026)
+
+The original spec incorrectly implied HL7 analyzers send directly via HTTP. This
+was WRONG.
+
+**Correct Understanding**:
+
+- **Protocol** = message format (ASTM LIS2-A2, HL7 v2.x, CSV)
+- **Transport** = delivery method (TCP, MLLP, Serial, File, HTTP)
+
+**HL7 Requires Bridge**: Most HL7 analyzers use MLLP (TCP with VT/FS/CR framing)
+or serial connections, NOT direct HTTP. The bridge translates these transports
+to HTTP for OpenELIS.
+
+### Transport Matrix
+
+| Transport          | Protocol     | Handled By                         |
+| ------------------ | ------------ | ---------------------------------- |
+| TCP (raw)          | ASTM         | ASTMListener (existing)            |
+| MLLP (TCP+framing) | HL7          | MLLPListener (HAPI)                |
+| Serial (RS232)     | ASTM or HL7  | SerialListener (jSerialComm)       |
+| File               | ASTM/HL7/CSV | FileWatcherListener (WatchService) |
+| HTTP POST          | Any          | AnalyzerInputController            |
+
+See: `/home/ubuntu/.claude/plans/universal-analyzer-bridge.md`
+```
+
+For **spec 004 research.md**, add section:
+
+```markdown
+## Universal Analyzer Bridge Integration
+
+### Architecture Change (Feb 2026)
+
+The ASTM-HTTP bridge has been extended to become a **Universal Analyzer Bridge**
+that handles ALL analyzer transports, not just ASTM/TCP.
+
+**Impact on Feature 004**:
+
+- The `X-Source-Analyzer-IP` header implementation (Section 13) is now part of
+  M6: ASTM Enhancements in the Universal Bridge plan
+- Analyzer identification strategies (Section 13) apply to all transports, not
+  just ASTM
+- Message processing workflow (Section 15) remains unchanged for ASTM; new
+  transports follow same pattern
+
+**Cross-Reference**: See Universal Bridge plan at
+`/home/ubuntu/.claude/plans/universal-analyzer-bridge.md`
+```
+
+---
+
+## Configuration Schema
+
+```yaml
+# tools/astm-http-bridge/application.yml
+bridge:
+  # OpenELIS connection (output)
+  openelis:
+    url: https://openelis:8443/api/analyzer/results
+    username: bridge
+    password: ${BRIDGE_PASSWORD}
+    timeout: 30000
+    retry:
+      maxAttempts: 3
+      backoffMs: 1000
+
+  # ASTM TCP listener (existing, enhanced)
+  astm:
+    enabled: true
+    port: 5001
+
+  # HL7 MLLP listener (new)
+  mllp:
+    enabled: true
+    port: 2575
+
+  # Serial listeners (new)
+  serial:
+    enabled: true
+    ports:
+      - name: /dev/ttyUSB0
+        baudRate: 9600
+        dataBits: 8
+        stopBits: 1
+        parity: NONE
+        protocol: AUTO # AUTO, ASTM, or HL7
+      - name: /dev/ttyUSB1
+        baudRate: 19200
+        protocol: ASTM
+
+  # File watcher (new)
+  file:
+    enabled: true
+    watchDirectories:
+      - /mnt/analyzer-import/quantstudio
+      - /mnt/analyzer-import/hain
+    archiveDirectory: /mnt/analyzer-archive
+    errorDirectory: /mnt/analyzer-error
+    pollIntervalMs: 5000
+
+  # HTTP input listener (new)
+  http:
+    enabled: true
+    port: 8080
+
+  # Analyzer identification
+  analyzers:
+    "192.168.1.10":
+      id: MINDRAY-BC5380-001
+      name: "Mindray BC-5380"
+      expectedProtocol: ASTM
+
+    "192.168.1.11":
+      id: SYSMEX-XN-001
+      name: "Sysmex XN-1000"
+      expectedProtocol: HL7
+
+    "/dev/ttyUSB0":
+      id: HORIBA-PENTRA60-001
+      name: "Horiba Pentra 60"
+      expectedProtocol: ASTM
+
+    "quantstudio-*":
+      id: QUANTSTUDIO-001
+      name: "QuantStudio 7 Flex"
+      expectedProtocol: CSV
+      filePattern: ".*/quantstudio-.*\\.csv"
+```
+
+---
+
+## Dependencies (pom.xml additions)
+
+```xml
+<!-- HL7 v2.x + MLLP -->
+<dependency>
+    <groupId>ca.uhn.hapi</groupId>
+    <artifactId>hapi-base</artifactId>
+    <version>2.5.1</version>
+</dependency>
+<dependency>
+    <groupId>ca.uhn.hapi</groupId>
+    <artifactId>hapi-structures-v251</artifactId>
+    <version>2.5.1</version>
+</dependency>
+
+<!-- Serial communication -->
+<dependency>
+    <groupId>com.fazecast</groupId>
+    <artifactId>jSerialComm</artifactId>
+    <version>2.11.0</version>
+</dependency>
+
+<!-- CSV parsing -->
+<dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-csv</artifactId>
+    <version>1.11.0</version>
+</dependency>
+```
+
+---
+
+## Git Workflow (Worktrees)
+
+### Branch Structure
+
+```
+main (or develop)
+├── feat/universal-bridge-foundation     # M1
+├── feat/universal-bridge-mllp           # M2 (worktree-a)
+├── feat/universal-bridge-serial         # M3 (worktree-b)
+├── feat/universal-bridge-file           # M4 (worktree-c)
+├── feat/universal-bridge-http-input     # M5 (worktree-d)
+├── feat/universal-bridge-astm-enhance   # M6 (worktree-e)
+├── feat/universal-bridge-normalizer     # M7
+├── feat/universal-bridge-integration    # M8
+└── feat/universal-bridge-docs           # M9
+```
+
+### Worktree Setup Commands
+
+```bash
+# Work directly in the submodule
+cd OpenELIS-Global-2/tools/astm-http-bridge/
+
+# Create M1 branch and complete foundation work
+git checkout -b feat/universal-bridge-foundation
+# [complete M1 tasks, create PR to bridge repo, merge to main]
+
+# After M1 merges to bridge main, pull changes and create worktrees:
+git checkout main
+git pull origin main
+
+# Create worktrees for parallel work (relative to submodule directory):
+git worktree add ../../bridge-worktree-a feat/universal-bridge-mllp          # M2
+git worktree add ../../bridge-worktree-b feat/universal-bridge-serial        # M3
+git worktree add ../../bridge-worktree-c feat/universal-bridge-file          # M4
+git worktree add ../../bridge-worktree-e feat/universal-bridge-astm-enhance  # M6
+
+# Later (after M2 or M3 establishes normalizer interface):
+git worktree add ../../bridge-worktree-d feat/universal-bridge-http-input    # M5
+
+# Each worktree is independent and can have different branches checked out
+cd ../../bridge-worktree-a  # Work on M2 (MLLP)
+cd ../bridge-worktree-b     # Work on M3 (Serial)
+# etc.
+```
+
+### PR Strategy (Repository-Specific)
+
+**Bridge Repo PRs** (`DIGI-UW/astm-http-bridge`):
+
+```
+PR #1: feat/universal-bridge-foundation → main (M1)
+  Foundation types, enums, DTOs
+
+PR #2: feat/universal-bridge-mllp → main (M2)
+  MLLP listener using HAPI
+
+PR #3: feat/universal-bridge-serial → main (M3)
+  Serial listener with jSerialComm
+
+PR #4: feat/universal-bridge-file → main (M4)
+  File watcher with WatchService
+
+PR #5: feat/universal-bridge-http-input → main (M5)
+  HTTP input endpoint
+
+PR #6: feat/universal-bridge-astm-enhance → main (M6)
+  X-Source-Analyzer-IP header
+
+PR #7: feat/universal-bridge-normalizer → main (M7)
+  Message normalizer integration
+
+PR #8: feat/universal-bridge-integration → main (M8)
+  Tests, Docker, README, Prometheus metrics
+  Tag: v2.0.0
+```
+
+**OpenELIS Repo PRs** (`I-TECH-UW/OpenELIS-Global-2`):
+
+```
+PR #9: Update tools/astm-http-bridge submodule to v2.0.0
+  (after bridge PR #8 merges and is tagged)
+
+PR #10: docs/universal-bridge-spec-alignment → develop (M9)
+  Update specs 011 & 004 research.md
+  References bridge v2.0.0 architecture
+```
+
+### Submodule Update Workflow
+
+**After each bridge PR merges**, update the OpenELIS parent repo to reference
+the new commit:
+
+```bash
+# 1. Pull latest bridge changes in the submodule
+cd OpenELIS-Global-2/tools/astm-http-bridge/
+git checkout main
+git pull origin main
+
+# 2. Go to parent repo and commit the submodule reference update
+cd ../../  # Back to OpenELIS-Global-2/
+git status  # Will show: modified: tools/astm-http-bridge (new commits)
+
+git add tools/astm-http-bridge
+git commit -m "Update bridge submodule: <describe what merged>"
+# Example: "Update bridge submodule: Add MLLP listener (M2)"
+
+# 3. Push to your OpenELIS branch (or create tracking branch)
+git push origin your-branch
+```
+
+**Why this matters**: The parent repo (`OpenELIS-Global-2`) stores a specific
+commit SHA of the submodule. When you update the submodule reference, you're
+telling OpenELIS "use this newer version of the bridge." This ensures:
+
+- Other developers get the latest bridge when they clone OpenELIS
+- CI/CD uses the correct bridge version
+- Deployment environments stay synchronized
+
+**Timing**: You can update the submodule reference after each PR merge, or batch
+multiple updates. The final update (after M8/v2.0.0) is mandatory before
+starting M9.
+
+---
+
+## Task Summary by Milestone
+
+| Milestone             | Tasks   | Days | Parallel?        |
+| --------------------- | ------- | ---- | ---------------- |
+| M1. Foundation        | T01-T07 | 2    | No (blocking)    |
+| M2. MLLP Listener     | T08-T13 | 3    | Yes (worktree A) |
+| M3. Serial Listener   | T14-T21 | 4    | Yes (worktree B) |
+| M4. File Watcher      | T22-T29 | 3    | Yes (worktree C) |
+| M5. HTTP Input        | T30-T34 | 2    | Yes (worktree D) |
+| M6. ASTM Enhancements | T35-T38 | 2    | Yes (worktree E) |
+| M7. Normalizer        | T39-T48 | 3    | No (integration) |
+| M8. Integration       | T49-T55 | 4    | No (testing)     |
+| M9. Documentation     | T56-T61 | 1    | No (final)       |
+
+**Total: 61 tasks, ~24 days sequential, ~14 days with parallelization**
+
+---
+
+## Success Criteria
+
+1. Single bridge handles: ASTM/TCP, HL7/MLLP, Serial (both protocols), File,
+   HTTP
+2. OpenELIS receives identical JSON regardless of transport
+3. All Madagascar analyzers work through bridge
+4. <100ms p95 latency for message forwarding
+5. Auto-reconnection on serial disconnect
+6. Prometheus metrics for all listeners
+7. Zero protocol code in OpenELIS (HTTP-only)
+8. Spec documentation updated with protocol/transport clarifications
+
+---
+
+## Quick Start
+
+```bash
+# Build
+cd tools/astm-http-bridge && mvn clean install -DskipTests
+
+# Run
+java -jar target/astm-http-app.jar
+
+# Test MLLP (HL7)
+echo -e "\x0bMSH|^~\\&|TEST|||...\x1c\r" | nc localhost 2575
+
+# Test ASTM
+echo "H|\\^&|||TEST|||..." | nc localhost 5001
+
+# Test HTTP input
+curl -X POST http://localhost:8080/input -d "MSH|^~\\&|TEST|||..."
+```


### PR DESCRIPTION
Updates universal-analyzer-bridge-v2.md with M7.1 auth/security milestone.

**Context**: Copilot review of submodule PR openelis-analyzer-bridge#11 identified a critical security gap — the `/input` HTTP endpoint has no authentication requirements.

**Changes**:
- Added M7.1 milestone section with 8 tasks (T7a-T7h)
- Updated milestone status table
- Updated dependency graph (M7.1 parallel with M8)
- Updated timeline and task summary
- Includes OE auth pattern research findings (Spring Security, HTTP Basic auth recommendation)

**Research Findings**:
- OE uses Spring Security with form-based sessions for REST endpoints
- HTTP Basic auth available via BasicAuthFilter (conditional)
- Recommended: HTTP Basic Authentication for bridge /input endpoint (aligns with OE patterns, stateless, simple credential management)

Triggered by: Copilot comment #2775830476

Made with [Cursor](https://cursor.com)