### PR TITLE
Fix export format dropdown in inventory reports

### DIFF
--- a/frontend/src/components/inventory/InventoryReports.jsx
+++ b/frontend/src/components/inventory/InventoryReports.jsx
@@ -163,7 +163,7 @@ const InventoryReports = () => {
       console.error("Error generating report:", err);
       setError(
         err.message ||
-          intl.formatMessage({ id: "reports.error.generationFailed" }),
+        intl.formatMessage({ id: "reports.error.generationFailed" }),
       );
     } finally {
       setGenerating(false);
@@ -212,6 +212,7 @@ const InventoryReports = () => {
                   titleText={intl.formatMessage({ id: "reports.format" })}
                   label={intl.formatMessage({ id: "reports.format.select" })}
                   items={exportFormats}
+                  itemToString={(item) => (item ? item.text : "")}
                   selectedItem={formData.exportFormat}
                   onChange={({ selectedItem }) =>
                     handleChange("exportFormat", selectedItem)
@@ -281,31 +282,31 @@ const InventoryReports = () => {
                 {["STOCK_LEVELS", "LOW_STOCK", "EXPIRATION_FORECAST"].includes(
                   formData.reportType.id,
                 ) && (
-                  <FormGroup
-                    legendText={intl.formatMessage({ id: "reports.grouping" })}
-                  >
-                    <Checkbox
-                      id="groupByType"
-                      labelText={intl.formatMessage({
-                        id: "reports.groupByType",
-                      })}
-                      checked={formData.groupByType}
-                      onChange={(e) =>
-                        handleChange("groupByType", e.target.checked)
-                      }
-                    />
-                    <Checkbox
-                      id="groupByLocation"
-                      labelText={intl.formatMessage({
-                        id: "reports.groupByLocation",
-                      })}
-                      checked={formData.groupByLocation}
-                      onChange={(e) =>
-                        handleChange("groupByLocation", e.target.checked)
-                      }
-                    />
-                  </FormGroup>
-                )}
+                    <FormGroup
+                      legendText={intl.formatMessage({ id: "reports.grouping" })}
+                    >
+                      <Checkbox
+                        id="groupByType"
+                        labelText={intl.formatMessage({
+                          id: "reports.groupByType",
+                        })}
+                        checked={formData.groupByType}
+                        onChange={(e) =>
+                          handleChange("groupByType", e.target.checked)
+                        }
+                      />
+                      <Checkbox
+                        id="groupByLocation"
+                        labelText={intl.formatMessage({
+                          id: "reports.groupByLocation",
+                        })}
+                        checked={formData.groupByLocation}
+                        onChange={(e) =>
+                          handleChange("groupByLocation", e.target.checked)
+                        }
+                      />
+                    </FormGroup>
+                  )}
 
                 {/* Error notification */}
                 {error && (


### PR DESCRIPTION
# Description

This PR fixes an issue where the Export Format dropdown in Inventory Reports opened with no visible options.
#2745 


## Screenshots
<img width="1053" height="254" alt="image" src="https://github.com/user-attachments/assets/d1fe730d-432a-480a-892a-17ae83b5dc8d" />


## Cause:
- Carbon Dropdown requires item ToString to render object items

## Fix:
- Added itemToString to export format dropdown

## Related Issue
N/A