### PR TITLE
Fix overlapping date/status fields and align Search button

### DIFF
--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -385,6 +385,14 @@ button {
   max-width: 200px;
 }
 
+.cds--select-input {
+  max-width: 200px;
+}
+
+.cds--select {
+  max-width: 200px;
+}
+
 .hidden {
   visibility: hidden;
 }

--- a/frontend/src/components/eOrder/EOrderSearch.js
+++ b/frontend/src/components/eOrder/EOrderSearch.js
@@ -183,11 +183,15 @@ const EOrderSearch = ({
           }}
         />
       </Column>
-      <Column lg={2}>
+      <Column lg={3} md={4} sm={4}>
         <div className="bottomAlign">
           <Checkbox
             id="allInfo1"
-            labelText={intl.formatMessage({ id: "eorder.allInfo" })}
+            labelText={
+              <span style={{ whiteSpace: "nowrap" }}>
+                {intl.formatMessage({ id: "eorder.allInfo" })}
+              </span>
+            }
             checked={allInfo}
             onChange={(e) => {
               setAllInfo(e.currentTarget.checked);
@@ -195,8 +199,12 @@ const EOrderSearch = ({
           />
         </div>
       </Column>
-      <Column lg={1}></Column>
-      <Column lg={4}>
+
+      <Column lg={16} md={8} sm={4}>
+        <br></br>
+      </Column>
+
+      <Column lg={4} md={4} sm={4}>
         <Button onClick={searchByIdentifier}>
           <FormattedMessage id="label.button.search" />
         </Button>
@@ -211,7 +219,8 @@ const EOrderSearch = ({
       <Column lg={16} md={8} sm={4}>
         <br></br>
       </Column>
-      <Column lg={3} md={2} sm={2}>
+
+      <Column lg={4} md={4} sm={4}>
         <CustomDatePicker
           id={"eOrder_startDate"}
           labelText={intl.formatMessage({ id: "eorder.date.start" })}
@@ -220,16 +229,16 @@ const EOrderSearch = ({
           onChange={(date) => setStartDate(date)}
         />
       </Column>
-      <Column lg={3} md={2} sm={2}>
+      <Column lg={4} md={4} sm={4}>
         <CustomDatePicker
-          id={"eOrder_startDate"}
+          id={"eOrder_endDate"}
           labelText={intl.formatMessage({ id: "eorder.date.end" })}
-          value={startDate}
+          value={endDate}
           className="inputDate"
           onChange={(date) => setEndDate(date)}
         />
       </Column>
-      <Column lg={3} md={2} sm={2}>
+      <Column lg={4} md={4} sm={4}>
         <Select
           id="statusId"
           labelText={intl.formatMessage({ id: "eorder.status" })}
@@ -250,11 +259,15 @@ const EOrderSearch = ({
           })}
         </Select>
       </Column>
-      <Column lg={2}>
+      <Column lg={4} md={4} sm={4}>
         <div className="bottomAlign">
           <Checkbox
             id="allInfo2"
-            labelText={intl.formatMessage({ id: "eorder.allInfo" })}
+            labelText={
+              <span style={{ whiteSpace: "nowrap" }}>
+                {intl.formatMessage({ id: "eorder.allInfo" })}
+              </span>
+            }
             checked={allInfo2}
             onChange={(e) => {
               setAllInfo2(e.currentTarget.checked);
@@ -262,8 +275,12 @@ const EOrderSearch = ({
           />
         </div>
       </Column>
-      <Column lg={1}></Column>
-      <Column lg={4} md={4} sm={2}>
+
+      <Column lg={16} md={8} sm={4}>
+        <br></br>
+      </Column>
+
+      <Column lg={4} md={4} sm={4}>
         <Button onClick={searchByDateAndStatus}>
           <FormattedMessage id="label.button.search" />
         </Button>
@@ -287,7 +304,7 @@ const EOrderSearch = ({
             flexDirection: "column",
             alignItems: "center",
             gap: "10px",
-            width: "110%",
+            width: "100%",
           }}
         >
           {pagination && (


### PR DESCRIPTION
# Changes
 
This change improves the search form layout by adding proper spacing between the Start Date, End Date, and Status fields to prevent overlapping at laptop screen widths. It also fixes the Search button alignment, ensuring a cleaner and more consistent UI across different screen sizes.

# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [X] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots


https://github.com/user-attachments/assets/f1746204-b3b6-4654-9797-71c8b12fc083



## Related Issue

[https://github.com/DIGI-UW/OpenELIS-Global-2/issues/2741]

## Other

[Add any additional information or notes here]
