### PR TITLE
Add force reload support for configuration initialization

### DIFF
--- a/src/main/java/org/openelisglobal/configuration/service/ConfigurationInitializationService.java
+++ b/src/main/java/org/openelisglobal/configuration/service/ConfigurationInitializationService.java
@@ -32,6 +32,9 @@ public class ConfigurationInitializationService implements ApplicationListener<C
     @Value("${org.openelisglobal.configuration.autocreate:true}")
     private boolean autocreateOn;
 
+    @Value("${org.openelisglobal.configuration.forcereload:true}")
+    private boolean forceReload;
+
     @Autowired(required = false)
     private List<DomainConfigurationHandler> domainHandlers;
 
@@ -51,6 +54,11 @@ public class ConfigurationInitializationService implements ApplicationListener<C
 
         LogEvent.logInfo(this.getClass().getSimpleName(), "onApplicationEvent",
                 "Starting configuration initialization from " + configurationBaseDir + "...");
+
+        if (forceReload) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "onApplicationEvent",
+                    "Force reload is ENABLED. All configurations will be reloaded regardless of checksums.");
+        }
 
         try {
             // Sort handlers by load order to ensure dependencies are loaded first
@@ -99,9 +107,10 @@ public class ConfigurationInitializationService implements ApplicationListener<C
                 String currentChecksum = calculateChecksum(inputStream);
                 inputStream.close();
 
-                // Check if this file has been loaded with the same checksum
+                // Check if this file has been loaded with the same checksum (unless force
+                // reload is enabled)
                 String storedChecksum = checksums.getProperty(fileName);
-                if (currentChecksum.equals(storedChecksum)) {
+                if (!forceReload && currentChecksum.equals(storedChecksum)) {
                     LogEvent.logInfo(this.getClass().getSimpleName(), "loadDomainConfiguration",
                             domainName + " configuration " + fileName + " unchanged (checksum matches). Skipping.");
                     continue;
@@ -136,9 +145,10 @@ public class ConfigurationInitializationService implements ApplicationListener<C
                         String fileName = file.getName();
                         String currentChecksum = calculateChecksum(new FileInputStream(file));
 
-                        // Check if this file has been loaded with the same checksum
+                        // Check if this file has been loaded with the same checksum (unless force
+                        // reload is enabled)
                         String storedChecksum = checksums.getProperty(fileName);
-                        if (currentChecksum.equals(storedChecksum)) {
+                        if (!forceReload && currentChecksum.equals(storedChecksum)) {
                             LogEvent.logInfo(this.getClass().getSimpleName(), "loadDomainConfiguration", domainName
                                     + " configuration " + fileName + " unchanged (checksum matches). Skipping.");
                             continue;

--- a/src/main/java/org/openelisglobal/notebook/service/NoteBookServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NoteBookServiceImpl.java
@@ -1283,7 +1283,8 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
 
         // Check for final storage pages by title
         if (title.contains("storage") || title.contains("inventory")) {
-            // Verify this is not bacteriology, traditional medicine, or pharmaceutical temporary storage by
+            // Verify this is not bacteriology, traditional medicine, or pharmaceutical
+            // temporary storage by
             // checking notebook type
             NoteBook notebook = page.getNotebook();
             if (notebook != null) {
@@ -1317,7 +1318,8 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
                     }
                 }
                 // For pharmaceutical workflows, "Storage & Inventory Management" (order 5) is
-                // NOT a final storage page - samples should proceed to "Reporting & Performance Monitoring" (page 6)
+                // NOT a final storage page - samples should proceed to "Reporting & Performance
+                // Monitoring" (page 6)
                 if (notebookTitle.contains("pharmaceutical")) {
                     // In pharmaceutical workflows, order 5 storage page is not final
                     // Samples should proceed to the next page in the workflow

--- a/src/main/java/org/openelisglobal/notebook/service/NotebookBulkOperationServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NotebookBulkOperationServiceImpl.java
@@ -1305,7 +1305,8 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
                 values.add("\"" + collectionDate + "\"");
 
                 // Extract validation_status (check QA approval or validation field)
-                String validationStatus = getStringValueWithFallback(data, "validationStatus", "validation_status", "validation");
+                String validationStatus = getStringValueWithFallback(data, "validationStatus", "validation_status",
+                        "validation");
                 values.add("\"" + validationStatus + "\"");
 
                 // Extract test_results (aggregate from quantificationResults array)
@@ -1520,12 +1521,13 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
     }
 
     /**
-     * Get string value from nested object in data map.
-     * E.g., getNestedStringValue(data, "testExecution", "sampleType") extracts data.testExecution.sampleType
+     * Get string value from nested object in data map. E.g.,
+     * getNestedStringValue(data, "testExecution", "sampleType") extracts
+     * data.testExecution.sampleType
      *
-     * @param data The data map
+     * @param data      The data map
      * @param parentKey The parent object key
-     * @param childKey The child field key
+     * @param childKey  The child field key
      * @return The string value if found, empty string otherwise
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/openelisglobal/notebook/service/NotebookEntryRoomEnvironmentLogServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NotebookEntryRoomEnvironmentLogServiceImpl.java
@@ -63,8 +63,8 @@ public class NotebookEntryRoomEnvironmentLogServiceImpl
 
         NotebookEntry entry = notebookEntryService.get(entryId);
         if (entry == null) {
-            throw new IllegalArgumentException("Notebook entry not found with ID: " + entryId +
-                ". This may indicate a data consistency issue. Please refresh the page or contact support if the problem persists.");
+            throw new IllegalArgumentException("Notebook entry not found with ID: " + entryId
+                    + ". This may indicate a data consistency issue. Please refresh the page or contact support if the problem persists.");
         }
 
         NotebookEntryRoomEnvironmentLog log = new NotebookEntryRoomEnvironmentLog();

--- a/src/main/java/org/openelisglobal/notebook/service/NotebookEntryTemperatureLogServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NotebookEntryTemperatureLogServiceImpl.java
@@ -59,8 +59,8 @@ public class NotebookEntryTemperatureLogServiceImpl
 
         NotebookEntry entry = notebookEntryService.get(entryId);
         if (entry == null) {
-            throw new IllegalArgumentException("Notebook entry not found with ID: " + entryId +
-                ". This may indicate a data consistency issue. Please refresh the page or contact support if the problem persists.");
+            throw new IllegalArgumentException("Notebook entry not found with ID: " + entryId
+                    + ". This may indicate a data consistency issue. Please refresh the page or contact support if the problem persists.");
         }
 
         NotebookEntryTemperatureLog log = new NotebookEntryTemperatureLog();

--- a/volume/properties/common.properties
+++ b/volume/properties/common.properties
@@ -79,6 +79,9 @@ org.openelisglobal.odoo.password=
 #Loading configurationss
 org.openelisglobal.configuration.autocreate=true
 org.openelisglobal.configuration.dir=/var/lib/openelis-global/configuration/backend
+# Force reload all configurations regardless of checksums (useful after docker-compose down -v)
+# Set to true to reload all configs on startup, false (default) to use checksum-based loading
+# org.openelisglobal.configuration.forcereload=false
 
 #OCL import
 org.openelisglobal.ocl.import.default.testsection=Hematology


### PR DESCRIPTION
# Pull Requests Requirements
`Fixes issue where configurations (storage locations, tests, etc.) are not
reloaded after docker-compose down -v because checksum files persist in
bind-mounted volumes.`

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
