### PR TITLE
Fix: responsive issue with zoom buttons on smaller screens

### DIFF
--- a/frontend/src/components/coldStorage/HistoricalTrends.js
+++ b/frontend/src/components/coldStorage/HistoricalTrends.js
@@ -272,7 +272,7 @@ export default function HistoricalTrends({
             }}
           />
         </Column>
-        <Column lg={4} md={3} sm={4}>
+        <Column lg={4} md={4} sm={4}>
           <Dropdown
             id="time-range-filter"
             titleText="Time Range"
@@ -283,7 +283,7 @@ export default function HistoricalTrends({
           />
         </Column>
 
-        <Column lg={6} md={5} sm={4} className="hist-toolbar">
+        <Column lg={16} md={8} sm={4} className="hist-toolbar">
           <Button
             kind="ghost"
             size="sm"

--- a/frontend/src/components/coldStorage/HistoricalTrends.scss
+++ b/frontend/src/components/coldStorage/HistoricalTrends.scss
@@ -14,10 +14,11 @@
 
 .hist-toolbar {
   display: flex;
-  justify-content: flex-end;
-  align-items: flex-end;
+  justify-content: flex-start;
+  align-items: center;
   gap: 0.5rem;
   margin-top: 1.5rem;
+  flex-wrap: wrap;
 }
 
 .hist-chart-card {


### PR DESCRIPTION
# Changes

Moved the Zoom In, Zoom Out, Reset, and Export CSV action buttons to a new row below the filter dropdowns.

Updated the grid layout to ensure the toolbar spans the full width, preventing button overlap and overflow.

Improved responsive behavior so the toolbar remains properly aligned across different screen sizes.

# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [X] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

https://github.com/user-attachments/assets/646cbe64-4d87-4738-b000-e96334bd8861




## Related Issue

[https://github.com/DIGI-UW/OpenELIS-Global-2/issues/2768]

## Other

[Add any additional information or notes here]
