### PR TITLE
Fix report date fields overlapping by moving them to a new row

### DIFF
--- a/frontend/src/components/coldStorage/Reports.js
+++ b/frontend/src/components/coldStorage/Reports.js
@@ -539,7 +539,10 @@ function Reports({ devices = [] }) {
             onChange={({ selectedItem }) => setFormat(selectedItem)}
           />
         </Column>
-        <Column lg={2} md={2} sm={4}>
+      </Grid>
+
+      <Grid fullWidth className="reports-form">
+        <Column lg={4} md={4} sm={4}>
           <DatePicker
             datePickerType="single"
             onChange={(dates) => {
@@ -558,7 +561,7 @@ function Reports({ devices = [] }) {
             />
           </DatePicker>
         </Column>
-        <Column lg={2} md={2} sm={4}>
+        <Column lg={4} md={4} sm={4}>
           <DatePicker
             datePickerType="single"
             onChange={(dates) => {

--- a/frontend/src/components/coldStorage/Reports.scss
+++ b/frontend/src/components/coldStorage/Reports.scss
@@ -23,6 +23,10 @@
   }
 }
 
+.reports-form .cds--col {
+  margin-bottom: 1rem;
+}
+
 .reports-compliance-box {
   background: var(--cds-layer);
   padding: 1rem 1.5rem;


### PR DESCRIPTION
# Change Description

Fixed overlapping of Start Date and End Date fields in the Regulatory Reports form.

Moved both date pickers to a separate grid row below the filter dropdowns.

Improved responsiveness to ensure the layout remains consistent across different screen sizes.

# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [X] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots


https://github.com/user-attachments/assets/ac5c43b9-ba29-455c-9418-0da45cb544a4



## Related Issue

[https://github.com/DIGI-UW/OpenELIS-Global-2/issues/2769]

## Other
