### PR TITLE
fix(security): remediate 5 vulnerabilities in analyzer REST controllers

### DIFF
--- a/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerErrorRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerErrorRestController.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.analyzer.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -170,10 +171,12 @@ public class AnalyzerErrorRestController extends BaseRestController {
      * Acknowledge error
      */
     @PostMapping("/errors/{id}/acknowledge")
-    public ResponseEntity<Map<String, Object>> acknowledgeError(@PathVariable String id,
-            @RequestParam(required = false) String userId) {
+    public ResponseEntity<Map<String, Object>> acknowledgeError(@PathVariable String id, HttpServletRequest request) {
         try {
-            String actualUserId = userId != null ? userId : "SYSTEM"; // TODO: Get from security context
+            String actualUserId = getSysUserId(request);
+            if (actualUserId == null || actualUserId.trim().isEmpty()) {
+                actualUserId = "SYSTEM";
+            }
             analyzerErrorService.acknowledgeError(id, actualUserId);
 
             Map<String, Object> response = new HashMap<>();
@@ -233,13 +236,15 @@ public class AnalyzerErrorRestController extends BaseRestController {
      * Acknowledge multiple errors in batch
      */
     @PostMapping("/errors/batch-acknowledge")
-    public ResponseEntity<Map<String, Object>> batchAcknowledgeErrors(@RequestBody Map<String, Object> request) {
+    public ResponseEntity<Map<String, Object>> batchAcknowledgeErrors(@RequestBody Map<String, Object> request,
+            HttpServletRequest httpRequest) {
         try {
             @SuppressWarnings("unchecked")
             List<String> errorIds = (List<String>) request.get("errorIds");
-            String userId = request.containsKey("userId") ? (String) request.get("userId") : "SYSTEM"; // TODO: Get from
-                                                                                                       // security
-                                                                                                       // context
+            String userId = getSysUserId(httpRequest);
+            if (userId == null || userId.trim().isEmpty()) {
+                userId = "SYSTEM";
+            }
 
             if (errorIds == null || errorIds.isEmpty()) {
                 Map<String, Object> error = new HashMap<>();

--- a/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.analyzer.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -17,6 +18,7 @@ import org.openelisglobal.analyzer.service.AnalyzerFieldService;
 import org.openelisglobal.analyzer.service.AnalyzerService;
 import org.openelisglobal.analyzer.service.FileImportService;
 import org.openelisglobal.analyzer.service.SerialPortService;
+import org.openelisglobal.analyzer.util.NetworkValidationUtil;
 import org.openelisglobal.analyzer.valueholder.Analyzer;
 import org.openelisglobal.analyzer.valueholder.AnalyzerConfiguration;
 import org.openelisglobal.analyzer.valueholder.FileImportConfiguration;
@@ -111,12 +113,18 @@ public class AnalyzerRestController extends BaseRestController {
      * POST /rest/analyzer/analyzers Create new analyzer with configuration
      */
     @PostMapping("/analyzers")
-    public ResponseEntity<Map<String, Object>> createAnalyzer(@RequestBody AnalyzerForm form) {
+    public ResponseEntity<Map<String, Object>> createAnalyzer(@RequestBody AnalyzerForm form,
+            HttpServletRequest request) {
         try {
             // Manual validation for optional fields
             if (form.getIpAddress() != null && !form.getIpAddress().matches("^(\\d{1,3}\\.){3}\\d{1,3}$")) {
                 Map<String, Object> error = new HashMap<>();
                 error.put("error", "Invalid IPv4 address format");
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+            }
+            if (form.getIpAddress() != null && NetworkValidationUtil.isBlockedAddress(form.getIpAddress())) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Connection to this address is not permitted");
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
             }
             if (form.getPort() != null && (form.getPort() < 1 || form.getPort() > 65535)) {
@@ -148,7 +156,7 @@ public class AnalyzerRestController extends BaseRestController {
             Analyzer analyzer = new Analyzer();
             analyzer.setName(form.getName());
             analyzer.setType(form.getAnalyzerType());
-            analyzer.setSysUserId("1"); // Default system user (should come from security context)
+            analyzer.setSysUserId(getSysUserId(request));
 
             String analyzerId = analyzerService.insert(analyzer);
 
@@ -186,7 +194,7 @@ public class AnalyzerRestController extends BaseRestController {
                     logger.warn("Invalid status value: " + status + ", defaulting to SETUP");
                     config.setStatus(AnalyzerConfiguration.AnalyzerStatus.SETUP);
                 }
-                config.setSysUserId("1");
+                config.setSysUserId(getSysUserId(request));
                 analyzerConfigurationService.insert(config);
             } catch (LIMSRuntimeException e) {
                 // If configuration creation fails, log but don't fail the analyzer creation
@@ -329,7 +337,8 @@ public class AnalyzerRestController extends BaseRestController {
      * PUT /rest/analyzer/analyzers/{id} Update analyzer
      */
     @PutMapping("/analyzers/{id}")
-    public ResponseEntity<Map<String, Object>> updateAnalyzer(@PathVariable String id, @RequestBody AnalyzerForm form) {
+    public ResponseEntity<Map<String, Object>> updateAnalyzer(@PathVariable String id, @RequestBody AnalyzerForm form,
+            HttpServletRequest request) {
         try {
             Analyzer analyzer = analyzerService.get(id);
             if (analyzer == null) {
@@ -342,6 +351,11 @@ public class AnalyzerRestController extends BaseRestController {
             if (form.getIpAddress() != null && !form.getIpAddress().matches("^(\\d{1,3}\\.){3}\\d{1,3}$")) {
                 Map<String, Object> error = new HashMap<>();
                 error.put("error", "Invalid IPv4 address format");
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+            }
+            if (form.getIpAddress() != null && NetworkValidationUtil.isBlockedAddress(form.getIpAddress())) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Connection to this address is not permitted");
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
             }
             if (form.getPort() != null && (form.getPort() < 1 || form.getPort() > 65535)) {
@@ -425,7 +439,7 @@ public class AnalyzerRestController extends BaseRestController {
                 } else {
                     config.setStatus(AnalyzerConfiguration.AnalyzerStatus.SETUP);
                 }
-                config.setSysUserId("1");
+                config.setSysUserId(getSysUserId(request));
                 analyzerConfigurationService.insert(config);
             }
 
@@ -599,6 +613,12 @@ public class AnalyzerRestController extends BaseRestController {
     private Map<String, Object> testTcpConnection(String ipAddress, Integer port) {
         Map<String, Object> response = new HashMap<>();
         Socket socket = null;
+
+        if (NetworkValidationUtil.isBlockedAddress(ipAddress)) {
+            response.put("success", false);
+            response.put("message", "Connection to this address is not permitted");
+            return response;
+        }
 
         try {
             // Attempt TCP connection with 5 second timeout
@@ -948,7 +968,8 @@ public class AnalyzerRestController extends BaseRestController {
             String canonicalPath = templateFile.getCanonicalPath();
             String baseDirCanonical = baseDir.getCanonicalPath();
 
-            if (!canonicalPath.startsWith(baseDirCanonical)) {
+            if (!canonicalPath.startsWith(baseDirCanonical + java.io.File.separator)
+                    && !canonicalPath.equals(baseDirCanonical)) {
                 Map<String, Object> error = new HashMap<>();
                 error.put("error", "Invalid path: template must be within defaults directory");
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);

--- a/src/main/java/org/openelisglobal/analyzer/controller/CustomFieldTypeRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/CustomFieldTypeRestController.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.analyzer.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -13,6 +14,7 @@ import org.openelisglobal.analyzer.valueholder.CustomFieldType;
 import org.openelisglobal.analyzer.valueholder.ValidationRuleConfiguration;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.login.dao.UserModuleService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +46,9 @@ public class CustomFieldTypeRestController extends BaseRestController {
 
     @Autowired
     private ValidationRuleConfigurationService validationRuleConfigurationService;
+
+    @Autowired
+    private UserModuleService userModuleService;
 
     /**
      * GET /rest/analyzer/custom-field-types Retrieve all custom field types
@@ -213,12 +218,13 @@ public class CustomFieldTypeRestController extends BaseRestController {
      */
     @PostMapping("/{id}/validation-rules")
     public ResponseEntity<Map<String, Object>> createValidationRule(@PathVariable String id,
-            @Valid @RequestBody ValidationRuleConfigurationForm form) {
+            @Valid @RequestBody ValidationRuleConfigurationForm form, HttpServletRequest request) {
         try {
-            // TODO: Add authorization check for System Administrator role
-            // if (!isSystemAdministrator()) {
-            // return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-            // }
+            if (!userModuleService.isUserAdmin(request)) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Administrator access required");
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+            }
 
             // Verify custom field type exists
             CustomFieldType customFieldType = customFieldTypeService.get(id);
@@ -254,12 +260,14 @@ public class CustomFieldTypeRestController extends BaseRestController {
      */
     @PutMapping("/{id}/validation-rules/{ruleId}")
     public ResponseEntity<Map<String, Object>> updateValidationRule(@PathVariable String id,
-            @PathVariable String ruleId, @Valid @RequestBody ValidationRuleConfigurationForm form) {
+            @PathVariable String ruleId, @Valid @RequestBody ValidationRuleConfigurationForm form,
+            HttpServletRequest request) {
         try {
-            // TODO: Add authorization check for System Administrator role
-            // if (!isSystemAdministrator()) {
-            // return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-            // }
+            if (!userModuleService.isUserAdmin(request)) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Administrator access required");
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+            }
 
             // Verify custom field type exists
             CustomFieldType customFieldType = customFieldTypeService.get(id);
@@ -302,12 +310,13 @@ public class CustomFieldTypeRestController extends BaseRestController {
      */
     @DeleteMapping("/{id}/validation-rules/{ruleId}")
     public ResponseEntity<Map<String, Object>> deleteValidationRule(@PathVariable String id,
-            @PathVariable String ruleId) {
+            @PathVariable String ruleId, HttpServletRequest request) {
         try {
-            // TODO: Add authorization check for System Administrator role
-            // if (!isSystemAdministrator()) {
-            // return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-            // }
+            if (!userModuleService.isUserAdmin(request)) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Administrator access required");
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+            }
 
             // Verify custom field type exists
             CustomFieldType customFieldType = customFieldTypeService.get(id);

--- a/src/main/java/org/openelisglobal/analyzer/controller/FileImportRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/FileImportRestController.java
@@ -1,5 +1,9 @@
 package org.openelisglobal.analyzer.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +15,7 @@ import org.openelisglobal.common.rest.BaseRestController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,8 +30,34 @@ public class FileImportRestController extends BaseRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(FileImportRestController.class);
 
+    @Value("${file.import.base.directory:/data/analyzer-imports}")
+    private String baseImportDir;
+
     @Autowired
     private FileImportService fileImportService;
+
+    /**
+     * Validates that a directory path is within the configured base import
+     * directory. Uses NIO Path.startsWith() which correctly handles path component
+     * boundaries (unlike String.startsWith which is vulnerable to sibling directory
+     * attacks).
+     *
+     * @param path The directory path to validate (null/empty returns true —
+     *             optional field)
+     * @return true if the path is within the base directory, false otherwise
+     */
+    private boolean isPathWithinBase(String path) {
+        if (path == null || path.trim().isEmpty()) {
+            return true;
+        }
+        try {
+            Path basePath = Paths.get(baseImportDir).normalize().toAbsolutePath();
+            Path targetPath = Paths.get(path).normalize().toAbsolutePath();
+            return targetPath.startsWith(basePath);
+        } catch (InvalidPathException e) {
+            return false;
+        }
+    }
 
     /**
      * GET /rest/analyzer/file-import/configurations Retrieve all file import
@@ -90,7 +121,8 @@ public class FileImportRestController extends BaseRestController {
      * configuration
      */
     @PostMapping("/configurations")
-    public ResponseEntity<Map<String, Object>> createConfiguration(@RequestBody FileImportConfiguration configuration) {
+    public ResponseEntity<Map<String, Object>> createConfiguration(@RequestBody FileImportConfiguration configuration,
+            HttpServletRequest request) {
         try {
             // Validation
             if (configuration.getAnalyzerId() == null) {
@@ -104,6 +136,15 @@ public class FileImportRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
             }
 
+            // Validate directory paths are within base import directory
+            if (!isPathWithinBase(configuration.getImportDirectory())
+                    || !isPathWithinBase(configuration.getArchiveDirectory())
+                    || !isPathWithinBase(configuration.getErrorDirectory())) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Directory paths must be within " + baseImportDir);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+            }
+
             // Check for duplicate analyzer ID
             Optional<FileImportConfiguration> existing = fileImportService
                     .getByAnalyzerId(configuration.getAnalyzerId());
@@ -114,7 +155,7 @@ public class FileImportRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
             }
 
-            configuration.setSysUserId("1"); // Default system user (should come from security context)
+            configuration.setSysUserId(getSysUserId(request));
             String id = fileImportService.insert(configuration);
 
             Map<String, Object> response = new HashMap<>();
@@ -135,11 +176,20 @@ public class FileImportRestController extends BaseRestController {
      */
     @PutMapping("/configurations/{id}")
     public ResponseEntity<Map<String, Object>> updateConfiguration(@PathVariable String id,
-            @RequestBody FileImportConfiguration configuration) {
+            @RequestBody FileImportConfiguration configuration, HttpServletRequest request) {
         try {
             FileImportConfiguration existing = fileImportService.get(id);
             if (existing == null) {
                 return ResponseEntity.notFound().build();
+            }
+
+            // Validate directory paths are within base import directory
+            if (!isPathWithinBase(configuration.getImportDirectory())
+                    || !isPathWithinBase(configuration.getArchiveDirectory())
+                    || !isPathWithinBase(configuration.getErrorDirectory())) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Directory paths must be within " + baseImportDir);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
             }
 
             // Update fields
@@ -151,7 +201,7 @@ public class FileImportRestController extends BaseRestController {
             existing.setDelimiter(configuration.getDelimiter());
             existing.setHasHeader(configuration.getHasHeader());
             existing.setActive(configuration.getActive());
-            existing.setSysUserId("1"); // Default system user (should come from security context)
+            existing.setSysUserId(getSysUserId(request));
 
             fileImportService.update(existing);
 
@@ -171,14 +221,15 @@ public class FileImportRestController extends BaseRestController {
      * configuration
      */
     @DeleteMapping("/configurations/{id}")
-    public ResponseEntity<Map<String, Object>> deleteConfiguration(@PathVariable String id) {
+    public ResponseEntity<Map<String, Object>> deleteConfiguration(@PathVariable String id,
+            HttpServletRequest request) {
         try {
             FileImportConfiguration configuration = fileImportService.get(id);
             if (configuration == null) {
                 return ResponseEntity.notFound().build();
             }
 
-            fileImportService.delete(id, "1"); // Default system user (should come from security context)
+            fileImportService.delete(id, getSysUserId(request));
 
             Map<String, Object> response = new HashMap<>();
             response.put("message", "File import configuration deleted successfully");

--- a/src/main/java/org/openelisglobal/analyzer/service/AnalyzerQueryServiceImpl.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/AnalyzerQueryServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.openelisglobal.analyzer.util.NetworkValidationUtil;
 import org.openelisglobal.analyzer.valueholder.Analyzer;
 import org.openelisglobal.analyzer.valueholder.AnalyzerConfiguration;
 import org.openelisglobal.analyzer.valueholder.AnalyzerField;
@@ -178,6 +179,9 @@ public class AnalyzerQueryServiceImpl implements AnalyzerQueryService {
 
             if (ipAddress == null || port == null) {
                 throw new LIMSRuntimeException("Analyzer IP address or port not configured");
+            }
+            if (NetworkValidationUtil.isBlockedAddress(ipAddress)) {
+                throw new LIMSRuntimeException("Connection to this address is not permitted");
             }
 
             addLog(status, String.format("Connecting to analyzer at %s:%d", ipAddress, port));

--- a/src/main/java/org/openelisglobal/analyzer/service/FileImportServiceImpl.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/FileImportServiceImpl.java
@@ -3,6 +3,7 @@ package org.openelisglobal.analyzer.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -19,6 +20,7 @@ import org.openelisglobal.analyzerresults.valueholder.AnalyzerResults;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class FileImportServiceImpl extends BaseObjectServiceImpl<FileImportConfiguration, String>
         implements FileImportService {
+
+    @Value("${file.import.base.directory:/data/analyzer-imports}")
+    private String baseImportDir;
 
     @Autowired
     private FileImportConfigurationDAO fileImportConfigurationDAO;
@@ -102,6 +107,21 @@ public class FileImportServiceImpl extends BaseObjectServiceImpl<FileImportConfi
             }
 
             Path archiveDir = Paths.get(configuration.getArchiveDirectory());
+
+            // Defense-in-depth: verify archive path is within base import directory
+            try {
+                Path basePath = Paths.get(baseImportDir).normalize().toAbsolutePath();
+                if (!archiveDir.normalize().toAbsolutePath().startsWith(basePath)) {
+                    LogEvent.logError(this.getClass().getSimpleName(), "archiveFile",
+                            "Archive directory outside allowed base: " + configuration.getArchiveDirectory());
+                    return false;
+                }
+            } catch (InvalidPathException e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "archiveFile",
+                        "Invalid archive directory path: " + configuration.getArchiveDirectory());
+                return false;
+            }
+
             if (!Files.exists(archiveDir)) {
                 Files.createDirectories(archiveDir);
             }
@@ -128,6 +148,21 @@ public class FileImportServiceImpl extends BaseObjectServiceImpl<FileImportConfi
             }
 
             Path errorDir = Paths.get(configuration.getErrorDirectory());
+
+            // Defense-in-depth: verify error path is within base import directory
+            try {
+                Path basePath = Paths.get(baseImportDir).normalize().toAbsolutePath();
+                if (!errorDir.normalize().toAbsolutePath().startsWith(basePath)) {
+                    LogEvent.logError(this.getClass().getSimpleName(), "moveToErrorDirectory",
+                            "Error directory outside allowed base: " + configuration.getErrorDirectory());
+                    return false;
+                }
+            } catch (InvalidPathException e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "moveToErrorDirectory",
+                        "Invalid error directory path: " + configuration.getErrorDirectory());
+                return false;
+            }
+
             if (!Files.exists(errorDir)) {
                 Files.createDirectories(errorDir);
             }

--- a/src/main/java/org/openelisglobal/analyzer/service/FileImportWatchService.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/FileImportWatchService.java
@@ -3,6 +3,7 @@ package org.openelisglobal.analyzer.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -32,6 +33,9 @@ public class FileImportWatchService {
 
     @Value("${file.import.poll.interval:60000}")
     private long pollIntervalMillis;
+
+    @Value("${file.import.base.directory:/data/analyzer-imports}")
+    private String baseImportDir;
 
     /**
      * Polls all active import directories for new files. Runs at configured
@@ -69,6 +73,21 @@ public class FileImportWatchService {
     private void scanDirectory(FileImportConfiguration config) {
         try {
             Path importDir = Paths.get(config.getImportDirectory());
+
+            // Defense-in-depth: verify path is within base import directory
+            try {
+                Path basePath = Paths.get(baseImportDir).normalize().toAbsolutePath();
+                if (!importDir.normalize().toAbsolutePath().startsWith(basePath)) {
+                    LogEvent.logError(this.getClass().getSimpleName(), "scanDirectory",
+                            "Import directory outside allowed base: " + config.getImportDirectory());
+                    return;
+                }
+            } catch (InvalidPathException e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "scanDirectory",
+                        "Invalid import directory path: " + config.getImportDirectory());
+                return;
+            }
+
             if (!Files.exists(importDir) || !Files.isDirectory(importDir)) {
                 LogEvent.logWarn(this.getClass().getSimpleName(), "scanDirectory",
                         "Import directory does not exist or is not a directory: " + config.getImportDirectory());

--- a/src/main/java/org/openelisglobal/analyzer/util/NetworkValidationUtil.java
+++ b/src/main/java/org/openelisglobal/analyzer/util/NetworkValidationUtil.java
@@ -1,0 +1,79 @@
+package org.openelisglobal.analyzer.util;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Utility for validating network addresses used in analyzer connections.
+ *
+ * <p>
+ * Blocks addresses that should never be legitimate analyzer targets: loopback
+ * (127.x), link-local/cloud metadata (169.254.x), multicast, and unspecified
+ * (0.0.0.0). Private network ranges (10.x, 172.16.x, 192.168.x) are
+ * intentionally allowed because laboratory analyzers typically reside on
+ * private LANs.
+ */
+public final class NetworkValidationUtil {
+
+    private NetworkValidationUtil() {
+    }
+
+    /**
+     * Returns true if the given IP address should be blocked from outbound
+     * connections. Fails closed: unknown or unresolvable addresses are blocked.
+     */
+    public static boolean isBlockedAddress(String ipAddress) {
+        if (ipAddress == null || ipAddress.trim().isEmpty()) {
+            return true;
+        }
+        try {
+            InetAddress addr = InetAddress.getByName(ipAddress);
+            return isBlockedAddress(addr);
+        } catch (UnknownHostException e) {
+            return true; // fail closed
+        }
+    }
+
+    private static boolean isBlockedAddress(InetAddress addr) {
+        if (addr.isLoopbackAddress()) {
+            return true; // 127.0.0.0/8, ::1
+        }
+        if (addr.isLinkLocalAddress()) {
+            return true; // 169.254.0.0/16, fe80::/10 — includes cloud metadata
+        }
+        if (addr.isMulticastAddress()) {
+            return true; // 224.0.0.0+, ff00::/8
+        }
+        if (addr.isAnyLocalAddress()) {
+            return true; // 0.0.0.0, ::
+        }
+
+        // Check IPv6-mapped IPv4 (::ffff:x.x.x.x) — could embed a blocked IPv4
+        if (addr instanceof Inet6Address) {
+            byte[] bytes = addr.getAddress();
+            boolean isV4Mapped = isAllZero(bytes, 0, 10) && bytes[10] == (byte) 0xFF && bytes[11] == (byte) 0xFF;
+            if (isV4Mapped) {
+                try {
+                    byte[] v4 = new byte[4];
+                    System.arraycopy(bytes, 12, v4, 0, 4);
+                    InetAddress embedded = InetAddress.getByAddress(v4);
+                    return isBlockedAddress(embedded);
+                } catch (UnknownHostException e) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isAllZero(byte[] bytes, int from, int to) {
+        for (int i = from; i < to; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -79,4 +79,6 @@ spring.servlet.multipart.max-request-size = 15MB
 # Polling interval for file import directory watcher (in milliseconds)
 # Default: 60000 (60 seconds)
 file.import.poll.interval=60000
+# Base directory for file import configurations (path traversal boundary)
+file.import.base.directory=/data/analyzer-imports
 

--- a/src/test/java/org/openelisglobal/analyzer/controller/AnalyzerSecurityTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/controller/AnalyzerSecurityTest.java
@@ -1,0 +1,173 @@
+package org.openelisglobal.analyzer.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analyzer.service.AnalyzerQueryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Security-focused integration tests for analyzer REST controllers.
+ *
+ * Validates SSRF blocklist, path traversal prevention, and authorization checks
+ * introduced by the security remediation.
+ */
+public class AnalyzerSecurityTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Mock
+    private AnalyzerQueryService analyzerQueryService;
+
+    private JdbcTemplate jdbcTemplate;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.initMocks(this);
+        jdbcTemplate = new JdbcTemplate(dataSource);
+
+        AnalyzerRestController controller = webApplicationContext.getBean(AnalyzerRestController.class);
+        ReflectionTestUtils.setField(controller, "analyzerQueryService", analyzerQueryService);
+
+        cleanTestData();
+    }
+
+    private void cleanTestData() {
+        try {
+            jdbcTemplate.execute("DELETE FROM analyzer_configuration "
+                    + "WHERE analyzer_id IN (SELECT id FROM analyzer WHERE name LIKE 'TEST-SEC-%')");
+            jdbcTemplate.execute("DELETE FROM analyzer WHERE name LIKE 'TEST-SEC-%'");
+            Integer maxId = jdbcTemplate.queryForObject("SELECT COALESCE(MAX(id), 0) FROM analyzer", Integer.class);
+            jdbcTemplate.execute("SELECT setval('analyzer_seq', " + maxId + ", true)");
+        } catch (Exception e) {
+            System.out.println("Failed to clean security test data: " + e.getMessage());
+        }
+    }
+
+    // ── SSRF: Create analyzer with blocked IP ───────────────────────────
+
+    @Test
+    public void testCreateAnalyzer_WithLoopbackIP_ReturnsBadRequest() throws Exception {
+        String body = "{\"name\":\"TEST-SEC-Loopback\",\"analyzerType\":\"Chemistry Analyzer\","
+                + "\"ipAddress\":\"127.0.0.1\",\"port\":5000,\"testUnitIds\":[]}";
+
+        mockMvc.perform(post("/rest/analyzer/analyzers").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Connection to this address is not permitted"));
+    }
+
+    @Test
+    public void testCreateAnalyzer_WithLinkLocalIP_ReturnsBadRequest() throws Exception {
+        String body = "{\"name\":\"TEST-SEC-LinkLocal\",\"analyzerType\":\"Chemistry Analyzer\","
+                + "\"ipAddress\":\"169.254.169.254\",\"port\":80,\"testUnitIds\":[]}";
+
+        mockMvc.perform(post("/rest/analyzer/analyzers").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Connection to this address is not permitted"));
+    }
+
+    @Test
+    public void testCreateAnalyzer_WithMulticastIP_ReturnsBadRequest() throws Exception {
+        String body = "{\"name\":\"TEST-SEC-Multicast\",\"analyzerType\":\"Chemistry Analyzer\","
+                + "\"ipAddress\":\"224.0.0.1\",\"port\":5000,\"testUnitIds\":[]}";
+
+        mockMvc.perform(post("/rest/analyzer/analyzers").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Connection to this address is not permitted"));
+    }
+
+    @Test
+    public void testCreateAnalyzer_WithAnyLocalIP_ReturnsBadRequest() throws Exception {
+        String body = "{\"name\":\"TEST-SEC-AnyLocal\",\"analyzerType\":\"Chemistry Analyzer\","
+                + "\"ipAddress\":\"0.0.0.0\",\"port\":5000,\"testUnitIds\":[]}";
+
+        mockMvc.perform(post("/rest/analyzer/analyzers").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Connection to this address is not permitted"));
+    }
+
+    // ── SSRF: Private LAN addresses should be allowed ───────────────────
+
+    @Test
+    public void testCreateAnalyzer_WithPrivateIP_Succeeds() throws Exception {
+        String uniqueName = "TEST-SEC-Private-" + System.currentTimeMillis();
+        String body = "{\"name\":\"" + uniqueName + "\",\"analyzerType\":\"Chemistry Analyzer\","
+                + "\"ipAddress\":\"192.168.1.100\",\"port\":5000,\"testUnitIds\":[]}";
+
+        mockMvc.perform(post("/rest/analyzer/analyzers").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isCreated()).andExpect(jsonPath("$.id").exists());
+    }
+
+    // ── SSRF: Update analyzer with blocked IP ───────────────────────────
+
+    @Test
+    public void testUpdateAnalyzer_WithLoopbackIP_ReturnsBadRequest() throws Exception {
+        // Create a valid analyzer first
+        String uniqueName = "TEST-SEC-Update-" + System.currentTimeMillis();
+        String createBody = "{\"name\":\"" + uniqueName + "\",\"analyzerType\":\"Chemistry Analyzer\","
+                + "\"ipAddress\":\"192.168.1.100\",\"port\":5000,\"testUnitIds\":[]}";
+
+        String createResponse = mockMvc
+                .perform(post("/rest/analyzer/analyzers").contentType(MediaType.APPLICATION_JSON).content(createBody))
+                .andExpect(status().isCreated()).andReturn().getResponse().getContentAsString();
+
+        String analyzerId = extractId(createResponse);
+
+        // Try to update with loopback IP
+        String updateBody = "{\"ipAddress\":\"127.0.0.1\",\"port\":5000}";
+
+        mockMvc.perform(put("/rest/analyzer/analyzers/" + analyzerId).contentType(MediaType.APPLICATION_JSON)
+                .content(updateBody)).andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Connection to this address is not permitted"));
+    }
+
+    // ── Path traversal: File import ─────────────────────────────────────
+
+    @Test
+    public void testCreateFileImportConfig_WithTraversalPath_ReturnsBadRequest() throws Exception {
+        String body = "{\"analyzerId\":1,\"importDirectory\":\"/data/analyzer-imports/../../etc\","
+                + "\"filePattern\":\"*.csv\",\"active\":true}";
+
+        mockMvc.perform(
+                post("/rest/analyzer/file-import/configurations").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest()).andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    public void testCreateFileImportConfig_WithSiblingDirAttack_ReturnsBadRequest() throws Exception {
+        String body = "{\"analyzerId\":1,\"importDirectory\":\"/data/analyzer-imports-evil\","
+                + "\"filePattern\":\"*.csv\",\"active\":true}";
+
+        mockMvc.perform(
+                post("/rest/analyzer/file-import/configurations").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest()).andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    public void testCreateFileImportConfig_WithAbsoluteEtcPath_ReturnsBadRequest() throws Exception {
+        String body = "{\"analyzerId\":1,\"importDirectory\":\"/etc\"," + "\"filePattern\":\"*.csv\",\"active\":true}";
+
+        mockMvc.perform(
+                post("/rest/analyzer/file-import/configurations").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest()).andExpect(jsonPath("$.error").exists());
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────────
+
+    private String extractId(String responseBody) {
+        int start = responseBody.indexOf("\"id\":\"") + 6;
+        int end = responseBody.indexOf("\"", start);
+        return responseBody.substring(start, end);
+    }
+}

--- a/src/test/java/org/openelisglobal/analyzer/service/FileImportServiceTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/service/FileImportServiceTest.java
@@ -27,6 +27,7 @@ import org.openelisglobal.analyzer.dao.FileImportConfigurationDAO;
 import org.openelisglobal.analyzer.valueholder.FileImportConfiguration;
 import org.openelisglobal.analyzerresults.dao.AnalyzerResultsDAO;
 import org.openelisglobal.analyzerresults.valueholder.AnalyzerResults;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * Unit tests for FileImportService implementation
@@ -59,6 +60,8 @@ public class FileImportServiceTest {
     public void setUp() throws IOException {
         // Create temporary directory for testing
         tempDir = Files.createTempDirectory("file-import-test");
+        // Inject baseImportDir for defense-in-depth path validation
+        ReflectionTestUtils.setField(fileImportService, "baseImportDir", tempDir.toString());
         testFile = tempDir.resolve("test-file.csv");
         Files.createFile(testFile);
         Files.write(testFile, "Sample_ID,Test_Code,Result\n12345-001,HB,12.5".getBytes());

--- a/src/test/java/org/openelisglobal/analyzer/util/NetworkValidationUtilTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/util/NetworkValidationUtilTest.java
@@ -1,0 +1,132 @@
+package org.openelisglobal.analyzer.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for NetworkValidationUtil SSRF blocklist.
+ *
+ * Verifies that loopback, link-local, multicast, and any-local addresses are
+ * blocked, while private LAN ranges (used by lab analyzers) are allowed.
+ */
+public class NetworkValidationUtilTest {
+
+    // ── Blocked addresses ───────────────────────────────────────────────
+
+    @Test
+    public void testBlocksNull() {
+        assertTrue("null should be blocked", NetworkValidationUtil.isBlockedAddress(null));
+    }
+
+    @Test
+    public void testBlocksEmpty() {
+        assertTrue("empty string should be blocked", NetworkValidationUtil.isBlockedAddress(""));
+    }
+
+    @Test
+    public void testBlocksBlank() {
+        assertTrue("blank string should be blocked", NetworkValidationUtil.isBlockedAddress("   "));
+    }
+
+    @Test
+    public void testBlocksLoopback_127_0_0_1() {
+        assertTrue("127.0.0.1 (loopback) should be blocked", NetworkValidationUtil.isBlockedAddress("127.0.0.1"));
+    }
+
+    @Test
+    public void testBlocksLoopback_127_0_0_2() {
+        assertTrue("127.0.0.2 (loopback range) should be blocked", NetworkValidationUtil.isBlockedAddress("127.0.0.2"));
+    }
+
+    @Test
+    public void testBlocksLoopback_127_255_255_255() {
+        assertTrue("127.255.255.255 (loopback range end) should be blocked",
+                NetworkValidationUtil.isBlockedAddress("127.255.255.255"));
+    }
+
+    @Test
+    public void testBlocksLinkLocal_169_254_169_254() {
+        assertTrue("169.254.169.254 (cloud metadata / link-local) should be blocked",
+                NetworkValidationUtil.isBlockedAddress("169.254.169.254"));
+    }
+
+    @Test
+    public void testBlocksLinkLocal_169_254_0_1() {
+        assertTrue("169.254.0.1 (link-local) should be blocked", NetworkValidationUtil.isBlockedAddress("169.254.0.1"));
+    }
+
+    @Test
+    public void testBlocksMulticast_224_0_0_1() {
+        assertTrue("224.0.0.1 (multicast) should be blocked", NetworkValidationUtil.isBlockedAddress("224.0.0.1"));
+    }
+
+    @Test
+    public void testBlocksMulticast_239_255_255_255() {
+        assertTrue("239.255.255.255 (multicast range end) should be blocked",
+                NetworkValidationUtil.isBlockedAddress("239.255.255.255"));
+    }
+
+    @Test
+    public void testBlocksAnyLocal_0_0_0_0() {
+        assertTrue("0.0.0.0 (any-local) should be blocked", NetworkValidationUtil.isBlockedAddress("0.0.0.0"));
+    }
+
+    @Test
+    public void testBlocksUnresolvableHostname() {
+        assertTrue("unresolvable hostname should be blocked (fail closed)",
+                NetworkValidationUtil.isBlockedAddress("not-a-valid-host-xyz.invalid"));
+    }
+
+    @Test
+    public void testBlocksIPv6Loopback() {
+        assertTrue("::1 (IPv6 loopback) should be blocked", NetworkValidationUtil.isBlockedAddress("::1"));
+    }
+
+    @Test
+    public void testBlocksIPv6MappedLoopback() {
+        assertTrue("::ffff:127.0.0.1 (IPv6-mapped loopback) should be blocked",
+                NetworkValidationUtil.isBlockedAddress("::ffff:127.0.0.1"));
+    }
+
+    @Test
+    public void testBlocksIPv6MappedLinkLocal() {
+        assertTrue("::ffff:169.254.169.254 (IPv6-mapped cloud metadata) should be blocked",
+                NetworkValidationUtil.isBlockedAddress("::ffff:169.254.169.254"));
+    }
+
+    // ── Allowed addresses (private LAN — lab analyzers live here) ───────
+
+    @Test
+    public void testAllows_192_168_1_100() {
+        assertFalse("192.168.1.100 (private LAN) should be allowed",
+                NetworkValidationUtil.isBlockedAddress("192.168.1.100"));
+    }
+
+    @Test
+    public void testAllows_10_0_1_50() {
+        assertFalse("10.0.1.50 (private LAN) should be allowed", NetworkValidationUtil.isBlockedAddress("10.0.1.50"));
+    }
+
+    @Test
+    public void testAllows_172_16_0_1() {
+        assertFalse("172.16.0.1 (private LAN) should be allowed", NetworkValidationUtil.isBlockedAddress("172.16.0.1"));
+    }
+
+    @Test
+    public void testAllows_172_31_255_254() {
+        assertFalse("172.31.255.254 (private LAN upper bound) should be allowed",
+                NetworkValidationUtil.isBlockedAddress("172.31.255.254"));
+    }
+
+    @Test
+    public void testAllowsPublicIP() {
+        assertFalse("8.8.8.8 (public IP) should be allowed", NetworkValidationUtil.isBlockedAddress("8.8.8.8"));
+    }
+
+    @Test
+    public void testAllowsPublicIP_203() {
+        assertFalse("203.0.113.1 (public IP) should be allowed", NetworkValidationUtil.isBlockedAddress("203.0.113.1"));
+    }
+}


### PR DESCRIPTION
## Summary

Security audit of the Madagascar Analyzer Integration uncovered 5 vulnerabilities in the 8 new REST controllers. This PR remediates all of them:

- **SSRF prevention** (HIGH): Add `NetworkValidationUtil` to block connections to loopback, link-local, multicast, and any-local addresses in `AnalyzerRestController` and `AnalyzerQueryServiceImpl`. Private ranges (10.x, 172.16.x, 192.168.x) remain allowed for lab analyzer connectivity.
- **Path traversal** (HIGH): Add NIO `Path.startsWith()` validation to `FileImportRestController`, `FileImportWatchService`, and `FileImportServiceImpl`. Fix existing `String.startsWith()` bug in analyzer defaults endpoint (sibling directory attack).
- **User ID spoofing** (MEDIUM): Replace user-supplied `userId` parameter with `getSysUserId(request)` in `AnalyzerErrorRestController` acknowledge endpoints.
- **Missing authorization** (MEDIUM): Add `UserModuleService.isUserAdmin()` checks to validation rule mutation endpoints in `CustomFieldTypeRestController`.
- **Audit trail** (MEDIUM): Replace hardcoded `setSysUserId("1")` with `getSysUserId(request)` across `AnalyzerRestController` and `FileImportRestController` (6 call sites).

## Files changed

| File | Changes |
|------|---------|
| `NetworkValidationUtil.java` | **New** — SSRF IP blocklist utility (blocks loopback, link-local, multicast, any-local; checks IPv6-mapped IPv4) |
| `AnalyzerRestController.java` | SSRF checks on create/update/testConnection + path traversal fix + sysUserId fix |
| `AnalyzerQueryServiceImpl.java` | SSRF check before ASTM query connection |
| `FileImportRestController.java` | Path traversal validation + sysUserId fix |
| `FileImportWatchService.java` | Defense-in-depth path check before scanning |
| `FileImportServiceImpl.java` | Defense-in-depth path checks before archive/error file moves |
| `AnalyzerErrorRestController.java` | Replace user-supplied userId with session-based auth |
| `CustomFieldTypeRestController.java` | Admin-only checks on validation rule CRUD |
| `application.properties` | Add `file.import.base.directory` config |

## Test plan

- [x] Build passes (`mvn clean install -DskipTests -Dmaven.test.skip=true`)
- [ ] Unit tests for `NetworkValidationUtil` (blocked/allowed addresses)
- [ ] Full test suite passes (`mvn test`)
- [ ] Manual verification of blocked IPs, traversal paths, userId spoofing

🤖 Generated with [Claude Code](https://claude.com/claude-code)