### PR TITLE
fix(ci): Fix e2e fixture SQL for empty organization table

### DIFF
--- a/src/test/resources/e2e-foundational-data.sql
+++ b/src/test/resources/e2e-foundational-data.sql
@@ -96,7 +96,6 @@ SELECT
   NULL,
   CURRENT_TIMESTAMP,
   gen_random_uuid()
-FROM organization
 WHERE NOT EXISTS (
   SELECT 1 FROM organization WHERE name = 'CAMES MAN'
 );
@@ -135,7 +134,6 @@ SELECT
   NULL,
   CURRENT_TIMESTAMP,
   gen_random_uuid()
-FROM organization
 WHERE NOT EXISTS (
   SELECT 1 FROM organization WHERE name = 'CEDRES'
 );


### PR DESCRIPTION
## Summary
- Fixes 9 E2E test failures on `develop` after PR #2766 merge
- Root cause: `INSERT INTO organization ... SELECT ... FROM organization WHERE NOT EXISTS (...)` returns zero rows when the organization table is empty (fresh CI build), silently skipping the insert
- Fix: Remove `FROM organization` — PostgreSQL `SELECT` without `FROM` returns exactly one row, preserving the `WHERE NOT EXISTS` idempotency guard

## Verified
- Ran fixed SQL against empty organization table locally → `Organizations: 2 (expected: 2)`
- Ran twice to confirm idempotency → no duplicates

## Test plan
- [ ] CI E2E tests pass (the 9 previously failing tests should now find CAMES MAN and CEDRES organizations)
- [ ] Verify fixture SQL is idempotent (re-running doesn't create duplicates)
