### PR TITLE
fix: Close main sidenav after navigating to Admin page

### DIFF
--- a/frontend/cypress/pages/HomePage.js
+++ b/frontend/cypress/pages/HomePage.js
@@ -79,6 +79,10 @@ class HomePage {
     cy.get(this.selectors.menuButton).click();
   }
 
+  closeNavigationMenu() {
+    cy.get(this.selectors.menuButton).click();
+  }
+
   // Order Entry related functions
   goToOrderPage() {
     this.openNavigationMenu();
@@ -284,12 +288,14 @@ class HomePage {
   goToAdminPageProgram() {
     this.openNavigationMenu();
     cy.get(this.selectors.administrationMenu).click();
+    this.closeNavigationMenu();
     return new AdminPage();
   }
 
   goToAdminPage() {
     this.openNavigationMenu();
     cy.get(this.selectors.administrationNav).click();
+    this.closeNavigationMenu();
     return new AdminPage();
   }
 


### PR DESCRIPTION
## Summary
- Close the main hamburger sidenav after clicking "Administration" to prevent it from overlapping the Admin page's own sidenav
- Adds `closeNavigationMenu()` to `HomePage.js` and calls it in `goToAdminPageProgram()` and `goToAdminPage()`
- Fixes local E2E test failures (`organizationManagement.cy.js`, `barcode.cy.js`, etc.) where admin sidenav links were covered by main nav chevron icons

## Problem
After navigating to the Admin page via the hamburger menu, the main app sidenav stays open. Its chevron icons (`<div class="cds--side-nav__submenu-chevron">`) cover the admin page's own sidenav links, causing Cypress visibility errors locally. Tests pass in CI headless Chrome due to subtle rendering differences, creating a local/CI parity gap.

## Test plan
- [ ] Run `npm run cy:spec "cypress/e2e/AdminE2E/organizationManagement.cy.js"` locally — navigation steps should pass
- [ ] Run `npm run cy:spec "cypress/e2e/AdminE2E/barcode.cy.js"` locally — navigation should pass
- [ ] Confirm CI still passes (no regression from closing the nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)