### PR TITLE
fix(e2e): Fix duplicate org names and admin sidenav overlap

### DIFF
--- a/frontend/cypress/e2e/AdminE2E/organizationManagement.cy.js
+++ b/frontend/cypress/e2e/AdminE2E/organizationManagement.cy.js
@@ -11,15 +11,20 @@ before("login", () => {
 });
 
 describe("Add Organization and Institute", function () {
+  beforeEach(() => {
+    // Intercept Organization save API to capture response details
+    cy.intercept("POST", "**/rest/Organization*").as("saveOrg");
+  });
+
   it("Navigate to Admin Page", function () {
     homePage = loginPage.goToHomePage();
     adminPage = homePage.goToAdminPageProgram();
-    cy.wait(500);
+    cy.screenshot("01-admin-page-loaded");
   });
 
   it("Navigate to organisation Management", function () {
     organizationManagement = adminPage.goToOrganizationManagement();
-    cy.wait(500);
+    cy.screenshot("02-org-management-loaded");
   });
 
   it("Add organisation/site details", function () {
@@ -29,13 +34,32 @@ describe("Add Organization and Institute", function () {
     organizationManagement.addPrefix();
     organizationManagement.addParentOrg();
     organizationManagement.checkReferringClinic();
+    cy.screenshot("03-org-form-filled");
+
     organizationManagement.saveOrganization();
+
+    // Wait for the save API call and log its response
+    cy.wait("@saveOrg").then((interception) => {
+      const { statusCode, body } = interception.response;
+      cy.log(`**Save Org API Response:** status=${statusCode}`);
+      cy.log(`**Response body:** ${JSON.stringify(body).substring(0, 500)}`);
+
+      // Screenshot after save completes
+      cy.screenshot("04-after-org-save", {
+        capture: "fullPage",
+      });
+
+      // Fail loudly if server returned an error
+      expect(statusCode).to.be.lessThan(400);
+    });
   });
 
   it("Validate added site/organization", function () {
     organizationManagement = adminPage.goToOrganizationManagement();
     organizationManagement.searchOrganzation();
+    cy.screenshot("05-org-search-results");
     organizationManagement.confirmOrganization();
+    cy.screenshot("06-org-confirmed");
   });
 
   it("Add institute details", function () {
@@ -45,12 +69,29 @@ describe("Add Organization and Institute", function () {
     //organizationManagement.addInstitutePrefix();
     organizationManagement.addParentOrg();
     organizationManagement.checkReferalLab();
+    cy.screenshot("07-institute-form-filled");
+
     organizationManagement.saveOrganization();
+
+    // Wait for the save API call and log its response
+    cy.wait("@saveOrg").then((interception) => {
+      const { statusCode, body } = interception.response;
+      cy.log(`**Save Institute API Response:** status=${statusCode}`);
+      cy.log(`**Response body:** ${JSON.stringify(body).substring(0, 500)}`);
+
+      cy.screenshot("08-after-institute-save", {
+        capture: "fullPage",
+      });
+
+      expect(statusCode).to.be.lessThan(400);
+    });
   });
 
   it("Validate added institute", function () {
     organizationManagement = adminPage.goToOrganizationManagement();
     organizationManagement.searchInstitute();
+    cy.screenshot("09-institute-search-results");
     organizationManagement.confirmInstitute();
+    cy.screenshot("10-institute-confirmed");
   });
 });

--- a/frontend/cypress/pages/HomePage.js
+++ b/frontend/cypress/pages/HomePage.js
@@ -79,6 +79,10 @@ class HomePage {
     cy.get(this.selectors.menuButton).click();
   }
 
+  closeNavigationMenu() {
+    cy.get(this.selectors.menuButton).click();
+  }
+
   // Order Entry related functions
   goToOrderPage() {
     this.openNavigationMenu();
@@ -284,12 +288,14 @@ class HomePage {
   goToAdminPageProgram() {
     this.openNavigationMenu();
     cy.get(this.selectors.administrationMenu).click();
+    this.closeNavigationMenu();
     return new AdminPage();
   }
 
   goToAdminPage() {
     this.openNavigationMenu();
     cy.get(this.selectors.administrationNav).click();
+    this.closeNavigationMenu();
     return new AdminPage();
   }
 

--- a/frontend/cypress/pages/HomePage.js
+++ b/frontend/cypress/pages/HomePage.js
@@ -80,7 +80,21 @@ class HomePage {
   }
 
   closeNavigationMenu() {
-    cy.get(this.selectors.menuButton).click();
+    cy.get(this.selectors.menuButton)
+      .then(($btn) => {
+        const ariaLabel = $btn.attr("aria-label");
+
+        // Only click if the current state indicates the menu is open.
+        if (ariaLabel && ariaLabel.toLowerCase().includes("close")) {
+          cy.wrap($btn).click();
+        }
+      })
+      .should(($btn) => {
+        const ariaLabel = $btn.attr("aria-label");
+        if (ariaLabel) {
+          expect(ariaLabel.toLowerCase()).not.to.include("close");
+        }
+      });
   }
 
   // Order Entry related functions

--- a/frontend/cypress/pages/OrganizationManagementPage.js
+++ b/frontend/cypress/pages/OrganizationManagementPage.js
@@ -1,3 +1,6 @@
+const TEST_ORG_NAME = TEST_ORG_NAME;
+const TEST_LAB_NAME = TEST_LAB_NAME;
+
 class OrganizationManagementPage {
   constructor() {
     this.selectors = {
@@ -20,12 +23,12 @@ class OrganizationManagementPage {
   }
 
   addOrgName() {
-    cy.get(this.selectors.orgName).should("be.visible").type("TEST-ORG-E2E");
+    cy.get(this.selectors.orgName).should("be.visible").type(TEST_ORG_NAME);
     cy.wait(200);
   }
 
   addInstituteName() {
-    cy.get(this.selectors.orgName).should("be.visible").type("TEST-LAB-E2E");
+    cy.get(this.selectors.orgName).should("be.visible").type(TEST_LAB_NAME);
     cy.wait(200);
   }
 
@@ -57,7 +60,7 @@ class OrganizationManagementPage {
   addParentOrg() {
     cy.get(this.selectors.parentOrgName)
       .should("be.visible")
-      .type("TEST-ORG-E2E");
+      .type(TEST_ORG_NAME);
     cy.wait(200);
   }
 
@@ -79,7 +82,7 @@ class OrganizationManagementPage {
       .clear({ force: true });
 
     // Re-query again before typing
-    cy.get(`input${this.selectors.orgSearchBar}`).type("TEST-ORG-E2E", {
+    cy.get(`input${this.selectors.orgSearchBar}`).type(TEST_ORG_NAME, {
       force: true,
     });
     cy.wait(200);
@@ -98,7 +101,7 @@ class OrganizationManagementPage {
       .clear({ force: true });
 
     // Re-query again before typing
-    cy.get(`input${this.selectors.orgSearchBar}`).type("TEST-LAB-E2E", {
+    cy.get(`input${this.selectors.orgSearchBar}`).type(TEST_LAB_NAME, {
       force: true,
     });
     cy.wait(200);
@@ -106,13 +109,13 @@ class OrganizationManagementPage {
 
   confirmOrganization() {
     cy.get(this.selectors.orgTableRow)
-      .contains("TEST-ORG-E2E")
+      .contains(TEST_ORG_NAME)
       .should("be.visible");
   }
 
   confirmInstitute() {
     cy.get(this.selectors.orgTableRow)
-      .contains("TEST-LAB-E2E")
+      .contains(TEST_LAB_NAME)
       .should("be.visible");
   }
 }

--- a/frontend/cypress/pages/OrganizationManagementPage.js
+++ b/frontend/cypress/pages/OrganizationManagementPage.js
@@ -1,5 +1,5 @@
-const TEST_ORG_NAME = TEST_ORG_NAME;
-const TEST_LAB_NAME = TEST_LAB_NAME;
+const TEST_ORG_NAME = "TEST-ORG-E2E";
+const TEST_LAB_NAME = "TEST-LAB-E2E";
 
 class OrganizationManagementPage {
   constructor() {
@@ -19,92 +19,87 @@ class OrganizationManagementPage {
 
   clickAddOrganization() {
     cy.get(this.selectors.addButton).should("be.visible").click();
-    cy.wait(200);
   }
 
   addOrgName() {
-    cy.get(this.selectors.orgName).should("be.visible").type(TEST_ORG_NAME);
-    cy.wait(200);
+    cy.get(this.selectors.orgName)
+      .should("be.visible")
+      .type(TEST_ORG_NAME)
+      .should("have.value", TEST_ORG_NAME);
   }
 
   addInstituteName() {
-    cy.get(this.selectors.orgName).should("be.visible").type(TEST_LAB_NAME);
-    cy.wait(200);
+    cy.get(this.selectors.orgName)
+      .should("be.visible")
+      .type(TEST_LAB_NAME)
+      .should("have.value", TEST_LAB_NAME);
   }
 
   activateOrganization() {
-    cy.get(this.selectors.isActive).clear().type("Y");
-    cy.wait(200);
+    cy.get(this.selectors.isActive).clear().type("Y").should("have.value", "Y");
   }
 
   addPrefix() {
-    cy.get(this.selectors.orgPrefix).should("be.visible").type("279");
-    cy.wait(200);
+    cy.get(this.selectors.orgPrefix)
+      .should("be.visible")
+      .type("279")
+      .should("have.value", "279");
   }
 
   addInstitutePrefix() {
-    cy.get(this.selectors.orgPrefix).should("be.visible").clear().type("");
-    cy.wait(200);
+    cy.get(this.selectors.orgPrefix).should("be.visible").clear();
   }
 
   checkReferringClinic() {
-    cy.get(this.selectors.referringClinic).check({ force: true });
-    cy.wait(200);
+    cy.get(this.selectors.referringClinic)
+      .check({ force: true })
+      .should("be.checked");
   }
 
   checkReferalLab() {
-    cy.get(this.selectors.referralLab).check({ force: true });
-    cy.wait(200);
+    cy.get(this.selectors.referralLab)
+      .check({ force: true })
+      .should("be.checked");
   }
 
   addParentOrg() {
     cy.get(this.selectors.parentOrgName)
       .should("be.visible")
-      .type(TEST_ORG_NAME);
-    cy.wait(200);
+      .type(TEST_ORG_NAME)
+      .should("have.value", TEST_ORG_NAME);
   }
 
   saveOrganization() {
     cy.get(this.selectors.saveButton).should("be.visible").click();
-    cy.wait(3000);
+    cy.url().should("include", "/MasterListsPage");
   }
 
   searchOrganzation() {
-    // Break up the chain to avoid detached DOM issues
-    // First, ensure the element is visible and scroll into view
     cy.get(`input${this.selectors.orgSearchBar}`)
       .should("be.visible")
       .scrollIntoView();
 
-    // Re-query after scroll (page may have updated)
     cy.get(`input${this.selectors.orgSearchBar}`)
       .focus()
       .clear({ force: true });
 
-    // Re-query again before typing
     cy.get(`input${this.selectors.orgSearchBar}`).type(TEST_ORG_NAME, {
       force: true,
     });
-    cy.wait(200);
   }
 
   searchInstitute() {
-    // Break up the chain to avoid detached DOM issues
-    // First, ensure the element is visible and scroll into view
     cy.get(`input${this.selectors.orgSearchBar}`)
       .should("be.visible")
       .scrollIntoView();
 
-    // Re-query after scroll (page may have updated)
     cy.get(`input${this.selectors.orgSearchBar}`)
       .focus()
       .clear({ force: true });
 
-    // Re-query again before typing
     cy.get(`input${this.selectors.orgSearchBar}`).type(TEST_LAB_NAME, {
       force: true,
     });
-    cy.wait(200);
   }
 
   confirmOrganization() {

--- a/frontend/cypress/pages/OrganizationManagementPage.js
+++ b/frontend/cypress/pages/OrganizationManagementPage.js
@@ -20,12 +20,12 @@ class OrganizationManagementPage {
   }
 
   addOrgName() {
-    cy.get(this.selectors.orgName).should("be.visible").type("CAMES MAN");
+    cy.get(this.selectors.orgName).should("be.visible").type("TEST-ORG-E2E");
     cy.wait(200);
   }
 
   addInstituteName() {
-    cy.get(this.selectors.orgName).should("be.visible").type("CEDRES");
+    cy.get(this.selectors.orgName).should("be.visible").type("TEST-LAB-E2E");
     cy.wait(200);
   }
 
@@ -55,7 +55,9 @@ class OrganizationManagementPage {
   }
 
   addParentOrg() {
-    cy.get(this.selectors.parentOrgName).should("be.visible").type("CAMESM AN");
+    cy.get(this.selectors.parentOrgName)
+      .should("be.visible")
+      .type("TEST-ORG-E2E");
     cy.wait(200);
   }
 
@@ -77,7 +79,7 @@ class OrganizationManagementPage {
       .clear({ force: true });
 
     // Re-query again before typing
-    cy.get(`input${this.selectors.orgSearchBar}`).type("CAMES MAN", {
+    cy.get(`input${this.selectors.orgSearchBar}`).type("TEST-ORG-E2E", {
       force: true,
     });
     cy.wait(200);
@@ -96,7 +98,7 @@ class OrganizationManagementPage {
       .clear({ force: true });
 
     // Re-query again before typing
-    cy.get(`input${this.selectors.orgSearchBar}`).type("CEDRES", {
+    cy.get(`input${this.selectors.orgSearchBar}`).type("TEST-LAB-E2E", {
       force: true,
     });
     cy.wait(200);
@@ -104,12 +106,14 @@ class OrganizationManagementPage {
 
   confirmOrganization() {
     cy.get(this.selectors.orgTableRow)
-      .contains("CAMES MAN")
+      .contains("TEST-ORG-E2E")
       .should("be.visible");
   }
 
   confirmInstitute() {
-    cy.get(this.selectors.orgTableRow).contains("CEDRES").should("be.visible");
+    cy.get(this.selectors.orgTableRow)
+      .contains("TEST-LAB-E2E")
+      .should("be.visible");
   }
 }
 


### PR DESCRIPTION
## Summary
- Rename organizations created by `organizationManagement.cy.js` from "CAMES MAN"/"CEDRES" to "TEST-ORG-E2E"/"TEST-LAB-E2E" (constants) to avoid collisions with `e2e-foundational-data.sql`
- Close main hamburger sidenav after navigating to Admin page to prevent it from covering admin sidenav links
- Fixes `cy.select() matched more than one option` failure in `orderEntity.cy.js` and cascade failures in `nonConform.cy.js` and others
- Supersedes #2786

## Root cause
1. **Duplicate orgs**: `organizationManagement.cy.js` created "CAMES MAN"/"CEDRES" via UI, duplicating the same names seeded by `e2e-foundational-data.sql`. With `testIsolation: false`, downstream tests saw duplicate dropdown entries.
2. **Sidenav overlap**: After navigating to Admin via hamburger menu, the main sidenav stayed open, its chevron icons covering admin sidenav links.

## Test plan
- [ ] CI E2E suite passes — `orderEntity.cy.js` no longer hits duplicate CEDRES
- [ ] `organizationManagement.cy.js` passes with new names
- [ ] Admin E2E tests pass without sidenav overlap errors

Closes #2786

🤖 Generated with [Claude Code](https://claude.com/claude-code)