### PR TITLE
fix(011): sidenav 3-state layout and style improvements

### DIFF
--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -1,3 +1,4 @@
+/* Sidenav style improvements — fix/011-sidenav-styles */
 .logo {
   height: 40px;
   width: auto;

--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -81,49 +81,6 @@ li.clickableUserDetails:hover {
   justify-content: space-between;
 }
 
-.first-division {
-  display: flex;
-  flex-direction: column;
-  margin: 0 5px 0.5rem 0;
-  width: 100%;
-}
-
-.second-division {
-  padding-top: 5%;
-}
-
-button {
-  background: none;
-  cursor: pointer;
-  font-weight: 500;
-  border-radius: 2px;
-  padding: 5px 10px;
-}
-
-.add_button {
-  align-self: flex-start;
-  display: flex;
-  align-items: center;
-  margin-top: 0.5rem;
-  color: rgb(0, 208, 255);
-  border-color: rgb(0, 208, 255);
-}
-
-.add_button,
-.remove-btn {
-  border: 1px solid;
-}
-
-.remove-btn {
-  color: red;
-  border-color: red;
-}
-
-.services {
-  display: flex;
-  justify-content: space-between;
-}
-
 .ruleBody,
 .gridBoundary,
 .columnBoundary,
@@ -148,30 +105,6 @@ button {
 .columnBoundary {
   margin: 2%;
   width: 120%;
-}
-
-.inlineDiv {
-  display: flex;
-  margin-top: 2%;
-  margin-bottom: 3%;
-  margin-left: 1%;
-}
-.section {
-  border: 0.5px solid green;
-  border-radius: 3px;
-  margin: 0.5%;
-}
-
-.errorMessage {
-  font-size: 12px;
-  color: red;
-  width: 150px;
-  margin-top: 0.25rem;
-}
-
-.errorMessage::before {
-  content: " ";
-  font-size: 10px;
 }
 
 .inlineDivBlock > div {
@@ -437,30 +370,6 @@ button {
   display: inline-flex !important;
 }
 
-.custom-sidenav-button {
-  box-sizing: border-box;
-  margin: 0;
-  border: 0;
-  cursor: pointer;
-  display: flex;
-  visibility: visible !important;
-  align-items: center;
-  background-color: var(--cds-background-hover, #072655);
-  color: var(--cds-text-secondary, #ffffff);
-  transition:
-    color 110ms,
-    background-color 110ms,
-    outline 110ms;
-  -webkit-user-select: none;
-  user-select: none;
-  width: 100%;
-  pointer-events: auto;
-}
-
-.custom-sidenav-button:hover {
-  background-color: var(--cds-background, #295785);
-}
-
 .cds--side-nav__link a {
   pointer-events: auto;
   text-decoration: none !important;
@@ -560,21 +469,18 @@ button {
   }
 }
 
-/* Fix sidenav scrollbar - scroll whole page not just nav */
+/* Fix sidenav scrollbar - scroll whole page not just nav; hide scrollbar */
 .cds--side-nav {
   overflow-y: visible !important;
   overflow-x: visible !important;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
 }
 
 .cds--side-nav__navigation {
   overflow-y: visible !important;
   overflow-x: visible !important;
-}
-
-/* Hide scrollbar on sidenav - let page scroll instead */
-.cds--side-nav {
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none; /* IE/Edge */
+  max-height: none !important;
 }
 
 .cds--side-nav::-webkit-scrollbar {
@@ -846,9 +752,11 @@ li.cds--side-nav__item.cds--side-nav__item--active {
   color: inherit !important;
 }
 
-/* Suppress icon fill change on active parent */
+/* Suppress icon fill change on active parent.
+ * Use currentColor (inherits CSS `color`, white in dark nav) not `inherit`
+ * (`inherit` walks the SVG `fill` chain which defaults to black). */
 .cds--side-nav__item--active .cds--side-nav__icon > svg {
-  fill: inherit !important;
+  fill: currentColor !important;
 }
 
 /* Micro-transition: suppress 1-frame flash when Carbon toggles active classes.
@@ -867,11 +775,6 @@ nav.cds--side-nav .cds--side-nav__item {
 nav.cds--side-nav .cds--side-nav__submenu::before,
 nav.cds--side-nav .cds--side-nav__link::before {
   transition: none !important;
-}
-
-.cds--side-nav__navigation {
-  overflow-y: visible !important;
-  max-height: none !important;
 }
 
 /* Subnav items (level 1+) - extra indent for visual hierarchy */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,6 +22,7 @@ code {
  */
 .cds--header.cds--header {
   background-color: var(--site-branding-header, #295785);
+  border-bottom: none;
 }
 
 .slide-over-root {


### PR DESCRIPTION
## Summary
- Fix black chevron arrow on Analyzers menu (`fill: inherit` → `currentColor`)
- Remove dark border under page header (Carbon default `border-bottom`)
- 3-state sidenav (close/show/lock) with localStorage persistence
- Suppress grey flash on navigation between menu levels
- CSS cleanup: remove hardcoded `--cds-text-primary: black` overrides
- Login page centering fix when sidenav is in LOCK mode
- New hooks: `useSideNavPreference`, `useMenuAutoExpand`
- Consolidate duplicate CSS selectors, remove orphaned rules, deduplicate legacy CSS

## Context
Sidenav style and layout improvements from feature 004, opened as a standalone PR for review while the main feature PR (#2767) awaits approval.

## Test plan
- [ ] Verify Analyzers chevron is white (matches all other expandable menus)
- [ ] Verify no dark border between header and content area
- [ ] Verify 3-state toggle: close → show → lock → close
- [ ] Verify preference persists across page refresh (localStorage)
- [ ] Verify login page stays centered regardless of sidenav state
- [ ] Verify no grey flash when navigating between menu levels
- [ ] Hover all top-level menu items — confirm consistent behavior
- [ ] Run `npm run test` for unit tests on new hooks