### PR TITLE
Command complexity and review

### DIFF
--- a/.specify/oe/commands/careful-rebase.md
+++ b/.specify/oe/commands/careful-rebase.md
@@ -4,14 +4,29 @@ When the user invokes `/careful-rebase` (optionally with arguments), perform a
 careful, checkpointed rebase workflow with:
 
 - A **backup branch** created up-front
-- A **rebase plan** (what will move, onto what)
-- A **conflict risk** report (where conflicts are likely)
+- A **rebase plan** (what will move, onto what) with a **projected change
+  summary**
+- A **conflict risk** report (where conflicts are likely) including **base-only
+  improvements**
 - An **answer session** to resolve ambiguities before/while resolving conflicts
+  (only if needed)
 - An **optional squash-before-rebase** step
 - **Validation** and a **post-rebase report** (including `git range-diff`)
 
 This command is intentionally conservative: it should **plan first**, then
 require explicit user confirmation before any history-rewriting actions.
+
+## Review Cycle (required gates)
+
+This workflow must have a clear, repeatable review cycle:
+
+1. **Pre-rebase confirmation (REQUIRED):** show the projected changes (commits
+   to replay, diffstat, hotspots, base-only improvements, and whether a
+   force-push will be needed) and stop until the user explicitly says **“Proceed
+   with rebase”**.
+2. **QA session checkpoint (REQUIRED):** after the rebase, produce a short QA
+   checklist and stop until the user explicitly confirms **“QA approved”**
+   before suggesting any force-push.
 
 ## User Input
 
@@ -61,6 +76,8 @@ Determine:
 - **BASE_SHA**: `git rev-parse <base>`
 - **FORK_SHA**: `git merge-base HEAD <base>`
 - Ahead/behind counts: `git rev-list --left-right --count <base>...HEAD`
+- **Upstream tracking ref** (if any):
+  `git rev-parse --abbrev-ref --symbolic-full-name @{u}`
 
 If working tree is not clean, stop and ask the user to commit/stash first.
 
@@ -81,12 +98,18 @@ Print the “restore” options clearly:
 
 ### 2) Build a careful rebase plan (checkpoint #2)
 
-Produce a short plan the user can review before any rebase starts:
+Produce a short plan the user can review before any rebase starts.
 
 - **Commits that will be replayed**:
   - `git log --oneline --decorate <base>..HEAD`
+- **Commits from base you will pick up**:
+  - `git log --oneline --decorate <FORK_SHA>..<base>`
 - **High-level change summary**:
   - `git diff --stat <FORK_SHA>..HEAD`
+- **Upstream divergence (if tracking ref exists)**:
+  - `git log --oneline --decorate @{u}..HEAD` (what we would push)
+  - `git log --oneline --decorate HEAD..@{u}` (what we'd be overwriting if
+    force-push)
 
 If there are merge commits on the branch (detect via
 `git rev-list --merges <base>..HEAD`):
@@ -94,21 +117,20 @@ If there are merge commits on the branch (detect via
 - Recommend `--preserve-merges` by default
 - Ask the user whether to preserve merges or linearize history
 
-### 3) Identify likely conflict hotspots AND base-only improvements
+### 3) Identify likely conflict hotspots and base-only improvements (projected risk)
 
-Classify every changed file into one of four categories:
+Compute the file sets (ours vs base) from the fork point:
 
 ```bash
 OUR_FILES=$(git diff --name-only <FORK_SHA>..HEAD)
 THEIR_FILES=$(git diff --name-only <FORK_SHA>..<base>)
 ```
 
-| Category                     | Definition                                   | Rebase risk                                                               |
-| ---------------------------- | -------------------------------------------- | ------------------------------------------------------------------------- |
-| **Both modified** (hotspots) | File in both `OUR_FILES` and `THEIR_FILES`   | HIGH — will likely conflict                                               |
-| **Base-only improvements**   | File in `THEIR_FILES` but NOT in `OUR_FILES` | MEDIUM — should auto-merge, but context shifts can cause silent reversion |
-| **Our-only changes**         | File in `OUR_FILES` but NOT in `THEIR_FILES` | LOW — should replay cleanly                                               |
-| **Untouched**                | Neither                                      | NONE                                                                      |
+Then report only what matters for review:
+
+- **Hotspots (both modified)**: likely conflicts
+- **Base-only improvements (base changed, we didn’t)**: easy to accidentally
+  lose
 
 #### 3a) Report hotspots (both-modified files)
 
@@ -133,13 +155,8 @@ unchanged.
 comm -23 <(echo "$THEIR_FILES" | sort) <(echo "$OUR_FILES" | sort)
 ```
 
-**Why this matters:** During conflict resolution, if a base-only file conflicts
-due to context-line shifts near our changes, the agent may default to "take
-ours" — which silently reverts the base's work. This is how harness scripts,
-shell configs, documentation, and non-Java files get lost. The user MUST be
-aware of these files so they can verify they survived after the rebase.
-
-Group base-only improvements by area and highlight:
+Group base-only improvements by area and highlight non-compiled/non-tested files
+(easy to miss):
 
 - Shell scripts (`*.sh`)
 - CI/CD configs (`.github/`, `Dockerfile`, `docker-compose*.yml`)
@@ -154,23 +171,10 @@ Group base-only improvements by area and highlight:
 Before rebasing, **always** scan all localization JSON files (whether or not
 they appear as hotspots) for pre-existing duplicate keys:
 
-```python
-python3 -c "
-import json, collections, sys
-errors = False
-for f in ['frontend/src/languages/en.json', 'frontend/src/languages/fr.json']:
-    try:
-        pairs = json.loads(open(f).read(), object_pairs_hook=lambda p: p)
-        dupes = {k: c for k, c in collections.Counter(k for k,v in pairs).items() if c > 1}
-        if dupes:
-            print(f'{f}: {len(dupes)} duplicate keys found!')
-            errors = True
-        else:
-            print(f'{f}: clean')
-    except FileNotFoundError:
-        pass
-sys.exit(1 if errors else 0)
-"
+```bash
+python3 .specify/scripts/python/check-json-duplicate-keys.py \
+  frontend/src/languages/en.json \
+  frontend/src/languages/fr.json
 ```
 
 If duplicates are found, **report them to the user and ask whether to
@@ -178,11 +182,30 @@ deduplicate before or after the rebase**. Do NOT silently proceed — duplicate
 keys in JSON cause CI failures (the `i18n-check` workflow rejects them) and can
 mask data loss when `JSON.parse` silently takes the last value for each key.
 
-### 4) Answer session (resolve ambiguities up-front)
+### 4) Pre-rebase confirmation (REQUIRED GATE)
+
+Before any history rewrite (squash/reset/rebase), provide a short “projected
+changes” summary:
+
+- Base ref + `BASE_SHA`
+- Fork point `FORK_SHA`
+- Backup branch name
+- Number of commits to replay (`git rev-list --count <base>..HEAD`)
+- Number of base commits to pick up (`git rev-list --count <FORK_SHA>..<base>`)
+- Diffstat (`git diff --stat <FORK_SHA>..HEAD`)
+- Hotspots count + list (Step 3a)
+- Base-only improvements count + list (Step 3b)
+- Rebase mode: `--preserve-merges` yes/no
+- Squash-before-rebase: yes/no
+- Push impact (if upstream tracking exists): whether a force-push is likely
+
+Then stop and wait for the user to explicitly say: **“Proceed with rebase”**.
+
+### 5) Answer session (resolve ambiguities up-front, only if needed)
 
 If hotspots exist (or if the user requests), run an "answer session":
 
-#### 4a) Hotspot resolution preferences
+#### 5a) Hotspot resolution preferences
 
 - Ask the user for **resolution preferences** for hotspot categories, e.g.:
   - "If we hit a lockfile conflict, should we regenerate post-rebase rather than
@@ -193,7 +216,7 @@ If hotspots exist (or if the user requests), run an "answer session":
 - For any single hotspot file that looks high-risk, ask:
   - "Should we prefer our changes, their changes, or do a manual merge?"
 
-#### 4b) Base-only improvement protection policy (MANDATORY)
+#### 5b) Base-only improvement protection policy (MANDATORY)
 
 For base-only improvements identified in Step 3b, establish a clear policy:
 
@@ -210,7 +233,7 @@ For base-only improvements identified in Step 3b, establish a clear policy:
 Record these decisions in the chat and apply them consistently if conflicts
 occur.
 
-### 5) Optional squash-before-rebase (checkpoint #3)
+### 6) Optional squash-before-rebase (checkpoint #3)
 
 Only do this if the user explicitly requested `--squash` (or answers “yes” when
 asked).
@@ -227,9 +250,7 @@ Squash method (non-interactive, safe with backup):
   - `git reset --soft <FORK_SHA>`
   - `git commit -m "<chosen message>"`
 
-### 6) Execute the rebase (checkpoint #4)
-
-Before running any rebase, ask for a clear “go / stop” from the user.
+### 7) Execute the rebase (checkpoint #4)
 
 Choose the command based on earlier decisions:
 
@@ -250,7 +271,7 @@ If the user wants to abandon:
 - `git rebase --abort`
 - Offer to restore from the backup branch
 
-### 7) Validation (checkpoint #5)
+### 8) Post-rebase review + validation (checkpoint #5)
 
 Always run these:
 
@@ -263,27 +284,10 @@ Always run these:
 After the rebase completes (even if there were no conflicts on i18n files),
 **always** re-run the duplicate key scan on all localization JSON files:
 
-```python
-python3 -c "
-import json, collections, sys
-errors = False
-for f in ['frontend/src/languages/en.json', 'frontend/src/languages/fr.json']:
-    try:
-        pairs = json.loads(open(f).read(), object_pairs_hook=lambda p: p)
-        dupes = {k: c for k, c in collections.Counter(k for k,v in pairs).items() if c > 1}
-        if dupes:
-            print(f'{f}: {len(dupes)} duplicate keys!')
-            for k, c in sorted(dupes.items())[:10]:
-                print(f'  {k} ({c}x)')
-            if len(dupes) > 10:
-                print(f'  ... and {len(dupes) - 10} more')
-            errors = True
-        else:
-            print(f'{f}: clean ({len(pairs)} unique keys)')
-    except FileNotFoundError:
-        pass
-sys.exit(1 if errors else 0)
-"
+```bash
+python3 .specify/scripts/python/check-json-duplicate-keys.py \
+  frontend/src/languages/en.json \
+  frontend/src/languages/fr.json
 ```
 
 If duplicates are found:
@@ -354,7 +358,18 @@ Then run validation level:
 If any validation fails, stop and report failures clearly before suggesting
 fixes.
 
-### 8) Post-rebase report
+### 9) Official QA session checkpoint (REQUIRED GATE)
+
+Run (or confirm CI ran) the agreed validation level, then produce a short QA
+checklist summary. At minimum, include:
+
+- What validations were run (quick/standard/thorough) and pass/fail
+- Any manual smoke steps performed (if applicable)
+- Any files restored from base due to regressions (if any)
+
+Then stop and wait for the user to explicitly confirm: **“QA approved”**.
+
+### 10) Post-rebase report
 
 Produce a concise report including:
 

--- a/.specify/scripts/python/check-json-duplicate-keys.py
+++ b/.specify/scripts/python/check-json-duplicate-keys.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Detect duplicate keys in JSON objects.
+
+Why: JSON allows duplicate keys syntactically; most parsers keep the *last* value silently.
+This script preserves key order and reports duplicates so CI failures and silent overwrites
+can be caught early (e.g., i18n message catalogs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+from pathlib import Path
+
+
+def load_pairs(path: Path) -> list[tuple[str, object]]:
+    # object_pairs_hook receives a list of (key, value) tuples for each object.
+    # We return that list so callers can count duplicates while preserving order.
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f, object_pairs_hook=lambda pairs: pairs)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report duplicate keys in JSON objects (preserving order).",
+    )
+    parser.add_argument("files", nargs="+", help="JSON files to scan")
+    parser.add_argument(
+        "--max-keys",
+        type=int,
+        default=20,
+        help="Maximum duplicate keys to print per file (default: 20)",
+    )
+    args = parser.parse_args(argv)
+
+    any_dupes = False
+    for raw in args.files:
+        path = Path(raw)
+        if not path.exists():
+            # Be permissive: missing files are not an error for multi-locale setups.
+            print(f"{path}: missing (skipped)")
+            continue
+
+        try:
+            pairs = load_pairs(path)
+        except json.JSONDecodeError as e:
+            print(f"{path}: invalid JSON: {e}", file=sys.stderr)
+            return 2
+
+        keys = [k for (k, _v) in pairs]
+        counts = collections.Counter(keys)
+        dupes = {k: c for k, c in counts.items() if c > 1}
+
+        if not dupes:
+            print(f"{path}: clean ({len(counts)} unique keys)")
+            continue
+
+        any_dupes = True
+        print(f"{path}: {len(dupes)} duplicate keys found")
+        for k, c in sorted(dupes.items())[: args.max_keys]:
+            print(f"  {k} ({c}x)")
+        remaining = len(dupes) - min(len(dupes), args.max_keys)
+        if remaining:
+            print(f"  ... and {remaining} more")
+
+    return 1 if any_dupes else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

This PR addresses the complexity and review cycle of the `/careful-rebase` command by:

-   **Simplifying the `careful-rebase` workflow**: The command at `/.specify/oe/commands/careful-rebase.md` has been refactored to be less convoluted at runtime.
-   **Introducing explicit review gates**:
    -   A **Pre-rebase confirmation** step now explicitly shows projected changes (commits to replay, base-only pickups, upstream divergence, diffstat, hotspots) and requires user approval before proceeding.
    -   A **QA session checkpoint** is added post-rebase, requiring explicit user confirmation ("QA approved") before any force-push guidance.
-   **Enhancing projected changes clarity**: The pre-rebase summary now includes more concrete details like commit counts and upstream divergence.
-   **Extracting i18n duplicate key checker**: The inline Python script for checking duplicate keys in i18n JSON files has been moved to a dedicated helper script at `/.specify/scripts/python/check-json-duplicate-keys.py` for better maintainability and readability.

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

This branch was pushed to `origin` as `cursor/command-complexity-and-review-f32d` to enable PR creation.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8636af8b-7aaf-4a04-b9c0-ee40ca7e25a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8636af8b-7aaf-4a04-b9c0-ee40ca7e25a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

