### PR TITLE
fix(test): make SampleTypeCreateServiceTest resilient to duplicates

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -37,6 +37,16 @@ jobs:
       - name: Prepare .env from template
         run: cp .env.example .env
 
+      - name: Free disk space before Docker build
+        run: |
+          echo "=== Disk usage before cleanup ==="
+          df -h
+          echo "=== Cleaning Docker cache ==="
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          echo "=== Disk usage after cleanup ==="
+          df -h
+
       - name: Build OpenELIS containers
         run: docker compose -f build.docker-compose.yml up -d --build --wait --wait-timeout 600
 

--- a/src/test/java/org/openelisglobal/testconfiguration/SampleTypeCreateServiceTest.java
+++ b/src/test/java/org/openelisglobal/testconfiguration/SampleTypeCreateServiceTest.java
@@ -47,8 +47,10 @@ public class SampleTypeCreateServiceTest extends BaseWebContextSensitiveTest {
         localization.setFrench("Salut");
         localization.setEnglish("Hi!");
 
+        String sampleTypeDescription = "CI SampleType " + System.currentTimeMillis();
+
         TypeOfSample typeOfSample = new TypeOfSample();
-        typeOfSample.setDescription("Fluidal acids");
+        typeOfSample.setDescription(sampleTypeDescription);
         typeOfSample.setDomain("H");
         typeOfSample.setLastupdated(Timestamp.valueOf("2024-11-01 12:00:00"));
         typeOfSample.setLocalAbbreviation("Fluids");
@@ -109,8 +111,8 @@ public class SampleTypeCreateServiceTest extends BaseWebContextSensitiveTest {
         // index
         // to avoid issues with test isolation and sorting changes
         TypeOfSample createdSample = newTypeOfSamples.stream()
-                .filter(sample -> "Fluidal acids".equals(sample.getDescription())).findFirst().orElse(null);
-        assertNotNull("Newly created TypeOfSample with description 'Fluidal acids' should be found", createdSample);
+                .filter(sample -> sampleTypeDescription.equals(sample.getDescription())).findFirst().orElse(null);
+        assertNotNull("Newly created TypeOfSample should be found", createdSample);
 
         List<SystemModule> newSystemModules = systemModuleService.getAll();
         assertEquals(initialSystemModuleCount + 3, newSystemModules.size());

--- a/src/test/java/org/openelisglobal/testconfiguration/SampleTypeCreateServiceTest.java
+++ b/src/test/java/org/openelisglobal/testconfiguration/SampleTypeCreateServiceTest.java
@@ -47,13 +47,15 @@ public class SampleTypeCreateServiceTest extends BaseWebContextSensitiveTest {
         localization.setFrench("Salut");
         localization.setEnglish("Hi!");
 
-        String sampleTypeDescription = "CI SampleType " + System.currentTimeMillis();
+        String uniqueSuffix = String.valueOf(System.currentTimeMillis());
+        String sampleTypeDescription = "CI SampleType " + uniqueSuffix;
+        String sampleTypeAbbrev = "CI" + uniqueSuffix.substring(uniqueSuffix.length() - 6);
 
         TypeOfSample typeOfSample = new TypeOfSample();
         typeOfSample.setDescription(sampleTypeDescription);
         typeOfSample.setDomain("H");
         typeOfSample.setLastupdated(Timestamp.valueOf("2024-11-01 12:00:00"));
-        typeOfSample.setLocalAbbreviation("Fluids");
+        typeOfSample.setLocalAbbreviation(sampleTypeAbbrev);
 
         SystemModule workPlanModule = new SystemModule();
         workPlanModule.setSystemModuleName("sample_type workPlan");


### PR DESCRIPTION
## Summary
- Fix CI failure in `SampleTypeCreateServiceTest` caused by a hardcoded `TypeOfSample.description` colliding with existing data.
- Generate a unique per-run description and assert against that value.

## Evidence
- Failed on `develop` in run `21957030185` with `LIMSDuplicateRecordException: Duplicate record exists for Fluidal acids`.

## Test plan
- `mvn test -Dtest=org.openelisglobal.testconfiguration.SampleTypeCreateServiceTest`
