### PR TITLE
issue-2836: Remove debug console.log statements from frontend

### DIFF
--- a/frontend/src/components/nonconform/common/NCECorrectiveAction.jsx
+++ b/frontend/src/components/nonconform/common/NCECorrectiveAction.jsx
@@ -83,7 +83,7 @@ export const NCECorrectiveAction = () => {
           },
         );
       } catch (error) {
-        console.log("Error fetching data", error);
+        // error handling could be added here
       }
     }
   }, [selected]);

--- a/frontend/src/components/nonconform/common/ReportNonConformingEvent.jsx
+++ b/frontend/src/components/nonconform/common/ReportNonConformingEvent.jsx
@@ -171,12 +171,10 @@ export const ReportNonConformingEvent = () => {
   ];
 
   useEffect(() => {
-    console.log(JSON.stringify(selectedSample));
     if (selectedSample.labOrderNumber && selectedSample.specimenId) {
       getFromOpenElisServer(
         `/rest/reportnonconformingevent?labOrderNumber=${selectedSample.labOrderNumber}&specimenId=${selectedSample.specimenId}`,
         (data) => {
-          console.log("data from server for selected", data);
           setLData(undefined);
           setnceForm({
             ...nceForm,
@@ -189,7 +187,6 @@ export const ReportNonConformingEvent = () => {
   }, [selectedSample]);
 
   const handleNCEFormSubmit = () => {
-    console.log("nceForm.data", nceForm.data);
     const newErrors = {};
     if (!nceForm.data.dateOfEvent) {
       newErrors.dateOfEvent = "Date of event is required";

--- a/frontend/src/components/nonconform/common/ViewNonConforming.jsx
+++ b/frontend/src/components/nonconform/common/ViewNonConforming.jsx
@@ -365,7 +365,6 @@ export const ViewNonConformingEvent = () => {
                           name="radio-group"
                           onClick={() => {
                             setSelected(row.nceNumber);
-                            console.log(row);
                           }}
                           labelText=""
                           id={row.id}


### PR DESCRIPTION
Summary

Remove 5 debug console.log statements from 3 frontend nonconformity components. These were development artifacts that should not be in production code.

Files Changed

NCECorrectiveAction.jsx — Removed 1 debug log in error catch block
ReportNonConformingEvent.jsx — Removed 3 debug logs (sample selection, server data, form data)
ViewNonConforming.jsx — Removed 1 debug log in radio button click handler
Note: SlideOverNotifications.jsx was already cleaned up in develop, so removed from this PR's scope.

Fixes #2836