### PR TITLE
Harden careful-rebase with mandatory no-loss audit guardrails

### DIFF
--- a/.specify/oe/commands/careful-rebase.md
+++ b/.specify/oe/commands/careful-rebase.md
@@ -242,8 +242,8 @@ For localization files (for example `frontend/src/languages/en.json` and
 
 - **Never resolve by taking ours/theirs wholesale** unless explicitly approved
   by the user for that file.
-- Resolve to a **key-set union outcome** (all keys that existed before rebase
-  on our branch must still exist after rebase unless explicitly approved for
+- Resolve to a **key-set union outcome** (all keys that existed before rebase on
+  our branch must still exist after rebase unless explicitly approved for
   removal).
 - If keys are intentionally removed, record those keys in chat and pass them to
   the no-loss audit as explicit allow-list entries.

--- a/.specify/oe/commands/careful-rebase.md
+++ b/.specify/oe/commands/careful-rebase.md
@@ -11,6 +11,8 @@ careful, checkpointed rebase workflow with:
 - An **answer session** to resolve ambiguities before/while resolving conflicts
   (only if needed)
 - An **optional squash-before-rebase** step
+- A **no-loss audit** that compares pre/post rebase branch deltas and i18n key
+  sets
 - **Validation** and a **post-rebase report** (including `git range-diff`)
 
 This command is intentionally conservative: it should **plan first**, then
@@ -233,6 +235,22 @@ For base-only improvements identified in Step 3b, establish a clear policy:
 Record these decisions in the chat and apply them consistently if conflicts
 occur.
 
+#### 5c) Translation protection policy (MANDATORY)
+
+For localization files (for example `frontend/src/languages/en.json` and
+`frontend/src/languages/fr.json`), use a strict policy:
+
+- **Never resolve by taking ours/theirs wholesale** unless explicitly approved
+  by the user for that file.
+- Resolve to a **key-set union outcome** (all keys that existed before rebase
+  on our branch must still exist after rebase unless explicitly approved for
+  removal).
+- If keys are intentionally removed, record those keys in chat and pass them to
+  the no-loss audit as explicit allow-list entries.
+
+This prevents silent regressions where a rebase "looks clean" but large key
+groups disappear from translations.
+
 ### 6) Optional squash-before-rebase (checkpoint #3)
 
 Only do this if the user explicitly requested `--squash` (or answers “yes” when
@@ -278,6 +296,34 @@ Always run these:
 - `git status`
 - `git log -n 10 --oneline --decorate`
 - `git range-diff <FORK_SHA>..<backup-branch> <BASE_SHA>..HEAD`
+
+#### Post-rebase no-loss audit vs backup (MANDATORY)
+
+Run a structured no-loss audit that compares the rebased branch (`HEAD`) to the
+pre-rebase backup branch, both relative to the same base ref:
+
+```bash
+python3 .specify/scripts/python/rebase-no-loss-audit.py \
+  --base <base> \
+  --before <backup-branch> \
+  --after HEAD \
+  --i18n-file frontend/src/languages/en.json \
+  --i18n-file frontend/src/languages/fr.json \
+  --fail-on-loss
+```
+
+What this blocks by default:
+
+- **Dropped branch-delta files**: files that were part of our pre-rebase delta
+  vs base, but are no longer part of the post-rebase delta
+- **Missing translation keys**: keys present pre-rebase but missing post-rebase
+
+If the audit fails:
+
+1. Stop and report the exact dropped files / missing keys
+2. Ask the user whether each item is intentional
+3. Re-run with explicit allow-list entries only for approved removals
+4. Do not proceed to QA approval or push until audit is clean
 
 #### Post-rebase i18n duplicate key check (MANDATORY)
 

--- a/.specify/oe/commands/careful-rebase.md
+++ b/.specify/oe/commands/careful-rebase.md
@@ -253,8 +253,10 @@ For localization files (for example `frontend/src/languages/en.json` and
   ```bash
   ./scripts/i18n-no-loss-audit \
     --allow-missing-key frontend/src/languages/en.json:my.removed.key
-This prevents silent regressions where a rebase "looks clean" but large key
-groups disappear from translations.
+  ```
+
+  This prevents silent regressions where a rebase "looks clean" but large key
+  groups disappear from translations.
 
 ### 6) Optional squash-before-rebase (checkpoint #3)
 

--- a/.specify/oe/commands/careful-rebase.md
+++ b/.specify/oe/commands/careful-rebase.md
@@ -311,7 +311,7 @@ pre-rebase backup branch, both relative to the same base ref:
 
 ```bash
 python3 .specify/scripts/python/rebase-no-loss-audit.py \
-  --base <base> \
+  --base "$BASE_SHA" \
   --before <backup-branch> \
   --after HEAD \
   --i18n-file frontend/src/languages/en.json \

--- a/.specify/oe/commands/careful-rebase.md
+++ b/.specify/oe/commands/careful-rebase.md
@@ -246,8 +246,13 @@ For localization files (for example `frontend/src/languages/en.json` and
   our branch must still exist after rebase unless explicitly approved for
   removal).
 - If keys are intentionally removed, record those keys in chat and pass them to
-  the no-loss audit as explicit allow-list entries.
+  the no-loss audit as explicit allow-list entries. For example, if you
+  intentionally remove `my.removed.key` from `frontend/src/languages/en.json`,
+  run the audit with:
 
+  ```bash
+  ./scripts/i18n-no-loss-audit \
+    --allow-missing-key frontend/src/languages/en.json:my.removed.key
 This prevents silent regressions where a rebase "looks clean" but large key
 groups disappear from translations.
 

--- a/.specify/scripts/python/rebase-no-loss-audit.py
+++ b/.specify/scripts/python/rebase-no-loss-audit.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Detect potential regressions introduced during rebase/merge.
+
+This script compares a "before" ref (usually backup branch / pre-rebase HEAD)
+and an "after" ref (usually rebased HEAD), both against a shared base ref.
+
+It reports:
+  - Files that were part of the before-branch delta vs base, but disappeared
+    from the after-branch delta (potential dropped branch changes)
+  - i18n JSON keys that existed before but are missing after
+
+Use --fail-on-loss to return non-zero when potential losses are detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+
+DEFAULT_I18N_FILES = [
+    "frontend/src/languages/en.json",
+    "frontend/src/languages/fr.json",
+]
+
+
+def run_git(args: List[str]) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def delta_files(base_ref: str, ref: str) -> Set[str]:
+    output = run_git(["diff", "--name-only", f"{base_ref}...{ref}"])
+    if not output:
+        return set()
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+def parse_json_at_ref(ref: str, file_path: str) -> Tuple[Dict[str, object] | None, str | None]:
+    try:
+        contents = run_git(["show", f"{ref}:{file_path}"])
+    except subprocess.CalledProcessError:
+        return None, "missing"
+    try:
+        parsed = json.loads(contents)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid-json: {exc}"
+    if not isinstance(parsed, dict):
+        return None, "not-json-object"
+    return parsed, None
+
+
+def parse_allow_missing_key(values: List[str]) -> Dict[str, Set[str]]:
+    allowed: Dict[str, Set[str]] = {}
+    for value in values:
+        if ":" not in value:
+            raise ValueError(
+                f"Invalid --allow-missing-key '{value}'. Expected '<file-path>:<key>'."
+            )
+        file_path, key = value.split(":", 1)
+        file_path = file_path.strip()
+        key = key.strip()
+        if not file_path or not key:
+            raise ValueError(
+                f"Invalid --allow-missing-key '{value}'. Expected '<file-path>:<key>'."
+            )
+        allowed.setdefault(file_path, set()).add(key)
+    return allowed
+
+
+def print_section(title: str) -> None:
+    print("")
+    print(f"=== {title} ===")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit rebase/merge for potential losses.")
+    parser.add_argument("--base", required=True, help="Base ref (e.g. origin/develop)")
+    parser.add_argument(
+        "--before",
+        required=True,
+        help="Pre-rebase ref (e.g. backup/branch/timestamp-sha)",
+    )
+    parser.add_argument("--after", required=True, help="Post-rebase ref (e.g. HEAD)")
+    parser.add_argument(
+        "--i18n-file",
+        action="append",
+        default=None,
+        help="Localization JSON path to compare key sets. Repeat for multiple files.",
+    )
+    parser.add_argument(
+        "--allow-dropped-file",
+        action="append",
+        default=[],
+        help="File path allowed to drop from branch delta. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--allow-missing-key",
+        action="append",
+        default=[],
+        help="Allowed missing i18n key in '<file-path>:<key>' format. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--fail-on-loss",
+        action="store_true",
+        help="Exit non-zero if unapproved dropped files or missing keys are detected.",
+    )
+    parser.add_argument(
+        "--output-json",
+        help="Optional path to write machine-readable JSON report.",
+    )
+    args = parser.parse_args()
+
+    i18n_files = args.i18n_file if args.i18n_file else DEFAULT_I18N_FILES
+    allowed_dropped_files = set(args.allow_dropped_file)
+    allowed_missing_keys = parse_allow_missing_key(args.allow_missing_key)
+
+    before_delta = delta_files(args.base, args.before)
+    after_delta = delta_files(args.base, args.after)
+
+    dropped_delta_files = sorted(before_delta - after_delta)
+    new_delta_files = sorted(after_delta - before_delta)
+    blocked_dropped_files = sorted(
+        file_path for file_path in dropped_delta_files if file_path not in allowed_dropped_files
+    )
+
+    i18n_report = []
+    blocked_missing_keys: List[str] = []
+
+    for file_path in i18n_files:
+        before_json, before_err = parse_json_at_ref(args.before, file_path)
+        after_json, after_err = parse_json_at_ref(args.after, file_path)
+
+        entry = {
+            "file": file_path,
+            "before_error": before_err,
+            "after_error": after_err,
+            "before_key_count": 0,
+            "after_key_count": 0,
+            "missing_keys": [],
+            "added_keys": [],
+        }
+
+        if before_json is not None:
+            before_keys = set(before_json.keys())
+            entry["before_key_count"] = len(before_keys)
+        else:
+            before_keys = set()
+
+        if after_json is not None:
+            after_keys = set(after_json.keys())
+            entry["after_key_count"] = len(after_keys)
+        else:
+            after_keys = set()
+
+        missing_keys = sorted(before_keys - after_keys)
+        added_keys = sorted(after_keys - before_keys)
+        entry["missing_keys"] = missing_keys
+        entry["added_keys"] = added_keys
+        i18n_report.append(entry)
+
+        allowed_for_file = allowed_missing_keys.get(file_path, set())
+        for key in missing_keys:
+            if key not in allowed_for_file:
+                blocked_missing_keys.append(f"{file_path}:{key}")
+
+    print("Rebase No-Loss Audit")
+    print("--------------------")
+    print(f"Base ref   : {args.base}")
+    print(f"Before ref : {args.before}")
+    print(f"After ref  : {args.after}")
+
+    print_section("Delta file comparison (vs base)")
+    print(f"Before delta files: {len(before_delta)}")
+    print(f"After delta files : {len(after_delta)}")
+    print(f"Dropped delta files: {len(dropped_delta_files)}")
+    print(f"New delta files    : {len(new_delta_files)}")
+
+    if dropped_delta_files:
+        print("")
+        print("Dropped delta files:")
+        for file_path in dropped_delta_files:
+            marker = " (allowed)" if file_path in allowed_dropped_files else ""
+            print(f"  - {file_path}{marker}")
+
+    if new_delta_files:
+        print("")
+        print("New delta files:")
+        for file_path in new_delta_files:
+            print(f"  + {file_path}")
+
+    print_section("i18n key comparison")
+    for entry in i18n_report:
+        print(
+            f"{entry['file']}: before={entry['before_key_count']} after={entry['after_key_count']} "
+            f"missing={len(entry['missing_keys'])} added={len(entry['added_keys'])}"
+        )
+        if entry["before_error"] or entry["after_error"]:
+            print(
+                f"  ! errors: before={entry['before_error'] or 'none'} "
+                f"after={entry['after_error'] or 'none'}"
+            )
+        if entry["missing_keys"]:
+            print("  Missing keys:")
+            allowed_for_file = allowed_missing_keys.get(entry["file"], set())
+            for key in entry["missing_keys"]:
+                marker = " (allowed)" if key in allowed_for_file else ""
+                print(f"    - {key}{marker}")
+
+    report = {
+        "base": args.base,
+        "before": args.before,
+        "after": args.after,
+        "before_delta_count": len(before_delta),
+        "after_delta_count": len(after_delta),
+        "dropped_delta_files": dropped_delta_files,
+        "new_delta_files": new_delta_files,
+        "blocked_dropped_files": blocked_dropped_files,
+        "i18n": i18n_report,
+        "blocked_missing_keys": blocked_missing_keys,
+    }
+
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print("")
+        print(f"Wrote JSON report: {output_path}")
+
+    blocked = bool(blocked_dropped_files or blocked_missing_keys)
+    if blocked:
+        print("")
+        print("AUDIT RESULT: POTENTIAL LOSS DETECTED")
+        print(f"  Unapproved dropped files: {len(blocked_dropped_files)}")
+        print(f"  Unapproved missing i18n keys: {len(blocked_missing_keys)}")
+        if args.fail_on_loss:
+            return 2
+    else:
+        print("")
+        print("AUDIT RESULT: OK (no unapproved losses found)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.specify/scripts/python/rebase-no-loss-audit.py
+++ b/.specify/scripts/python/rebase-no-loss-audit.py
@@ -34,7 +34,11 @@ def run_git(args: List[str]) -> str:
 
 
 def delta_files(base_ref: str, ref: str) -> Set[str]:
-    output = run_git(["diff", "--name-only", f"{base_ref}...{ref}"])
+    # Resolve base_ref to a concrete commit SHA to ensure a stable comparison base
+    base_sha = run_git(["rev-parse", base_ref])
+    # Use a direct two-dot diff from the pinned base SHA to the ref to avoid
+    # merge-base semantics that can change before vs. after a rebase.
+    output = run_git(["diff", "--name-only", f"{base_sha}..{ref}"])
     if not output:
         return set()
     return {line.strip() for line in output.splitlines() if line.strip()}

--- a/.specify/scripts/python/rebase-no-loss-audit.py
+++ b/.specify/scripts/python/rebase-no-loss-audit.py
@@ -117,7 +117,10 @@ def main() -> int:
 
     i18n_files = args.i18n_file if args.i18n_file else DEFAULT_I18N_FILES
     allowed_dropped_files = set(args.allow_dropped_file)
-    allowed_missing_keys = parse_allow_missing_key(args.allow_missing_key)
+    try:
+        allowed_missing_keys = parse_allow_missing_key(args.allow_missing_key)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     before_delta = delta_files(args.base, args.before)
     after_delta = delta_files(args.base, args.after)

--- a/.specify/scripts/python/rebase-no-loss-audit.py
+++ b/.specify/scripts/python/rebase-no-loss-audit.py
@@ -30,7 +30,11 @@ DEFAULT_I18N_FILES = [
 
 
 def run_git(args: List[str]) -> str:
-    return subprocess.check_output(["git", *args], text=True).strip()
+    try:
+        return subprocess.check_output(["git", *args], text=True, stderr=subprocess.PIPE).strip()
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: git {' '.join(args)} failed (exit {exc.returncode}): {exc.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
 
 
 def delta_files(base_ref: str, ref: str) -> Set[str]:
@@ -238,12 +242,14 @@ def main() -> int:
         print("")
         print(f"Wrote JSON report: {output_path}")
 
-    blocked = bool(blocked_dropped_files or blocked_missing_keys)
+    i18n_errors = [e for e in i18n_report if e["before_error"] or e["after_error"]]
+    blocked = bool(blocked_dropped_files or blocked_missing_keys or i18n_errors)
     if blocked:
         print("")
         print("AUDIT RESULT: POTENTIAL LOSS DETECTED")
         print(f"  Unapproved dropped files: {len(blocked_dropped_files)}")
         print(f"  Unapproved missing i18n keys: {len(blocked_missing_keys)}")
+        print(f"  i18n files with errors: {len(i18n_errors)}")
         if args.fail_on_loss:
             return 2
     else:


### PR DESCRIPTION
This pull request introduces a robust "no-loss audit" to the careful, checkpointed rebase workflow, with both documentation and implementation changes. The goal is to prevent accidental loss of branch-specific changes or translation keys during rebases. The most important changes are:

**Rebase workflow documentation and policy:**

* Added a mandatory "no-loss audit" step to the rebase workflow documentation in `.specify/oe/commands/careful-rebase.md`, requiring a comparison of pre- and post-rebase branch deltas and i18n key sets to catch any unintentional loss. [[1]](diffhunk://#diff-a71cdbfa891be192849b96eef672711d1ddb1610f8c18ddca87cc081d4d507f7R14-R15) [[2]](diffhunk://#diff-a71cdbfa891be192849b96eef672711d1ddb1610f8c18ddca87cc081d4d507f7R300-R327)
* Established a strict translation protection policy in the documentation, mandating that i18n files must not lose keys during a rebase unless explicitly approved and documented.

**No-loss audit implementation:**

* Added a new script, `.specify/scripts/python/rebase-no-loss-audit.py`, which compares branch deltas and i18n JSON key sets before and after a rebase. The script reports dropped files and missing translation keys, supports allow-lists for intentional removals, and can block the workflow if unapproved losses are detected.