### PR TITLE
fix(validation): add @NotNull validation for ExternalConnection URI

### DIFF
--- a/src/main/java/org/openelisglobal/externalconnections/valueholder/ExternalConnection.java
+++ b/src/main/java/org/openelisglobal/externalconnections/valueholder/ExternalConnection.java
@@ -19,7 +19,7 @@ import org.openelisglobal.common.valueholder.BaseObject;
 import org.openelisglobal.hibernate.converter.URIConverter;
 import org.openelisglobal.internationalization.MessageUtil;
 import org.openelisglobal.localization.valueholder.Localization;
-
+import jakarta.validation.constraints.NotNull;
 @Entity
 @Table(name = "external_connection")
 public class ExternalConnection extends BaseObject<Integer> {
@@ -81,6 +81,7 @@ public class ExternalConnection extends BaseObject<Integer> {
     @Column
     private Boolean active;
 
+    @NotNull(message = "Connection URI is required")
     @Convert(converter = URIConverter.class)
     @Column
     private URI uri;


### PR DESCRIPTION

## Summary
Added @NotNull validation for the ExternalConnection URI field to prevent null values and improve backend data validation.

## Screenshots
N/A – backend validation only

## Related Issue
N/A

## Other
- Backend-only change
- No UI impact
- Manually tested
