### PR TITLE
fix: Resolved PatientMergeRestController and AnalyzerMappingAudit tes…

### DIFF
--- a/src/test/java/org/openelisglobal/analyzer/service/AnalyzerMappingAuditTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/service/AnalyzerMappingAuditTest.java
@@ -260,8 +260,6 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
         int mappingCount = 100;
         String[] mappingIds = new String[mappingCount];
 
-        long startTime = System.currentTimeMillis();
-
         // Create 100 mappings
         for (int i = 0; i < mappingCount; i++) {
             AnalyzerFieldMapping mapping = new AnalyzerFieldMapping();
@@ -293,6 +291,7 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
 
         // Act: Query all mappings individually and verify audit trail entries
         // Use get() method to retrieve individual mappings with audit trail fields
+        long startTime = System.currentTimeMillis();
         int mappingsWithAuditTrail = 0;
         for (int i = 0; i < mappingCount; i++) {
             AnalyzerFieldMapping mapping = analyzerFieldMappingService.get(mappingIds[i]);
@@ -313,7 +312,7 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
         // Note: We're creating 100 mappings with 3 operations each (create, update,
         // disable) = 300 changes
         // The query should complete in <1 second
-        assertTrue("Audit trail query should complete in <1 second", queryTime < 1000);
+        assertTrue("Audit trail query should complete in <1 second (actual: " + queryTime + "ms)", queryTime < 1000);
     }
 
     /**

--- a/src/test/java/org/openelisglobal/patient/merge/controller/rest/PatientMergeRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/patient/merge/controller/rest/PatientMergeRestControllerTest.java
@@ -17,7 +17,6 @@ import org.openelisglobal.patient.dao.PatientDAO;
 import org.openelisglobal.patient.merge.dto.PatientMergeRequestDTO;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.person.service.PersonService;
-import org.openelisglobal.person.valueholder.Person;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
@@ -52,7 +51,7 @@ public class PatientMergeRestControllerTest extends BaseWebContextSensitiveTest 
         objectMapper = new ObjectMapper();
 
         // Load system user dataset for audit
-        executeDataSetWithStateManagement("testdata/system-user.xml");
+        executeDataSetWithStateManagement("testdata/patient-merge-testdata.xml");
 
         // Set up authenticated session with Global Admin user (system_user id=1)
         UserSessionData userSessionData = new UserSessionData();
@@ -60,35 +59,12 @@ public class PatientMergeRestControllerTest extends BaseWebContextSensitiveTest 
         mockSession = new MockHttpSession();
         mockSession.setAttribute(IActionConstants.USER_SESSION_DATA, userSessionData);
 
-        // Create test patients
-        Person person1 = new Person();
-        person1.setFirstName("John");
-        person1.setLastName("Doe");
-        String person1Id = personService.insert(person1);
-        person1.setId(person1Id);
-
-        Person person2 = new Person();
-        person2.setFirstName("Jon");
-        person2.setLastName("Doe");
-        String person2Id = personService.insert(person2);
-        person2.setId(person2Id);
-
-        patient1 = new Patient();
-        patient1.setPerson(person1);
-        patient1.setNationalId("CTRL-TEST-P1-" + System.currentTimeMillis());
-        patient1.setIsMerged(false);
-        String patient1Id = patientDAO.insert(patient1);
-        patient1.setId(patient1Id);
-
-        patient2 = new Patient();
-        patient2.setPerson(person2);
-        patient2.setNationalId("CTRL-TEST-P2-" + System.currentTimeMillis());
-        patient2.setIsMerged(false);
-        String patient2Id = patientDAO.insert(patient2);
-        patient2.setId(patient2Id);
+        // Retrieve test patients from the loaded dataset
+        patient1 = patientDAO.get("9001")
+                .orElseThrow(() -> new AssertionError("Patient 9001 should be loaded from dataset"));
+        patient2 = patientDAO.get("9002")
+                .orElseThrow(() -> new AssertionError("Patient 9002 should be loaded from dataset"));
     }
-
-    // ========== GET /rest/patient/merge/details/{patientId} Tests ==========
 
     /**
      * Test: GET merge details for existing patient returns 200 OK. Business Rule:


### PR DESCRIPTION
…t failures

# Pull Requests Requirements

- [ x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ x] The PR title follows conventional commit label standards.
- [x ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x ] The changes include tests or are validated by existing tests.
- [x ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
- Fixed PatientMergeRestControllerTest by deleting programmatic data creation & maintained XML dataset loading but i changed the xml file name to patient-merge-testdata.xml which has the data being loaded.
Then i fixed optional handling for Patient by using orElseThrow() to unwrap the Optional<Patient>.
- Fixed AnalyzerMappingAuditTest failure by moving startTime to measure only query performance, not total operation time. The query now completes in ~100ms instead of timing out at 1463ms.
## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
