### PR TITLE
Solved #2863 : Added missing translation for properties update success message

### DIFF
--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -1476,6 +1476,7 @@
   "menu.validation.date": "By Date",
   "message.method.activation": "This method unit will not be active until at least one test has been assigned to it.",
   "message.noPluginFound": "No plugins Found",
+  "message.propertiesupdate.success": "Properties updated successfully",
   "method.browse.title": "Method Section",
   "method.methodName": "Method Name",
   "modal.add.method": "Add New Method",

--- a/frontend/src/languages/fr.json
+++ b/frontend/src/languages/fr.json
@@ -1475,6 +1475,7 @@
   "menu.study.title": "Configuration du menu d'étude",
   "menu.validation.date": "Rechercher par date de test",
   "message.method.activation": "Cette méthode ne sera pas active tant qu'au moins un test ne lui aura pas été assigné.",
+  "message.propertiesupdate.success": "Propriétés mises à jour avec succès",
   "message.noPluginFound": "Aucun plugin trouvé",
   "method.browse.title": "Section de méthode",
   "method.methodName": "Nom de la méthode",


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
This PR fixes a bug where the success notification on the **Application Properties** page displayed a raw translation key (`message.propertiesupdate.success`) instead of a localized message.

I have added the missing key to both `en.json` and `fr.json` to ensure user sees a proper success message.

## Screenshots

BEFORE:
<img width="1470" height="956" alt="7a562d77-73b3-4cae-92a2-607ac3990db5" src="https://github.com/user-attachments/assets/a31f40e9-ffb1-41a5-b592-747912f3a738" />


AFTER:
<img width="1470" height="956" alt="Screenshot 2026-02-18 at 7 43 47 PM" src="https://github.com/user-attachments/assets/7dd276b7-6e21-4a17-8655-9debf1db150f" />

## Related Issue

**Fixes #2863**

## Other

[Add any additional information or notes here]
