### PR TITLE
Solved #2869 : add missing translations for generic sample edit success

### DIFF
--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -1067,6 +1067,7 @@
   "genericSample.field.storageLocation": "Storage freezer # & location",
   "genericSample.field.type": "Type",
   "genericSample.notebook.selection.title": "Notebook Selection (Optional)",
+  "genericSample.edit.success": "Sample updated successfully",
   "genericSample.order.error.labNoRequired": "Please generate a Lab Number before saving.",
   "genericSample.order.generateLabNo": "Generate Lab Number",
   "genericSample.order.labNo.placeholder": "Click 'Generate Lab Number' to create",

--- a/frontend/src/languages/fr.json
+++ b/frontend/src/languages/fr.json
@@ -1067,6 +1067,7 @@
   "genericSample.field.storageLocation": "Congélateur de stockage n° et emplacement",
   "genericSample.field.type": "Type",
   "genericSample.notebook.selection.title": "Sélection du projet (facultatif)",
+  "genericSample.edit.success": "Échantillon mis à jour avec succès",
   "genericSample.order.error.labNoRequired": "Veuillez générer un numéro de laboratoire avant d'enregistrer.",
   "genericSample.order.generateLabNo": "Générer un numéro de laboratoire",
   "genericSample.order.labNo.placeholder": "Cliquez sur « Générer un numéro de laboratoire » pour générer ",


### PR DESCRIPTION
…#2869)

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

This PR fixes a missing translation key in the "Generic Sample Edit" workflow. Previously, updating a sample would display the raw key `genericSample.edit.success` in the alert box instead of a readable message.

**Changes:**
* Added `"genericSample.edit.success": "Sample updated successfully"` to `en.json`.
* Added `"genericSample.edit.success": "Échantillon mis à jour avec succès"` to `fr.json`.

## Screenshots

<img width="708" height="837" alt="Screenshot 2026-02-19 at 2 17 39 AM" src="https://github.com/user-attachments/assets/67b7aeaa-68fb-4137-a6ea-7f8c55e1613d" />


## Related Issue

Fixes #2869

## Other

[Add any additional information or notes here]
