### PR TITLE
feat: extend FHIR facade with DELETE, metadata endpoints and bug fixes

### DIFF
--- a/src/main/java/org/openelisglobal/dataexchange/fhir/controller/InternalFhirApi.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/controller/InternalFhirApi.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,6 +49,12 @@ public class InternalFhirApi {
         binder.setAllowedFields(ALLOWED_FIELDS);
     }
 
+    @GetMapping("/metadata")
+    public void receiveMetadataRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        forwardToFacade(request, response);
+    }
+
     @GetMapping("/**")
     public ResponseEntity<Object> recieveGetFhirRequests(HttpServletRequest request) {
         return forwardGetRequest(request);
@@ -62,6 +69,13 @@ public class InternalFhirApi {
     @PutMapping("/{resourceType}/**")
     public void receivePutFhirRequest(@PathVariable("resourceType") ResourceType resourceType,
             HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        forwardToFacade(request, response);
+    }
+
+    @DeleteMapping("/{resourceType}/{id}")
+    public void receiveDeleteFhirRequest(@PathVariable("resourceType") String resourceType,
+            @PathVariable("id") String id, HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
         forwardToFacade(request, response);
     }
 
@@ -94,12 +108,7 @@ public class InternalFhirApi {
             String targetUrl = buildQueryPath(fhirConfig.getLocalFhirStorePath(), fhirPath, request.getQueryString());
 
             HttpGet httpGet = new HttpGet(targetUrl);
-            String username = fhirConfig.getUsername();
-            String password = fhirConfig.getPassword();
-            if (username != null && !username.isBlank()) {
-                String encoding = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
-                httpGet.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoding);
-            }
+            addAuthHeader(httpGet);
             httpGet.setHeader(HttpHeaders.ACCEPT, "application/json");
 
             try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
@@ -122,6 +131,15 @@ public class InternalFhirApi {
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error in GET FHIR request: " + e.getMessage());
             return ResponseEntity.internalServerError().body("Unexpected server error");
+        }
+    }
+
+    private void addAuthHeader(org.apache.http.HttpRequest httpRequest) {
+        String username = fhirConfig.getUsername();
+        String password = fhirConfig.getPassword();
+        if (username != null && !username.isBlank()) {
+            String encoding = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
+            httpRequest.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoding);
         }
     }
 

--- a/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformService.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformService.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ContactPoint;
+import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Reference;
@@ -71,6 +73,10 @@ public interface FhirTransformService {
     Practitioner transformProviderToPractitioner(Provider provider);
 
     Provider transformToProvider(Practitioner practitioner);
+
+    void addHumanNameToPerson(HumanName humanName, org.openelisglobal.person.valueholder.Person person);
+
+    void addTelecomToPerson(List<ContactPoint> telecoms, org.openelisglobal.person.valueholder.Person person);
 
     PatientSearchResults transformToOpenElisPatientSearchResults(org.hl7.fhir.r4.model.Patient externalPatient);
 

--- a/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
@@ -1756,12 +1756,14 @@ public class FhirTransformServiceImpl implements FhirTransformService {
         public List<ServiceRequest> serviceRequests = new ArrayList<>();
     }
 
+    @Override
     public void addHumanNameToPerson(HumanName humanName, Person person) {
         person.setFirstName(
                 humanName.getGivenAsSingleString() == null ? "" : humanName.getGivenAsSingleString().strip());
         person.setLastName(humanName.getFamily() == null ? "" : humanName.getFamily().strip());
     }
 
+    @Override
     public void addTelecomToPerson(List<ContactPoint> telecoms, Person person) {
         for (ContactPoint contact : telecoms) {
             String contactValue = contact.getValue();

--- a/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.rest.annotation.Create;
+import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.annotation.Update;
@@ -8,18 +9,19 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.util.ControllerUtills;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
-import org.openelisglobal.dataexchange.fhir.service.FhirTransformServiceImpl;
 import org.openelisglobal.person.service.PersonService;
 import org.openelisglobal.person.valueholder.Person;
 import org.openelisglobal.provider.service.ProviderService;
@@ -125,9 +127,8 @@ public class PractitionerProvider implements IResourceProvider {
                     .getProviderByFhirId(UUID.fromString(practitioner.getIdElement().getIdPart()));
             Person existingPerson = personService.get(provider.getPerson().getId());
 
-            FhirTransformServiceImpl transForm = new FhirTransformServiceImpl();
-            transForm.addHumanNameToPerson(practitioner.getNameFirstRep(), existingPerson);
-            transForm.addTelecomToPerson(practitioner.getTelecom(), existingPerson);
+            fhirTransformService.addHumanNameToPerson(practitioner.getNameFirstRep(), existingPerson);
+            fhirTransformService.addTelecomToPerson(practitioner.getTelecom(), existingPerson);
             existingPerson.setSysUserId(ControllerUtills.getSysUserId(request));
             Person updatedPerson = personService.save(existingPerson);
             provider.setPerson(updatedPerson);
@@ -163,4 +164,60 @@ public class PractitionerProvider implements IResourceProvider {
         }
     }
 
+    @Delete
+    public MethodOutcome delete(@IdParam IdType theId, HttpServletRequest request) {
+
+        String method = "delete";
+        LogEvent.logDebug(this.getClass().getSimpleName(), method,
+                "Received FHIR DELETE request for Practitioner ID: " + (theId != null ? theId.getIdPart() : "null"));
+
+        try {
+
+            if (theId == null || !theId.hasIdPart()) {
+                LogEvent.logError(this.getClass().getSimpleName(), method, "Missing Practitioner ID for delete");
+                throw new InvalidRequestException("Practitioner ID must be provided for delete");
+            }
+
+            Provider provider = providerService.getProviderByFhirId(UUID.fromString(theId.getIdPart()));
+
+            if (provider == null) {
+                throw new ResourceNotFoundException("Practitioner/" + theId.getIdPart());
+            }
+
+            provider.setActive(false);
+            provider.setSysUserId(ControllerUtills.getSysUserId(request));
+            providerService.save(provider);
+
+            try {
+                Practitioner practitionerToDelete = fhirTransformService.transformProviderToPractitioner(provider);
+                practitionerToDelete.setActive(false);
+                fhirPersistenceService.updateFhirResourceInFhirStore(practitionerToDelete);
+            } catch (Exception syncEx) {
+                LogEvent.logError(this.getClass().getSimpleName(), method,
+                        "FHIR store sync failed during delete (continuing anyway): " + syncEx.getMessage());
+            }
+
+            LogEvent.logInfo(this.getClass().getSimpleName(), method,
+                    "Successfully deleted Practitioner with ID: " + theId.getIdPart());
+
+            MethodOutcome outcome = new MethodOutcome();
+            outcome.setId(theId);
+            outcome.setResponseStatusCode(204);
+
+            OperationOutcome operationOutcome = new OperationOutcome();
+            operationOutcome.addIssue().setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+                    .setDiagnostics("Practitioner " + theId.getIdPart() + " has been deleted");
+            outcome.setOperationOutcome(operationOutcome);
+
+            return outcome;
+
+        } catch (ResourceNotFoundException | InvalidRequestException e) {
+            throw e;
+
+        } catch (Exception e) {
+            LogEvent.logError(this.getClass().getSimpleName(), method,
+                    "Unexpected error while deleting Practitioner: " + e.getMessage());
+            throw new InternalErrorException("Unexpected server error while deleting Practitioner", e);
+        }
+    }
 }

--- a/src/main/java/org/openelisglobal/fhir/servlets/FhirRestfulServer.java
+++ b/src/main/java/org/openelisglobal/fhir/servlets/FhirRestfulServer.java
@@ -22,7 +22,8 @@ public class FhirRestfulServer extends RestfulServer {
 
         super.initialize();
 
-        setFhirContext(FhirContext.forR4());
+        FhirContext ctx = applicationContext.getBean(FhirContext.class);
+        setFhirContext(ctx);
 
         Map<String, IResourceProvider> providerMap = applicationContext.getBeansOfType(IResourceProvider.class);
 


### PR DESCRIPTION
- Add DELETE endpoint to InternalFhirApi (proxy to FHIR store)
- Add /metadata CapabilityStatement endpoint
- Fix PractitionerProvider: use injected fhirTransformService instead of new FhirTransformServiceImpl()
- Add addHumanNameToPerson/addTelecomToPerson to FhirTransformService interface
- Optimize FhirRestfulServer to reuse FhirContext bean
- Extract addAuthHeader helper to reduce code duplication
