### PR TITLE
fix: remove console.log debug statements from frontend production code

### DIFF
--- a/frontend/src/components/ChangePassword.js
+++ b/frontend/src/components/ChangePassword.js
@@ -40,7 +40,6 @@ function ChangePassword() {
       body: qs.stringify(values),
     })
       .then((response) => {
-        console.log(response);
         if (response.redirected === true) {
           addNotification({
             kind: NotificationKinds.success,

--- a/frontend/src/components/addOrder/AddOrder.js
+++ b/frontend/src/components/addOrder/AddOrder.js
@@ -140,7 +140,6 @@ const AddOrder = (props) => {
     });
   }
   function handleChange(path) {
-    console.log([path]);
     setChanged({
       ...changed,
       [path]: true,

--- a/frontend/src/components/addOrder/Index.js
+++ b/frontend/src/components/addOrder/Index.js
@@ -602,7 +602,6 @@ const Index = () => {
     orderFormValues.sampleOrderItems.providersList = [];
     orderFormValues.sampleOrderItems.paymentOptions = [];
     orderFormValues.sampleOrderItems.testLocationCodeList = [];
-    console.log(JSON.stringify(orderFormValues));
     postToOpenElisServer(
       "/rest/SamplePatientEntry",
       JSON.stringify(orderFormValues),
@@ -617,7 +616,6 @@ const Index = () => {
   }, [page]);
 
   useEffect(() => {
-    console.log(changed);
     OrderEntryValidationSchema.validate(orderFormValues, { abortEarly: false })
       .then((validData) => {
         setErrors([]);

--- a/frontend/src/components/admin/calculatedValue/CalculatedValueForm.tsx
+++ b/frontend/src/components/admin/calculatedValue/CalculatedValueForm.tsx
@@ -114,7 +114,6 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
 
   const loadCalculationList = (calculations) => {
     if (componentMounted.current) {
-      // console.log(JSON.stringify(reflexRuleList))
       const sampleList = [];
       if (calculations.length > 0) {
         setCalculationList(calculations);
@@ -241,7 +240,6 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     };
 
     list[index]["operations"].push(operation);
-    console.log(JSON.stringify(list[index]["operations"]));
     setCalculationList(list);
   };
 
@@ -260,7 +258,6 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     const list = [...calculationList];
     //list[index]['operations'].push(operation);
     list[index]["operations"].splice(operationIndex + 1, 0, operation);
-    console.log(JSON.stringify(list[index]["operations"]));
     setCalculationList(list);
   };
 
@@ -410,7 +407,6 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     try {
       // Code that might throw an error
       eval(mathematicalOperation);
-      console.log(JSON.stringify(calculationList[index]));
       postToOpenElisServer(
         "/rest/test-calculation",
         JSON.stringify(calculationList[index]),

--- a/frontend/src/components/admin/menu/CommonProperties.js
+++ b/frontend/src/components/admin/menu/CommonProperties.js
@@ -47,9 +47,7 @@ export const CommonProperties = () => {
     setLoading(true);
     const url = `/rest/properties`;
     let body = JSON.stringify(commonProperties);
-    postToOpenElisServerJsonResponse(url, body, (response, err) => {
-      console.log("response from server", response);
-    });
+    postToOpenElisServerJsonResponse(url, body, (response, err) => {});
     addNotification({
       kind: "success",
       message: intl.formatMessage({ id: "message.propertiesupdate.success" }),

--- a/frontend/src/components/admin/testManagementConfigMenu/TestActivation.js
+++ b/frontend/src/components/admin/testManagementConfigMenu/TestActivation.js
@@ -333,10 +333,6 @@ function TestActivation() {
           const sample = changedTestActivationData?.activeTestList.find(
             (s) => String(s.sampleType.id) === String(sampleTypeId),
           );
-          console.log(sample?.inactiveTests?.length);
-          console.log(sample?.activeTests?.length);
-          console.log(sample?.inactiveTests?.length > 0);
-          console.log(sample?.activeTests?.length === 1);
           if (
             sample?.inactiveTests?.length > 0 &&
             sample?.activeTests?.length === 1
@@ -436,8 +432,6 @@ function TestActivation() {
           const sample = changedTestActivationData?.inactiveTestList.find(
             (s) => String(s.sampleType.id) === String(sampleTypeId),
           );
-          console.log(sample?.activeTests?.length > 0);
-          console.log(sample?.inactiveTests?.length === 1); // 0 or 1
           if (sample?.activeTests?.length > 0 && sample?.inactiveTests === 1) {
             if (!deactivateSample.some((item) => item.id === sampleTypeId)) {
               deactivateSample.push({ id: sampleTypeId });
@@ -570,8 +564,6 @@ function TestActivation() {
           const sample = changedTestActivationData?.inactiveTestList.find(
             (s) => String(s.sampleType.id) === String(sampleTypeId),
           );
-          console.log(sample?.activeTests?.length > 0);
-          console.log(sample?.inactiveTests?.length === 1); // 0 or 1
           if (
             sample?.activateTest?.length > 0 &&
             sample?.inactiveTest?.length === 1

--- a/frontend/src/components/batchOrderEntry/SampleBatchEntrySetup.js
+++ b/frontend/src/components/batchOrderEntry/SampleBatchEntrySetup.js
@@ -333,7 +333,6 @@ const SampleBatchEntrySetup = () => {
     if (res.status === 200) {
       setPostRequestMade(true);
     } else {
-      console.log("Response from server:", res);
       setStatus("error");
     }
   }

--- a/frontend/src/components/data/patientphoto.js
+++ b/frontend/src/components/data/patientphoto.js
@@ -650,7 +650,6 @@ const PatientFormExample = () => {
     e.preventDefault();
 
     // Envoi de toutes les données y compris la photo
-    console.log("Données du formulaire:", formData);
 
     // Exemple d'envoi API
     // const response = await fetch('/rest/patient', {

--- a/frontend/src/components/eOrder/EOrderSearch.js
+++ b/frontend/src/components/eOrder/EOrderSearch.js
@@ -51,9 +51,7 @@ const EOrderSearch = ({
     );
   }, []);
 
-  const handleElectronicOrders = (response) => {
-    console.log(response);
-  };
+  const handleElectronicOrders = (response) => {};
 
   const handleOrderStatus = (response) => {
     setStatusOptions(response);

--- a/frontend/src/components/home/Dashboard.tsx
+++ b/frontend/src/components/home/Dashboard.tsx
@@ -340,7 +340,6 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
   ];
 
   const handleMinimizeClick = () => {
-    console.log("Icon clicked!");
     if (selectedTile.type == "ORDERS_FOR_USER") {
       const tile: Tile = {
         title: <FormattedMessage id="dashboard.user.orders.label" />,
@@ -376,7 +375,6 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
   };
 
   const viewUserOrders = (row) => {
-    console.log("Icon clicked!");
     const firstName = row.cells.find(
       (e) => e.info.header === "userFirstName",
     ).value;

--- a/frontend/src/components/layout/Header.js
+++ b/frontend/src/components/layout/Header.js
@@ -199,7 +199,6 @@ function OEHeader({
         `/rest/notification/markasread/${notificationId}`,
         null,
         (response) => {
-          console.log("Notification marked as read", response);
           getNotifications();
         },
       );
@@ -214,7 +213,6 @@ function OEHeader({
         `/rest/notification/markasread/all`,
         null,
         (response) => {
-          console.log("All Notifications marked as read", response);
           getNotifications();
         },
       );

--- a/frontend/src/components/modifyOrder/ModifyOrder.js
+++ b/frontend/src/components/modifyOrder/ModifyOrder.js
@@ -156,7 +156,6 @@ const ModifyOrder = () => {
     orderFormValues.sampleOrderItems.providersList = [];
     orderFormValues.sampleOrderItems.paymentOptions = [];
     orderFormValues.sampleOrderItems.testLocationCodeList = [];
-    console.log(JSON.stringify(orderFormValues));
     postToOpenElisServer(
       "/rest/SampleEdit",
       JSON.stringify(orderFormValues),

--- a/frontend/src/components/nonconform/common/NCECorrectiveAction.jsx
+++ b/frontend/src/components/nonconform/common/NCECorrectiveAction.jsx
@@ -83,7 +83,7 @@ export const NCECorrectiveAction = () => {
           },
         );
       } catch (error) {
-        console.log("Error fetching data", error);
+        console.error("Error fetching data", error);
       }
     }
   }, [selected]);

--- a/frontend/src/components/nonconform/common/ReportNonConformingEvent.jsx
+++ b/frontend/src/components/nonconform/common/ReportNonConformingEvent.jsx
@@ -171,12 +171,10 @@ export const ReportNonConformingEvent = () => {
   ];
 
   useEffect(() => {
-    console.log(JSON.stringify(selectedSample));
     if (selectedSample.labOrderNumber && selectedSample.specimenId) {
       getFromOpenElisServer(
         `/rest/reportnonconformingevent?labOrderNumber=${selectedSample.labOrderNumber}&specimenId=${selectedSample.specimenId}`,
         (data) => {
-          console.log("data from server for selected", data);
           setLData(undefined);
           setnceForm({
             ...nceForm,
@@ -189,7 +187,6 @@ export const ReportNonConformingEvent = () => {
   }, [selectedSample]);
 
   const handleNCEFormSubmit = () => {
-    console.log("nceForm.data", nceForm.data);
     const newErrors = {};
     if (!nceForm.data.dateOfEvent) {
       newErrors.dateOfEvent = "Date of event is required";

--- a/frontend/src/components/nonconform/common/ViewNonConforming.jsx
+++ b/frontend/src/components/nonconform/common/ViewNonConforming.jsx
@@ -365,7 +365,6 @@ export const ViewNonConformingEvent = () => {
                           name="radio-group"
                           onClick={() => {
                             setSelected(row.nceNumber);
-                            console.log(row);
                           }}
                           labelText=""
                           id={row.id}

--- a/frontend/src/components/notebook/NoteBookEntryForm.js
+++ b/frontend/src/components/notebook/NoteBookEntryForm.js
@@ -202,7 +202,6 @@ const NoteBookEntryForm = () => {
     noteBookForm.comments = comments
       .filter((c) => c.id === null)
       .map((c) => ({ id: null, text: c.text }));
-    console.log(JSON.stringify(noteBookForm));
     var url =
       mode === MODES.EDIT
         ? "/rest/notebook/update/" + notebookid
@@ -216,7 +215,6 @@ const NoteBookEntryForm = () => {
 
   const handleSubmited = async (response) => {
     var body = await response.json();
-    console.log(body);
     var status = response.status;
     setIsSubmitting(false);
     setNotificationVisible(true);

--- a/frontend/src/components/notebook/NoteBookInstanceEntryForm.js
+++ b/frontend/src/components/notebook/NoteBookInstanceEntryForm.js
@@ -174,7 +174,6 @@ const NoteBookInstanceEntryForm = () => {
     noteBookForm.comments = comments
       .filter((c) => c.id === null)
       .map((c) => ({ id: null, text: c.text }));
-    console.log(JSON.stringify(noteBookForm));
     var url =
       mode === MODES.EDIT
         ? "/rest/notebook/update/" + notebookentryid
@@ -188,7 +187,6 @@ const NoteBookInstanceEntryForm = () => {
 
   const handleSubmited = async (response) => {
     var body = await response.json();
-    console.log(body);
     var status = response.status;
     setIsSubmitting(false);
     setNotificationVisible(true);
@@ -258,7 +256,6 @@ const NoteBookInstanceEntryForm = () => {
     orderFormValues.sampleOrderItems.providersList = [];
     orderFormValues.sampleOrderItems.paymentOptions = [];
     orderFormValues.sampleOrderItems.testLocationCodeList = [];
-    console.log(JSON.stringify(orderFormValues));
     postToOpenElisServer(
       "/rest/SampleEdit",
       JSON.stringify(orderFormValues),

--- a/frontend/src/components/notifications/SlideOverNotifications.jsx
+++ b/frontend/src/components/notifications/SlideOverNotifications.jsx
@@ -44,15 +44,10 @@ export default function SlideOverNotifications(props) {
       const subscription = await reg.pushManager.getSubscription();
       if (!subscription && !res?.pf_endpoint) {
         setSubscriptionState("NotSubscribed");
-        console.log("NotSubscribed");
       } else if (subscription?.endpoint === res?.pfEndpoint) {
         setSubscriptionState("SubscribedOnThisDevice");
-        console.log("SubscribedOnThisDevice");
       } else {
-        console.log("subscription?.endpoint", subscription?.endpoint);
-
         setSubscriptionState("SubscribedOnAnotherDevice");
-        console.log("SubscribedOnAnotherDevice");
       }
     } catch (error) {
       console.error("Error checking subscription status:", error);
@@ -153,9 +148,7 @@ export default function SlideOverNotifications(props) {
       postToOpenElisServer(
         "/rest/notification/subscribe",
         JSON.stringify(data),
-        (res) => {
-          console.log("res", res);
-        },
+        (res) => {},
       );
 
       // Set the loading state to false

--- a/frontend/src/components/patient/CreatePatientForm.js
+++ b/frontend/src/components/patient/CreatePatientForm.js
@@ -448,7 +448,6 @@ function CreatePatientForm(props) {
     if ("days" in values) {
       delete values.days;
     }
-    console.log(JSON.stringify(values));
     postToOpenElisServer(
       "/rest/PatientManagement",
       JSON.stringify(values),

--- a/frontend/src/components/patient/SearchPatientForm.js
+++ b/frontend/src/components/patient/SearchPatientForm.js
@@ -63,12 +63,9 @@ function SearchPatientForm(props) {
   const [prevlastName, setPrevlastName] = useState("");
 
   const handlePatientImport = (patientId) => {
-    console.log("Import button clicked, patientId:", patientId);
-
     const patientSelected = patientSearchResults.find(
       (patient) => patient.patientID === patientId,
     );
-    console.log("Patient selected:", patientSelected);
 
     if (!patientSelected) {
       addNotification({
@@ -107,8 +104,6 @@ function SearchPatientForm(props) {
         },
       },
     };
-
-    console.log("Data to send:", dataToSend);
 
     postToOpenElisServer(
       "/rest/PatientManagement",

--- a/frontend/src/components/printBarcode/PrePrint.js
+++ b/frontend/src/components/printBarcode/PrePrint.js
@@ -150,7 +150,6 @@ const PrePrint = () => {
   };
 
   const prePrintLabels = () => {
-    console.log(selectedPanels);
     const selectedTestIds = selectedTests
       .map((selectedTest) => selectedTest.id)
       .join(",");

--- a/frontend/src/components/reports/auditTrailReport/AuditTrailReport.js
+++ b/frontend/src/components/reports/auditTrailReport/AuditTrailReport.js
@@ -81,7 +81,6 @@ const AuditTrailReport = ({ id }) => {
           setIsLabNoError(null);
           setAuditTrailItems(updatedAuditTrailItems);
           setData(data);
-          console.log("site name", data.sampleOrderItems.referringSiteName);
         }
         setIsLoading(false);
         setShowNotification(true);

--- a/frontend/src/components/reports/common/ReportByDate.js
+++ b/frontend/src/components/reports/common/ReportByDate.js
@@ -148,7 +148,6 @@ const ReportByDate = (props) => {
       }
     };
 
-    console.log("props", props);
     if (
       props.report === "activityReportByTest" ||
       props.report === "activityReportByPanel" ||

--- a/frontend/src/components/reports/common/ReportByDateCSV.js
+++ b/frontend/src/components/reports/common/ReportByDateCSV.js
@@ -120,7 +120,6 @@ const ReportByDateCSV = (props) => {
     if (props.report === "CIStudyExport") {
       getFromOpenElisServer("/rest/projects", (data) => {
         setStatusOptions(data);
-        console.log("data", data);
       });
     } else {
       getFromOpenElisServer("/rest/trendsprojects", (data) => {

--- a/frontend/src/components/reports/common/ReportByID.js
+++ b/frontend/src/components/reports/common/ReportByID.js
@@ -20,7 +20,6 @@ function ReportByID(props) {
 
     setLoading(true);
 
-    console.log("National ID:", nationalId);
     const baseParams = `report=${props.report}&type=patient`;
     const baseUrl = `${config.serverBaseUrl}/ReportPrint`;
     const url = `${baseUrl}?${baseParams}&patientNumberDirect=${nationalId}`;

--- a/frontend/src/components/utils/Utils.js
+++ b/frontend/src/components/utils/Utils.js
@@ -453,8 +453,6 @@ export function encodeDate(dateString) {
 }
 
 export function getDifferenceInDays(date1, date2) {
-  console.log("secondDate", date2);
-
   // Function to parse dates in DD/MM/YYYY format
   function parseDate(dateStr) {
     const [day, month, year] = dateStr.split("/").map(Number);


### PR DESCRIPTION
Summary
Remove 56 leftover [console.log()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls from 26 frontend files. These leak sensitive data (patient info, form values, server responses) to the browser console in production.

What changed
Removed debug [console.log()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from production code paths across reports, patient forms, orders, admin, notebook, notifications, and nonconform components
Upgraded 1 [console.log](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [console.error](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [NCECorrectiveAction.jsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) catch block
Preserved intentional [console.error](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[console.debug](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls and service worker logs
Impact
Pure deletions — no logic or behavior changes
26 files changed, 4 insertions, 60 deletions
Prettier formatted on all modified files