### PR TITLE
Fix All Permissions checkbox to select all available roles

### DIFF
--- a/frontend/src/components/admin/userManagement/UserAddModify.js
+++ b/frontend/src/components/admin/userManagement/UserAddModify.js
@@ -1317,13 +1317,20 @@ function UserAddModify() {
                         <Checkbox
                           id={`all-permissions-${key}`}
                           labelText={"All Permissions"}
-                          checked={["4", "5", "7", "10"].every(
+                          checked={(
+                            userDataShow?.labUnitRoles?.map(
+                              (section) => section.roleId,
+                            ) ?? []
+                          ).every(
                             (num) =>
                               selectedTestSectionLabUnits[key] &&
                               selectedTestSectionLabUnits[key].includes(num),
                           )}
                           onChange={() => {
-                            const numbersToAdd = ["4", "5", "7", "10"];
+                            const numbersToAdd =
+                              userDataShow?.labUnitRoles?.map(
+                                (section) => section.roleId,
+                              ) ?? [];
                             const updatedRoles = selectedTestSectionLabUnits[
                               key
                             ]


### PR DESCRIPTION
Fixes #2913

The "All Permissions" checkbox in the user role management form was hardcoded to only check for 4 specific role IDs (4, 5, 7, 10). This prevented users from selecting all roles when more than 4 roles existed in the system.

This change replaces the hardcoded role list with a dynamic lookup that uses all available roles from `userDataShow.labUnitRoles`. The checkbox now correctly validates against and selects all roles present in the system, not just a fixed subset.