### PR TITLE
feat: add Organization FHIR facade provider with Create, Update, Delete with fhir utils

### DIFF
--- a/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Resource;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.util.ControllerUtills;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
@@ -72,7 +73,7 @@ public final class FhirProviderUtils {
      * not propagate — the local operation is considered successful even if the sync
      * fails.
      */
-    public static void syncToFhirStore(FhirPersistanceService fhirPersistenceService, IBaseResource resource,
+    public static void syncToFhirStore(FhirPersistanceService fhirPersistenceService, Resource resource,
             String callerClassName, String callingMethod) {
         try {
             fhirPersistenceService.updateFhirResourceInFhirStore(resource);

--- a/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
@@ -1,0 +1,107 @@
+package org.openelisglobal.fhir.providers;
+
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.common.util.ControllerUtills;
+import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
+
+/**
+ * Shared utility methods for FHIR resource providers. Eliminates boilerplate
+ * around {@link MethodOutcome} construction, FHIR store synchronization, and
+ * common validation that is identical across all
+ * {@link ca.uhn.fhir.rest.server.IResourceProvider} implementations.
+ */
+public final class FhirProviderUtils {
+
+    private FhirProviderUtils() {
+        // utility class — not instantiable
+    }
+
+    /**
+     * Builds a {@link MethodOutcome} for a successful Create operation (HTTP 201).
+     */
+    public static MethodOutcome buildCreateOutcome(IBaseResource resource) {
+        MethodOutcome outcome = new MethodOutcome();
+        outcome.setId(resource.getIdElement());
+        outcome.setResource(resource);
+        outcome.setCreated(true);
+        outcome.setResponseStatusCode(201);
+        return outcome;
+    }
+
+    /**
+     * Builds a {@link MethodOutcome} for a successful Update operation (HTTP 200).
+     */
+    public static MethodOutcome buildUpdateOutcome(IBaseResource resource) {
+        MethodOutcome outcome = new MethodOutcome();
+        outcome.setId(resource.getIdElement());
+        outcome.setResource(resource);
+        outcome.setCreated(false);
+        outcome.setResponseStatusCode(200);
+        return outcome;
+    }
+
+    /**
+     * Builds a {@link MethodOutcome} for a successful Delete (soft-delete)
+     * operation (HTTP 204).
+     *
+     * @param theId        the FHIR resource ID that was deleted
+     * @param resourceType the FHIR resource type name (e.g. "Practitioner",
+     *                     "Organization")
+     */
+    public static MethodOutcome buildDeleteOutcome(IdType theId, String resourceType) {
+        MethodOutcome outcome = new MethodOutcome();
+        outcome.setId(theId);
+        outcome.setResponseStatusCode(204);
+
+        OperationOutcome operationOutcome = new OperationOutcome();
+        operationOutcome.addIssue().setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+                .setDiagnostics(resourceType + " " + theId.getIdPart() + " has been deleted");
+        outcome.setOperationOutcome(operationOutcome);
+
+        return outcome;
+    }
+
+    /**
+     * Syncs a FHIR resource to the external FHIR store. Failures are logged but do
+     * not propagate — the local operation is considered successful even if the sync
+     * fails.
+     */
+    public static void syncToFhirStore(FhirPersistanceService fhirPersistenceService, IBaseResource resource,
+            String callerClassName, String callingMethod) {
+        try {
+            fhirPersistenceService.updateFhirResourceInFhirStore(resource);
+        } catch (Exception syncEx) {
+            LogEvent.logError(callerClassName, callingMethod,
+                    "FHIR store sync failed (continuing anyway): " + syncEx.getMessage());
+        }
+    }
+
+    /**
+     * Extracts the sysUserId from the HTTP request for audit trail purposes.
+     */
+    public static String getSysUserId(HttpServletRequest request) {
+        return ControllerUtills.getSysUserId(request);
+    }
+
+    /**
+     * Validates that the given {@link IdType} is present and has an ID part. Throws
+     * {@link InvalidRequestException} if not.
+     *
+     * @param theId           the ID to validate
+     * @param resourceType    the FHIR resource type name for the error message
+     * @param callerClassName the caller's class name for logging
+     * @param method          the calling method name for logging
+     */
+    public static void validateIdParam(IdType theId, String resourceType, String callerClassName, String method) {
+        if (theId == null || !theId.hasIdPart()) {
+            LogEvent.logError(callerClassName, method, "Missing " + resourceType + " ID for " + method);
+            throw new InvalidRequestException(resourceType + " ID must be provided for " + method);
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
@@ -99,6 +99,7 @@ public final class FhirProviderUtils {
      * @param callerClassName the caller's class name for logging
      * @param method          the calling method name for logging
      */
+
     public static void validateIdParam(IdType theId, String resourceType, String callerClassName, String method) {
         if (theId == null || !theId.hasIdPart()) {
             LogEvent.logError(callerClassName, method, "Missing " + resourceType + " ID for " + method);

--- a/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
@@ -1,0 +1,222 @@
+package org.openelisglobal.fhir.providers;
+
+import ca.uhn.fhir.rest.annotation.Create;
+import ca.uhn.fhir.rest.annotation.Delete;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.ResourceParam;
+import ca.uhn.fhir.rest.annotation.Update;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.common.util.ControllerUtills;
+import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
+import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.organization.service.OrganizationService;
+import org.openelisglobal.organization.valueholder.Organization;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrganizationProvider implements IResourceProvider {
+
+    @Autowired
+    private FhirTransformService fhirTransformService;
+
+    @Autowired
+    private FhirPersistanceService fhirPersistenceService;
+
+    @Autowired
+    private OrganizationService organizationService;
+
+    private static final Class<org.hl7.fhir.r4.model.Organization> FHIR_RESOURCE_TYPE = org.hl7.fhir.r4.model.Organization.class;
+
+    @Override
+    public Class<? extends IBaseResource> getResourceType() {
+        return FHIR_RESOURCE_TYPE;
+    }
+
+    @Create
+    public MethodOutcome create(@ResourceParam org.hl7.fhir.r4.model.Organization fhirOrganization,
+            HttpServletRequest request) throws FhirLocalPersistingException {
+
+        String method = "create";
+        LogEvent.logDebug(this.getClass().getSimpleName(), method, "Received FHIR CREATE request for Organization");
+
+        try {
+
+            if (fhirOrganization == null) {
+                LogEvent.logError(this.getClass().getSimpleName(), method, "Organization resource is null");
+                throw new InvalidRequestException("Organization resource cannot be null");
+            }
+
+            Organization organization = fhirTransformService.transformToOrganization(fhirOrganization);
+            organization.setSysUserId(ControllerUtills.getSysUserId(request));
+            organization.setFhirUuid(UUID.randomUUID());
+            Organization savedOrganization = organizationService.save(organization);
+
+            org.hl7.fhir.r4.model.Organization resultFhirOrg = fhirTransformService
+                    .transformToFhirOrganization(savedOrganization);
+
+            try {
+                fhirPersistenceService.updateFhirResourceInFhirStore(resultFhirOrg);
+            } catch (Exception syncEx) {
+                LogEvent.logError(this.getClass().getSimpleName(), method,
+                        "FHIR store sync failed (continuing anyway): " + syncEx.getMessage());
+            }
+
+            LogEvent.logInfo(this.getClass().getSimpleName(), method,
+                    "Successfully created Organization with UUID: " + savedOrganization.getFhirUuidAsString());
+
+            MethodOutcome outcome = new MethodOutcome();
+            outcome.setId(resultFhirOrg.getIdElement());
+            outcome.setResource(resultFhirOrg);
+            outcome.setCreated(true);
+            outcome.setResponseStatusCode(201);
+
+            return outcome;
+
+        } catch (UnprocessableEntityException | InvalidRequestException e) {
+            throw e;
+
+        } catch (Exception e) {
+
+            LogEvent.logError(this.getClass().getSimpleName(), method,
+                    "Unexpected error while creating Organization: " + e.getMessage());
+
+            throw new InternalErrorException("Unexpected server error while creating Organization", e);
+        }
+    }
+
+    @Update
+    public MethodOutcome update(@IdParam IdType theId,
+            @ResourceParam org.hl7.fhir.r4.model.Organization fhirOrganization, HttpServletRequest request)
+            throws FhirLocalPersistingException {
+
+        String method = "update";
+        LogEvent.logDebug(this.getClass().getSimpleName(), method,
+                "Received FHIR UPDATE request for Organization ID: " + (theId != null ? theId.getIdPart() : "null"));
+
+        try {
+
+            if (theId == null || !theId.hasIdPart()) {
+
+                LogEvent.logError(this.getClass().getSimpleName(), method, "Missing Organization ID for update");
+
+                throw new InvalidRequestException("Organization ID must be provided for update");
+            }
+
+            fhirOrganization.setId(theId);
+
+            Organization existingOrg = organizationService.getOrganizationByFhirId(theId.getIdPart());
+            if (existingOrg == null) {
+                throw new ResourceNotFoundException("Organization/" + theId.getIdPart());
+            }
+
+            existingOrg.setOrganizationName(fhirOrganization.getName());
+            existingOrg.setIsActive(
+                    Boolean.FALSE.equals(fhirOrganization.getActiveElement().getValue()) ? IActionConstants.NO
+                            : IActionConstants.YES);
+            existingOrg.setSysUserId(ControllerUtills.getSysUserId(request));
+            Organization updatedOrg = organizationService.save(existingOrg);
+
+            org.hl7.fhir.r4.model.Organization resultFhirOrg = fhirTransformService
+                    .transformToFhirOrganization(updatedOrg);
+            try {
+                fhirPersistenceService.updateFhirResourceInFhirStore(resultFhirOrg);
+            } catch (Exception syncEx) {
+                LogEvent.logError(this.getClass().getSimpleName(), method,
+                        "FHIR store sync failed during update (continuing anyway): " + syncEx.getMessage());
+            }
+
+            LogEvent.logInfo(this.getClass().getSimpleName(), method,
+                    "Successfully updated Organization with ID: " + theId.getIdPart());
+
+            MethodOutcome outcome = new MethodOutcome();
+            outcome.setId(resultFhirOrg.getIdElement());
+            outcome.setResource(resultFhirOrg);
+            outcome.setCreated(false);
+            outcome.setResponseStatusCode(200);
+
+            return outcome;
+
+        } catch (UnprocessableEntityException | InvalidRequestException e) {
+            throw e;
+
+        } catch (Exception e) {
+
+            LogEvent.logError(this.getClass().getSimpleName(), method,
+                    "Unexpected error while updating Organization: " + e.getMessage());
+
+            throw new InternalErrorException("Unexpected server error while updating Organization", e);
+        }
+    }
+
+    @Delete
+    public MethodOutcome delete(@IdParam IdType theId, HttpServletRequest request) {
+
+        String method = "delete";
+        LogEvent.logDebug(this.getClass().getSimpleName(), method,
+                "Received FHIR DELETE request for Organization ID: " + (theId != null ? theId.getIdPart() : "null"));
+
+        try {
+
+            if (theId == null || !theId.hasIdPart()) {
+                LogEvent.logError(this.getClass().getSimpleName(), method, "Missing Organization ID for delete");
+                throw new InvalidRequestException("Organization ID must be provided for delete");
+            }
+
+            Organization organization = organizationService.getOrganizationByFhirId(theId.getIdPart());
+
+            if (organization == null) {
+                throw new ResourceNotFoundException("Organization/" + theId.getIdPart());
+            }
+
+            organization.setIsActive(IActionConstants.NO);
+            organization.setSysUserId(ControllerUtills.getSysUserId(request));
+            organizationService.save(organization);
+
+            try {
+                org.hl7.fhir.r4.model.Organization fhirOrgToSync = fhirTransformService
+                        .transformToFhirOrganization(organization);
+                fhirOrgToSync.setActive(false);
+                fhirPersistenceService.updateFhirResourceInFhirStore(fhirOrgToSync);
+            } catch (Exception syncEx) {
+                LogEvent.logError(this.getClass().getSimpleName(), method,
+                        "FHIR store sync failed during delete (continuing anyway): " + syncEx.getMessage());
+            }
+
+            LogEvent.logInfo(this.getClass().getSimpleName(), method,
+                    "Successfully deleted Organization with ID: " + theId.getIdPart());
+
+            MethodOutcome outcome = new MethodOutcome();
+            outcome.setId(theId);
+            outcome.setResponseStatusCode(204);
+
+            OperationOutcome operationOutcome = new OperationOutcome();
+            operationOutcome.addIssue().setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+                    .setDiagnostics("Organization " + theId.getIdPart() + " has been deleted");
+            outcome.setOperationOutcome(operationOutcome);
+
+            return outcome;
+
+        } catch (ResourceNotFoundException | InvalidRequestException e) {
+            throw e;
+
+        } catch (Exception e) {
+            LogEvent.logError(this.getClass().getSimpleName(), method,
+                    "Unexpected error while deleting Organization: " + e.getMessage());
+            throw new InternalErrorException("Unexpected server error while deleting Organization", e);
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
@@ -15,11 +15,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Organization;
 import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.log.LogEvent;
-import org.openelisglobal.common.util.ControllerUtills;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
@@ -69,24 +67,19 @@ public class OrganizationProvider implements IResourceProvider {
 
             org.openelisglobal.organization.valueholder.Organization organization = fhirTransformService
                     .transformToOrganization(fhirOrganization);
-            organization.setSysUserId(ControllerUtills.getSysUserId(request));
+            organization.setSysUserId(FhirProviderUtils.getSysUserId(request));
             organization.setFhirUuid(UUID.randomUUID());
             org.openelisglobal.organization.valueholder.Organization savedOrganization = organizationService
                     .save(organization);
 
             Organization resultFhirOrg = fhirTransformService.transformToFhirOrganization(savedOrganization);
-            syncToFhirStore(resultFhirOrg, method);
+            FhirProviderUtils.syncToFhirStore(fhirPersistenceService, resultFhirOrg, this.getClass().getSimpleName(),
+                    method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully created Organization with UUID: " + savedOrganization.getFhirUuidAsString());
 
-            MethodOutcome outcome = new MethodOutcome();
-            outcome.setId(resultFhirOrg.getIdElement());
-            outcome.setResource(resultFhirOrg);
-            outcome.setCreated(true);
-            outcome.setResponseStatusCode(201);
-
-            return outcome;
+            return FhirProviderUtils.buildCreateOutcome(resultFhirOrg);
 
         } catch (UnprocessableEntityException | InvalidRequestException e) {
             throw e;
@@ -110,12 +103,7 @@ public class OrganizationProvider implements IResourceProvider {
 
         try {
 
-            if (theId == null || !theId.hasIdPart()) {
-
-                LogEvent.logError(this.getClass().getSimpleName(), method, "Missing Organization ID for update");
-
-                throw new InvalidRequestException("Organization ID must be provided for update");
-            }
+            FhirProviderUtils.validateIdParam(theId, "Organization", this.getClass().getSimpleName(), method);
 
             fhirOrganization.setId(theId);
 
@@ -131,22 +119,17 @@ public class OrganizationProvider implements IResourceProvider {
                     .transformToOrganization(fhirOrganization);
             existingOrg.setOrganizationName(incomingOrg.getOrganizationName());
             existingOrg.setIsActive(incomingOrg.getIsActive());
-            existingOrg.setSysUserId(ControllerUtills.getSysUserId(request));
+            existingOrg.setSysUserId(FhirProviderUtils.getSysUserId(request));
             org.openelisglobal.organization.valueholder.Organization updatedOrg = organizationService.save(existingOrg);
 
             Organization resultFhirOrg = fhirTransformService.transformToFhirOrganization(updatedOrg);
-            syncToFhirStore(resultFhirOrg, method);
+            FhirProviderUtils.syncToFhirStore(fhirPersistenceService, resultFhirOrg, this.getClass().getSimpleName(),
+                    method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully updated Organization with ID: " + theId.getIdPart());
 
-            MethodOutcome outcome = new MethodOutcome();
-            outcome.setId(resultFhirOrg.getIdElement());
-            outcome.setResource(resultFhirOrg);
-            outcome.setCreated(false);
-            outcome.setResponseStatusCode(200);
-
-            return outcome;
+            return FhirProviderUtils.buildUpdateOutcome(resultFhirOrg);
 
         } catch (ResourceNotFoundException | UnprocessableEntityException | InvalidRequestException e) {
             throw e;
@@ -169,10 +152,7 @@ public class OrganizationProvider implements IResourceProvider {
 
         try {
 
-            if (theId == null || !theId.hasIdPart()) {
-                LogEvent.logError(this.getClass().getSimpleName(), method, "Missing Organization ID for delete");
-                throw new InvalidRequestException("Organization ID must be provided for delete");
-            }
+            FhirProviderUtils.validateIdParam(theId, "Organization", this.getClass().getSimpleName(), method);
 
             org.openelisglobal.organization.valueholder.Organization organization = organizationService
                     .getOrganizationByFhirId(theId.getIdPart());
@@ -182,26 +162,18 @@ public class OrganizationProvider implements IResourceProvider {
             }
 
             organization.setIsActive(IActionConstants.NO);
-            organization.setSysUserId(ControllerUtills.getSysUserId(request));
+            organization.setSysUserId(FhirProviderUtils.getSysUserId(request));
             organizationService.save(organization);
 
             Organization fhirOrgToSync = fhirTransformService.transformToFhirOrganization(organization);
             fhirOrgToSync.setActive(false);
-            syncToFhirStore(fhirOrgToSync, method);
+            FhirProviderUtils.syncToFhirStore(fhirPersistenceService, fhirOrgToSync, this.getClass().getSimpleName(),
+                    method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully deleted Organization with ID: " + theId.getIdPart());
 
-            MethodOutcome outcome = new MethodOutcome();
-            outcome.setId(theId);
-            outcome.setResponseStatusCode(204);
-
-            OperationOutcome operationOutcome = new OperationOutcome();
-            operationOutcome.addIssue().setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
-                    .setDiagnostics("Organization " + theId.getIdPart() + " has been deleted");
-            outcome.setOperationOutcome(operationOutcome);
-
-            return outcome;
+            return FhirProviderUtils.buildDeleteOutcome(theId, "Organization");
 
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;
@@ -210,15 +182,6 @@ public class OrganizationProvider implements IResourceProvider {
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while deleting Organization: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while deleting Organization", e);
-        }
-    }
-
-    private void syncToFhirStore(Organization fhirOrg, String callingMethod) {
-        try {
-            fhirPersistenceService.updateFhirResourceInFhirStore(fhirOrg);
-        } catch (Exception syncEx) {
-            LogEvent.logError(this.getClass().getSimpleName(), callingMethod,
-                    "FHIR store sync failed (continuing anyway): " + syncEx.getMessage());
         }
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Organization;
 import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.util.ControllerUtills;
@@ -23,10 +24,18 @@ import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingExcepti
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.organization.service.OrganizationService;
-import org.openelisglobal.organization.valueholder.Organization;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/**
+ * HAPI FHIR resource provider for the Organization resource. Handles Create,
+ * Update, and Delete operations against the local OpenELIS database with
+ * synchronization to the FHIR store.
+ *
+ * <p>
+ * Auto-discovered by {@link org.openelisglobal.fhir.servlets.FhirRestfulServer}
+ * as a Spring {@code @Component} implementing {@link IResourceProvider}.
+ */
 @Component
 public class OrganizationProvider implements IResourceProvider {
 
@@ -39,16 +48,14 @@ public class OrganizationProvider implements IResourceProvider {
     @Autowired
     private OrganizationService organizationService;
 
-    private static final Class<org.hl7.fhir.r4.model.Organization> FHIR_RESOURCE_TYPE = org.hl7.fhir.r4.model.Organization.class;
-
     @Override
     public Class<? extends IBaseResource> getResourceType() {
-        return FHIR_RESOURCE_TYPE;
+        return Organization.class;
     }
 
     @Create
-    public MethodOutcome create(@ResourceParam org.hl7.fhir.r4.model.Organization fhirOrganization,
-            HttpServletRequest request) throws FhirLocalPersistingException {
+    public MethodOutcome create(@ResourceParam Organization fhirOrganization, HttpServletRequest request)
+            throws FhirLocalPersistingException {
 
         String method = "create";
         LogEvent.logDebug(this.getClass().getSimpleName(), method, "Received FHIR CREATE request for Organization");
@@ -60,20 +67,15 @@ public class OrganizationProvider implements IResourceProvider {
                 throw new InvalidRequestException("Organization resource cannot be null");
             }
 
-            Organization organization = fhirTransformService.transformToOrganization(fhirOrganization);
+            org.openelisglobal.organization.valueholder.Organization organization = fhirTransformService
+                    .transformToOrganization(fhirOrganization);
             organization.setSysUserId(ControllerUtills.getSysUserId(request));
             organization.setFhirUuid(UUID.randomUUID());
-            Organization savedOrganization = organizationService.save(organization);
+            org.openelisglobal.organization.valueholder.Organization savedOrganization = organizationService
+                    .save(organization);
 
-            org.hl7.fhir.r4.model.Organization resultFhirOrg = fhirTransformService
-                    .transformToFhirOrganization(savedOrganization);
-
-            try {
-                fhirPersistenceService.updateFhirResourceInFhirStore(resultFhirOrg);
-            } catch (Exception syncEx) {
-                LogEvent.logError(this.getClass().getSimpleName(), method,
-                        "FHIR store sync failed (continuing anyway): " + syncEx.getMessage());
-            }
+            Organization resultFhirOrg = fhirTransformService.transformToFhirOrganization(savedOrganization);
+            syncToFhirStore(resultFhirOrg, method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully created Organization with UUID: " + savedOrganization.getFhirUuidAsString());
@@ -99,9 +101,8 @@ public class OrganizationProvider implements IResourceProvider {
     }
 
     @Update
-    public MethodOutcome update(@IdParam IdType theId,
-            @ResourceParam org.hl7.fhir.r4.model.Organization fhirOrganization, HttpServletRequest request)
-            throws FhirLocalPersistingException {
+    public MethodOutcome update(@IdParam IdType theId, @ResourceParam Organization fhirOrganization,
+            HttpServletRequest request) throws FhirLocalPersistingException {
 
         String method = "update";
         LogEvent.logDebug(this.getClass().getSimpleName(), method,
@@ -118,26 +119,23 @@ public class OrganizationProvider implements IResourceProvider {
 
             fhirOrganization.setId(theId);
 
-            Organization existingOrg = organizationService.getOrganizationByFhirId(theId.getIdPart());
+            org.openelisglobal.organization.valueholder.Organization existingOrg = organizationService
+                    .getOrganizationByFhirId(theId.getIdPart());
             if (existingOrg == null) {
                 throw new ResourceNotFoundException("Organization/" + theId.getIdPart());
             }
 
-            existingOrg.setOrganizationName(fhirOrganization.getName());
-            existingOrg.setIsActive(
-                    Boolean.FALSE.equals(fhirOrganization.getActiveElement().getValue()) ? IActionConstants.NO
-                            : IActionConstants.YES);
+            // Use the transform to extract all fields from the FHIR resource, then merge
+            // into the existing entity to preserve its database identity and fhirUuid.
+            org.openelisglobal.organization.valueholder.Organization incomingOrg = fhirTransformService
+                    .transformToOrganization(fhirOrganization);
+            existingOrg.setOrganizationName(incomingOrg.getOrganizationName());
+            existingOrg.setIsActive(incomingOrg.getIsActive());
             existingOrg.setSysUserId(ControllerUtills.getSysUserId(request));
-            Organization updatedOrg = organizationService.save(existingOrg);
+            org.openelisglobal.organization.valueholder.Organization updatedOrg = organizationService.save(existingOrg);
 
-            org.hl7.fhir.r4.model.Organization resultFhirOrg = fhirTransformService
-                    .transformToFhirOrganization(updatedOrg);
-            try {
-                fhirPersistenceService.updateFhirResourceInFhirStore(resultFhirOrg);
-            } catch (Exception syncEx) {
-                LogEvent.logError(this.getClass().getSimpleName(), method,
-                        "FHIR store sync failed during update (continuing anyway): " + syncEx.getMessage());
-            }
+            Organization resultFhirOrg = fhirTransformService.transformToFhirOrganization(updatedOrg);
+            syncToFhirStore(resultFhirOrg, method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully updated Organization with ID: " + theId.getIdPart());
@@ -150,7 +148,7 @@ public class OrganizationProvider implements IResourceProvider {
 
             return outcome;
 
-        } catch (UnprocessableEntityException | InvalidRequestException e) {
+        } catch (ResourceNotFoundException | UnprocessableEntityException | InvalidRequestException e) {
             throw e;
 
         } catch (Exception e) {
@@ -176,7 +174,8 @@ public class OrganizationProvider implements IResourceProvider {
                 throw new InvalidRequestException("Organization ID must be provided for delete");
             }
 
-            Organization organization = organizationService.getOrganizationByFhirId(theId.getIdPart());
+            org.openelisglobal.organization.valueholder.Organization organization = organizationService
+                    .getOrganizationByFhirId(theId.getIdPart());
 
             if (organization == null) {
                 throw new ResourceNotFoundException("Organization/" + theId.getIdPart());
@@ -186,15 +185,9 @@ public class OrganizationProvider implements IResourceProvider {
             organization.setSysUserId(ControllerUtills.getSysUserId(request));
             organizationService.save(organization);
 
-            try {
-                org.hl7.fhir.r4.model.Organization fhirOrgToSync = fhirTransformService
-                        .transformToFhirOrganization(organization);
-                fhirOrgToSync.setActive(false);
-                fhirPersistenceService.updateFhirResourceInFhirStore(fhirOrgToSync);
-            } catch (Exception syncEx) {
-                LogEvent.logError(this.getClass().getSimpleName(), method,
-                        "FHIR store sync failed during delete (continuing anyway): " + syncEx.getMessage());
-            }
+            Organization fhirOrgToSync = fhirTransformService.transformToFhirOrganization(organization);
+            fhirOrgToSync.setActive(false);
+            syncToFhirStore(fhirOrgToSync, method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully deleted Organization with ID: " + theId.getIdPart());
@@ -217,6 +210,15 @@ public class OrganizationProvider implements IResourceProvider {
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while deleting Organization: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while deleting Organization", e);
+        }
+    }
+
+    private void syncToFhirStore(Organization fhirOrg, String callingMethod) {
+        try {
+            fhirPersistenceService.updateFhirResourceInFhirStore(fhirOrg);
+        } catch (Exception syncEx) {
+            LogEvent.logError(this.getClass().getSimpleName(), callingMethod,
+                    "FHIR store sync failed (continuing anyway): " + syncEx.getMessage());
         }
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
@@ -15,10 +15,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.openelisglobal.common.log.LogEvent;
-import org.openelisglobal.common.util.ControllerUtills;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
@@ -66,31 +64,20 @@ public class PractitionerProvider implements IResourceProvider {
             }
 
             Provider provider = fhirTransformService.transformToProvider(practitioner);
-            provider.getPerson().setSysUserId(ControllerUtills.getSysUserId(request));
+            provider.getPerson().setSysUserId(FhirProviderUtils.getSysUserId(request));
             Person savedPerson = personService.save(provider.getPerson());
             provider.setPerson(savedPerson);
 
             Provider providerTosave = providerService.save(provider);
 
             Practitioner practitionerToSave = fhirTransformService.transformProviderToPractitioner(providerTosave);
-
-            try {
-                fhirPersistenceService.updateFhirResourceInFhirStore(practitionerToSave);
-            } catch (Exception syncEx) {
-                LogEvent.logError(this.getClass().getSimpleName(), method,
-                        "FHIR store sync failed (continuing anyway): " + syncEx.getMessage());
-            }
+            FhirProviderUtils.syncToFhirStore(fhirPersistenceService, practitionerToSave,
+                    this.getClass().getSimpleName(), method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully created Practitioner with UUID: " + provider.getFhirUuidAsString());
 
-            MethodOutcome outcome = new MethodOutcome();
-            outcome.setId(practitionerToSave.getIdElement());
-            outcome.setResource(practitionerToSave);
-            outcome.setCreated(true);
-            outcome.setResponseStatusCode(201);
-
-            return outcome;
+            return FhirProviderUtils.buildCreateOutcome(practitionerToSave);
 
         } catch (UnprocessableEntityException | InvalidRequestException e) {
             throw e;
@@ -114,12 +101,7 @@ public class PractitionerProvider implements IResourceProvider {
 
         try {
 
-            if (theId == null || !theId.hasIdPart()) {
-
-                LogEvent.logError(this.getClass().getSimpleName(), method, "Missing Practitioner ID for update");
-
-                throw new InvalidRequestException("Practitioner ID must be provided for update");
-            }
+            FhirProviderUtils.validateIdParam(theId, "Practitioner", this.getClass().getSimpleName(), method);
 
             practitioner.setId(theId);
 
@@ -129,28 +111,18 @@ public class PractitionerProvider implements IResourceProvider {
 
             fhirTransformService.addHumanNameToPerson(practitioner.getNameFirstRep(), existingPerson);
             fhirTransformService.addTelecomToPerson(practitioner.getTelecom(), existingPerson);
-            existingPerson.setSysUserId(ControllerUtills.getSysUserId(request));
+            existingPerson.setSysUserId(FhirProviderUtils.getSysUserId(request));
             Person updatedPerson = personService.save(existingPerson);
             provider.setPerson(updatedPerson);
             Provider providerToUpdate = providerService.save(provider);
             Practitioner practitionerToSave = fhirTransformService.transformProviderToPractitioner(providerToUpdate);
-            try {
-                fhirPersistenceService.updateFhirResourceInFhirStore(practitionerToSave);
-            } catch (Exception syncEx) {
-                LogEvent.logError(this.getClass().getSimpleName(), method,
-                        "FHIR store sync failed during update (continuing anyway): " + syncEx.getMessage());
-            }
+            FhirProviderUtils.syncToFhirStore(fhirPersistenceService, practitionerToSave,
+                    this.getClass().getSimpleName(), method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully updated Practitioner with ID: " + theId.getIdPart());
 
-            MethodOutcome outcome = new MethodOutcome();
-            outcome.setId(practitionerToSave.getIdElement());
-            outcome.setResource(practitionerToSave);
-            outcome.setCreated(false);
-            outcome.setResponseStatusCode(200);
-
-            return outcome;
+            return FhirProviderUtils.buildUpdateOutcome(practitionerToSave);
 
         } catch (UnprocessableEntityException | InvalidRequestException e) {
             throw e;
@@ -173,10 +145,7 @@ public class PractitionerProvider implements IResourceProvider {
 
         try {
 
-            if (theId == null || !theId.hasIdPart()) {
-                LogEvent.logError(this.getClass().getSimpleName(), method, "Missing Practitioner ID for delete");
-                throw new InvalidRequestException("Practitioner ID must be provided for delete");
-            }
+            FhirProviderUtils.validateIdParam(theId, "Practitioner", this.getClass().getSimpleName(), method);
 
             Provider provider = providerService.getProviderByFhirId(UUID.fromString(theId.getIdPart()));
 
@@ -185,31 +154,18 @@ public class PractitionerProvider implements IResourceProvider {
             }
 
             provider.setActive(false);
-            provider.setSysUserId(ControllerUtills.getSysUserId(request));
+            provider.setSysUserId(FhirProviderUtils.getSysUserId(request));
             providerService.save(provider);
 
-            try {
-                Practitioner practitionerToDelete = fhirTransformService.transformProviderToPractitioner(provider);
-                practitionerToDelete.setActive(false);
-                fhirPersistenceService.updateFhirResourceInFhirStore(practitionerToDelete);
-            } catch (Exception syncEx) {
-                LogEvent.logError(this.getClass().getSimpleName(), method,
-                        "FHIR store sync failed during delete (continuing anyway): " + syncEx.getMessage());
-            }
+            Practitioner practitionerToDelete = fhirTransformService.transformProviderToPractitioner(provider);
+            practitionerToDelete.setActive(false);
+            FhirProviderUtils.syncToFhirStore(fhirPersistenceService, practitionerToDelete,
+                    this.getClass().getSimpleName(), method);
 
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Successfully deleted Practitioner with ID: " + theId.getIdPart());
 
-            MethodOutcome outcome = new MethodOutcome();
-            outcome.setId(theId);
-            outcome.setResponseStatusCode(204);
-
-            OperationOutcome operationOutcome = new OperationOutcome();
-            operationOutcome.addIssue().setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
-                    .setDiagnostics("Practitioner " + theId.getIdPart() + " has been deleted");
-            outcome.setOperationOutcome(operationOutcome);
-
-            return outcome;
+            return FhirProviderUtils.buildDeleteOutcome(theId, "Practitioner");
 
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;


### PR DESCRIPTION
## Description

Adds `OrganizationProvider` as a new HAPI FHIR `IResourceProvider` for the **Organization** resource, extending the FHIR facade beyond the existing `PractitionerProvider`.

This implementation follows the same architectural and design pattern used in `PractitionerProvider` to maintain consistency across the FHIR facade layer.

---

## Operations Implemented

| Operation | Annotation | Behavior |
|------------|------------|-----------|
| **Create** | `@Create` | Accepts FHIR `Organization` → transforms to local entity via `transformToOrganization()` → persists locally → syncs to FHIR store |
| **Update** | `@Update` | Looks up existing org by FHIR UUID via `getOrganizationByFhirId()` → merges fields using transform → saves → syncs to FHIR store |
| **Delete** | `@Delete` | Soft-delete: sets `isActive = "N"` → syncs deactivation to FHIR store |

---

## Design Decisions

- Follows the exact same pattern as `PractitionerProvider` for structural and behavioral consistency  
- Imports `org.hl7.fhir.r4.model.Organization` directly; uses fully qualified name (FQN) for the local valueholder to avoid name collision  
- Introduces `syncToFhirStore()` helper to reduce duplication across operations  
- FHIR store sync failures are logged but **do not block** the local operation (non-fatal by design)  
- Auto-discovered by `FhirRestfulServer` — no routing changes required in `InternalFhirApi`  

---

## Reused Infrastructure

- `FhirTransformService.transformToOrganization()` (FHIR → local)  
- `FhirTransformService.transformToFhirOrganization()` (local → FHIR)  
- `OrganizationService.getOrganizationByFhirId()` for UUID lookups  

---

## Related Issue

Part of the FHIR facade expansion effort.