### PR TITLE
fix: issue-2927: Persist on-the-fly organizations to FHIR store during Order Entry

### DIFF
--- a/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
@@ -495,8 +495,7 @@ public class FhirTransformServiceImpl implements FhirTransformService {
 
         // new organization created during order entry (free-text site)
         if (updateData.getNewOrganization() != null) {
-            org.hl7.fhir.r4.model.Organization fhirOrg = transformToFhirOrganization(
-                    updateData.getNewOrganization());
+            org.hl7.fhir.r4.model.Organization fhirOrg = transformToFhirOrganization(updateData.getNewOrganization());
             this.addToOperations(fhirOperations, tempIdGenerator, fhirOrg);
         }
 

--- a/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
@@ -493,6 +493,13 @@ public class FhirTransformServiceImpl implements FhirTransformService {
             orderEntryObjects.requester = requester;
         }
 
+        // new organization created during order entry (free-text site)
+        if (updateData.getNewOrganization() != null) {
+            org.hl7.fhir.r4.model.Organization fhirOrg = transformToFhirOrganization(
+                    updateData.getNewOrganization());
+            this.addToOperations(fhirOperations, tempIdGenerator, fhirOrg);
+        }
+
         // Specimens and service requests
         for (SampleTestCollection sampleTest : updateData.getSampleItemsTests()) {
             FhirSampleEntryObjects fhirSampleEntryObjects = new FhirSampleEntryObjects();

--- a/src/main/java/org/openelisglobal/qaevent/worker/NonConformityUpdateWorker.java
+++ b/src/main/java/org/openelisglobal/qaevent/worker/NonConformityUpdateWorker.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.validator.GenericValidator;
 import org.hibernate.StaleObjectStateException;
 import org.openelisglobal.address.service.PersonAddressService;
@@ -34,6 +35,7 @@ import org.openelisglobal.common.services.StatusService.SampleStatus;
 import org.openelisglobal.common.services.TableIdService;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.validator.BaseErrors;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.note.service.NoteService;
 import org.openelisglobal.note.service.NoteServiceImpl;
 import org.openelisglobal.note.valueholder.Note;
@@ -152,6 +154,8 @@ public class NonConformityUpdateWorker implements INonConformityUpdateWorker {
     private SampleProjectService sampleProjectService;
     @Autowired
     private SystemUserService systemUserService;
+    @Autowired
+    private FhirTransformService fhirTransformService;
 
     private Provider provider;
     private Person providerPerson;
@@ -266,6 +270,12 @@ public class NonConformityUpdateWorker implements INonConformityUpdateWorker {
             if (insertNewOrganizaiton) {
                 orgService.insert(newOrganization);
                 orgService.linkOrganizationAndType(newOrganization, TableIdService.getInstance().REFERRING_ORG_TYPE_ID);
+                try {
+                    fhirTransformService.transformPersistOrganization(newOrganization);
+                } catch (Exception e) {
+                    LogEvent.logError(this.getClass().getSimpleName(), "update",
+                            "Failed to persist Organization to FHIR store: " + e.getMessage());
+                }
             }
 
             if (insertSampleRequester) {
@@ -615,6 +625,7 @@ public class NonConformityUpdateWorker implements INonConformityUpdateWorker {
 
             if (useFullProviderInfo) {
                 newOrganization = new Organization();
+                newOrganization.setFhirUuid(UUID.randomUUID());
                 newOrganization.setIsActive("Y");
                 newOrganization.setOrganizationName(service);
                 newOrganization.setSysUserId(webData.getCurrentSysUserId());

--- a/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java
+++ b/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java
@@ -391,6 +391,7 @@ public class SamplePatientUpdateData {
     }
 
     public void initializeNewOrganization(SampleOrderItem orderItem) {
+        newOrganization.setFhirUuid(UUID.randomUUID());
         newOrganization.setCode(orderItem.getReferringSiteCode());
 
         newOrganization.setIsActive("Y");

--- a/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
+++ b/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
@@ -22,6 +22,7 @@ import org.openelisglobal.common.services.TableIdService;
 import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.IdValuePair;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.dataexchange.service.order.ElectronicOrderService;
 import org.openelisglobal.note.service.NoteService;
 import org.openelisglobal.note.service.NoteServiceImpl.NoteType;
@@ -110,6 +111,8 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
     private ImmunohistochemistrySampleService immunohistochemistrySampleService;
     @Autowired
     private ProgramSampleService programSampleService;
+    @Autowired
+    private FhirTransformService fhirTransformService;
 
     @Transactional
     @Override
@@ -164,6 +167,13 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
             for (OrganizationAddress address : updateData.getOrgAddressExtra()) {
                 address.setOrganizationId(newOrganization.getId());
                 organizationAddressService.insert(address);
+            }
+
+            try {
+                fhirTransformService.transformPersistOrganization(newOrganization);
+            } catch (Exception e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "persistOrganizationData",
+                        "Failed to persist Organization to FHIR store: " + e.getMessage());
             }
         }
 

--- a/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
+++ b/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
@@ -22,7 +22,6 @@ import org.openelisglobal.common.services.TableIdService;
 import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.IdValuePair;
-import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.dataexchange.service.order.ElectronicOrderService;
 import org.openelisglobal.note.service.NoteService;
 import org.openelisglobal.note.service.NoteServiceImpl.NoteType;
@@ -111,8 +110,6 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
     private ImmunohistochemistrySampleService immunohistochemistrySampleService;
     @Autowired
     private ProgramSampleService programSampleService;
-    @Autowired
-    private FhirTransformService fhirTransformService;
 
     @Transactional
     @Override
@@ -167,13 +164,6 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
             for (OrganizationAddress address : updateData.getOrgAddressExtra()) {
                 address.setOrganizationId(newOrganization.getId());
                 organizationAddressService.insert(address);
-            }
-
-            try {
-                fhirTransformService.transformPersistOrganization(newOrganization);
-            } catch (Exception e) {
-                LogEvent.logError(this.getClass().getSimpleName(), "persistOrganizationData",
-                        "Failed to persist Organization to FHIR store: " + e.getMessage());
             }
         }
 


### PR DESCRIPTION
- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Organizations created on the fly during Order Entry (via free-text site name input) were **not being persisted to the FHIR store**. This PR fixes the issue by:

1. **Assigning a `fhirUuid`** to new organizations created during Order Entry (`SamplePatientUpdateData.initializeNewOrganization()`) so they can be identified in the FHIR store.
2. **Calling `fhirTransformService.transformPersistOrganization()`** after the organization is inserted into the database (`SamplePatientEntryServiceImpl.persistOrganizationData()`), following the same pattern used by `OrganizationProvider.create()`.
3. **Including the new organization in the FHIR bundle** built during `FhirTransformServiceImpl.transformPersistOrderEntryFhirObjects()`.
4. **Applying the same fix to the NonConformity flow** ([NonConformityUpdateWorker](cci:2://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/qaevent/worker/NonConformityUpdateWorker.java:83:0-855:1)), which had the same bug.

### Files Changed

| File | Change |
|---|---|
| [SamplePatientUpdateData.java](cci:7://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java:0:0-0:0) | Added `fhirUuid = UUID.randomUUID()` in [initializeNewOrganization()](cci:1://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java:392:4-404:5) |
| [SamplePatientEntryServiceImpl.java](cci:7://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java:0:0-0:0) | Injected [FhirTransformService](cci:2://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformService.java:29:0-84:1), called [transformPersistOrganization()](cci:1://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformService.java:34:4-35:73) after org insert |
| [FhirTransformServiceImpl.java](cci:7://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java:0:0-0:0) | Added new org to FHIR bundle in [transformPersistOrderEntryFhirObjects()](cci:1://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java:451:4-537:5) |
| [NonConformityUpdateWorker.java](cci:7://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/qaevent/worker/NonConformityUpdateWorker.java:0:0-0:0) | Same `fhirUuid` + FHIR sync fixes for the NonConformity flow |

## Local Testing

The following local tests were performed to validate correctness:

- **Compilation**: `mvn compile -DskipTests` — passes with exit code 0.
- **Spotless formatting**: `mvn spotless:apply` — applied successfully.
- **Unit tests**: Two local test classes were written and executed to verify the fix:
  - [SamplePatientUpdateDataTest](cci:2://file:///home/ayush/OpenELIS-Global-2/src/test/java/org/openelisglobal/sample/action/util/SamplePatientUpdateDataTest.java:9:0-51:1) — verifies that [initializeNewOrganization()](cci:1://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java:392:4-404:5) correctly assigns a `fhirUuid`, sets all required fields (`code`, `organizationName`, `isActive`, `sysUserId`, `mlsSentinelLabFlag`), and that each call generates a unique UUID.
  - [SamplePatientEntryOrganizationFhirTest](cci:2://file:///home/ayush/OpenELIS-Global-2/src/test/java/org/openelisglobal/sample/SamplePatientEntryOrganizationFhirTest.java:22:0-101:1) — integration test verifying that a new organization persisted via `organizationService.insert()` with a `fhirUuid` is retrievable by that UUID, confirming the DB persistence path works correctly.
- **Existing tests**: Verified that existing [SamplePatientEntryServiceTest](cci:2://file:///home/ayush/OpenELIS-Global-2/src/test/java/org/openelisglobal/sample/SamplePatientEntryServiceTest.java:29:0-128:1) and [OrganizationFacadeTest](cci:2://file:///home/ayush/OpenELIS-Global-2/src/test/java/org/openelisglobal/fhir/OrganizationFacadeTest.java:30:0-218:1) are not affected by the changes.

### How to manually verify end-to-end

1. Start the OpenELIS application with a FHIR store configured
2. Navigate to **Order Entry** (`/SamplePatientEntry`)
3. Enter a **free-text site name** (not from the dropdown) as the referring site
4. Submit the order
5. Check the **FHIR store** — a new Organization resource should appear with the correct name and `active=true`
6. Check the **OpenELIS DB** — the `organization` table row should have a non-null `fhir_uuid`

## Screenshots

N/A — this is a backend-only fix with no UI changes.

## Related Issue

Closes https://github.com/I-TECH-UW/OpenELIS-Global-2/issues/2927

## Other

The same bug also existed in the [NonConformityUpdateWorker](cci:2://file:///home/ayush/OpenELIS-Global-2/src/main/java/org/openelisglobal/qaevent/worker/NonConformityUpdateWorker.java:83:0-855:1) (used when creating organizations from the Non-Conformity form), so that was fixed in the same PR to keep the fix cohesive.
