### PR TITLE
feat: OGC-319: Allow instance-specific configurations

### DIFF
--- a/src/main/java/org/openelisglobal/configuration/service/ConfigurationInitializationService.java
+++ b/src/main/java/org/openelisglobal/configuration/service/ConfigurationInitializationService.java
@@ -11,7 +11,10 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.openelisglobal.common.log.LogEvent;
@@ -26,44 +29,75 @@ import org.springframework.stereotype.Component;
 @Component
 public class ConfigurationInitializationService implements ApplicationListener<ContextRefreshedEvent> {
 
+    private static final String CLASS_NAME = "ConfigurationInitializationService";
+
     @Value("${org.openelisglobal.configuration.dir:/var/lib/openelis-global/configuration/backend}")
     private String configurationBaseDir;
 
     @Value("${org.openelisglobal.configuration.autocreate:true}")
     private boolean autocreateOn;
 
-    @Autowired(required = false)
+    /**
+     * Identifies this OpenELIS instance for loading instance-specific
+     * configuration. When set, the system looks for files in a subdirectory named
+     * after this ID (e.g., {@code configuration/tests/{instanceId}/}) and, if
+     * found, uses those instead of the base domain files.
+     *
+     * <p>
+     * Maps from env var {@code OPENELIS_CONFIGURATION_INSTANCE_ID} via Spring's
+     * relaxed binding.
+     */
+    @Value("${org.openelisglobal.configuration.instance-id:#{null}}")
+    private String instanceId;
+
     private List<DomainConfigurationHandler> domainHandlers;
+
+    private final PathMatchingResourcePatternResolver resolver;
+
+    private volatile boolean initialized = false;
+
+    ConfigurationInitializationService() {
+        this(new PathMatchingResourcePatternResolver());
+    }
+
+    ConfigurationInitializationService(PathMatchingResourcePatternResolver resolver) {
+        this.resolver = resolver;
+    }
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent event) {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+
         if (!autocreateOn) {
-            LogEvent.logInfo(this.getClass().getSimpleName(), "onApplicationEvent",
+            LogEvent.logInfo(CLASS_NAME, "onApplicationEvent",
                     "Configuration auto-initialization is disabled. Skipping configuration loading.");
             return;
         }
 
         if (domainHandlers == null || domainHandlers.isEmpty()) {
-            LogEvent.logInfo(this.getClass().getSimpleName(), "onApplicationEvent",
+            LogEvent.logInfo(CLASS_NAME, "onApplicationEvent",
                     "No domain configuration handlers found. Skipping configuration loading.");
             return;
         }
 
-        LogEvent.logInfo(this.getClass().getSimpleName(), "onApplicationEvent",
+        LogEvent.logInfo(CLASS_NAME, "onApplicationEvent",
                 "Starting configuration initialization from " + configurationBaseDir + "...");
 
-        try {
-            // Sort handlers by load order to ensure dependencies are loaded first
-            List<DomainConfigurationHandler> sortedHandlers = domainHandlers.stream()
-                    .sorted(Comparator.comparingInt(DomainConfigurationHandler::getLoadOrder))
-                    .collect(Collectors.toList());
+        if (instanceId != null && !instanceId.isBlank()) {
+            LogEvent.logInfo(CLASS_NAME, "onApplicationEvent", "Instance ID is set to '" + instanceId
+                    + "'. Instance-specific configurations will be preferred when available.");
+        }
 
-            LogEvent.logInfo(this.getClass().getSimpleName(), "onApplicationEvent",
+        try {
+            LogEvent.logInfo(CLASS_NAME, "onApplicationEvent",
                     "Loading configuration handlers in order: "
-                            + sortedHandlers.stream().map(h -> h.getDomainName() + "(" + h.getLoadOrder() + ")")
+                            + domainHandlers.stream().map(h -> h.getDomainName() + "(" + h.getLoadOrder() + ")")
                                     .collect(Collectors.joining(", ")));
 
-            for (DomainConfigurationHandler handler : sortedHandlers) {
+            for (DomainConfigurationHandler handler : domainHandlers) {
                 try {
                     loadDomainConfiguration(handler);
                 } catch (Exception e) {
@@ -71,116 +105,167 @@ public class ConfigurationInitializationService implements ApplicationListener<C
                 }
             }
         } catch (Exception e) {
-            LogEvent.logError(e);
+            LogEvent.logError("Error occurred while processing domains", e);
         }
     }
 
     private void loadDomainConfiguration(DomainConfigurationHandler handler) throws Exception {
         String domainName = handler.getDomainName();
+        String ext = handler.getFileExtension();
         String checksumsFile = configurationBaseDir + "/" + domainName + "-checksums.properties";
-        String classpathPattern = "classpath*:configuration/" + domainName + "/*." + handler.getFileExtension();
-        String filesystemDir = configurationBaseDir + "/" + domainName;
-
         Properties checksums = loadChecksums(checksumsFile);
-        boolean checksumsUpdated = false;
 
-        // Load from classpath
-        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-        Resource[] resources = resolver.getResources(classpathPattern);
+        // When an instance ID is configured, try instance-specific paths first.
+        // If any instance files are found (classpath or filesystem), use only those
+        // and skip the base domain files entirely.
+        if (instanceId != null && !instanceId.isBlank()) {
+            Map<String, InputStreamSource> instanceFiles = collectFiles(
+                    "classpath*:configuration/" + domainName + "/" + instanceId + "/*." + ext,
+                    configurationBaseDir + "/" + domainName + "/" + instanceId, ext);
 
-        for (Resource resource : resources) {
-            try {
+            if (!instanceFiles.isEmpty()) {
+                LoadResult result = processFiles(handler, instanceFiles, checksums, domainName);
+                if (result.checksumsUpdated()) {
+                    saveChecksums(checksums, checksumsFile);
+                }
+                LogEvent.logInfo(CLASS_NAME, "loadDomainConfiguration",
+                        "Using instance-specific configuration for domain: " + domainName + " (instance: " + instanceId
+                                + ")");
+                return;
+            }
+
+            LogEvent.logInfo(CLASS_NAME, "loadDomainConfiguration",
+                    "No instance-specific configuration found for domain: " + domainName + " (instance: " + instanceId
+                            + "). Falling back to base configuration.");
+        }
+
+        // Base behavior: load from classpath then filesystem
+        Map<String, InputStreamSource> baseFiles = collectFiles("classpath*:configuration/" + domainName + "/*." + ext,
+                configurationBaseDir + "/" + domainName, ext);
+
+        LoadResult result = processFiles(handler, baseFiles, checksums, domainName);
+        if (result.checksumsUpdated()) {
+            saveChecksums(checksums, checksumsFile);
+        }
+    }
+
+    /**
+     * Collects configuration files from both classpath and filesystem into a single
+     * map of filename to stream source. Filesystem files are checked first; if any
+     * exist, only those are used. Otherwise, classpath resources are used as a
+     * fallback. The two sources are never merged — configuration is loaded from
+     * exactly one place.
+     *
+     * <p>
+     * Stream sources are used instead of buffering file contents so that large
+     * files are not held entirely in memory. Each consumer (checksum calculation,
+     * handler processing) opens its own stream.
+     */
+    private Map<String, InputStreamSource> collectFiles(String classpathPattern, String filesystemDir,
+            String extension) {
+        // Filesystem files take precedence — if any exist, use only those
+        Map<String, InputStreamSource> fsFiles = collectFilesystemFiles(filesystemDir, extension);
+        if (!fsFiles.isEmpty()) {
+            return fsFiles;
+        }
+
+        // Fall back to classpath resources
+        return collectClasspathFiles(classpathPattern);
+    }
+
+    private Map<String, InputStreamSource> collectFilesystemFiles(String filesystemDir, String extension) {
+        Map<String, InputStreamSource> files = new LinkedHashMap<>();
+        Path configDir = Paths.get(filesystemDir);
+        if (Files.exists(configDir) && Files.isDirectory(configDir)) {
+            File[] fsFiles = configDir.toFile().listFiles((dir, name) -> name.toLowerCase().endsWith("." + extension));
+            if (fsFiles != null) {
+                for (File file : fsFiles) {
+                    files.put(file.getName(), () -> Files.newInputStream(file.toPath()));
+                }
+            }
+        }
+        return files;
+    }
+
+    private Map<String, InputStreamSource> collectClasspathFiles(String classpathPattern) {
+        Map<String, InputStreamSource> files = new LinkedHashMap<>();
+        try {
+            Resource[] resources = resolver.getResources(classpathPattern);
+            for (Resource resource : resources) {
                 String fileName = resource.getFilename();
                 if (fileName == null) {
                     continue;
                 }
+                files.put(fileName, resource::getInputStream);
+            }
+        } catch (IOException e) {
+            LogEvent.logError("Failed to resolve classpath pattern: " + classpathPattern, e);
+        }
+        return files;
+    }
 
-                InputStream inputStream = resource.getInputStream();
-                String currentChecksum = calculateChecksum(inputStream);
-                inputStream.close();
+    /**
+     * Processes collected files through the handler, skipping any whose checksum
+     * matches the previously stored value. Each file is read twice via its stream
+     * source: once for checksum calculation, once for handler processing. This
+     * avoids buffering entire file contents in memory.
+     */
+    private LoadResult processFiles(DomainConfigurationHandler handler, Map<String, InputStreamSource> files,
+            Properties checksums, String domainName) {
+        boolean filesFound = false;
+        boolean checksumsUpdated = false;
 
+        for (Map.Entry<String, InputStreamSource> entry : files.entrySet()) {
+            String fileName = entry.getKey();
+            InputStreamSource streamSource = entry.getValue();
+            filesFound = true;
+
+            try {
                 // Check if this file has been loaded with the same checksum
+                String currentChecksum;
+                try (InputStream is = streamSource.open()) {
+                    currentChecksum = calculateChecksum(is);
+                }
+
                 String storedChecksum = checksums.getProperty(fileName);
                 if (currentChecksum.equals(storedChecksum)) {
-                    LogEvent.logInfo(this.getClass().getSimpleName(), "loadDomainConfiguration",
+                    LogEvent.logInfo(CLASS_NAME, "loadDomainConfiguration",
                             domainName + " configuration " + fileName + " unchanged (checksum matches). Skipping.");
                     continue;
                 }
 
                 // Load and process the configuration
-                inputStream = resource.getInputStream();
-                handler.processConfiguration(inputStream, fileName);
-                inputStream.close();
+                try (InputStream is = streamSource.open()) {
+                    handler.processConfiguration(is, fileName);
+                }
 
                 // Update checksum
                 checksums.setProperty(fileName, currentChecksum);
                 checksumsUpdated = true;
 
-                LogEvent.logInfo(this.getClass().getSimpleName(), "loadDomainConfiguration",
+                LogEvent.logInfo(CLASS_NAME, "loadDomainConfiguration",
                         "Successfully loaded " + domainName + " configuration: " + fileName);
-
             } catch (Exception e) {
-                LogEvent.logError(
-                        "Failed to load " + domainName + " configuration from resource: " + resource.getFilename(), e);
+                LogEvent.logError("Failed to load " + domainName + " configuration from file: " + fileName, e);
             }
         }
 
-        // Load from filesystem directory
-        Path configDir = Paths.get(filesystemDir);
-        if (Files.exists(configDir) && Files.isDirectory(configDir)) {
-            String extension = handler.getFileExtension();
-            File[] files = configDir.toFile().listFiles((dir, name) -> name.toLowerCase().endsWith("." + extension));
-            if (files != null) {
-                for (File file : files) {
-                    try {
-                        String fileName = file.getName();
-                        String currentChecksum = calculateChecksum(new FileInputStream(file));
-
-                        // Check if this file has been loaded with the same checksum
-                        String storedChecksum = checksums.getProperty(fileName);
-                        if (currentChecksum.equals(storedChecksum)) {
-                            LogEvent.logInfo(this.getClass().getSimpleName(), "loadDomainConfiguration", domainName
-                                    + " configuration " + fileName + " unchanged (checksum matches). Skipping.");
-                            continue;
-                        }
-
-                        // Load and process the configuration
-                        handler.processConfiguration(new FileInputStream(file), fileName);
-
-                        // Update checksum
-                        checksums.setProperty(fileName, currentChecksum);
-                        checksumsUpdated = true;
-
-                        LogEvent.logInfo(this.getClass().getSimpleName(), "loadDomainConfiguration",
-                                "Successfully loaded " + domainName + " configuration: " + fileName);
-
-                    } catch (Exception e) {
-                        LogEvent.logError(
-                                "Failed to load " + domainName + " configuration from file: " + file.getName(), e);
-                    }
-                }
-            }
-        }
-
-        // Save updated checksums if any were updated
-        if (checksumsUpdated) {
-            saveChecksums(checksums, checksumsFile);
-        }
+        return new LoadResult(filesFound, checksumsUpdated);
     }
 
-    private String calculateChecksum(InputStream inputStream) throws IOException, NoSuchAlgorithmException {
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        byte[] buffer = new byte[8192];
-        int bytesRead;
-        while ((bytesRead = inputStream.read(buffer)) != -1) {
-            digest.update(buffer, 0, bytesRead);
+    private static String calculateChecksum(InputStream inputStream) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                digest.update(buffer, 0, bytesRead);
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is guaranteed by the JVM specification; this cannot happen
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
         }
-        byte[] hashBytes = digest.digest();
-        StringBuilder sb = new StringBuilder();
-        for (byte b : hashBytes) {
-            sb.append(String.format("%02x", b));
-        }
-        return sb.toString();
     }
 
     private Properties loadChecksums(String checksumsFile) {
@@ -209,5 +294,37 @@ public class ConfigurationInitializationService implements ApplicationListener<C
         } catch (IOException e) {
             LogEvent.logError("Failed to save checksums file: " + checksumsFile, e);
         }
+    }
+
+    /**
+     * Used internally to load {@code InputStream}s for files that have been
+     * identified
+     */
+    @FunctionalInterface
+    interface InputStreamSource {
+        InputStream open() throws IOException;
+    }
+
+    // Sort handlers by load order to ensure dependencies are loaded first
+    @Autowired(required = false)
+    void setDomainHandlers(List<DomainConfigurationHandler> domainHandlers) {
+        if (domainHandlers != null && !domainHandlers.isEmpty()) {
+            this.domainHandlers = domainHandlers.stream()
+                    .sorted(Comparator.comparingInt(DomainConfigurationHandler::getLoadOrder))
+                    .collect(Collectors.toList());
+        } else {
+            this.domainHandlers = domainHandlers;
+        }
+    }
+
+    /**
+     * This is used to hold the result of attempting to load a file
+     *
+     * @param filesFound       Whether files were found (used so that classpath
+     *                         overrides filesystem)
+     * @param checksumsUpdated Whether checksums were updated so these can be
+     *                         flushed to disk
+     */
+    private record LoadResult(boolean filesFound, boolean checksumsUpdated) {
     }
 }

--- a/src/test/java/org/openelisglobal/configuration/service/ConfigurationInitializationServiceTest.java
+++ b/src/test/java/org/openelisglobal/configuration/service/ConfigurationInitializationServiceTest.java
@@ -1,0 +1,495 @@
+package org.openelisglobal.configuration.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationInitializationServiceTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Mock
+    private PathMatchingResourcePatternResolver resolver;
+
+    @InjectMocks
+    private ConfigurationInitializationService service;
+
+    private DomainConfigurationHandler mockHandler;
+    private ContextRefreshedEvent mockEvent;
+
+    @Before
+    public void setUp() throws Exception {
+        mockHandler = mock(DomainConfigurationHandler.class);
+        when(mockHandler.getDomainName()).thenReturn("tests");
+        when(mockHandler.getFileExtension()).thenReturn("csv");
+        when(mockHandler.getLoadOrder()).thenReturn(100);
+
+        mockEvent = mock(ContextRefreshedEvent.class);
+
+        ReflectionTestUtils.setField(service, "configurationBaseDir", tempFolder.getRoot().getAbsolutePath());
+        ReflectionTestUtils.setField(service, "autocreateOn", true);
+        ReflectionTestUtils.setField(service, "instanceId", null);
+        ReflectionTestUtils.setField(service, "initialized", false);
+        service.setDomainHandlers(Arrays.asList(mockHandler));
+
+        when(resolver.getResources(anyString())).thenReturn(new Resource[] {});
+    }
+
+    // -- Skipping / early-exit tests --
+
+    @Test
+    public void onApplicationEvent_shouldSkipLoadingWhenAutocreateDisabled() throws Exception {
+        ReflectionTestUtils.setField(service, "autocreateOn", false);
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(resolver, never()).getResources(anyString());
+        verify(mockHandler, never()).processConfiguration(any(), anyString());
+    }
+
+    @Test
+    public void onApplicationEvent_shouldSkipLoadingWhenHandlersNull() throws Exception {
+        service.setDomainHandlers(null);
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(resolver, never()).getResources(anyString());
+    }
+
+    @Test
+    public void onApplicationEvent_shouldSkipLoadingWhenHandlersEmpty() throws Exception {
+        service.setDomainHandlers(Collections.emptyList());
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(resolver, never()).getResources(anyString());
+    }
+
+    // -- Initialized guard --
+
+    @Test
+    public void onApplicationEvent_shouldOnlyProcessOnceWhenFiredMultipleTimes() throws Exception {
+        Resource resource = createMockResource("data.csv", "content");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv")).thenReturn(new Resource[] { resource });
+
+        service.onApplicationEvent(mockEvent);
+        service.onApplicationEvent(mockEvent);
+
+        // Handler is called only once — the second event is short-circuited by the
+        // initialized guard before any handler processing occurs
+        verify(mockHandler, times(1)).processConfiguration(any(InputStream.class), eq("data.csv"));
+    }
+
+    // -- Handler ordering --
+
+    @Test
+    public void onApplicationEvent_shouldProcessHandlersInLoadOrder() throws Exception {
+        DomainConfigurationHandler laterHandler = mock(DomainConfigurationHandler.class);
+        when(laterHandler.getDomainName()).thenReturn("roles");
+        when(laterHandler.getFileExtension()).thenReturn("csv");
+        when(laterHandler.getLoadOrder()).thenReturn(300);
+
+        DomainConfigurationHandler earlyHandler = mock(DomainConfigurationHandler.class);
+        when(earlyHandler.getDomainName()).thenReturn("sample-types");
+        when(earlyHandler.getFileExtension()).thenReturn("csv");
+        when(earlyHandler.getLoadOrder()).thenReturn(50);
+
+        // Provide resources so processConfiguration gets called
+        Resource earlyResource = createMockResource("samples.csv", "sample data");
+        Resource laterResource = createMockResource("roles.csv", "role data");
+        when(resolver.getResources("classpath*:configuration/sample-types/*.csv"))
+                .thenReturn(new Resource[] { earlyResource });
+        when(resolver.getResources("classpath*:configuration/roles/*.csv"))
+                .thenReturn(new Resource[] { laterResource });
+
+        // Deliberately add in reverse order to verify sorting
+        service.setDomainHandlers(Arrays.asList(laterHandler, earlyHandler));
+
+        service.onApplicationEvent(mockEvent);
+
+        InOrder order = inOrder(earlyHandler, laterHandler);
+        order.verify(earlyHandler).processConfiguration(any(), eq("samples.csv"));
+        order.verify(laterHandler).processConfiguration(any(), eq("roles.csv"));
+    }
+
+    @Test
+    public void setDomainHandlers_shouldSortByLoadOrder() throws Exception {
+        DomainConfigurationHandler handler200 = mock(DomainConfigurationHandler.class);
+        when(handler200.getLoadOrder()).thenReturn(200);
+
+        DomainConfigurationHandler handler50 = mock(DomainConfigurationHandler.class);
+        when(handler50.getLoadOrder()).thenReturn(50);
+
+        // Set handlers in reverse order — setDomainHandlers sorts them
+        service.setDomainHandlers(Arrays.asList(handler200, handler50));
+
+        // Verify domainHandlers is sorted after setter injection
+        @SuppressWarnings("unchecked")
+        java.util.List<DomainConfigurationHandler> handlers = (java.util.List<DomainConfigurationHandler>) ReflectionTestUtils
+                .getField(service, "domainHandlers");
+        assertEquals("First handler should have lower load order", 50, handlers.get(0).getLoadOrder());
+        assertEquals("Second handler should have higher load order", 200, handlers.get(1).getLoadOrder());
+    }
+
+    // -- Basic classpath loading --
+
+    @Test
+    public void loadDomainConfiguration_shouldProcessClasspathResource() throws Exception {
+        Resource resource = createMockResource("test-data.csv", "header\nrow1\n");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv")).thenReturn(new Resource[] { resource });
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("test-data.csv"));
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldProcessAllClasspathResources() throws Exception {
+        Resource resource1 = createMockResource("file1.csv", "data1");
+        Resource resource2 = createMockResource("file2.csv", "data2");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv"))
+                .thenReturn(new Resource[] { resource1, resource2 });
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("file1.csv"));
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("file2.csv"));
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldSkipResourceWhenFilenameNull() throws Exception {
+        Resource nullNameResource = mock(Resource.class);
+        when(nullNameResource.getFilename()).thenReturn(null);
+
+        Resource validResource = createMockResource("valid.csv", "data");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv"))
+                .thenReturn(new Resource[] { nullNameResource, validResource });
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("valid.csv"));
+        verify(mockHandler, times(1)).processConfiguration(any(), anyString());
+    }
+
+    // -- Basic filesystem loading --
+
+    @Test
+    public void loadDomainConfiguration_shouldProcessFilesystemFile() throws Exception {
+        createTestFile("tests/lab-tests.csv", "header\nrow1\n");
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("lab-tests.csv"));
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldIgnoreFilesWithWrongExtension() throws Exception {
+        createTestFile("tests/data.csv", "csv data");
+        createTestFile("tests/notes.txt", "text data");
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("data.csv"));
+        verify(mockHandler, times(1)).processConfiguration(any(), anyString());
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldNotErrorWhenFilesystemDirMissing() throws Exception {
+        // No filesystem directory created; resolver returns nothing
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler, never()).processConfiguration(any(), anyString());
+    }
+
+    // -- Filesystem takes precedence over classpath --
+
+    @Test
+    public void loadDomainConfiguration_shouldUseOnlyFilesystemWhenFilesystemFilesExist() throws Exception {
+        createTestFile("tests/fs-tests.csv", "fs data");
+
+        service.onApplicationEvent(mockEvent);
+
+        // Only filesystem file should be processed — classpath is not even consulted
+        // when filesystem files exist
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("fs-tests.csv"));
+        verify(resolver, never()).getResources(eq("classpath*:configuration/tests/*.csv"));
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldFallBackToClasspathWhenNoFilesystemFiles() throws Exception {
+        Resource cpResource = createMockResource("classpath-tests.csv", "cp data");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv")).thenReturn(new Resource[] { cpResource });
+        // No filesystem directory created
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("classpath-tests.csv"));
+    }
+
+    // -- Checksum behavior --
+
+    @Test
+    public void loadDomainConfiguration_shouldSkipUnchangedFileOnSecondRun() throws Exception {
+        createTestFile("tests/stable.csv", "unchanging content");
+
+        service.onApplicationEvent(mockEvent);
+
+        // Reset guard to allow a second run (simulating a restart with persisted
+        // checksums)
+        ReflectionTestUtils.setField(service, "initialized", false);
+        service.onApplicationEvent(mockEvent);
+
+        // Processed on first run, skipped on second (checksum match)
+        verify(mockHandler, times(1)).processConfiguration(any(InputStream.class), eq("stable.csv"));
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldReprocessFileWhenContentChanges() throws Exception {
+        File testFile = createTestFile("tests/mutable.csv", "original content");
+
+        service.onApplicationEvent(mockEvent);
+
+        // Change the file content to produce a different checksum
+        Files.write(testFile.toPath(), "modified content".getBytes());
+
+        ReflectionTestUtils.setField(service, "initialized", false);
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler, times(2)).processConfiguration(any(InputStream.class), eq("mutable.csv"));
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldPersistChecksumFileAfterProcessing() throws Exception {
+        createTestFile("tests/persisted.csv", "some content");
+
+        service.onApplicationEvent(mockEvent);
+
+        File checksumFile = new File(tempFolder.getRoot(), "tests-checksums.properties");
+        assertTrue("Checksum file should be created after processing", checksumFile.exists());
+
+        Properties checksums = new Properties();
+        try (FileInputStream fis = new FileInputStream(checksumFile)) {
+            checksums.load(fis);
+        }
+        assertFalse("Checksum properties should contain an entry for the processed file",
+                checksums.getProperty("persisted.csv").isEmpty());
+    }
+
+    // -- Error handling --
+
+    @Test
+    public void onApplicationEvent_shouldContinueWithNextHandlerWhenOneThrows() throws Exception {
+        DomainConfigurationHandler failingHandler = mock(DomainConfigurationHandler.class);
+        when(failingHandler.getDomainName()).thenReturn("bad-domain");
+        when(failingHandler.getFileExtension()).thenReturn("csv");
+        when(failingHandler.getLoadOrder()).thenReturn(50);
+
+        DomainConfigurationHandler goodHandler = mock(DomainConfigurationHandler.class);
+        when(goodHandler.getDomainName()).thenReturn("good-domain");
+        when(goodHandler.getFileExtension()).thenReturn("csv");
+        when(goodHandler.getLoadOrder()).thenReturn(100);
+
+        // Make the first handler's resolver call throw
+        when(resolver.getResources("classpath*:configuration/bad-domain/*.csv"))
+                .thenThrow(new IOException("simulated failure"));
+
+        Resource goodResource = createMockResource("good.csv", "data");
+        when(resolver.getResources("classpath*:configuration/good-domain/*.csv"))
+                .thenReturn(new Resource[] { goodResource });
+
+        service.setDomainHandlers(Arrays.asList(failingHandler, goodHandler));
+
+        service.onApplicationEvent(mockEvent);
+
+        // The good handler should still be processed despite the first one failing
+        verify(goodHandler).processConfiguration(any(InputStream.class), eq("good.csv"));
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldContinueWithNextFileWhenProcessingFails() throws Exception {
+        Resource failResource = createMockResource("fail.csv", "fail data");
+        Resource okResource = createMockResource("ok.csv", "ok data");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv"))
+                .thenReturn(new Resource[] { failResource, okResource });
+
+        doThrow(new RuntimeException("processing error")).when(mockHandler).processConfiguration(any(InputStream.class),
+                eq("fail.csv"));
+
+        service.onApplicationEvent(mockEvent);
+
+        // The second file should still be processed
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("ok.csv"));
+    }
+
+    // -- Instance-specific loading: classpath --
+
+    @Test
+    public void loadDomainConfiguration_shouldSkipBaseFilesWhenInstanceFilesFoundOnClasspath() throws Exception {
+        ReflectionTestUtils.setField(service, "instanceId", "myinstance");
+
+        Resource instanceResource = createMockResource("instance-tests.csv", "instance data");
+        when(resolver.getResources("classpath*:configuration/tests/myinstance/*.csv"))
+                .thenReturn(new Resource[] { instanceResource });
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("instance-tests.csv"));
+        // The base classpath pattern should never be resolved since instance files were
+        // found
+        verify(resolver, never()).getResources(eq("classpath*:configuration/tests/*.csv"));
+    }
+
+    // -- Instance-specific loading: filesystem --
+
+    @Test
+    public void loadDomainConfiguration_shouldSkipBaseFilesWhenInstanceFilesFoundOnFilesystem() throws Exception {
+        ReflectionTestUtils.setField(service, "instanceId", "myinstance");
+
+        // Create instance-specific filesystem files
+        createTestFile("tests/myinstance/instance-data.csv", "instance fs data");
+        // Create base filesystem files (should NOT be loaded)
+        createTestFile("tests/base-data.csv", "base fs data");
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("instance-data.csv"));
+        verify(mockHandler, never()).processConfiguration(any(InputStream.class), eq("base-data.csv"));
+    }
+
+    // -- Instance-specific loading: fallback --
+
+    @Test
+    public void loadDomainConfiguration_shouldFallBackToBaseWhenNoInstanceFilesExist() throws Exception {
+        ReflectionTestUtils.setField(service, "instanceId", "myinstance");
+
+        // No instance-specific files anywhere
+        // Base classpath has a resource
+        Resource baseResource = createMockResource("base-tests.csv", "base data");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv")).thenReturn(new Resource[] { baseResource });
+
+        service.onApplicationEvent(mockEvent);
+
+        // Should fall back to base
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("base-tests.csv"));
+        // Instance pattern was checked (but returned nothing)
+        verify(resolver).getResources(eq("classpath*:configuration/tests/myinstance/*.csv"));
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldFallBackToBaseFilesystemWhenNoInstanceFilesExist() throws Exception {
+        ReflectionTestUtils.setField(service, "instanceId", "myinstance");
+
+        // No instance-specific files; base filesystem has a file
+        createTestFile("tests/fallback.csv", "fallback data");
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("fallback.csv"));
+    }
+
+    // -- No instance ID --
+
+    @Test
+    public void loadDomainConfiguration_shouldUseBaseFilesWhenInstanceIdNull() throws Exception {
+        ReflectionTestUtils.setField(service, "instanceId", null);
+
+        Resource baseResource = createMockResource("base.csv", "base data");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv")).thenReturn(new Resource[] { baseResource });
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("base.csv"));
+        // Only one resolver call (the base pattern) — no instance pattern checked
+        verify(resolver, times(1)).getResources(anyString());
+    }
+
+    @Test
+    public void loadDomainConfiguration_shouldUseBaseFilesWhenInstanceIdBlank() throws Exception {
+        ReflectionTestUtils.setField(service, "instanceId", "   ");
+
+        Resource baseResource = createMockResource("base.csv", "base data");
+        when(resolver.getResources("classpath*:configuration/tests/*.csv")).thenReturn(new Resource[] { baseResource });
+
+        service.onApplicationEvent(mockEvent);
+
+        verify(mockHandler).processConfiguration(any(InputStream.class), eq("base.csv"));
+        // Only the base pattern should be resolved (blank instanceId treated as unset)
+        verify(resolver, times(1)).getResources(anyString());
+    }
+
+    // -- Instance + checksum interaction --
+
+    @Test
+    public void loadDomainConfiguration_shouldRespectChecksumsForInstanceFiles() throws Exception {
+        ReflectionTestUtils.setField(service, "instanceId", "myinstance");
+
+        createTestFile("tests/myinstance/instance.csv", "instance content");
+
+        // First run: processes the file
+        service.onApplicationEvent(mockEvent);
+        verify(mockHandler, times(1)).processConfiguration(any(InputStream.class), eq("instance.csv"));
+
+        // Second run: same file, should be skipped (checksum match)
+        ReflectionTestUtils.setField(service, "initialized", false);
+        service.onApplicationEvent(mockEvent);
+        verify(mockHandler, times(1)).processConfiguration(any(InputStream.class), eq("instance.csv"));
+    }
+
+    // -- Helpers --
+
+    /**
+     * Creates a mock classpath Resource that returns a fresh InputStream on every
+     * call to getInputStream().
+     */
+    private Resource createMockResource(String fileName, String content) throws IOException {
+        Resource resource = mock(Resource.class);
+        when(resource.getFilename()).thenReturn(fileName);
+        when(resource.getInputStream()).thenAnswer(invocation -> new ByteArrayInputStream(content.getBytes()));
+        return resource;
+    }
+
+    /**
+     * Creates a real file under the temp folder at the given relative path.
+     */
+    private File createTestFile(String relativePath, String content) throws IOException {
+        File file = new File(tempFolder.getRoot(), relativePath);
+        file.getParentFile().mkdirs();
+        Files.write(file.toPath(), content.getBytes());
+        return file;
+    }
+}


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

This is an implementation of instance-specific configuration from a shared configuration, but also heavily re-writes the existing configuration loading, largely to remove ambiguity.

With these changes there are two dimensions that we check:

1. Are there instance-specific configurations or do we use the "base" configurations?
2. Are the files located in the filesystem or on the classpath?

Each of these dimensions are evaluated on a per-domain basis and allow only one answer. Basically, we check (in order):

1. Are there instance-specific domain configurations on the filesystem?
2. Are there instance-specific domain configurations on the classpath?
3. Are there domain configurations on the filesystem?
4. Are there domain configurations on the classpath?

Once configurations for the domain are found, the files are loaded. **Importantly** this means that there is no merging, as merging would be somewhat fragile and based on filename.

The goal here is that configurations are installed in one place and if we can find those we use them.

Instance id is identified via either the `org.openelisglobal.configuration.instance-id` Spring property or the `OPENELIS_CONFIGURATION_INSTANCE_ID` environment variable. This is because the grouping of configuration instance may be somewhat different from other ideas of an OE instance (e.g., for multiple labs that support the same set of tests).

## Screenshots


## Related Issue


## Other

@caseyi I'm mostly interested in your views on the loading logic I described above.
