### PR TITLE
fix(analyzer): resolve NumberFormatException and separate config vs instance fields

### DIFF
--- a/.specify/plan-archive/fix-011-analyzer-config-form.md
+++ b/.specify/plan-archive/fix-011-analyzer-config-form.md
@@ -1,0 +1,272 @@
+# Plan: Fix GeneXpert ASTM Analyzer Configuration — Bug Fix + Config/Form Separation + E2E Tests
+
+## Context
+
+**Branch**: `fix/011-analyzer-config-form` (bugfix off current
+`fix/plugin-init-order`)
+
+When creating or editing a Generic ASTM analyzer (e.g., GeneXpert) through the
+UI, two bugs and one design gap block ASTM testing:
+
+1. **Bug**: `NumberFormatException: For input string: "generic-astm"` — frontend
+   sends hardcoded string IDs to backend that expects numeric DB IDs
+2. **Bug**: Default config loading doesn't populate `identifierPattern`
+   (critical for generic plugin device matching)
+3. **Design gap**: Config template fields (plugin metadata) and instance fields
+   (IP/port/name) are conflated in the form UX. The "Load Default Config"
+   dropdown is hidden in edit mode.
+4. **Missing**: No E2E tests for the create/edit analyzer form workflow
+5. **Missing**: Default configs contain `default_test_mappings` (the
+   `/rest/analyzer/defaults/{protocol}/{name}` endpoint returns the full JSON
+   including these) but these never get persisted to the DB
+
+After this fix, a user should be able to: select Generic ASTM → load GeneXpert
+config → see plugin-level fields auto-populated → provide instance-specific
+IP/port → save → have test mappings auto-created.
+
+---
+
+## 1. Backend: Graceful resolution of non-numeric `pluginTypeId`
+
+**File**:
+[AnalyzerRestController.java:191-196](src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java#L191-L196)
+and
+[line 402-406](src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java#L402-L406)
+
+Add a private `resolvePluginType(String pluginTypeId)` method:
+
+- If numeric → `analyzerTypeService.get(pluginTypeId)` (current behavior)
+- If non-numeric → map aliases (`"generic-astm"` → name `"Generic ASTM"`) then
+  `analyzerTypeService.getAnalyzerTypeByName(lookupName)` (method already exists
+  at
+  [AnalyzerTypeServiceImpl.java:47](src/main/java/org/openelisglobal/analyzer/service/AnalyzerTypeServiceImpl.java#L47))
+- If unresolvable → log warning, return `null` (graceful degradation, not 500)
+
+Replace both `analyzerTypeService.get(form.getPluginTypeId())` calls (create at
+line 192, update at line 403) with `resolvePluginType(form.getPluginTypeId())`.
+
+**Test** (TDD — RED first): Add to
+[AnalyzerRestControllerTest.java](src/test/java/org/openelisglobal/analyzer/controller/AnalyzerRestControllerTest.java):
+
+- `testCreateAnalyzer_WithNonNumericPluginTypeId_ReturnsCreated` — POST with
+  `pluginTypeId: "generic-astm"`, expect 201 not 500
+- `testUpdateAnalyzer_WithNonNumericPluginTypeId_ReturnsOk` — PUT with
+  `pluginTypeId: "generic-astm"`, expect 200 not 500
+
+---
+
+## 2. Frontend: Separate config-level vs instance-level fields in the form
+
+**File**:
+[AnalyzerForm.jsx](frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx)
+
+### 2a. Remove hardcoded fallback plugin types (root cause of NumberFormatException)
+
+| Lines   | Change                                                                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 58-71   | **Delete** `FALLBACK_PLUGIN_TYPES` constant entirely                                                                                                    |
+| 164-166 | Replace `setPluginTypes(FALLBACK_PLUGIN_TYPES)` with `setPluginTypes([])` — if API returns empty, plugin system hasn't initialized; show empty dropdown |
+
+### 2b. Enable default config loading in edit mode
+
+| Lines | Change                                                                                         |
+| ----- | ---------------------------------------------------------------------------------------------- |
+| 178   | `if (!isEditMode && open)` → `if (open)` — fetch default configs in both modes                 |
+| 449   | `{!isEditMode && isGenericPlugin && (` → `{isGenericPlugin && (` — show dropdown in both modes |
+
+### 2c. Fix `handleDefaultConfigSelect` to properly separate concerns
+
+**Current** (lines 233-243): Sets `name`, `analyzerType`, `protocolVersion`,
+`port` — mixes config-level and instance-level.
+
+**New behavior**: Config loading should set **plugin/protocol-level** fields
+only:
+
+- `identifierPattern` ← `configData.identifier_pattern` (CRITICAL — currently
+  missing)
+- `analyzerType` (category) ← `configData.category` (this is type metadata)
+- `protocolVersion` ← derived from protocol (this is type metadata)
+- `pluginTypeId` ← auto-resolve from `configData.protocol.name` to matching
+  Generic ASTM/HL7 type ID (currently NOT set — user must manually pick plugin
+  type before seeing config dropdown, which is backwards)
+
+Config loading should **NOT** set instance-level fields:
+
+- `name` — instance-specific (user provides, e.g., "Lab Room 3 GeneXpert")
+- `port` — instance-specific (depends on physical machine config)
+- `ipAddress` — instance-specific (never in config template)
+
+### 2d. Reorder form fields for seamless UX
+
+Current order: Name → Category → Plugin Type → [Default Config] → [Identifier
+Pattern] → Protocol → IP/Port → Status
+
+**Proposed order** (group by concern):
+
+**Section 1 — Instance Identity** (user provides):
+
+1. Name (required)
+2. Status
+
+**Section 2 — Plugin Configuration** (from template or manual): 3. Plugin Type
+dropdown (Generic ASTM / Generic HL7 / specific plugins) 4. Load Default Config
+dropdown (visible when generic plugin selected) 5. Identifier Pattern
+(auto-filled from config, editable) 6. Category / Analyzer Type (auto-filled
+from config, editable) 7. Protocol Version (auto-filled from config, editable)
+
+**Section 3 — Connection** (instance-specific): 8. IP Address 9. Port 10. Test
+Connection button
+
+This groups fields by the user's mental model: "What is this machine?" → "What
+software/protocol does it use?" → "Where is it on the network?"
+
+---
+
+## 3. Backend: Auto-create test mappings from default config on save
+
+**Files**:
+
+- [AnalyzerRestController.java](src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java)
+- [AnalyzerForm.java](src/main/java/org/openelisglobal/analyzer/form/AnalyzerForm.java)
+  — currently has fields: `id`, `name`, `analyzerType`, `ipAddress`, `port`,
+  `protocolVersion`, `testUnitIds`, `status`, `identifierPattern`,
+  `pluginTypeId` (NO `defaultConfigId` yet)
+
+### Backend changes:
+
+**Step 3a**: Add `defaultConfigId` field (String, optional) to
+`AnalyzerForm.java`. This is a transient hint — not persisted to DB, just tells
+the controller which config template the user selected.
+
+**Step 3b**: In the create endpoint (line ~207, after
+`analyzerService.insert(analyzer)`), if `form.getDefaultConfigId()` is non-null:
+
+1. Load the config JSON from filesystem — extract the file-reading logic from
+   the existing `getDefaultConfig` endpoint (lines 895-958) into a reusable
+   private method
+2. Extract `default_test_mappings` array from the parsed JSON
+3. For each mapping entry (`analyzer_code`, `loinc`):
+   - Look up OpenELIS test by LOINC using
+     `testService.getActiveTestsByLoinc(loinc)` (method exists at
+     [TestService.java:46](src/main/java/org/openelisglobal/test/service/TestService.java#L46))
+   - If test found, create an `AnalyzerTestMapping` record (entity at
+     [AnalyzerTestMapping.java](src/main/java/org/openelisglobal/analyzerimport/valueholder/AnalyzerTestMapping.java))
+     with composite PK (analyzerId + analyzerTestName=analyzer_code) and
+     `testId`
+   - If no test found for LOINC, log warning and skip (don't fail the save)
+4. Use `analyzerTestMappingService.insert()` for each mapping
+
+**Frontend change**: In `handleSubmit`
+([AnalyzerForm.jsx:308](frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx#L308)),
+include `defaultConfigId: selectedDefault?.id || null` in `submitData`.
+
+---
+
+## 4. Playwright E2E tests
+
+### New file: `frontend/playwright/fixtures/analyzer-form.ts`
+
+Page Object Model for the analyzer form modal. Uses existing `data-testid`
+attributes:
+
+- `analyzer-form` (modal), `analyzer-form-name-input`,
+  `analyzer-form-type-dropdown`
+- `analyzer-form-plugin-type-dropdown`, `analyzer-form-default-config-dropdown`
+- `analyzer-form-identifier-pattern-input`, `analyzer-form-ip-input`,
+  `analyzer-form-port-input`
+- `analyzer-form-save-button`, `analyzer-form-cancel-button`,
+  `analyzer-form-notification`
+
+Methods: `expectOpen()`, `fillName(name)`, `selectPluginType(text)`,
+`selectDefaultConfig(text)`, `fillIpAddress(ip)`, `fillPort(port)`, `save()`,
+`expectSuccessNotification()`, `expectFieldValue(field, value)`
+
+### New file: `frontend/playwright/tests/analyzer-form.spec.ts`
+
+| Test                                            | Covers                                                                                                                                                                           |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Creates GeneXpert ASTM with default config      | Select Generic ASTM → load genexpert-astm config → verify identifierPattern="GENEXPERT\|CEPHEID", category=MOLECULAR auto-filled → fill name + IP + port → save → verify in list |
+| Edits existing GeneXpert                        | Open edit → verify fields populated → change port → save → reopen → verify port updated                                                                                          |
+| Loads default config in edit mode               | Open edit on existing → verify config dropdown visible → load config → verify identifierPattern updated                                                                          |
+| Form validation rejects missing required fields | Open add → save empty → verify error messages on name and category                                                                                                               |
+
+Test isolation: `TEST-GeneXpert-{timestamp}` names, cleanup via delete API in
+`afterAll`.
+
+**Auth**: Playwright auth setup
+([auth.setup.ts](frontend/playwright/tests/auth.setup.ts)) uses `TEST_USER` and
+`TEST_PASS` env vars (not hardcoded). Tests must set these or have them in CI.
+For harness: `TEST_USER=admin TEST_PASS=adminADMIN!`.
+
+Follow existing patterns from
+[analyzer-list.ts](frontend/playwright/fixtures/analyzer-list.ts) and
+[analyzer-list.spec.ts](frontend/playwright/tests/analyzer-list.spec.ts).
+
+---
+
+## 5. Update 011 spec artifacts
+
+Update these files to document the bugfix and design clarification:
+
+- **[spec.md](specs/011-madagascar-analyzer-integration/spec.md)**: Add
+  clarification session entry documenting the config vs instance field
+  separation decision
+- **[plan.md](specs/011-madagascar-analyzer-integration/plan.md)**: Add bugfix
+  milestone entry (M-BF1: Analyzer Config Form Fix)
+- **[tasks.md](specs/011-madagascar-analyzer-integration/tasks.md)**: Add task
+  entries for the fix, referencing this branch
+
+---
+
+## Implementation Order (TDD)
+
+1. **Archive plan**: Save this plan to
+   `.specify/plan-archive/fix-011-analyzer-config-form.md` before starting any
+   code changes
+2. Create branch `fix/011-analyzer-config-form` from current
+   `fix/plugin-init-order`
+3. **RED**: Write backend test for non-numeric `pluginTypeId` → verify it fails
+   (NumberFormatException)
+4. **GREEN**: Add `resolvePluginType()` to controller → verify test passes
+5. **RED**: Write Playwright E2E test for create GeneXpert → verify it fails
+   (config doesn't populate identifierPattern, form field order wrong)
+6. **GREEN**: Apply frontend fixes (remove fallbacks, fix
+   handleDefaultConfigSelect, reorder fields, enable edit-mode config)
+7. Add `defaultConfigId` to AnalyzerForm.java + auto-create test mappings logic
+8. **GREEN**: Verify all Playwright tests pass
+9. Update spec/plan/tasks docs
+10. Format: `mvn spotless:apply` + `cd frontend && npm run format`
+
+## Verification
+
+1. `mvn test -pl . -Dtest=AnalyzerRestControllerTest` — backend tests pass
+   (including new non-numeric pluginTypeId tests)
+2. `cd frontend && npx playwright test analyzer-form` — E2E tests pass against
+   running harness
+3. Manual workflow against harness:
+   - Open https://localhost/analyzers → Add Analyzer
+   - Fill name "Lab GeneXpert" → select Generic ASTM
+   - Load "Cepheid GeneXpert (ASTM Mode)" config
+   - Verify: identifierPattern="GENEXPERT|CEPHEID", category=MOLECULAR auto-set,
+     name/port NOT overwritten
+   - Fill IP=35.82.47.81, port=1200 → save
+   - Edit the analyzer → verify config dropdown visible → change port → save
+   - Verify test mappings (MTB, RIF, COVID19, HIV) created in DB
+
+## Critical Files
+
+| File                                                                                                                    | Action                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [AnalyzerRestController.java](src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java)         | Add `resolvePluginType()`, add test mapping auto-creation              |
+| [AnalyzerForm.java](src/main/java/org/openelisglobal/analyzer/form/AnalyzerForm.java)                                   | Add `defaultConfigId` field                                            |
+| [AnalyzerForm.jsx](frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx)                                     | Remove fallbacks, fix config loading, reorder fields, enable edit mode |
+| [AnalyzerRestControllerTest.java](src/test/java/org/openelisglobal/analyzer/controller/AnalyzerRestControllerTest.java) | Add non-numeric pluginTypeId tests                                     |
+| `frontend/playwright/fixtures/analyzer-form.ts`                                                                         | **New** — Page Object Model                                            |
+| `frontend/playwright/tests/analyzer-form.spec.ts`                                                                       | **New** — E2E tests                                                    |
+| [spec.md](specs/011-madagascar-analyzer-integration/spec.md)                                                            | Add clarification session                                              |
+| [plan.md](specs/011-madagascar-analyzer-integration/plan.md)                                                            | Add bugfix milestone                                                   |
+| [tasks.md](specs/011-madagascar-analyzer-integration/tasks.md)                                                          | Add fix tasks                                                          |
+| [genexpert-astm.json](projects/analyzer-defaults/astm/genexpert-astm.json)                                              | Read-only reference                                                    |
+| [AnalyzerTypeServiceImpl.java](src/main/java/org/openelisglobal/analyzer/service/AnalyzerTypeServiceImpl.java)          | Read-only — reuse `getAnalyzerTypeByName()` at line 47                 |
+| [TestService.java](src/main/java/org/openelisglobal/test/service/TestService.java)                                      | Read-only — reuse `getActiveTestsByLoinc()` at line 46                 |
+| `.specify/plan-archive/fix-011-analyzer-config-form.md`                                                                 | **New** — Archive copy of this plan                                    |

--- a/frontend/playwright/fixtures/analyzer-form.ts
+++ b/frontend/playwright/fixtures/analyzer-form.ts
@@ -1,0 +1,141 @@
+import { Page, expect, Locator } from "@playwright/test";
+
+/**
+ * AnalyzerForm Page Object
+ *
+ * Encapsulates interactions with the analyzer create/edit modal (AnalyzerForm component).
+ * Uses data-testid selectors that match the component's DOM structure.
+ */
+export class AnalyzerFormPage {
+  readonly page: Page;
+  readonly modal: Locator;
+  readonly header: Locator;
+  readonly nameInput: Locator;
+  readonly typeDropdown: Locator;
+  readonly pluginTypeDropdown: Locator;
+  readonly defaultConfigDropdown: Locator;
+  readonly identifierPatternInput: Locator;
+  readonly protocolVersionDropdown: Locator;
+  readonly ipAddressInput: Locator;
+  readonly portInput: Locator;
+  readonly statusDropdown: Locator;
+  readonly saveButton: Locator;
+  readonly cancelButton: Locator;
+  readonly notification: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.modal = page.locator('[data-testid="analyzer-form"]');
+    this.header = page.locator('[data-testid="analyzer-form-header"]');
+    this.nameInput = page.locator(
+      '[data-testid="analyzer-form-name-input"] input',
+    );
+    this.typeDropdown = page.locator(
+      '[data-testid="analyzer-form-type-dropdown"]',
+    );
+    this.pluginTypeDropdown = page.locator(
+      '[data-testid="analyzer-form-plugin-type-dropdown"]',
+    );
+    this.defaultConfigDropdown = page.locator(
+      '[data-testid="analyzer-form-default-config-dropdown"]',
+    );
+    this.identifierPatternInput = page.locator(
+      '[data-testid="analyzer-form-identifier-pattern-input"] input',
+    );
+    this.protocolVersionDropdown = page.locator(
+      '[data-testid="analyzer-form-protocol-version-dropdown"]',
+    );
+    this.ipAddressInput = page.locator(
+      '[data-testid="analyzer-form-ip-input"] input',
+    );
+    this.portInput = page.locator(
+      '[data-testid="analyzer-form-port-input"] input',
+    );
+    this.statusDropdown = page.locator(
+      '[data-testid="analyzer-form-status-dropdown"]',
+    );
+    this.saveButton = page.locator('[data-testid="analyzer-form-save-button"]');
+    this.cancelButton = page.locator(
+      '[data-testid="analyzer-form-cancel-button"]',
+    );
+    this.notification = page.locator(
+      '[data-testid="analyzer-form-notification"]',
+    );
+  }
+
+  /** Assert the form modal is open and visible */
+  async expectOpen() {
+    await expect(this.modal).toBeVisible();
+    await expect(this.header).toBeVisible();
+  }
+
+  /** Fill the analyzer name field */
+  async fillName(name: string) {
+    await this.nameInput.fill(name);
+  }
+
+  /** Select an item from a Carbon Dropdown by visible text */
+  private async selectDropdownItem(dropdown: Locator, text: string) {
+    await dropdown.click();
+    const item = this.page.locator(`.cds--list-box__menu-item`).filter({
+      hasText: text,
+    });
+    await item.first().click();
+  }
+
+  /** Select an analyzer type (category) from the dropdown */
+  async selectType(typeText: string) {
+    await this.selectDropdownItem(this.typeDropdown, typeText);
+  }
+
+  /** Select a plugin type from the dropdown */
+  async selectPluginType(typeText: string) {
+    await this.selectDropdownItem(this.pluginTypeDropdown, typeText);
+  }
+
+  /** Select a default config template from the dropdown */
+  async selectDefaultConfig(configText: string) {
+    await this.selectDropdownItem(this.defaultConfigDropdown, configText);
+  }
+
+  /** Fill the IP address field */
+  async fillIpAddress(ip: string) {
+    await this.ipAddressInput.fill(ip);
+  }
+
+  /** Fill the port field */
+  async fillPort(port: string) {
+    await this.portInput.fill(port);
+  }
+
+  /** Click the save button */
+  async save() {
+    await this.saveButton.click();
+  }
+
+  /** Assert a success notification appeared */
+  async expectSuccessNotification() {
+    await expect(this.notification).toBeVisible({ timeout: 10000 });
+    await expect(this.notification).toHaveAttribute("class", /success|info/i);
+  }
+
+  /** Assert a notification of any kind appeared */
+  async expectNotification() {
+    await expect(this.notification).toBeVisible({ timeout: 10000 });
+  }
+
+  /** Get the current value of the identifier pattern input */
+  async getIdentifierPattern(): Promise<string> {
+    return (await this.identifierPatternInput.inputValue()) || "";
+  }
+
+  /** Get the current value of the name input */
+  async getName(): Promise<string> {
+    return (await this.nameInput.inputValue()) || "";
+  }
+
+  /** Get the current value of the port input */
+  async getPort(): Promise<string> {
+    return (await this.portInput.inputValue()) || "";
+  }
+}

--- a/frontend/playwright/tests/analyzer-form.spec.ts
+++ b/frontend/playwright/tests/analyzer-form.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from "@playwright/test";
+import { AnalyzerListPage } from "../fixtures/analyzer-list";
+import { AnalyzerFormPage } from "../fixtures/analyzer-form";
+
+/**
+ * Analyzer Form E2E Tests — GeneXpert ASTM Create/Edit Workflow
+ *
+ * Tests the full lifecycle of creating and editing a GeneXpert ASTM analyzer
+ * using the Generic ASTM plugin with default config loading from templates.
+ *
+ * Prerequisites:
+ *   - Harness running with analyzer fixtures loaded
+ *   - Generic ASTM plugin type registered in analyzer_type table
+ *   - Default configs available at /data/analyzer-defaults/astm/
+ */
+test.describe("Analyzer Form - GeneXpert ASTM Create/Edit", () => {
+  const uniqueSuffix = Date.now();
+  const analyzerName = `TEST-GeneXpert-${uniqueSuffix}`;
+  let createdAnalyzerId: string;
+
+  test.afterAll(async ({ request }) => {
+    // Cleanup: delete the test analyzer if it was created
+    if (createdAnalyzerId) {
+      try {
+        await request.post(
+          `/rest/analyzer/analyzers/${createdAnalyzerId}/delete`,
+        );
+      } catch {
+        // Best effort cleanup
+      }
+    }
+  });
+
+  test("creates a GeneXpert ASTM analyzer with default config", async ({
+    page,
+  }) => {
+    const list = new AnalyzerListPage(page);
+    const form = new AnalyzerFormPage(page);
+
+    // Navigate to analyzer list and open add form
+    await list.goto();
+    await list.expectLoaded();
+    await list.clickAdd();
+    await form.expectOpen();
+
+    // Fill instance identity
+    await form.fillName(analyzerName);
+
+    // Select plugin type: Generic ASTM
+    await form.selectPluginType("Generic ASTM");
+
+    // Load default config: GeneXpert
+    await expect(form.defaultConfigDropdown).toBeVisible({ timeout: 5000 });
+    await form.selectDefaultConfig("Cepheid GeneXpert");
+
+    // Verify config-level fields were auto-populated
+    // identifierPattern should be set from the config template
+    const identifierPattern = await form.getIdentifierPattern();
+    expect(identifierPattern).toContain("GENEXPERT");
+
+    // Name should NOT be overwritten by config (instance field)
+    const name = await form.getName();
+    expect(name).toBe(analyzerName);
+
+    // Fill instance-specific connection details
+    await form.fillIpAddress("192.168.1.100");
+    await form.fillPort("1200");
+
+    // Save
+    await form.save();
+    await form.expectSuccessNotification();
+
+    // Wait for modal to close and list to refresh
+    await expect(form.modal).not.toBeVisible({ timeout: 5000 });
+
+    // Verify analyzer appears in the list
+    await list.goto();
+    await list.expectLoaded();
+    await list.search(analyzerName);
+
+    // Find the row and extract ID for cleanup
+    const rows = page.locator("tbody tr");
+    await expect(rows).toHaveCount(1, { timeout: 5000 });
+
+    // Store ID for cleanup (from data-testid pattern)
+    const row = rows.first();
+    const testid = await row.getAttribute("data-testid");
+    if (testid && testid.startsWith("analyzer-row-")) {
+      createdAnalyzerId = testid.replace("analyzer-row-", "");
+    }
+  });
+
+  test("edits an existing GeneXpert analyzer", async ({ page }) => {
+    test.skip(!createdAnalyzerId, "Requires analyzer created in previous test");
+
+    const list = new AnalyzerListPage(page);
+    const form = new AnalyzerFormPage(page);
+
+    // Navigate and find the analyzer
+    await list.goto();
+    await list.expectLoaded();
+    await list.search(analyzerName);
+
+    // Open edit via overflow menu
+    await list.openOverflowMenu(createdAnalyzerId);
+    await list.clickAction(createdAnalyzerId, "edit");
+    await form.expectOpen();
+
+    // Verify fields are populated from the saved analyzer
+    const name = await form.getName();
+    expect(name).toBe(analyzerName);
+
+    const port = await form.getPort();
+    expect(port).toBe("1200");
+
+    // Change port
+    await form.fillPort("1300");
+
+    // Save
+    await form.save();
+    await form.expectSuccessNotification();
+
+    // Wait for modal to close
+    await expect(form.modal).not.toBeVisible({ timeout: 5000 });
+
+    // Reopen edit and verify port updated
+    await list.goto();
+    await list.expectLoaded();
+    await list.search(analyzerName);
+    await list.openOverflowMenu(createdAnalyzerId);
+    await list.clickAction(createdAnalyzerId, "edit");
+    await form.expectOpen();
+
+    const updatedPort = await form.getPort();
+    expect(updatedPort).toBe("1300");
+
+    await form.cancelButton.click();
+  });
+
+  test("loads default config in edit mode", async ({ page }) => {
+    test.skip(!createdAnalyzerId, "Requires analyzer created in previous test");
+
+    const list = new AnalyzerListPage(page);
+    const form = new AnalyzerFormPage(page);
+
+    // Navigate and open edit
+    await list.goto();
+    await list.expectLoaded();
+    await list.search(analyzerName);
+    await list.openOverflowMenu(createdAnalyzerId);
+    await list.clickAction(createdAnalyzerId, "edit");
+    await form.expectOpen();
+
+    // Verify "Load Default Config" dropdown is visible in edit mode
+    await expect(form.defaultConfigDropdown).toBeVisible({ timeout: 5000 });
+
+    // Load a config and verify it updates config-level fields
+    await form.selectDefaultConfig("Cepheid GeneXpert");
+
+    const identifierPattern = await form.getIdentifierPattern();
+    expect(identifierPattern).toContain("GENEXPERT");
+
+    await form.cancelButton.click();
+  });
+
+  test("form validation rejects missing required fields", async ({ page }) => {
+    const list = new AnalyzerListPage(page);
+    const form = new AnalyzerFormPage(page);
+
+    // Navigate and open add form
+    await list.goto();
+    await list.expectLoaded();
+    await list.clickAdd();
+    await form.expectOpen();
+
+    // Try to save with empty form
+    await form.save();
+
+    // Validation errors should appear (name is required)
+    const nameError = page.locator(
+      '[data-testid="analyzer-form-name-input"] .cds--form-requirement',
+    );
+    await expect(nameError).toBeVisible({ timeout: 3000 });
+
+    await form.cancelButton.click();
+  });
+});

--- a/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
+++ b/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
@@ -55,21 +55,6 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
   const [pluginTypes, setPluginTypes] = useState([]);
   const [loadingPluginTypes, setLoadingPluginTypes] = useState(false);
 
-  const FALLBACK_PLUGIN_TYPES = [
-    {
-      id: "generic-astm",
-      name: "Generic ASTM",
-      protocol: "ASTM",
-      isGenericPlugin: true,
-    },
-    {
-      id: "generic-hl7",
-      name: "Generic HL7",
-      protocol: "HL7",
-      isGenericPlugin: true,
-    },
-  ];
-
   // Analyzer type options (must match DB analyzer_type column values)
   const analyzerTypeOptions = [
     { id: "HEMATOLOGY", text: "Hematology" },
@@ -162,8 +147,8 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
           }
           setPluginTypes(typesToUse);
         } else {
-          // Fallback to hardcoded list if API returns empty
-          setPluginTypes(FALLBACK_PLUGIN_TYPES);
+          // No plugin types loaded — plugin system may not be initialized yet
+          setPluginTypes([]);
         }
       });
     }
@@ -175,7 +160,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
   const isGenericPlugin = selectedPluginType?.isGenericPlugin === true;
 
   useEffect(() => {
-    if (!isEditMode && open) {
+    if (open) {
       setLoadingDefaults(true);
       getDefaultConfigs((data) => {
         setLoadingDefaults(false);
@@ -186,7 +171,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
         }
       });
     }
-  }, [isEditMode, open]);
+  }, [open]);
 
   const validateIPAddress = (ip) => {
     const ipRegex = /^(\d{1,3}\.){3}\d{1,3}$/;
@@ -230,16 +215,22 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
 
     getDefaultConfig(protocol, name, (configData) => {
       if (configData && !configData.error) {
+        // Set plugin/protocol-level fields only — NOT instance-level (name, port, IP)
+        const protocolUpper = protocol.toUpperCase();
+        // Auto-resolve pluginTypeId from config protocol
+        const matchingPluginType = pluginTypes.find(
+          (t) =>
+            t.isGenericPlugin && t.protocol?.toUpperCase() === protocolUpper,
+        );
+
         setFormData((prev) => ({
           ...prev,
-          name: configData.analyzer_name || prev.name,
+          identifierPattern:
+            configData.identifier_pattern || prev.identifierPattern,
           analyzerType: configData.category || prev.analyzerType,
           protocolVersion:
-            PLUGIN_PROTOCOL_DEFAULTS[protocol.toUpperCase()] ||
-            prev.protocolVersion,
-          port: configData.default_port
-            ? String(configData.default_port)
-            : prev.port,
+            PLUGIN_PROTOCOL_DEFAULTS[protocolUpper] || prev.protocolVersion,
+          pluginTypeId: matchingPluginType?.id || prev.pluginTypeId,
         }));
 
         setNotification({
@@ -308,6 +299,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
     const submitData = {
       ...formData,
       port: formData.port ? parseInt(formData.port, 10) : null,
+      defaultConfigId: selectedDefault?.id || null,
     };
 
     const callback = (response, extraParams) => {
@@ -371,6 +363,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
             />
           )}
 
+          {/* Section 1 — Instance Identity */}
           <FormGroup legendText="">
             <TextInput
               id="analyzer-name"
@@ -387,27 +380,33 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
             />
 
             <Dropdown
-              id="analyzer-type"
-              data-testid="analyzer-form-type-dropdown"
-              titleText={intl.formatMessage({ id: "analyzer.form.type" })}
-              label={intl.formatMessage({
-                id: "analyzer.form.type.placeholder",
+              id="analyzer-status"
+              data-testid="analyzer-form-status-dropdown"
+              titleText={intl.formatMessage({
+                id: "analyzer.form.status",
               })}
-              items={analyzerTypeOptions}
-              selectedItem={
-                analyzerTypeOptions.find(
-                  (opt) => opt.id === formData.analyzerType,
-                ) || null
-              }
+              label={intl.formatMessage({
+                id: "analyzer.form.status",
+              })}
+              items={statusOptions}
               itemToString={(item) => (item ? item.text : "")}
-              onChange={({ selectedItem }) =>
-                handleFieldChange("analyzerType", selectedItem?.id || "")
+              selectedItem={
+                statusOptions.find((opt) => opt.id === formData.status) ||
+                statusOptions[1] // Default to SETUP
               }
-              invalid={!!errors.analyzerType}
-              invalidText={errors.analyzerType}
-              required
+              onChange={({ selectedItem }) => {
+                if (selectedItem) {
+                  handleFieldChange("status", selectedItem.id);
+                }
+              }}
+              helperText={intl.formatMessage({
+                id: "analyzer.form.status.helperText",
+              })}
             />
+          </FormGroup>
 
+          {/* Section 2 — Plugin Configuration */}
+          <FormGroup legendText="">
             <Dropdown
               id="analyzer-plugin-type"
               data-testid="analyzer-form-plugin-type-dropdown"
@@ -446,7 +445,7 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
               })}
             />
 
-            {!isEditMode && isGenericPlugin && (
+            {isGenericPlugin && (
               <Dropdown
                 id="analyzer-default-config"
                 data-testid="analyzer-form-default-config-dropdown"
@@ -496,6 +495,28 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
             )}
 
             <Dropdown
+              id="analyzer-type"
+              data-testid="analyzer-form-type-dropdown"
+              titleText={intl.formatMessage({ id: "analyzer.form.type" })}
+              label={intl.formatMessage({
+                id: "analyzer.form.type.placeholder",
+              })}
+              items={analyzerTypeOptions}
+              selectedItem={
+                analyzerTypeOptions.find(
+                  (opt) => opt.id === formData.analyzerType,
+                ) || null
+              }
+              itemToString={(item) => (item ? item.text : "")}
+              onChange={({ selectedItem }) =>
+                handleFieldChange("analyzerType", selectedItem?.id || "")
+              }
+              invalid={!!errors.analyzerType}
+              invalidText={errors.analyzerType}
+              required
+            />
+
+            <Dropdown
               id="analyzer-protocol-version"
               data-testid="analyzer-form-protocol-version-dropdown"
               titleText={intl.formatMessage({
@@ -515,7 +536,10 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
                 }
               }}
             />
+          </FormGroup>
 
+          {/* Section 3 — Connection */}
+          <FormGroup legendText="">
             <div
               className="connection-fields"
               data-testid="analyzer-form-connection-fields"
@@ -556,31 +580,6 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
                 {intl.formatMessage({ id: "analyzer.form.testConnection" })}
               </Button>
             </div>
-
-            <Dropdown
-              id="analyzer-status"
-              data-testid="analyzer-form-status-dropdown"
-              titleText={intl.formatMessage({
-                id: "analyzer.form.status",
-              })}
-              label={intl.formatMessage({
-                id: "analyzer.form.status",
-              })}
-              items={statusOptions}
-              itemToString={(item) => (item ? item.text : "")}
-              selectedItem={
-                statusOptions.find((opt) => opt.id === formData.status) ||
-                statusOptions[1] // Default to SETUP
-              }
-              onChange={({ selectedItem }) => {
-                if (selectedItem) {
-                  handleFieldChange("status", selectedItem.id);
-                }
-              }}
-              helperText={intl.formatMessage({
-                id: "analyzer.form.status.helperText",
-              })}
-            />
           </FormGroup>
         </ModalBody>
         <ModalFooter>

--- a/specs/011-madagascar-analyzer-integration/plan.md
+++ b/specs/011-madagascar-analyzer-integration/plan.md
@@ -808,9 +808,30 @@ Per specification, these are deferred:
 
 ---
 
-**Plan Created**: 2026-01-22 | **Updated**: 2026-01-29 (external plugin
-architecture alignment) **Plan Author**: Claude Code with /speckit.plan **Next
-Step**: Run `/speckit.tasks` to generate task breakdown by milestone
+**Plan Created**: 2026-01-22 | **Updated**: 2026-02-25 (M-BF1 bugfix milestone)
+**Plan Author**: Claude Code with /speckit.plan **Next Step**: Run
+`/speckit.tasks` to generate task breakdown by milestone
+
+## M-BF1: Analyzer Config Form Bugfix (2026-02-25)
+
+**Branch**: `fix/011-analyzer-config-form` (off `fix/plugin-init-order`)
+
+Fixes blocking bugs discovered during GeneXpert ASTM testing:
+
+1. **NumberFormatException**: Frontend `FALLBACK_PLUGIN_TYPES` used string IDs
+   ("generic-astm") that backend tried to parse as numeric DB IDs. Fixed with
+   two-layer defense: backend `resolvePluginType()` + frontend fallback removal.
+2. **Config vs Instance field separation**: `handleDefaultConfigSelect` was
+   setting instance-level fields (name, port) from config templates. Fixed to
+   only set plugin-level fields (identifierPattern, category, protocol).
+3. **Edit mode config dropdown hidden**: Default config loading was gated on
+   `!isEditMode`. Removed guard so configs can be loaded/reloaded in edit mode.
+4. **Test mapping auto-creation**: Added `defaultConfigId` transient field to
+   `AnalyzerForm`. Controller loads config JSON and auto-creates
+   `AnalyzerTestMapping` records via LOINC lookup.
+5. **Form field reorder**: Grouped fields by user mental model: Instance
+   Identity (name, status) → Plugin Config (type, config, pattern, category,
+   protocol) → Connection (IP, port, test).
 
 ---
 

--- a/specs/011-madagascar-analyzer-integration/spec.md
+++ b/specs/011-madagascar-analyzer-integration/spec.md
@@ -77,6 +77,25 @@ openelisglobal-plugins repository to reduce development effort by approximately
   This keeps architecture consistent with existing ASTM bridge pattern and
   avoids additional hardware costs beyond USB adapters.
 
+### Session 2026-02-25 (Bugfix: Config Form Separation)
+
+- Q: Should the analyzer form's "Load Default Config" set instance-level fields
+  (name, port, IP) from the config template? → A: **No — config and instance
+  fields must be clearly separated.** Config templates contain plugin metadata
+  (identifier_pattern, category, protocol, test_mappings). Instance fields
+  (name, IP, port, status) are user-provided per physical machine. Loading a
+  config should populate plugin fields only.
+- Q: Should default configs contain test mappings that get auto-created on save?
+  → A: **Yes — configs may contain `default_test_mappings` (LOINC-based) that
+  are auto-persisted as `AnalyzerTestMapping` records when creating an
+  analyzer.** Mappings that can't be resolved (unknown LOINC) are skipped
+  gracefully.
+- Q: How should the frontend handle non-numeric plugin type IDs? → A: **Frontend
+  should use real DB IDs from API, not hardcoded fallbacks.** The
+  `FALLBACK_PLUGIN_TYPES` constant with string IDs ("generic-astm") caused
+  `NumberFormatException` on the backend. Backend also adds
+  `resolvePluginType()` as defense-in-depth for alias-to-name mapping.
+
 ---
 
 ## User Scenarios & Testing _(mandatory)_

--- a/specs/011-madagascar-analyzer-integration/tasks.md
+++ b/specs/011-madagascar-analyzer-integration/tasks.md
@@ -1506,3 +1506,29 @@ milestones**: M19-M22
       dropdown
 - [x] T326 [M22] Update InstanceAwareAnalyzerRouterTest for merged model
       (stacked PR fix)
+
+### M-BF1: Analyzer Config Form Fix (1 day)
+
+**Branch**: `fix/011-analyzer-config-form` **Goal**: Fix NumberFormatException
+with non-numeric pluginTypeId, separate config vs instance fields in form,
+auto-create test mappings from default configs **Depends On**: M22
+
+- [x] T327 [M-BF1] RED: Write backend test for non-numeric pluginTypeId
+      (`AnalyzerRestControllerTest`)
+- [x] T328 [M-BF1] GREEN: Add `resolvePluginType()` to `AnalyzerRestController`
+      — graceful numeric/alias resolution
+- [x] T329 [M-BF1] RED: Write Playwright E2E tests for GeneXpert form
+      (`analyzer-form.spec.ts`)
+- [x] T330 [M-BF1] GREEN: Frontend — remove `FALLBACK_PLUGIN_TYPES` (root cause
+      of NumberFormatException)
+- [x] T331 [M-BF1] GREEN: Frontend — enable default config loading in edit mode
+- [x] T332 [M-BF1] GREEN: Frontend — fix `handleDefaultConfigSelect` to set
+      plugin fields only (identifierPattern, category, protocol), not instance
+      fields (name, port)
+- [x] T333 [M-BF1] GREEN: Frontend — reorder form fields (Instance Identity →
+      Plugin Config → Connection)
+- [x] T334 [M-BF1] Add `defaultConfigId` field to `AnalyzerForm.java`
+- [x] T335 [M-BF1] Add `autoCreateTestMappings()` + `loadDefaultConfigFile()` to
+      controller
+- [x] T336 [M-BF1] Wire test mapping auto-creation in create endpoint
+- [x] T337 [M-BF1] Update spec/plan/tasks docs

--- a/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
@@ -71,6 +71,12 @@ public class AnalyzerRestController extends BaseRestController {
     @Autowired
     private AnalyzerTypeService analyzerTypeService;
 
+    @Autowired
+    private org.openelisglobal.analyzerimport.service.AnalyzerTestMappingService analyzerTestMappingService;
+
+    @Autowired
+    private org.openelisglobal.test.service.TestService testService;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /** ASTM LIS2-A2 Enquiry — initiates transmission. */
@@ -189,7 +195,7 @@ public class AnalyzerRestController extends BaseRestController {
             }
 
             if (form.getPluginTypeId() != null && !form.getPluginTypeId().trim().isEmpty()) {
-                AnalyzerType pluginType = analyzerTypeService.get(form.getPluginTypeId());
+                AnalyzerType pluginType = resolvePluginType(form.getPluginTypeId());
                 if (pluginType != null) {
                     analyzer.setAnalyzerType(pluginType);
                 }
@@ -205,6 +211,17 @@ public class AnalyzerRestController extends BaseRestController {
 
             analyzer.setSysUserId(getSysUserId(request));
             String analyzerId = analyzerService.insert(analyzer);
+
+            // Auto-create test mappings from default config if provided
+            if (form.getDefaultConfigId() != null && !form.getDefaultConfigId().isEmpty()) {
+                Map<String, Object> configData = loadDefaultConfigFile(form.getDefaultConfigId());
+                if (configData != null) {
+                    autoCreateTestMappings(analyzerId, configData);
+                } else {
+                    logger.warn("Could not load default config '{}' for test mapping auto-creation",
+                            form.getDefaultConfigId());
+                }
+            }
 
             Analyzer createdAnalyzer = analyzerService.get(analyzerId);
             if (createdAnalyzer == null) {
@@ -400,7 +417,7 @@ public class AnalyzerRestController extends BaseRestController {
                 analyzer.setIdentifierPattern(form.getIdentifierPattern());
             }
             if (form.getPluginTypeId() != null && !form.getPluginTypeId().trim().isEmpty()) {
-                AnalyzerType pluginType = analyzerTypeService.get(form.getPluginTypeId());
+                AnalyzerType pluginType = resolvePluginType(form.getPluginTypeId());
                 if (pluginType != null) {
                     analyzer.setAnalyzerType(pluginType);
                 }
@@ -954,6 +971,155 @@ public class AnalyzerRestController extends BaseRestController {
             Map<String, Object> error = new LinkedHashMap<>();
             error.put("error", "Failed to load template: " + e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+        }
+    }
+
+    /**
+     * Resolve a pluginTypeId that may be numeric (database ID) or a well-known
+     * alias like "generic-astm". Returns null if unresolvable.
+     *
+     * <p>
+     * The frontend fallback list historically used string IDs ("generic-astm",
+     * "generic-hl7") instead of database numeric IDs. This method gracefully
+     * handles both formats to prevent NumberFormatException.
+     */
+    private AnalyzerType resolvePluginType(String pluginTypeId) {
+        if (pluginTypeId == null || pluginTypeId.trim().isEmpty()) {
+            return null;
+        }
+
+        // Try numeric ID first (normal path when frontend has real DB IDs)
+        try {
+            Integer.parseInt(pluginTypeId.trim());
+            return analyzerTypeService.get(pluginTypeId);
+        } catch (NumberFormatException e) {
+            logger.info("Non-numeric pluginTypeId '{}', attempting name-based lookup", pluginTypeId);
+        }
+
+        // Map well-known frontend aliases to database names
+        String lookupName;
+        switch (pluginTypeId.toLowerCase()) {
+        case "generic-astm":
+            lookupName = "Generic ASTM";
+            break;
+        case "generic-hl7":
+            lookupName = "Generic HL7";
+            break;
+        default:
+            lookupName = pluginTypeId;
+        }
+
+        AnalyzerType type = analyzerTypeService.getAnalyzerTypeByName(lookupName);
+        if (type == null) {
+            logger.warn("Could not resolve pluginTypeId '{}' (tried name '{}')", pluginTypeId, lookupName);
+        }
+        return type;
+    }
+
+    /**
+     * Load a default config JSON file from the filesystem. Returns null if
+     * validation fails or file not found.
+     *
+     * @param configId Config ID in "protocol/name" format (e.g.,
+     *                 "astm/genexpert-astm")
+     * @return Parsed JSON as Map, or null
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loadDefaultConfigFile(String configId) {
+        if (configId == null || !configId.contains("/")) {
+            return null;
+        }
+
+        String[] parts = configId.split("/", 2);
+        String protocol = parts[0];
+        String name = parts[1];
+
+        if (!protocol.equalsIgnoreCase("astm") && !protocol.equalsIgnoreCase("hl7")) {
+            return null;
+        }
+        if (!name.matches("^[a-zA-Z0-9\\-_.]+$")) {
+            return null;
+        }
+
+        String filename = name.endsWith(".json") ? name : name + ".json";
+        String defaultsDir = System.getenv("ANALYZER_DEFAULTS_DIR");
+        if (defaultsDir == null || defaultsDir.isEmpty()) {
+            defaultsDir = "/data/analyzer-defaults";
+        }
+
+        Path baseDir = Path.of(defaultsDir);
+        Path templateFile = baseDir.resolve(protocol).resolve(filename).normalize();
+        if (!templateFile.startsWith(baseDir.normalize())) {
+            return null;
+        }
+
+        if (!Files.exists(templateFile) || !Files.isRegularFile(templateFile)) {
+            return null;
+        }
+
+        try {
+            String jsonContent = Files.readString(templateFile, StandardCharsets.UTF_8);
+            return objectMapper.readValue(jsonContent, Map.class);
+        } catch (IOException e) {
+            logger.error("Error reading default config file: {}", configId, e);
+            return null;
+        }
+    }
+
+    /**
+     * Auto-create test mappings from a default config's
+     * {@code default_test_mappings} array. Each mapping entry with a valid LOINC
+     * code is resolved to an OpenELIS test and persisted as an AnalyzerTestMapping.
+     *
+     * <p>
+     * Mappings that can't be resolved (unknown LOINC) are logged and skipped.
+     *
+     * @param analyzerId The newly created analyzer's ID
+     * @param config     Parsed default config JSON
+     */
+    @SuppressWarnings("unchecked")
+    private void autoCreateTestMappings(String analyzerId, Map<String, Object> config) {
+        Object mappingsObj = config.get("default_test_mappings");
+        if (!(mappingsObj instanceof List)) {
+            return;
+        }
+
+        List<Map<String, Object>> mappings = (List<Map<String, Object>>) mappingsObj;
+        int created = 0;
+
+        for (Map<String, Object> mapping : mappings) {
+            String analyzerCode = (String) mapping.get("analyzer_code");
+            String loinc = (String) mapping.get("loinc");
+
+            if (analyzerCode == null || loinc == null || analyzerCode.isEmpty() || loinc.isEmpty()) {
+                logger.warn("Skipping test mapping with missing analyzer_code or loinc");
+                continue;
+            }
+
+            List<org.openelisglobal.test.valueholder.Test> tests = testService.getActiveTestsByLoinc(loinc);
+            if (tests == null || tests.isEmpty()) {
+                logger.warn("No active test found for LOINC '{}' (analyzer_code '{}')", loinc, analyzerCode);
+                continue;
+            }
+
+            org.openelisglobal.test.valueholder.Test test = tests.get(0);
+
+            org.openelisglobal.analyzerimport.valueholder.AnalyzerTestMapping atm = new org.openelisglobal.analyzerimport.valueholder.AnalyzerTestMapping();
+            atm.setAnalyzerId(analyzerId);
+            atm.setAnalyzerTestName(analyzerCode);
+            atm.setTestId(test.getId());
+            atm.setSysUserId("1");
+
+            try {
+                analyzerTestMappingService.insert(atm);
+                created++;
+            } catch (Exception e) {
+                logger.warn("Failed to create test mapping for analyzer_code '{}': {}", analyzerCode, e.getMessage());
+            }
+        }
+
+        if (created > 0) {
+            logger.info("Auto-created {} test mappings for analyzer {}", created, analyzerId);
         }
     }
 

--- a/src/main/java/org/openelisglobal/analyzer/form/AnalyzerForm.java
+++ b/src/main/java/org/openelisglobal/analyzer/form/AnalyzerForm.java
@@ -34,6 +34,9 @@ public class AnalyzerForm {
 
     private String pluginTypeId; // FK to analyzer_type table (the plugin that handles messages)
 
+    private String defaultConfigId; // Transient: e.g. "astm/genexpert-astm" — hints controller to auto-create test
+                                    // mappings
+
     // Getters and Setters
 
     public String getId() {
@@ -114,5 +117,13 @@ public class AnalyzerForm {
 
     public void setPluginTypeId(String pluginTypeId) {
         this.pluginTypeId = pluginTypeId;
+    }
+
+    public String getDefaultConfigId() {
+        return defaultConfigId;
+    }
+
+    public void setDefaultConfigId(String defaultConfigId) {
+        this.defaultConfigId = defaultConfigId;
     }
 }

--- a/src/test/java/org/openelisglobal/analyzer/controller/AnalyzerRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/controller/AnalyzerRestControllerTest.java
@@ -420,4 +420,55 @@ public class AnalyzerRestControllerTest extends BaseWebContextSensitiveTest {
         mockMvc.perform(get("/rest/analyzer/analyzers/" + analyzerId).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.pluginLoaded").value(false));
     }
+
+    /**
+     * Test: POST /rest/analyzer/analyzers with non-numeric pluginTypeId should not
+     * throw NumberFormatException.
+     *
+     * Regression test for "For input string: generic-astm" bug: the frontend
+     * fallback list used hardcoded string IDs like "generic-astm" instead of
+     * database numeric IDs. The backend should gracefully resolve these by name
+     * rather than crashing with a 500.
+     */
+    @Test
+    public void testCreateAnalyzer_WithNonNumericPluginTypeId_ReturnsCreated() throws Exception {
+        String uniqueName = "TEST-NonNumericPlugin-" + System.currentTimeMillis();
+        String requestBody = "{\"name\":\"" + uniqueName + "\",\"analyzerType\":\"MOLECULAR\","
+                + "\"pluginTypeId\":\"generic-astm\"," + "\"ipAddress\":\"192.168.1.100\",\"port\":1200}";
+
+        // Should return 201 (gracefully ignoring unresolvable pluginTypeId)
+        // instead of 500 NumberFormatException
+        mockMvc.perform(post("/rest/analyzer/analyzers").contentType(MediaType.APPLICATION_JSON).content(requestBody))
+                .andExpect(status().isCreated()).andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.name").value(uniqueName));
+    }
+
+    /**
+     * Test: PUT /rest/analyzer/analyzers/{id} with non-numeric pluginTypeId should
+     * not throw NumberFormatException.
+     *
+     * Same regression test as above, but for the update path.
+     */
+    @Test
+    public void testUpdateAnalyzer_WithNonNumericPluginTypeId_ReturnsOk() throws Exception {
+        // Arrange: Create analyzer first (without pluginTypeId)
+        String uniqueName = "TEST-NonNumericPluginUpdate-" + System.currentTimeMillis();
+        String createBody = "{\"name\":\"" + uniqueName + "\",\"analyzerType\":\"MOLECULAR\","
+                + "\"ipAddress\":\"192.168.1.100\",\"port\":1200}";
+
+        MvcResult createResult = mockMvc
+                .perform(post("/rest/analyzer/analyzers").contentType(MediaType.APPLICATION_JSON).content(createBody))
+                .andExpect(status().isCreated()).andReturn();
+
+        String responseBody = createResult.getResponse().getContentAsString();
+        String analyzerId = responseBody.substring(responseBody.indexOf("\"id\":\"") + 6);
+        analyzerId = analyzerId.substring(0, analyzerId.indexOf("\""));
+
+        // Act: Update with non-numeric pluginTypeId "generic-astm"
+        String updateBody = "{\"pluginTypeId\":\"generic-astm\"}";
+
+        // Should return 200 (gracefully resolving by name) instead of 500
+        mockMvc.perform(put("/rest/analyzer/analyzers/" + analyzerId).contentType(MediaType.APPLICATION_JSON)
+                .content(updateBody)).andExpect(status().isOk()).andExpect(jsonPath("$.id").value(analyzerId));
+    }
 }


### PR DESCRIPTION
## Summary

- **Fix NumberFormatException** when creating/editing analyzers with Generic ASTM/HL7 plugin types — frontend `FALLBACK_PLUGIN_TYPES` used string IDs ("generic-astm") that backend tried to parse as numeric DB IDs
- **Separate config vs instance fields** in the analyzer form — loading a default config now sets plugin-level fields only (identifierPattern, category, protocol), not instance fields (name, port, IP)
- **Enable default config dropdown in edit mode** — was hidden by `!isEditMode` guard
- **Reorder form fields** into 3 logical sections: Instance Identity → Plugin Configuration → Connection
- **Auto-create test mappings** from default config `default_test_mappings` via LOINC lookup when creating an analyzer
- **Backend defense-in-depth** — `resolvePluginType()` gracefully handles both numeric DB IDs and string aliases

## Changes

### Backend
- `AnalyzerRestController.java` — Added `resolvePluginType()`, `loadDefaultConfigFile()`, `autoCreateTestMappings()`, wired into create endpoint
- `AnalyzerForm.java` — Added `defaultConfigId` transient field
- `AnalyzerRestControllerTest.java` — 2 new tests for non-numeric pluginTypeId (create + update), all 15 tests pass

### Frontend
- `AnalyzerForm.jsx` — Removed `FALLBACK_PLUGIN_TYPES`, fixed `handleDefaultConfigSelect`, enabled edit-mode config, reordered fields into 3 sections, sends `defaultConfigId` on submit

### E2E Tests (new)
- `analyzer-form.ts` — Playwright Page Object Model
- `analyzer-form.spec.ts` — 4 test cases (create GeneXpert, edit, config in edit mode, validation)

### Docs
- Updated spec.md, plan.md, tasks.md with M-BF1 bugfix milestone (T327-T337)

## Test plan

- [x] Backend: `mvn test -Dtest=AnalyzerRestControllerTest` — 15/15 pass (including 2 new non-numeric pluginTypeId tests)
- [ ] E2E: `cd frontend && npx playwright test analyzer-form` (requires running harness)
- [ ] Manual: Add Analyzer → select Generic ASTM → load GeneXpert config → verify identifierPattern auto-populated, name/port NOT overwritten → fill instance details → save

🤖 Generated with [Claude Code](https://claude.com/claude-code)