### PR TITLE
test: added integration tests for QAService

### DIFF
--- a/src/test/java/org/openelisglobal/common/services/QAServiceTest.java
+++ b/src/test/java/org/openelisglobal/common/services/QAServiceTest.java
@@ -1,0 +1,127 @@
+package org.openelisglobal.common.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.sampleqaevent.valueholder.SampleQaEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class QAServiceTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private SampleService sampleService;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        executeDataSetWithStateManagement("testdata/qaservice-test.xml");
+    }
+
+    // -------------------------------------------------------------------------
+    // isOrderNonConforming tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void isOrderNonConforming_shouldReturnTrue_whenSampleHasQaEvent() {
+        Sample sample = sampleService.get("401");
+
+        boolean result = QAService.isOrderNonConforming(sample);
+
+        assertTrue("Sample with QA event should be non-conforming", result);
+    }
+
+    @Test
+    public void isOrderNonConforming_shouldReturnFalse_whenSampleHasNoQaEvent() {
+        Sample sample = sampleService.get("402");
+
+        boolean result = QAService.isOrderNonConforming(sample);
+
+        assertFalse("Sample without QA event should not be non-conforming", result);
+    }
+
+    @Test
+    public void isOrderNonConforming_shouldReturnFalse_whenSampleIsNull() {
+        boolean result = QAService.isOrderNonConforming(null);
+
+        assertFalse("Null sample should not be non-conforming", result);
+    }
+
+    @Test
+    public void isOrderNonConforming_shouldReturnTrue_whenSampleHasDeprecatedNonConformingStatus() {
+        Sample sample = sampleService.get("403");
+
+        boolean result = QAService.isOrderNonConforming(sample);
+
+        assertTrue("Sample with NonConforming deprecated status should be non-conforming", result);
+    }
+
+    // -------------------------------------------------------------------------
+    // getNonConformingSampleItems tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getNonConformingSampleItems_shouldReturnSampleItems_whenSampleHasQaEvents() {
+        Sample sample = sampleService.get("401");
+
+        List<SampleItem> result = QAService.getNonConformingSampleItems(sample);
+
+        assertNotNull("Result should not be null", result);
+        assertFalse("Result should not be empty", result.isEmpty());
+        assertEquals("601", result.get(0).getId());
+    }
+
+    @Test
+    public void getNonConformingSampleItems_shouldReturnEmptyList_whenSampleHasNoQaEvents() {
+        Sample sample = sampleService.get("402");
+
+        List<SampleItem> result = QAService.getNonConformingSampleItems(sample);
+
+        assertNotNull("Result should not be null", result);
+        assertTrue("Result should be empty", result.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // QAService instance tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getEventId_shouldReturnSampleQaEventId() {
+        SampleQaEvent sampleQaEvent = new SampleQaEvent();
+        sampleQaEvent.setId("1");
+
+        QAService qaService = new QAService(sampleQaEvent);
+
+        assertEquals("1", qaService.getEventId());
+    }
+
+    @Test
+    public void getUpdatedObservations_shouldReturnEmptyList_whenNoObservationsSet() {
+        SampleQaEvent sampleQaEvent = new SampleQaEvent();
+        QAService qaService = new QAService(sampleQaEvent);
+
+        List<?> observations = qaService.getUpdatedObservations();
+
+        assertNotNull("Observations list should not be null", observations);
+        assertTrue("Observations list should be empty", observations.isEmpty());
+    }
+
+    @Test
+    public void getSampleQaEvent_shouldReturnSetEvent() {
+        SampleQaEvent sampleQaEvent = new SampleQaEvent();
+        sampleQaEvent.setId("99");
+
+        QAService qaService = new QAService(sampleQaEvent);
+
+        assertNotNull("SampleQaEvent should not be null", qaService.getSampleQaEvent());
+        assertEquals("99", qaService.getSampleQaEvent().getId());
+    }
+}

--- a/src/test/resources/testdata/qaservice-test.xml
+++ b/src/test/resources/testdata/qaservice-test.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+
+    <status_of_sample id="1" description="Sample Entered"
+        code="1" status_type="SAMPLE" lastupdated="2024-01-01"
+        name="SampleEntered" display_key="status.sample.entered" is_active="Y" />
+    <status_of_sample id="12"
+        description="Non Conforming Order" code="2" status_type="ORDER"
+        lastupdated="2024-01-01" name="NonConforming"
+        display_key="status.order.nonconforming" is_active="Y" />
+
+    <qa_event id="301" name="QA Event 1"
+        description="QA Event for testing" is_billable="Y"
+        reporting_sequence="1" reporting_text="QA event reporting text."
+        is_holdable="N" lastupdated="2024-06-01 12:00:00"
+        display_key="QA_EVENT_1" />
+
+    <sample id="401" accession_number="ACC-401" status_id="1"
+        received_date="2024-06-03 00:00:00.0"
+        entered_date="2024-06-03 00:00:00.0"
+        collection_date="2024-06-03 00:00:00.0"
+        lastupdated="2024-06-03 12:00:00" />
+    <sample id="402" accession_number="ACC-402" status_id="1"
+        received_date="2024-06-04 00:00:00.0"
+        entered_date="2024-06-04 00:00:00.0"
+        collection_date="2024-06-04 00:00:00.0"
+        lastupdated="2024-06-04 12:00:00" />
+    <sample id="403" accession_number="ACC-403"
+        received_date="2024-06-05 00:00:00.0"
+        entered_date="2024-06-05 00:00:00.0"
+        collection_date="2024-06-05 00:00:00.0" status_id="12"
+        lastupdated="2024-06-05 12:00:00" />
+
+    <sample_item id="601" sort_order="1" status_id="1"
+        collection_date="2024-06-03 10:00:00"
+        lastupdated="2024-06-03 12:00:00" />
+
+    <sample_qaevent id="1" qa_event_id="301" sample_id="401"
+        completed_date="2025-03-01" lastupdated="2024-06-25 09:00:00"
+        sampleitem_id="601" entered_date="2025-06-25 09:30:00" />
+
+</dataset>


### PR DESCRIPTION
# Pull Requests Requirements

- [ x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x ] The PR title follows conventional commit label standards.
- [ x The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ x] The changes include tests or are validated by existing tests.
- [x ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Add ed QAServiceTest with 9 tests covering isOrderNonConforming,
getNonConformingSampleItems, getEventId, getUpdatedObservations,
and getSampleQaEvent methods. Also added test dataset qaservice-test.xml"

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
