### PR TITLE
test: added unit tests for AlphanumAccessionValidator static methods

### DIFF
--- a/src/test/java/org/openelisglobal/common/provider/validation/AccessionNumberValidationProviderTest.java
+++ b/src/test/java/org/openelisglobal/common/provider/validation/AccessionNumberValidationProviderTest.java
@@ -1,0 +1,95 @@
+package org.openelisglobal.common.provider.validation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+
+public class AccessionNumberValidationProviderTest extends BaseWebContextSensitiveTest {
+
+    private AccessionNumberValidationProvider provider;
+
+    private static final String VALID = "valid";
+    private static final String INVALID = "invalid";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        provider = new AccessionNumberValidationProvider();
+        executeDataSetWithStateManagement("testdata/accession-number-validation-test.xml");
+    }
+
+    // -------------------------------------------------------------------------
+    // validate() - null/empty targetId tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void validate_shouldReturnInvalid_whenTargetIdIsNull() throws Exception {
+        String result = provider.validate(null, null);
+        assertEquals(INVALID, result);
+    }
+
+    @Test
+    public void validate_shouldReturnInvalid_whenTargetIdIsEmpty() throws Exception {
+        String result = provider.validate("", null);
+        assertEquals(INVALID, result);
+    }
+
+    @Test
+    public void validate_shouldReturnInvalid_whenTargetIdIsBlank() throws Exception {
+        String result = provider.validate("   ", null);
+        assertEquals(INVALID, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // validate() - sample not found
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void validate_shouldReturnInvalid_whenSampleNotFound() throws Exception {
+        String result = provider.validate("NONEXISTENT999", null);
+        assertEquals(INVALID, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // validate() - sample found, no form specified
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void validate_shouldReturnValid_whenSampleFoundAndNoFormSpecified() throws Exception {
+        String result = provider.validate("ACC-401", null);
+        assertEquals(VALID, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // validate() - sample found, unrecognized form
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void validate_shouldReturnValid_whenSampleFoundAndUnrecognizedForm() throws Exception {
+        String result = provider.validate("ACC-401", "unknownForm");
+        assertEquals(VALID, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // validate() - humanSampleOneForm with null status
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void validate_shouldReturnInvalid_whenHumanSampleOneFormAndSampleStatusIsNull() throws Exception {
+        // sample 402 has no status
+        String result = provider.validate("ACC-402", "humanSampleOneForm");
+        assertEquals(INVALID, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // validate() - humanSampleTwoForm with null status
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void validate_shouldReturnInvalid_whenHumanSampleTwoFormAndSampleStatusIsNull() throws Exception {
+        String result = provider.validate("ACC-402", "humanSampleTwoForm");
+        assertEquals(INVALID, result);
+    }
+}

--- a/src/test/java/org/openelisglobal/common/provider/validation/AlphanumAccessionValidatorTest.java
+++ b/src/test/java/org/openelisglobal/common/provider/validation/AlphanumAccessionValidatorTest.java
@@ -1,0 +1,65 @@
+package org.openelisglobal.common.provider.validation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class AlphanumAccessionValidatorTest {
+
+    // -------------------------------------------------------------------------
+    // normalizeAccessionString tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void normalizeAccessionString_shouldRemoveDashes_whenDashesPresent() {
+        String result = AlphanumAccessionValidator.normalizeAccessionString("26-ABC-123-456");
+        assertEquals("26ABC123456", result);
+    }
+
+    @Test
+    public void normalizeAccessionString_shouldReturnSameString_whenNoDashesPresent() {
+        String result = AlphanumAccessionValidator.normalizeAccessionString("26ABC123456");
+        assertEquals("26ABC123456", result);
+    }
+
+    @Test
+    public void normalizeAccessionString_shouldReturnNull_whenInputIsNull() {
+        String result = AlphanumAccessionValidator.normalizeAccessionString(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void normalizeAccessionString_shouldReturnEmptyString_whenInputIsEmpty() {
+        String result = AlphanumAccessionValidator.normalizeAccessionString("");
+        assertEquals("", result);
+    }
+
+    // -------------------------------------------------------------------------
+    // convertAlphaNumLabNumForDisplay tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void convertAlphaNumLabNumForDisplay_shouldReturnNull_whenInputIsNull() {
+        String result = AlphanumAccessionValidator.convertAlphaNumLabNumForDisplay(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void convertAlphaNumLabNumForDisplay_shouldReturnEmpty_whenInputIsEmpty() {
+        String result = AlphanumAccessionValidator.convertAlphaNumLabNumForDisplay("");
+        assertEquals("", result);
+    }
+
+    @Test
+    public void convertAlphaNumLabNumForDisplay_shouldFormatWithDashes_whenNoPrefix() {
+        String result = AlphanumAccessionValidator.convertAlphaNumLabNumForDisplay("26123456");
+        assertEquals("26-123-456", result);
+    }
+
+    @Test
+    public void convertAlphaNumLabNumForDisplay_shouldFormatWithPrefixAndDashes_whenPrefixPresent() {
+        String result = AlphanumAccessionValidator.convertAlphaNumLabNumForDisplay("26AB123456");
+        assertEquals("26-AB-123-456", result);
+    }
+}

--- a/src/test/java/org/openelisglobal/common/provider/validation/ProgramAccessionValidatorTest.java
+++ b/src/test/java/org/openelisglobal/common/provider/validation/ProgramAccessionValidatorTest.java
@@ -1,0 +1,105 @@
+package org.openelisglobal.common.provider.validation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+
+public class ProgramAccessionValidatorTest extends BaseWebContextSensitiveTest {
+
+    // -------------------------------------------------------------------------
+    // createFirstAccessionNumber tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void createFirstAccessionNumber_shouldReturnProgramCodeWithStartingIncrement() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        String result = validator.createFirstAccessionNumber("ABCD");
+        assertEquals("ABCD00001", result);
+    }
+
+    @Test
+    public void createFirstAccessionNumber_shouldWorkWithDifferentProgramCodes() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        assertEquals("TEST00001", validator.createFirstAccessionNumber("TEST"));
+        assertEquals("VCT000001", validator.createFirstAccessionNumber("VCT0"));
+    }
+
+    // -------------------------------------------------------------------------
+    // incrementAccessionNumber tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void incrementAccessionNumber_shouldIncrementByOne() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        String result = validator.incrementAccessionNumber("ABCD00001");
+        assertEquals("ABCD00002", result);
+    }
+
+    @Test
+    public void incrementAccessionNumber_shouldPadWithLeadingZeros() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        String result = validator.incrementAccessionNumber("ABCD00009");
+        assertEquals("ABCD00010", result);
+    }
+
+    @Test
+    public void incrementAccessionNumber_shouldHandleLargeIncrement() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        String result = validator.incrementAccessionNumber("ABCD09999");
+        assertEquals("ABCD10000", result);
+    }
+
+    @Test
+    public void incrementAccessionNumber_shouldUppercaseProgramCode() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        String result = validator.incrementAccessionNumber("abcd00001");
+        assertEquals("ABCD00002", result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void incrementAccessionNumber_shouldThrowException_whenAtMaxValue() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        validator.incrementAccessionNumber("ABCD99999");
+    }
+
+    // -------------------------------------------------------------------------
+    // getMaxAccessionLength / getMinAccessionLength / getChangeableLength tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getMaxAccessionLength_shouldReturn9() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        assertEquals(9, validator.getMaxAccessionLength());
+    }
+
+    @Test
+    public void getMinAccessionLength_shouldEqualMaxAccessionLength() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        assertEquals(validator.getMaxAccessionLength(), validator.getMinAccessionLength());
+    }
+
+    @Test
+    public void getChangeableLength_shouldReturn5() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        assertEquals(5, validator.getChangeableLength());
+    }
+
+    @Test
+    public void getInvarientLength_shouldReturn4() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        assertEquals(4, validator.getInvarientLength());
+    }
+
+    @Test
+    public void needProgramCode_shouldReturnTrue() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        assertEquals(true, validator.needProgramCode());
+    }
+
+    @Test
+    public void getPrefix_shouldReturnNull() {
+        ProgramAccessionValidator validator = new ProgramAccessionValidator();
+        assertEquals(null, validator.getPrefix());
+    }
+}

--- a/src/test/java/org/openelisglobal/common/provider/validation/YearNumAccessionValidatorTest.java
+++ b/src/test/java/org/openelisglobal/common/provider/validation/YearNumAccessionValidatorTest.java
@@ -1,0 +1,112 @@
+package org.openelisglobal.common.provider.validation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+
+public class YearNumAccessionValidatorTest extends BaseWebContextSensitiveTest {
+
+    // -------------------------------------------------------------------------
+    // createFirstAccessionNumber tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void createFirstAccessionNumber_shouldReturnYearWithIncrement_whenNoSeparator() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        String result = validator.createFirstAccessionNumber(null);
+        // should be current 2-digit year + 000001
+        assertEquals(6 + 2, result.length());
+    }
+
+    @Test
+    public void createFirstAccessionNumber_shouldIncludesSeparator_whenSeparatorProvided() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, '-');
+        String result = validator.createFirstAccessionNumber(null);
+        // should be YY-000001 (9 chars)
+        assertEquals(9, result.length());
+    }
+
+    @Test
+    public void createFirstAccessionNumber_shouldEndWithAllOnesInLastDigit() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        String result = validator.createFirstAccessionNumber(null);
+        assertEquals("000001", result.substring(2));
+    }
+
+    // -------------------------------------------------------------------------
+    // incrementAccessionNumber tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void incrementAccessionNumber_shouldIncrementByOne_whenNoSeparator() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        String current = validator.createFirstAccessionNumber(null); // YY000001
+        String next = validator.incrementAccessionNumber(current);
+        assertEquals(current.substring(0, 2) + "000002", next);
+    }
+
+    @Test
+    public void incrementAccessionNumber_shouldIncrementByOne_whenSeparatorProvided() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, '-');
+        String current = validator.createFirstAccessionNumber(null); // YY-000001
+        String next = validator.incrementAccessionNumber(current);
+        assertEquals(current.substring(0, 2) + "-000002", next);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void incrementAccessionNumber_shouldThrowException_whenAtMaxValue() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        String year = current2DigitYear();
+        validator.incrementAccessionNumber(year + "999999");
+    }
+
+    // -------------------------------------------------------------------------
+    // getMaxAccessionLength / getMinAccessionLength / needProgramCode tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getMaxAccessionLength_shouldReturn8_whenLengthIs6AndNoSeparator() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        assertEquals(8, validator.getMaxAccessionLength());
+    }
+
+    @Test
+    public void getMaxAccessionLength_shouldReturn9_whenLengthIs6AndSeparatorProvided() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, '-');
+        assertEquals(9, validator.getMaxAccessionLength());
+    }
+
+    @Test
+    public void getMinAccessionLength_shouldEqualMaxAccessionLength() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        assertEquals(validator.getMaxAccessionLength(), validator.getMinAccessionLength());
+    }
+
+    @Test
+    public void needProgramCode_shouldReturnFalse() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        assertEquals(false, validator.needProgramCode());
+    }
+
+    @Test
+    public void getPrefix_shouldReturnNull() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        assertEquals(null, validator.getPrefix());
+    }
+
+    @Test
+    public void getInvarientLength_shouldReturn0() {
+        YearNumAccessionValidator validator = new YearNumAccessionValidator(6, null);
+        assertEquals(0, validator.getInvarientLength());
+    }
+
+    // -------------------------------------------------------------------------
+    // helper
+    // -------------------------------------------------------------------------
+
+    private String current2DigitYear() {
+        int year = new java.util.GregorianCalendar().get(java.util.Calendar.YEAR) - 2000;
+        return String.format("%02d", year);
+    }
+}

--- a/src/test/resources/testdata/accession-number-validation-test.xml
+++ b/src/test/resources/testdata/accession-number-validation-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <status_of_sample id="1" description="Sample Entered"
+        code="1" status_type="SAMPLE" lastupdated="2024-01-01"
+        name="SampleEntered" display_key="status.sample.entered" is_active="Y" />
+    <!-- sample 401: has accession number, no status (null status) -->
+    <sample id="401" accession_number="ACC-401"
+        received_date="2024-06-03 00:00:00.0"
+        entered_date="2024-06-03 00:00:00.0"
+        collection_date="2024-06-03 00:00:00.0"
+        lastupdated="2024-06-03 12:00:00" />
+    <!-- sample 402: has accession number, no status -->
+    <sample id="402" accession_number="ACC-402"
+        received_date="2024-06-04 00:00:00.0"
+        entered_date="2024-06-04 00:00:00.0"
+        collection_date="2024-06-04 00:00:00.0"
+        lastupdated="2024-06-04 12:00:00" />
+</dataset>


### PR DESCRIPTION
# Pull Requests Requirements

- [x ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x ] The PR title follows conventional commit label standards.
- [x ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ x] The changes include tests or are validated by existing tests.
- [x ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Added 8 tests covering normalizeAccessionString and convertAlphaNumLabNumForDisplay methods. The tests cover null, empty, with/without dashes, with/without prefix"
## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
