### PR TITLE
fix(011): remove stale analyzer_configuration from fixtures

### DIFF
--- a/projects/analyzer-harness/bootstrap.sh
+++ b/projects/analyzer-harness/bootstrap.sh
@@ -33,13 +33,37 @@ mkdir -p "$HARNESS_VOLUME/menu"
 mkdir -p "$HARNESS_VOLUME/logs/oeLogs"
 mkdir -p "$HARNESS_VOLUME/logs/tomcatLogs"
 mkdir -p "$HARNESS_VOLUME/plugins"
-# Copy analyzer plugin JARs from submodule (idempotent: skips existing)
+# Copy analyzer plugin JARs from submodule (idempotent: skips existing).
+# HARNESS_PLUGINS controls which JARs are copied:
+#   all     (default) - all plugin JARs (backward-compatible)
+#   generic           - only GenericASTM + GenericHL7 (avoids legacy auto-created analyzer rows)
+HARNESS_PLUGINS="${HARNESS_PLUGINS:-all}"
 PLUGIN_SRC="$REPO_ROOT/plugins/plugins"
-if [ -d "$PLUGIN_SRC" ] && ls "$PLUGIN_SRC"/*.jar 1>/dev/null 2>&1; then
-  cp -n "$PLUGIN_SRC"/*.jar "$HARNESS_VOLUME/plugins/" 2>/dev/null || true
-  echo -e "  ${GREEN}✓ Analyzer plugins copied ($(ls "$HARNESS_VOLUME/plugins/"*.jar 2>/dev/null | wc -l) JARs)${NC}"
+if [ -d "$PLUGIN_SRC" ]; then
+  if [ "$HARNESS_PLUGINS" = "generic" ]; then
+    GENERIC_JARS="GenericASTM-1.0.jar GenericHL7-1.0.jar"
+    copied=0
+    for jar in $GENERIC_JARS; do
+      if [ -f "$PLUGIN_SRC/$jar" ]; then
+        cp -n "$PLUGIN_SRC/$jar" "$HARNESS_VOLUME/plugins/" 2>/dev/null || true
+        copied=$((copied + 1))
+      fi
+    done
+    if [ "$copied" -gt 0 ]; then
+      echo -e "  ${GREEN}✓ Generic analyzer plugins only ($copied JARs)${NC}"
+    else
+      echo -e "  ${YELLOW}WARN: No generic plugin JARs found. Run 'cd plugins && mvn package' to build them.${NC}"
+    fi
+  else
+    if ls "$PLUGIN_SRC"/*.jar 1>/dev/null 2>&1; then
+      cp -n "$PLUGIN_SRC"/*.jar "$HARNESS_VOLUME/plugins/" 2>/dev/null || true
+      echo -e "  ${GREEN}✓ All analyzer plugins copied ($(ls "$HARNESS_VOLUME/plugins/"*.jar 2>/dev/null | wc -l) JARs)${NC}"
+    else
+      echo -e "  ${YELLOW}WARN: No plugin JARs found at plugins/plugins/. Run 'cd plugins && mvn package' to build them.${NC}"
+    fi
+  fi
 else
-  echo -e "  ${YELLOW}WARN: No plugin JARs found at plugins/plugins/. Run 'cd plugins && mvn package' to build them.${NC}"
+  echo -e "  ${YELLOW}WARN: Plugin source directory not found at plugins/plugins/.${NC}"
 fi
 mkdir -p "$HARNESS_VOLUME/programs"
 mkdir -p "$HARNESS_VOLUME/configuration"

--- a/specs/011-madagascar-analyzer-integration/data-model.md
+++ b/specs/011-madagascar-analyzer-integration/data-model.md
@@ -50,7 +50,7 @@ analyzer (Device Instance + Operational Config — MERGED)
      analyzer_type_id (FK),
      ip_address, port, protocol_version, status,
      identifier_pattern, test_unit_ids, last_activated_date
-     Status: INACTIVE | SETUP | VALIDATION | ACTIVE | ERROR_PENDING | OFFLINE
+     Status: INACTIVE | SETUP | VALIDATION | ACTIVE | ERROR_PENDING | OFFLINE | DELETED
 ```
 
 **Removed**: `analyzer_configuration` table, `is_generic_plugin` on config

--- a/src/test/resources/analyzer-minimal.sql
+++ b/src/test/resources/analyzer-minimal.sql
@@ -12,20 +12,23 @@ SET search_path TO clinlims;
 -- =============================================================================
 -- 1. ANALYZER TYPES (Plugin Capability — normally created at startup)
 -- =============================================================================
--- Generic plugins don't auto-create analyzer_type rows via addAnalyzerDatabaseParts();
--- they only register in-memory via registerAnalyzer(). We must INSERT here so
--- findGenericAnalyzersWithPatterns() can JOIN on analyzer_type.is_generic_plugin.
+-- PluginRegistryService auto-creates these at startup when plugin JARs are loaded.
+-- Names MUST match PluginRegistryService.derivePluginName() output:
+--   GenericASTMAnalyzer → "Generic ASTM"
+--   GenericHL7Analyzer  → "Generic HL7"
+-- These INSERTs are a fallback for environments where plugins aren't loaded
+-- (e.g., unit tests without the full plugin JAR lifecycle).
 
 INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
-VALUES (nextval('analyzer_type_seq'), 'GenericASTM', 'Generic ASTM analyzer plugin',
+VALUES (nextval('analyzer_type_seq'), 'Generic ASTM', 'Generic ASTM - Dashboard-configurable analyzer (requires identifier_pattern)',
         'org.openelisglobal.plugins.analyzer.genericastm.GenericASTMAnalyzer',
-        'ASTM_LIS2_A2', true, true, NOW())
+        'ASTM', true, true, NOW())
 ON CONFLICT (name) DO NOTHING;
 
 INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
-VALUES (nextval('analyzer_type_seq'), 'GenericHL7', 'Generic HL7 analyzer plugin',
+VALUES (nextval('analyzer_type_seq'), 'Generic HL7', 'Generic HL7 - Dashboard-configurable analyzer (requires identifier_pattern)',
         'org.openelisglobal.plugins.analyzer.generichl7.GenericHL7Analyzer',
-        'HL7_V2_3_1', true, true, NOW())
+        'HL7', true, true, NOW())
 ON CONFLICT (name) DO NOTHING;
 
 -- =============================================================================
@@ -57,11 +60,11 @@ ON CONFLICT (id) DO NOTHING;
 -- =============================================================================
 
 UPDATE analyzer SET analyzer_type_id = (
-  SELECT id FROM analyzer_type WHERE name = 'GenericASTM'
+  SELECT id FROM analyzer_type WHERE name = 'Generic ASTM'
 ) WHERE id IN (2006, 2013) AND analyzer_type_id IS NULL;
 
 UPDATE analyzer SET analyzer_type_id = (
-  SELECT id FROM analyzer_type WHERE name = 'GenericHL7'
+  SELECT id FROM analyzer_type WHERE name = 'Generic HL7'
 ) WHERE id = 2007 AND analyzer_type_id IS NULL;
 
 -- =============================================================================
@@ -101,7 +104,7 @@ DECLARE
   v_linked_count     INTEGER;
 BEGIN
   SELECT COUNT(*) INTO v_analyzer_count FROM analyzer WHERE id IN (2006, 2007, 2013);
-  SELECT COUNT(*) INTO v_type_count FROM analyzer_type WHERE name IN ('GenericASTM', 'GenericHL7');
+  SELECT COUNT(*) INTO v_type_count FROM analyzer_type WHERE name IN ('Generic ASTM', 'Generic HL7');
   SELECT COUNT(*) INTO v_map_count FROM analyzer_test_map WHERE analyzer_id = '2013';
   SELECT COUNT(*) INTO v_linked_count FROM analyzer WHERE id IN (2006, 2007, 2013) AND analyzer_type_id IS NOT NULL;
 

--- a/src/test/resources/analyzer-minimal.sql
+++ b/src/test/resources/analyzer-minimal.sql
@@ -1,0 +1,113 @@
+-- Analyzer Minimal Fixture (2-Table Model)
+-- Self-contained, hand-authored SQL for focused plugin testing.
+-- Creates 3 analyzers (2006, 2007, 2013) with config columns on the analyzer row.
+-- No dependency on xml-to-sql.py or load-analyzer-test-data.sh.
+--
+-- Schema: 2-table model (analyzer_type + analyzer) after PR #2802 merge.
+-- Enum values: ProtocolVersion (ASTM_LIS2_A2, HL7_V2_3_1, HL7_V2_5)
+--              AnalyzerStatus  (INACTIVE, SETUP, VALIDATION, ACTIVE, ERROR_PENDING, OFFLINE, DELETED)
+
+SET search_path TO clinlims;
+
+-- =============================================================================
+-- 1. ANALYZER TYPES (Plugin Capability — normally created at startup)
+-- =============================================================================
+-- Generic plugins don't auto-create analyzer_type rows via addAnalyzerDatabaseParts();
+-- they only register in-memory via registerAnalyzer(). We must INSERT here so
+-- findGenericAnalyzersWithPatterns() can JOIN on analyzer_type.is_generic_plugin.
+
+INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
+VALUES (nextval('analyzer_type_seq'), 'GenericASTM', 'Generic ASTM analyzer plugin',
+        'org.openelisglobal.plugins.analyzer.genericastm.GenericASTMAnalyzer',
+        'ASTM_LIS2_A2', true, true, NOW())
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
+VALUES (nextval('analyzer_type_seq'), 'GenericHL7', 'Generic HL7 analyzer plugin',
+        'org.openelisglobal.plugins.analyzer.generichl7.GenericHL7Analyzer',
+        'HL7_V2_3_1', true, true, NOW())
+ON CONFLICT (name) DO NOTHING;
+
+-- =============================================================================
+-- 2. ANALYZERS (Device Instance + Config — merged 2-table model)
+-- =============================================================================
+-- Config columns (ip_address, port, protocol_version, status, identifier_pattern)
+-- live directly on the analyzer row since PR #2802.
+
+INSERT INTO analyzer (id, name, analyzer_type, description, is_active,
+                      ip_address, port, protocol_version, status,
+                      identifier_pattern, last_updated)
+VALUES
+  -- Mindray BA-88A: GenericASTM, chemistry, RS232
+  (2006, 'Mindray BA-88A', 'CHEMISTRY', 'ASTM over RS232 Serial', true,
+   '172.20.1.100', 9600, 'ASTM_LIS2_A2', 'ACTIVE',
+   'MINDRAY.*BA-88A|BA88A', NOW()),
+  -- Mindray BC-5380: GenericHL7, hematology, TCP/MLLP
+  (2007, 'Mindray BC-5380', 'HEMATOLOGY', 'HL7 v2.3.1 over TCP/IP (MLLP)', true,
+   '172.20.1.101', 5562, 'HL7_V2_3_1', 'ACTIVE',
+   'MINDRAY.*BC.?5380|BC5380', NOW()),
+  -- GeneXpert ASTM Mode: GenericASTM, molecular, TCP/IP
+  (2013, 'Cepheid GeneXpert (ASTM Mode)', 'MOLECULAR', 'ASTM LIS2-A2 over TCP/IP', true,
+   '172.20.1.110', 9600, 'ASTM_LIS2_A2', 'ACTIVE',
+   'GENEXPERT|CEPHEID', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- =============================================================================
+-- 3. LINK ANALYZERS TO ANALYZER_TYPE (idempotent)
+-- =============================================================================
+
+UPDATE analyzer SET analyzer_type_id = (
+  SELECT id FROM analyzer_type WHERE name = 'GenericASTM'
+) WHERE id IN (2006, 2013) AND analyzer_type_id IS NULL;
+
+UPDATE analyzer SET analyzer_type_id = (
+  SELECT id FROM analyzer_type WHERE name = 'GenericHL7'
+) WHERE id = 2007 AND analyzer_type_id IS NULL;
+
+-- =============================================================================
+-- 4. TEST MAPPINGS for GeneXpert ASTM (analyzer_test_map composite PK)
+-- =============================================================================
+-- analyzer_test_map has composite PK: (analyzer_id, analyzer_test_name)
+-- test_id references clinlims.test (FK constraint).
+-- Using Liquibase-seeded test IDs: 3=Glucose, 5=Amylase, 192=CD4 absolute count.
+-- These are placeholder mappings for E2E routing validation, not clinical accuracy.
+
+INSERT INTO analyzer_test_map (analyzer_id, analyzer_test_name, test_id, last_updated)
+VALUES
+  ('2013', 'MTB-RIF',  '3',   NOW()),
+  ('2013', 'RIF',      '5',   NOW()),
+  ('2013', 'HIV-VL',   '192', NOW()),
+  ('2013', 'COVID19',  '3',   NOW())
+ON CONFLICT (analyzer_id, analyzer_test_name) DO NOTHING;
+
+-- =============================================================================
+-- 5. ADVANCE SEQUENCE (avoid ID collisions with future inserts)
+-- =============================================================================
+
+SELECT setval('analyzer_seq', GREATEST(
+  (SELECT COALESCE(MAX(id), 0) FROM analyzer)::bigint,
+  nextval('analyzer_seq')
+));
+
+-- =============================================================================
+-- 6. VERIFICATION (DO block — raises NOTICE, never fails)
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_analyzer_count   INTEGER;
+  v_type_count       INTEGER;
+  v_map_count        INTEGER;
+  v_linked_count     INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_analyzer_count FROM analyzer WHERE id IN (2006, 2007, 2013);
+  SELECT COUNT(*) INTO v_type_count FROM analyzer_type WHERE name IN ('GenericASTM', 'GenericHL7');
+  SELECT COUNT(*) INTO v_map_count FROM analyzer_test_map WHERE analyzer_id = '2013';
+  SELECT COUNT(*) INTO v_linked_count FROM analyzer WHERE id IN (2006, 2007, 2013) AND analyzer_type_id IS NOT NULL;
+
+  RAISE NOTICE 'analyzer-minimal.sql verification:';
+  RAISE NOTICE '  analyzers:      % / 3 expected', v_analyzer_count;
+  RAISE NOTICE '  analyzer_types: % / 2 expected', v_type_count;
+  RAISE NOTICE '  test_mappings:  % / 4 expected', v_map_count;
+  RAISE NOTICE '  type_linked:    % / 3 expected', v_linked_count;
+END $$;

--- a/src/test/resources/analyzer-test-data.sql
+++ b/src/test/resources/analyzer-test-data.sql
@@ -15,29 +15,26 @@ SET search_path TO clinlims;
 -- Note: This assumes the analyzer table already exists (legacy table)
 -- We'll create test analyzers with IDs starting from 1000 to avoid conflicts
 
--- Insert test analyzers (analyzer table: id, name, analyzer_type, is_active, last_updated after Liquibase 047)
+-- Insert test analyzers (2-table model: config columns merged onto analyzer row per PR #2802)
 -- Using INSERT ... ON CONFLICT DO NOTHING to allow re-running this script
 -- Note: analyzer_type must match form dropdown options: HEMATOLOGY, CHEMISTRY, IMMUNOLOGY, MICROBIOLOGY, OTHER
-INSERT INTO analyzer (id, name, analyzer_type, is_active, last_updated)
-VALUES
-  (1000, 'Mock Hematology Analyzer (ASTM Simulator)', 'HEMATOLOGY', true, NOW()),
-  (1001, 'Chemistry Analyzer 1', 'CHEMISTRY', true, NOW()),
-  (1002, 'Immunology Analyzer 1', 'IMMUNOLOGY', true, NOW()),
-  (1003, 'Microbiology Analyzer 1', 'MICROBIOLOGY', true, NOW()),
-  (1004, 'Hematology Analyzer 2 (Inactive)', 'HEMATOLOGY', false, NOW())
-ON CONFLICT (id) DO NOTHING;
-
--- Insert analyzer configurations
--- Note: status field uses unified AnalyzerStatus enum: INACTIVE, SETUP, VALIDATION, ACTIVE, ERROR_PENDING, OFFLINE
--- Analyzer 1000 uses the mock server IP (172.20.1.100:5000) for testing
+-- Note: status uses AnalyzerStatus enum: INACTIVE, SETUP, VALIDATION, ACTIVE, ERROR_PENDING, OFFLINE, DELETED
+-- Note: protocol_version uses ProtocolVersion enum: ASTM_LIS2_A2, HL7_V2_3_1, HL7_V2_5
 -- Analyzer 1000 is configured as "newly added" (SETUP status, no fields, no mappings) for testing the initial workflow
-INSERT INTO analyzer_configuration (id, analyzer_id, ip_address, port, protocol_version, test_unit_ids, status, sys_user_id, last_updated)
+INSERT INTO analyzer (id, name, analyzer_type, is_active,
+                      ip_address, port, protocol_version, status, test_unit_ids,
+                      last_updated)
 VALUES
-  ('CONFIG-001', 1000, '172.20.1.100', 5000, 'ASTM LIS2-A2', '1,2,3', 'SETUP', '1', NOW()),
-  ('CONFIG-002', 1001, '192.168.1.101', 8081, 'ASTM LIS2-A2', '1,2', 'ERROR_PENDING', '1', NOW()),
-  ('CONFIG-003', 1002, '192.168.1.102', 8082, 'ASTM LIS2-A2', '1,2,3,4', 'VALIDATION', '1', NOW()),
-  ('CONFIG-004', 1003, '192.168.1.103', 8083, 'ASTM LIS2-A2', '1,2', 'SETUP', '1', NOW()),
-  ('CONFIG-005', 1004, '192.168.1.104', 8084, 'ASTM LIS2-A2', NULL, 'INACTIVE', '1', NOW())
+  (1000, 'Mock Hematology Analyzer (ASTM Simulator)', 'HEMATOLOGY', true,
+   '172.20.1.100', 5000, 'ASTM_LIS2_A2', 'SETUP', '1,2,3', NOW()),
+  (1001, 'Chemistry Analyzer 1', 'CHEMISTRY', true,
+   '192.168.1.101', 8081, 'ASTM_LIS2_A2', 'ERROR_PENDING', '1,2', NOW()),
+  (1002, 'Immunology Analyzer 1', 'IMMUNOLOGY', true,
+   '192.168.1.102', 8082, 'ASTM_LIS2_A2', 'VALIDATION', '1,2,3,4', NOW()),
+  (1003, 'Microbiology Analyzer 1', 'MICROBIOLOGY', true,
+   '192.168.1.103', 8083, 'ASTM_LIS2_A2', 'SETUP', '1,2', NOW()),
+  (1004, 'Hematology Analyzer 2 (Inactive)', 'HEMATOLOGY', false,
+   '192.168.1.104', 8084, 'ASTM_LIS2_A2', 'INACTIVE', NULL, NOW())
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert analyzer fields (expanded for better testing)

--- a/src/test/resources/analyzer-type-linking.sql
+++ b/src/test/resources/analyzer-type-linking.sql
@@ -1,0 +1,34 @@
+-- Analyzer Type Linking SQL
+-- Ensures generic plugin AnalyzerType rows exist and links fixture analyzers.
+-- Extracted from load-test-fixtures.sh for reuse by multiple fixture modes.
+--
+-- Generic plugins (GenericASTM, GenericHL7) don't auto-create analyzer_type rows
+-- via addAnalyzerDatabaseParts() — they only register in-memory via registerAnalyzer().
+-- We must INSERT the analyzer_type rows ourselves so findGenericAnalyzersWithPatterns()
+-- can JOIN on analyzer_type.is_generic_plugin = true.
+
+SET search_path TO clinlims;
+
+-- Ensure GenericASTM analyzer_type exists (ON CONFLICT DO NOTHING if already seeded)
+INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
+VALUES (nextval('analyzer_type_seq'), 'GenericASTM', 'Generic ASTM analyzer plugin',
+        'org.openelisglobal.plugins.analyzer.genericastm.GenericASTMAnalyzer',
+        'ASTM_LIS2_A2', true, true, NOW())
+ON CONFLICT (name) DO NOTHING;
+
+-- Ensure GenericHL7 analyzer_type exists
+INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
+VALUES (nextval('analyzer_type_seq'), 'GenericHL7', 'Generic HL7 analyzer plugin',
+        'org.openelisglobal.plugins.analyzer.generichl7.GenericHL7Analyzer',
+        'HL7_V2_3_1', true, true, NOW())
+ON CONFLICT (name) DO NOTHING;
+
+-- Link GenericASTM analyzers (IDs 2006, 2013 from Feature 011)
+UPDATE analyzer SET analyzer_type_id = (
+  SELECT id FROM analyzer_type WHERE name = 'GenericASTM'
+) WHERE id IN (2006, 2013) AND analyzer_type_id IS NULL;
+
+-- Link GenericHL7 analyzers (IDs 2007, 2008, 2012 from Feature 011)
+UPDATE analyzer SET analyzer_type_id = (
+  SELECT id FROM analyzer_type WHERE name = 'GenericHL7'
+) WHERE id IN (2007, 2008, 2012) AND analyzer_type_id IS NULL;

--- a/src/test/resources/analyzer-type-linking.sql
+++ b/src/test/resources/analyzer-type-linking.sql
@@ -2,33 +2,34 @@
 -- Ensures generic plugin AnalyzerType rows exist and links fixture analyzers.
 -- Extracted from load-test-fixtures.sh for reuse by multiple fixture modes.
 --
--- Generic plugins (GenericASTM, GenericHL7) don't auto-create analyzer_type rows
--- via addAnalyzerDatabaseParts() — they only register in-memory via registerAnalyzer().
--- We must INSERT the analyzer_type rows ourselves so findGenericAnalyzersWithPatterns()
--- can JOIN on analyzer_type.is_generic_plugin = true.
+-- PluginRegistryService auto-creates analyzer_type rows at startup when plugin
+-- JARs are loaded. Names MUST match PluginRegistryService.derivePluginName():
+--   GenericASTMAnalyzer → "Generic ASTM"
+--   GenericHL7Analyzer  → "Generic HL7"
+-- These INSERTs are a fallback for environments without the plugin JAR lifecycle.
 
 SET search_path TO clinlims;
 
--- Ensure GenericASTM analyzer_type exists (ON CONFLICT DO NOTHING if already seeded)
+-- Ensure Generic ASTM analyzer_type exists (ON CONFLICT DO NOTHING if already seeded)
 INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
-VALUES (nextval('analyzer_type_seq'), 'GenericASTM', 'Generic ASTM analyzer plugin',
+VALUES (nextval('analyzer_type_seq'), 'Generic ASTM', 'Generic ASTM - Dashboard-configurable analyzer (requires identifier_pattern)',
         'org.openelisglobal.plugins.analyzer.genericastm.GenericASTMAnalyzer',
-        'ASTM_LIS2_A2', true, true, NOW())
+        'ASTM', true, true, NOW())
 ON CONFLICT (name) DO NOTHING;
 
--- Ensure GenericHL7 analyzer_type exists
+-- Ensure Generic HL7 analyzer_type exists
 INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
-VALUES (nextval('analyzer_type_seq'), 'GenericHL7', 'Generic HL7 analyzer plugin',
+VALUES (nextval('analyzer_type_seq'), 'Generic HL7', 'Generic HL7 - Dashboard-configurable analyzer (requires identifier_pattern)',
         'org.openelisglobal.plugins.analyzer.generichl7.GenericHL7Analyzer',
-        'HL7_V2_3_1', true, true, NOW())
+        'HL7', true, true, NOW())
 ON CONFLICT (name) DO NOTHING;
 
--- Link GenericASTM analyzers (IDs 2006, 2013 from Feature 011)
+-- Link Generic ASTM analyzers (IDs 2006, 2013 from Feature 011)
 UPDATE analyzer SET analyzer_type_id = (
-  SELECT id FROM analyzer_type WHERE name = 'GenericASTM'
+  SELECT id FROM analyzer_type WHERE name = 'Generic ASTM'
 ) WHERE id IN (2006, 2013) AND analyzer_type_id IS NULL;
 
--- Link GenericHL7 analyzers (IDs 2007, 2008, 2012 from Feature 011)
+-- Link Generic HL7 analyzers (IDs 2007, 2008, 2012 from Feature 011)
 UPDATE analyzer SET analyzer_type_id = (
-  SELECT id FROM analyzer_type WHERE name = 'GenericHL7'
+  SELECT id FROM analyzer_type WHERE name = 'Generic HL7'
 ) WHERE id IN (2007, 2008, 2012) AND analyzer_type_id IS NULL;

--- a/src/test/resources/load-test-fixtures.sh
+++ b/src/test/resources/load-test-fixtures.sh
@@ -3,14 +3,20 @@
 # Load Test Fixtures for OpenELIS Global
 # Single unified script for loading ALL E2E test fixtures
 # Supports both Docker and direct psql connections
-# Usage: ./load-test-fixtures.sh [--reset] [--no-verify]
+#
+# Usage: ./load-test-fixtures.sh [--reset] [--no-verify] [--analyzers=MODE]
+#
+# Analyzer modes (--analyzers=MODE):
+#   minimal  - analyzer-minimal.sql only (3 analyzers for focused plugin testing)
+#   legacy   - analyzer-test-data.sql only (Feature 004 UI testing, IDs 1000-1004)
+#   full     - Legacy + generated + type-linking (full regression, default)
+#   none     - Skip all analyzer fixtures (storage/patient only)
 #
 # Files loaded (in order):
 #   1. e2e-foundational-data.sql - Providers, Organizations (base data for ALL tests)
-#   2. analyzer-test-data.sql - Analyzer E2E fixtures (IDs 1000-1004, configs, fields, mappings)
+#   2. Analyzer fixtures (depends on --analyzers= mode)
 #   3. storage-e2e.xml (DBUnit XML) - Storage hierarchy + E2E test data
 #      Converted to SQL on-demand (*.generated.sql files never committed)
-#   4. (Docker only) load-analyzer-test-data.sh --dataset-011 - Madagascar/011 analyzer set (IDs 2000-2012)
 
 set -e
 
@@ -18,32 +24,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 FOUNDATIONAL_SQL_FILE="$SCRIPT_DIR/e2e-foundational-data.sql"
 ANALYZER_SQL_FILE="$SCRIPT_DIR/analyzer-test-data.sql"
-ANALYZER_011_LOADER="$SCRIPT_DIR/load-analyzer-test-data.sh"
+ANALYZER_MINIMAL_SQL_FILE="$SCRIPT_DIR/analyzer-minimal.sql"
+ANALYZER_TYPE_LINKING_SQL="$SCRIPT_DIR/analyzer-type-linking.sql"
 RESET_SCRIPT="$SCRIPT_DIR/reset-test-database.sh"
 
 RESET=false
 VERIFY=true
-
-# SQL to link fixture analyzers to their AnalyzerType records.
-# AnalyzerType IDs are auto-generated at startup by PluginRegistryService, so we
-# match by plugin_class_name (stable) rather than by ID (auto-generated).
-# Only generic plugins (GenericASTM, GenericHL7) are used — no legacy plugins.
-LINK_ANALYZER_TYPES_SQL="
-SET search_path TO clinlims;
--- Link GenericASTM analyzers to their AnalyzerType (auto-created by PluginRegistryService)
-UPDATE analyzer SET analyzer_type_id = (
-  SELECT id FROM analyzer_type
-  WHERE plugin_class_name = 'org.openelisglobal.plugins.analyzer.genericastm.GenericASTMAnalyzer'
-  LIMIT 1
-) WHERE id IN (2006, 2013) AND analyzer_type_id IS NULL;
-
--- Link GenericHL7 analyzers to their AnalyzerType
-UPDATE analyzer SET analyzer_type_id = (
-  SELECT id FROM analyzer_type
-  WHERE plugin_class_name = 'org.openelisglobal.plugins.analyzer.generichl7.GenericHL7Analyzer'
-  LIMIT 1
-) WHERE id IN (2007, 2008, 2012) AND analyzer_type_id IS NULL;
-"
+ANALYZER_MODE="full"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -56,9 +43,18 @@ while [[ $# -gt 0 ]]; do
             VERIFY=false
             shift
             ;;
+        --analyzers=*)
+            ANALYZER_MODE="${1#*=}"
+            if [[ ! "$ANALYZER_MODE" =~ ^(minimal|legacy|full|none)$ ]]; then
+                echo "ERROR: Invalid analyzer mode: $ANALYZER_MODE"
+                echo "Valid modes: minimal, legacy, full, none"
+                exit 1
+            fi
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--reset] [--no-verify]"
+            echo "Usage: $0 [--reset] [--no-verify] [--analyzers=minimal|legacy|full|none]"
             exit 1
             ;;
     esac
@@ -69,7 +65,8 @@ echo "Loading Test Fixtures"
 echo "======================================"
 echo ""
 echo "Foundational SQL: $FOUNDATIONAL_SQL_FILE"
-echo "Storage fixtures: DBUnit XML → Generated SQL (on-demand)"
+echo "Analyzer mode: $ANALYZER_MODE"
+echo "Storage fixtures: DBUnit XML -> Generated SQL (on-demand)"
 if [ "$RESET" = true ]; then
     echo "Reset: Enabled (will reset test data before loading)"
 fi
@@ -84,9 +81,9 @@ if [ ! -f "$FOUNDATIONAL_SQL_FILE" ]; then
     exit 1
 fi
 
-# Check if Python is available (needed for XML→SQL generation)
+# Check if Python is available (needed for XML->SQL generation)
 if ! command -v python3 &> /dev/null; then
-    echo "ERROR: Python 3 not found. Required for XML→SQL conversion."
+    echo "ERROR: Python 3 not found. Required for XML->SQL conversion."
     exit 1
 fi
 
@@ -103,7 +100,7 @@ fi
 
 # Check if converter script exists
 if [ ! -f "$XML_TO_SQL_SCRIPT" ]; then
-    echo "ERROR: XML→SQL converter not found: $XML_TO_SQL_SCRIPT"
+    echo "ERROR: XML->SQL converter not found: $XML_TO_SQL_SCRIPT"
     exit 1
 fi
 
@@ -116,10 +113,10 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Generate analyzer E2E SQL from DBUnit XML (Feature 011, IDs 2000-2012)
+# Generate analyzer E2E SQL from DBUnit XML (Feature 011) — only for full mode
 ANALYZER_E2E_XML="$SCRIPT_DIR/testdata/madagascar-analyzer-test-data.xml"
 ANALYZER_E2E_SQL="$SCRIPT_DIR/testdata/analyzer-e2e.generated.sql"
-if [ -f "$ANALYZER_E2E_XML" ]; then
+if [ "$ANALYZER_MODE" = "full" ] && [ -f "$ANALYZER_E2E_XML" ]; then
     echo "Generating analyzer E2E SQL from DBUnit XML..."
     python3 "$XML_TO_SQL_SCRIPT" "$ANALYZER_E2E_XML" "$ANALYZER_E2E_SQL" \
         --on-conflict-do-nothing
@@ -173,9 +170,9 @@ check_dependencies() {
         # Note: ROOM_COUNT check is optional (will be loaded by DBUnit loader if missing)
         if [ "$TYPE_COUNT" -ge 3 ] && [ "$STATUS_COUNT" -ge 1 ]; then
             if [ "$ROOM_COUNT" -ge 3 ]; then
-                echo "✅ Dependencies verified (type_of_sample: $TYPE_COUNT rows, status_of_sample: required statuses present, storage hierarchy: $ROOM_COUNT rooms)"
+                echo "Dependencies verified (type_of_sample: $TYPE_COUNT rows, status_of_sample: required statuses present, storage hierarchy: $ROOM_COUNT rooms)"
             else
-                echo "✅ Dependencies verified (type_of_sample: $TYPE_COUNT rows, status_of_sample: required statuses present)"
+                echo "Dependencies verified (type_of_sample: $TYPE_COUNT rows, status_of_sample: required statuses present)"
                 echo "   Note: Storage hierarchy will be loaded by DBUnit loader"
             fi
             echo ""
@@ -185,7 +182,7 @@ check_dependencies() {
         # If not all dependencies met, retry
         RETRY_COUNT=$((RETRY_COUNT + 1))
         if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-            echo "⚠️  Dependencies not ready (attempt $RETRY_COUNT/$MAX_RETRIES):"
+            echo "WARNING: Dependencies not ready (attempt $RETRY_COUNT/$MAX_RETRIES):"
             echo "   type_of_sample: $TYPE_COUNT rows (need 3+)"
             echo "   status_of_sample: $STATUS_COUNT 'Entered' rows (need 1+)"
             echo "   storage hierarchy: $ROOM_COUNT rooms (need 3+)"
@@ -206,9 +203,75 @@ check_dependencies() {
         echo "Please ensure database is properly initialized with status values."
         exit 1
     fi
+}
 
-    # Note: Storage hierarchy check removed - it will be loaded by DBUnit loader
-    # (ROOM_COUNT check is informational only, not a hard requirement)
+# Helper: Load a SQL file via Docker or psql (reduces duplication)
+# Usage: load_sql_file <file_path> <label> [fatal]
+# If third arg is "fatal", exit on error; otherwise warn and continue.
+load_sql_file() {
+    local sql_file="$1"
+    local label="$2"
+    local fatal="${3:-nonfatal}"
+
+    if [ ! -f "$sql_file" ]; then
+        if [ "$fatal" = "fatal" ]; then
+            echo "ERROR: $label not found: $sql_file"
+            exit 1
+        else
+            echo "WARNING: $label not found: $sql_file (skipping)"
+            return 0
+        fi
+    fi
+
+    echo "Loading $label..."
+    if [ "$USE_DOCKER" = true ]; then
+        docker exec -i "$DB_CONTAINER" psql -U clinlims -d clinlims < "$sql_file"
+    else
+        psql -U "$DB_USER" -d "$DB_NAME" -h "$DB_HOST" -p "$DB_PORT" -f "$sql_file"
+    fi
+
+    if [ $? -eq 0 ]; then
+        echo "OK: $label loaded"
+    else
+        if [ "$fatal" = "fatal" ]; then
+            echo ""
+            echo "======================================"
+            echo "ERROR loading $label"
+            echo "======================================"
+            exit 1
+        else
+            echo "WARNING: $label had errors (non-fatal)"
+        fi
+    fi
+    echo ""
+}
+
+# Load analyzer fixtures based on --analyzers= mode
+load_analyzer_fixtures() {
+    case "$ANALYZER_MODE" in
+        none)
+            echo "Analyzer mode: none (skipping all analyzer fixtures)"
+            echo ""
+            ;;
+        minimal)
+            load_sql_file "$ANALYZER_MINIMAL_SQL_FILE" "analyzer-minimal.sql (3 analyzers, plugin testing)" "fatal"
+            ;;
+        legacy)
+            load_sql_file "$ANALYZER_SQL_FILE" "analyzer-test-data.sql (Feature 004, IDs 1000-1004)"
+            ;;
+        full)
+            # Load legacy fixtures (IDs 1000-1004)
+            load_sql_file "$ANALYZER_SQL_FILE" "analyzer-test-data.sql (Feature 004, IDs 1000-1004)"
+
+            # Load generated analyzer E2E fixtures (Feature 011, IDs 2006-2013)
+            if [ -f "$ANALYZER_E2E_SQL" ]; then
+                load_sql_file "$ANALYZER_E2E_SQL" "analyzer-e2e.generated.sql (Feature 011)"
+            fi
+
+            # Link fixture analyzers to their AnalyzerType records
+            load_sql_file "$ANALYZER_TYPE_LINKING_SQL" "analyzer-type-linking.sql (plugin type linking)"
+            ;;
+    esac
 }
 
 # Verification function
@@ -224,7 +287,7 @@ verify_fixtures() {
 
     if [ "$USE_DOCKER" = true ]; then
         # Verify storage hierarchy
-        docker exec openelisglobal-database psql -U clinlims -d clinlims -t -c "
+        docker exec "${DB_CONTAINER:-openelisglobal-database}" psql -U clinlims -d clinlims -t -c "
             SELECT
                 'Storage Hierarchy' AS category,
                 'Rooms' AS type, COUNT(*) AS count FROM storage_room WHERE code IN ('MAIN', 'SEC', 'INACTIVE')
@@ -306,13 +369,13 @@ verify_fixtures() {
 
     # Validate counts
     if [ "$ROOM_COUNT" -lt 3 ]; then
-        echo "⚠️  WARNING: Expected 3 test rooms, found $ROOM_COUNT"
+        echo "WARNING: Expected 3 test rooms, found $ROOM_COUNT"
     fi
     if [ "$SAMPLE_COUNT" -lt 10 ]; then
-        echo "⚠️  WARNING: Expected 10+ test samples, found $SAMPLE_COUNT"
+        echo "WARNING: Expected 10+ test samples, found $SAMPLE_COUNT"
     fi
     if [ "$PATIENT_COUNT" -lt 3 ]; then
-        echo "⚠️  WARNING: Expected 3 test patients, found $PATIENT_COUNT"
+        echo "WARNING: Expected 3 test patients, found $PATIENT_COUNT"
     fi
 }
 
@@ -327,95 +390,14 @@ if command -v docker &> /dev/null; then
     fi
 fi
 
-if [ "$USE_DOCKER" = true ]; then
-    # Check dependencies before loading
-    check_dependencies true "" "" "" ""
-
-    # Load foundational data first (providers, organizations)
-    echo "Loading foundational fixtures via Docker..."
-    docker exec -i "$DB_CONTAINER" psql -U clinlims -d clinlims < "$FOUNDATIONAL_SQL_FILE"
-
-    if [ $? -ne 0 ]; then
-        echo ""
-        echo "======================================"
-        echo "❌ Error loading foundational fixtures"
-        echo "======================================"
-        exit 1
-    fi
-
-    echo "✅ Foundational data loaded (providers, organizations)"
-    echo ""
-
-    # Load analyzer E2E fixtures (same as CI frontend-qa; IDs 1000-1004)
-    if [ -f "$ANALYZER_SQL_FILE" ]; then
-        echo "Loading analyzer fixtures via SQL..."
-        docker exec -i "$DB_CONTAINER" psql -U clinlims -d clinlims < "$ANALYZER_SQL_FILE"
-        if [ $? -eq 0 ]; then
-            echo "✅ Analyzer fixtures loaded (analyzer-test-data.sql)"
-        else
-            echo "⚠️  WARNING: Analyzer fixture load had errors (non-fatal)"
-        fi
-        echo ""
-    else
-        echo "⚠️  WARNING: analyzer-test-data.sql not found; skipping analyzer fixtures"
-        echo ""
-    fi
-
-    # Load unified analyzer fixtures (IDs 2000-2012) from canonical SQL
-    if [ -f "$ANALYZER_E2E_SQL" ]; then
-        echo "Loading analyzer fixtures (analyzer-e2e.generated.sql)..."
-        docker exec -i "$DB_CONTAINER" psql -U clinlims -d clinlims < "$ANALYZER_E2E_SQL"
-        if [ $? -eq 0 ]; then
-            echo "✅ Analyzer fixtures loaded (12 analyzers 2000-2012)"
-        else
-            echo "⚠️  WARNING: Analyzer fixture loading failed (non-fatal; manually load if needed: $ANALYZER_E2E_SQL)"
-        fi
-
-        # Link fixture analyzers to their AnalyzerType records
-        echo "Linking fixture analyzers to plugin types..."
-        echo "$LINK_ANALYZER_TYPES_SQL" | docker exec -i "$DB_CONTAINER" psql -U clinlims -d clinlims 2>/dev/null
-        echo "✅ Fixture analyzers linked to plugin types"
-        echo ""
-    fi
-
-    # Load storage hierarchy + E2E test data via generated SQL
-    echo "Loading storage fixtures via generated SQL..."
-    docker exec -i "$DB_CONTAINER" psql -U clinlims -d clinlims < "$STORAGE_SQL"
-
-    if [ $? -eq 0 ]; then
-        echo ""
-        echo "✅ All fixtures loaded successfully!"
-        echo ""
-
-        if [ "$VERIFY" = true ]; then
-            verify_fixtures true "" "" "" ""
-            echo "======================================"
-            echo "✅ Verification complete!"
-            echo "======================================"
-        fi
-
-        echo ""
-        echo "Test data ready for:"
-        echo "  - Manual testing"
-        echo "  - E2E testing (Cypress)"
-        echo "  - Integration testing"
-        echo ""
-    else
-        echo ""
-        echo "======================================"
-        echo "❌ Error loading storage fixtures"
-        echo "======================================"
-        exit 1
-    fi
-else
-    # Use direct psql connection
+# Set up psql connection parameters (used when USE_DOCKER=false)
+if [ "$USE_DOCKER" = false ]; then
     if ! command -v psql &> /dev/null; then
         echo "ERROR: psql not found. Please install PostgreSQL client."
         echo "Alternatively, ensure Docker is running (openelisglobal-database or analyzer-harness DB container)."
         exit 1
     fi
 
-    # Database connection parameters
     DB_USER="${DB_USER:-clinlims}"
     DB_NAME="${DB_NAME:-clinlims}"
     DB_HOST="${DB_HOST:-localhost}"
@@ -425,88 +407,44 @@ else
     echo "Using direct psql connection"
     echo "Database: $DB_NAME@$DB_HOST:$DB_PORT"
     echo "User: $DB_USER"
-    echo ""
-
-    # Check dependencies before loading
-    check_dependencies false "$DB_USER" "$DB_NAME" "$DB_HOST" "$DB_PORT"
-
-    # Load foundational data first
-    echo "Loading foundational test data..."
-    echo ""
-    psql -U "$DB_USER" -d "$DB_NAME" -h "$DB_HOST" -p "$DB_PORT" -f "$FOUNDATIONAL_SQL_FILE"
-
-    if [ $? -ne 0 ]; then
-        echo ""
-        echo "======================================"
-        echo "❌ Error loading foundational data"
-        echo "======================================"
-        exit 1
-    fi
-
-    echo "✅ Foundational data loaded (providers, organizations)"
-    echo ""
-
-    # Load analyzer E2E fixtures (same as CI frontend-qa; IDs 1000-1004)
-    if [ -f "$ANALYZER_SQL_FILE" ]; then
-        echo "Loading analyzer fixtures via SQL..."
-        psql -U "$DB_USER" -d "$DB_NAME" -h "$DB_HOST" -p "$DB_PORT" -f "$ANALYZER_SQL_FILE"
-        if [ $? -eq 0 ]; then
-            echo "✅ Analyzer fixtures loaded (analyzer-test-data.sql)"
-        else
-            echo "⚠️  WARNING: Analyzer fixture load had errors (non-fatal)"
-        fi
-        echo ""
-    else
-        echo "⚠️  WARNING: analyzer-test-data.sql not found; skipping analyzer fixtures"
-        echo ""
-    fi
-
-    # Load unified analyzer fixtures (IDs 2000-2012) from canonical SQL
-    if [ -f "$ANALYZER_E2E_SQL" ]; then
-        echo "Loading analyzer fixtures (analyzer-e2e.generated.sql)..."
-        psql -U "$DB_USER" -d "$DB_NAME" -h "$DB_HOST" -p "$DB_PORT" -f "$ANALYZER_E2E_SQL"
-        if [ $? -eq 0 ]; then
-            echo "✅ Analyzer fixtures loaded (12 analyzers 2000-2012)"
-        else
-            echo "⚠️  WARNING: Analyzer fixture loading failed (non-fatal)"
-        fi
-
-        # Link fixture analyzers to their AnalyzerType records
-        echo "Linking fixture analyzers to plugin types..."
-        echo "$LINK_ANALYZER_TYPES_SQL" | psql -U "$DB_USER" -d "$DB_NAME" -h "$DB_HOST" -p "$DB_PORT" 2>/dev/null
-        echo "✅ Fixture analyzers linked to plugin types"
-        echo ""
-    fi
-
-    # Load storage hierarchy + E2E test data via generated SQL
-    echo "Loading storage fixtures via generated SQL..."
-    psql -U "$DB_USER" -d "$DB_NAME" -h "$DB_HOST" -p "$DB_PORT" -f "$STORAGE_SQL"
-
-    if [ $? -eq 0 ]; then
-        echo ""
-        echo "======================================"
-        echo "✅ All test data loaded successfully!"
-        echo "======================================"
-        echo ""
-
-        if [ "$VERIFY" = true ]; then
-            verify_fixtures false "$DB_USER" "$DB_NAME" "$DB_HOST" "$DB_PORT"
-            echo "======================================"
-            echo "✅ Verification complete!"
-            echo "======================================"
-        fi
-    else
-        echo ""
-        echo "======================================"
-        echo "❌ Error loading storage test data"
-        echo "======================================"
-        echo ""
-        echo "Troubleshooting:"
-        echo "1. Verify PostgreSQL is running"
-        echo "2. Check database credentials"
-        echo "3. Ensure storage tables exist (run Liquibase migrations first)"
-        echo "4. Verify Python 3 is installed for XML→SQL conversion"
-        echo ""
-        exit 1
-    fi
 fi
+echo ""
+
+# Check dependencies before loading
+if [ "$USE_DOCKER" = true ]; then
+    check_dependencies true "" "" "" ""
+else
+    check_dependencies false "$DB_USER" "$DB_NAME" "$DB_HOST" "$DB_PORT"
+fi
+
+# 1. Load foundational data (providers, organizations)
+load_sql_file "$FOUNDATIONAL_SQL_FILE" "foundational fixtures (providers, organizations)" "fatal"
+
+# 2. Load analyzer fixtures (based on --analyzers= mode)
+load_analyzer_fixtures
+
+# 3. Load storage hierarchy + E2E test data via generated SQL
+load_sql_file "$STORAGE_SQL" "storage fixtures (generated SQL)" "fatal"
+
+echo "======================================"
+echo "All fixtures loaded successfully!"
+echo "======================================"
+echo ""
+
+if [ "$VERIFY" = true ]; then
+    if [ "$USE_DOCKER" = true ]; then
+        verify_fixtures true "" "" "" ""
+    else
+        verify_fixtures false "$DB_USER" "$DB_NAME" "$DB_HOST" "$DB_PORT"
+    fi
+    echo "======================================"
+    echo "Verification complete!"
+    echo "======================================"
+fi
+
+echo ""
+echo "Test data ready for:"
+echo "  - Manual testing"
+echo "  - E2E testing (Cypress)"
+echo "  - Integration testing"
+echo ""

--- a/src/test/resources/testdata/madagascar-analyzer-test-data.xml
+++ b/src/test/resources/testdata/madagascar-analyzer-test-data.xml
@@ -2,15 +2,13 @@
 <!-- Madagascar Analyzer Test Data (DBUnit Flat XML Dataset) Feature: specs/011-madagascar-analyzer-integration
     Usage: executeDataSetWithStateManagement("testdata/madagascar-analyzer-test-data.xml")
     Contents: - 5 Active Analyzers (IDs 2006-2008, 2012-2013) using ONLY GenericASTM
-    / GenericHL7 plugins - 5 Analyzer Configurations (protocol metadata) - 4
-    Test Mappings for GeneXpert ASTM (analyzer_test_map) ID Range: 2006-2013
-    (reserved for Feature 011, avoids conflict with Feature 004 IDs 1000-1004)
-    NOTE: identifier_pattern is on the analyzer row (not analyzer_configuration)
-    because the runtime DAO query (AnalyzerDAOImpl.findGenericAnalyzersWithPatterns)
-    reads analyzer.identifier_pattern joined with analyzer_type.is_generic_plugin.
-    NOTE: analyzer_type_id is set post-load by LINK_ANALYZER_TYPES_SQL in load-test-fixtures.sh,
-    which matches by plugin_class_name on analyzer_type (auto-created at startup
-    by PluginRegistryService). Reference: specs/011-madagascar-analyzer-integration/plans/genexpert-astm-e2e-readiness.md -->
+    / GenericHL7 plugins - 4 Test Mappings for GeneXpert ASTM (analyzer_test_map)
+    ID Range: 2006-2013 (reserved for Feature 011, avoids conflict with Feature
+    004 IDs 1000-1004) Schema: 2-table model (analyzer_type + analyzer) after
+    PR #2802 merge. Config columns (ip_address, port, protocol_version, status)
+    live on the analyzer row. NOTE: analyzer_type_id is set post-load by analyzer-type-linking.sql
+    (or LINK_ANALYZER_TYPES_SQL), which matches by plugin_class_name on analyzer_type
+    (auto-created at startup by PluginRegistryService). Reference: specs/011-madagascar-analyzer-integration/plans/genexpert-astm-e2e-readiness.md -->
 <dataset>
     <!-- ================================================================= -->
     <!-- ANALYZERS (GenericASTM + GenericHL7 only) -->
@@ -21,62 +19,36 @@
     <analyzer id="2006" name="Mindray BA-88A"
         analyzer_type="CHEMISTRY" DESCRIPTION="ASTM over RS232 Serial"
         identifier_pattern="MINDRAY.*BA-88A|BA88A" is_active="true"
-        last_updated="2026-02-02 00:00:00" />
+        ip_address="172.20.1.100" port="9600" protocol_version="ASTM_LIS2_A2"
+        status="ACTIVE" last_updated="2026-02-02 00:00:00" />
 
     <!-- ID 2007: Mindray BC-5380 (GenericHL7 / HEMATOLOGY) -->
     <analyzer id="2007" name="Mindray BC-5380"
         analyzer_type="HEMATOLOGY" DESCRIPTION="HL7 v2.3.1 over TCP/IP (MLLP)"
         identifier_pattern="MINDRAY.*BC.?5380|BC5380" is_active="true"
-        last_updated="2026-02-02 00:00:00" />
+        ip_address="172.20.1.101" port="5562" protocol_version="HL7_V2_3_1"
+        status="ACTIVE" last_updated="2026-02-02 00:00:00" />
 
     <!-- ID 2008: Mindray BS-360E (GenericHL7 / CHEMISTRY) -->
     <analyzer id="2008" name="Mindray BS-360E"
         analyzer_type="CHEMISTRY" DESCRIPTION="HL7 v2.3.1 over TCP/IP (MLLP)"
         identifier_pattern="MINDRAY.*BS.?360E|BS360E" is_active="true"
-        last_updated="2026-02-02 00:00:00" />
+        ip_address="172.20.1.102" port="5563" protocol_version="HL7_V2_3_1"
+        status="ACTIVE" last_updated="2026-02-02 00:00:00" />
 
     <!-- ID 2012: Mindray BC2000 (GenericHL7 / HEMATOLOGY) -->
     <analyzer id="2012" name="Mindray BC2000"
         analyzer_type="HEMATOLOGY" DESCRIPTION="HL7 v2.3.1 over TCP/IP (MLLP)"
         identifier_pattern="MINDRAY.*BC.?2000" is_active="true"
-        last_updated="2026-02-02 00:00:00" />
+        ip_address="172.20.1.103" port="5564" protocol_version="HL7_V2_3_1"
+        status="ACTIVE" last_updated="2026-02-02 00:00:00" />
 
-    <!-- ID 2013: GeneXpert ASTM Mode (GenericASTM / MOLECULAR) — NEW -->
+    <!-- ID 2013: GeneXpert ASTM Mode (GenericASTM / MOLECULAR) -->
     <analyzer id="2013" name="Cepheid GeneXpert (ASTM Mode)"
-        analyzer_type="MOLECULAR" DESCRIPTION="ASTM E-1394-97 over TCP/IP"
+        analyzer_type="MOLECULAR" DESCRIPTION="ASTM LIS2-A2 over TCP/IP"
         identifier_pattern="GENEXPERT|CEPHEID" is_active="true"
-        last_updated="2026-02-02 00:00:00" />
-
-    <!-- ================================================================= -->
-    <!-- ANALYZER CONFIGURATIONS (protocol metadata only) -->
-    <!-- identifier_pattern and is_generic_plugin removed — runtime reads -->
-    <!-- these from analyzer and analyzer_type tables respectively. -->
-    <!-- ================================================================= -->
-
-    <!-- CONFIG-2006: Mindray BA-88A (ASTM RS232) -->
-    <analyzer_configuration id="CONFIG-2006"
-        analyzer_id="2006" protocol_version="ASTM LIS2-A2" status="ACTIVE"
-        sys_user_id="1" last_updated="2026-02-02 00:00:00" />
-
-    <!-- CONFIG-2007: Mindray BC-5380 (HL7 TCP) -->
-    <analyzer_configuration id="CONFIG-2007"
-        analyzer_id="2007" protocol_version="HL7 v2.3.1" status="ACTIVE"
-        sys_user_id="1" last_updated="2026-02-02 00:00:00" />
-
-    <!-- CONFIG-2008: Mindray BS-360E (HL7 TCP) -->
-    <analyzer_configuration id="CONFIG-2008"
-        analyzer_id="2008" protocol_version="HL7 v2.3.1" status="ACTIVE"
-        sys_user_id="1" last_updated="2026-02-02 00:00:00" />
-
-    <!-- CONFIG-2012: Mindray BC2000 (HL7 TCP) -->
-    <analyzer_configuration id="CONFIG-2012"
-        analyzer_id="2012" protocol_version="HL7 v2.3.1" status="ACTIVE"
-        sys_user_id="1" last_updated="2026-02-02 00:00:00" />
-
-    <!-- CONFIG-2013: GeneXpert ASTM Mode (TCP/IP or RS232) -->
-    <analyzer_configuration id="CONFIG-2013"
-        analyzer_id="2013" protocol_version="ASTM E-1394-97" status="ACTIVE"
-        sys_user_id="1" last_updated="2026-02-02 00:00:00" />
+        ip_address="172.20.1.110" port="9600" protocol_version="ASTM_LIS2_A2"
+        status="ACTIVE" last_updated="2026-02-02 00:00:00" />
 
     <!-- ================================================================= -->
     <!-- TEST MAPPINGS for GeneXpert ASTM (ID 2013) -->
@@ -84,23 +56,23 @@
     <!-- test_id = FK to clinlims.test (using foundational test IDs) -->
     <!-- ================================================================= -->
 
-    <!-- MTB-RIF → Blood Test (placeholder test_id=101) -->
+    <!-- MTB-RIF → Glucose (test_id=3, placeholder for E2E routing) -->
     <analyzer_test_map analyzer_id="2013"
-        analyzer_test_name="MTB-RIF" test_id="101"
+        analyzer_test_name="MTB-RIF" test_id="3"
         last_updated="2026-02-02 00:00:00" />
 
-    <!-- RIF → Urine Test (placeholder test_id=102) -->
+    <!-- RIF → Amylase (test_id=5, placeholder for E2E routing) -->
     <analyzer_test_map analyzer_id="2013"
-        analyzer_test_name="RIF" test_id="102"
+        analyzer_test_name="RIF" test_id="5"
         last_updated="2026-02-02 00:00:00" />
 
-    <!-- HIV-VL → Glucose Test (placeholder test_id=103) -->
+    <!-- HIV-VL → CD4 absolute count (test_id=192, placeholder for E2E routing) -->
     <analyzer_test_map analyzer_id="2013"
-        analyzer_test_name="HIV-VL" test_id="103"
+        analyzer_test_name="HIV-VL" test_id="192"
         last_updated="2026-02-02 00:00:00" />
 
-    <!-- COVID19 → Blood Test (placeholder test_id=101) -->
+    <!-- COVID19 → Glucose (test_id=3, placeholder for E2E routing) -->
     <analyzer_test_map analyzer_id="2013"
-        analyzer_test_name="COVID19" test_id="101"
+        analyzer_test_name="COVID19" test_id="3"
         last_updated="2026-02-02 00:00:00" />
 </dataset>


### PR DESCRIPTION
## Summary
- **Remove all references** to the deleted `analyzer_configuration` table from test fixtures (`analyzer-test-data.sql`, `madagascar-analyzer-test-data.xml`, `load-test-fixtures.sh`)
- **Add config columns** (`ip_address`, `port`, `protocol_version`, `status`) directly to `analyzer` INSERT/elements with correct Java enum names (`ASTM_LIS2_A2` not `ASTM LIS2-A2`)
- **Create `analyzer-minimal.sql`** — self-contained 3-analyzer fixture for focused plugin testing (2-table model)
- **Extract `analyzer-type-linking.sql`** — reusable GenericASTM/GenericHL7 type creation + FK linking
- **Add `--analyzers=` flag** to `load-test-fixtures.sh` with modes: `minimal`, `legacy`, `full` (default), `none`
- **Fix `data-model.md`** — add missing `DELETED` status to AnalyzerStatus list

## Context

PR #2802 (M21 refactor) correctly merged `analyzer_configuration` columns onto `analyzer`, but fixture files were never updated. INSERTs into the deleted table either fail silently or write to a dead table.

| Finding | Severity | Fixed |
|---------|----------|-------|
| `analyzer-test-data.sql` INSERTs into non-existent table | CRITICAL | Removed phantom block, added config to analyzer row |
| `madagascar-analyzer-test-data.xml` references deleted table | CRITICAL | Removed `<analyzer_configuration>` elements |
| `load-test-fixtures.sh` has embedded SQL without `protocol` column | CRITICAL | Extracted to standalone file with `protocol` |
| Fixtures use human labels (`ASTM LIS2-A2`) not enum names (`ASTM_LIS2_A2`) | CRITICAL | All values use Java enum constants |
| `analyzer_test_map` used non-existent `test_id=101` | CRITICAL | Use Liquibase-seeded IDs (3, 5, 192) |
| `data-model.md` missing `DELETED` from AnalyzerStatus | MEDIUM | Added |

## Test plan
- [x] Verified `--analyzers=minimal` loads 3 analyzers with correct enum values on fresh DB
- [x] Verified `analyzer_type_id` FK linking works (3/3 linked)
- [x] Verified 4 GeneXpert test mappings load with valid FK test_ids
- [x] Verified `findGenericAnalyzersWithPatterns()` query returns 3 rows
- [x] Verified zero `analyzer_configuration` references remain in modified files
- [x] Shell syntax validation passes (`bash -n`)
- [ ] CI passes (no Java code changes, only SQL/XML/shell fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)