### PR TITLE
fix(storage): correct status badge and improve location search in Sam…

### DIFF
--- a/frontend/src/components/storage/StorageDashboard.jsx
+++ b/frontend/src/components/storage/StorageDashboard.jsx
@@ -2822,22 +2822,27 @@ const StorageDashboard = () => {
       // Secondary context: Parent Sample accession number
       const sampleAccessionNumber = sampleItem.sampleAccessionNumber || "";
 
+      // Backend returns "status" as a status ID (or "active" as default string when no statusId).
+      // For UI purposes, treat anything other than the default "active" string as "disposed".
+      const statusId = sampleItem.status || "";
+      const isDisposed =
+        statusId &&
+        statusId.toString().toLowerCase() !== "active";
+
       return {
         id: sampleItemId, // Use sampleItemId for row ID
         sampleItemId: displayId, // Display: External ID if available, otherwise ID
         sampleAccessionNumber: sampleAccessionNumber, // Parent Sample accession for context
         type: sampleItem.type || sampleItem.sampleType || "",
-        status:
-          sampleItem.status === "disposed" ||
-          sampleItem.status === "Disposed" ? (
-            <Tag type="red">
-              <FormattedMessage id="storage.status.disposed" />
-            </Tag>
-          ) : (
-            <Tag type="green">
-              <FormattedMessage id="label.active" />
-            </Tag>
-          ),
+        status: isDisposed ? (
+          <Tag type="red">
+            <FormattedMessage id="storage.status.disposed" />
+          </Tag>
+        ) : (
+          <Tag type="green">
+            <FormattedMessage id="label.active" />
+          </Tag>
+        ),
         location: sampleItem.location || sampleItem.hierarchicalPath || "",
         assignedBy: sampleItem.assignedBy || sampleItem.assignedByUserId || "",
         date: sampleItem.date || sampleItem.assignedDate || "",

--- a/frontend/src/components/storage/StorageDashboard/LocationAutocomplete.jsx
+++ b/frontend/src/components/storage/StorageDashboard/LocationAutocomplete.jsx
@@ -13,7 +13,7 @@ import "./LocationAutocomplete.css";
  * - onSearchTermChange: function - Callback when search term changes
  * - allowInactive: boolean - Allow selection of inactive locations (default: false)
  */
-const LocationAutocomplete = ({
+  const LocationAutocomplete = ({
   onLocationSelect,
   searchTerm,
   onSearchTermChange,
@@ -25,14 +25,15 @@ const LocationAutocomplete = ({
 
   // Perform search when searchTerm changes
   const performSearch = useCallback((term) => {
-    if (!term || term.trim().length < 2) {
+    const trimmed = term ? term.trim() : "";
+    if (!trimmed || trimmed.length < 2) {
       setSearchResults([]);
       return;
     }
 
     setIsLoading(true);
     getFromOpenElisServer(
-      `/rest/storage/locations/search?q=${encodeURIComponent(term)}`,
+      `/rest/storage/locations/search?q=${encodeURIComponent(trimmed)}`,
       (results) => {
         // Ensure results is an array - API might return non-array
         const resultsArray = Array.isArray(results) ? results : [];


### PR DESCRIPTION
…# Pull Requests Requirements

* [x] The PR title includes a brief description of the work done, including the Issue number.
* [x] The PR includes a video showing the changes for the work done.
* [x] The PR title follows conventional commit label standards.
* [x] The changes conform to the OpenELIS Global x3 Styleguide and Design documentation.
* [x] The changes include tests or are validated by existing tests.
* [x] I have read and agree to the Contributing Guidelines of this project.

---

## Summary

This PR fixes the **status badge inconsistency in the Sample Items tab** of the Storage Dashboard.

When filtering by **Disposed**, the backend correctly returns disposed records, but the UI still displayed the **Active** badge.

### Root Cause

The backend returns the `status` field as a **status ID** (or `"active"` when no status ID exists).
However, the frontend logic expected literal values such as `"active"` or `"disposed"`.

Because of this mismatch, the UI always displayed the **Active** badge.

### Changes

* Updated `formatSamplesData` in `StorageDashboard.jsx` to correctly interpret the backend `status` value and render the appropriate status badge.
* Added a small robustness improvement to the **location search** by trimming the search input before sending the query.

### Result

* Disposed records now display the **Disposed (red) badge**.
* Active records display the **Active (green) badge**.
* Location search behaves more reliably when users enter text with leading or trailing spaces.

---

## Screenshots

Before Fix
Filtering by **Disposed** returned correct records but the badge still showed **Active**.

After Fix
Filtering by **Disposed** correctly displays the **Disposed** badge for those records.

(Attached screenshots / video demonstrating the behavior.)

---

## Related Issue

Closes #2989

---

## Other

The fix maintains the existing UI logic while ensuring the status badge reflects the actual record state returned by the backend.
The change is limited to frontend display logic and does not affect backend behavior.

