### PR TITLE
feat(OGC-284): finish M2 persistence verification and hardening

### DIFF
--- a/.specify/oe/commands/daily-priorities.md
+++ b/.specify/oe/commands/daily-priorities.md
@@ -107,22 +107,20 @@ Deduplicate by issue key across all queries.
 
 ### Step 3: Build the Report
 
-The report has **two major sections**: a short recommendation up front, then
-the full data so the user can evaluate it. Structure it exactly like this:
+The report has **two major sections**: a short recommendation up front, then the
+full data so the user can evaluate it. Structure it exactly like this:
 
 ```markdown
 ## Daily Priorities — [Date]
 
 ### Suggested Focus (top 3)
 
-1. **KEY** — Summary
-   _[Why: deadline in N days / only High priority / active momentum / unblocks N other tickets / production issue]_
+1. **KEY** — Summary _[Why: deadline in N days / only High priority / active
+   momentum / unblocks N other tickets / production issue]_
 
-2. **KEY** — Summary
-   _[Why: ...]_
+2. **KEY** — Summary _[Why: ...]_
 
-3. **KEY** — Summary
-   _[Why: ...]_
+3. **KEY** — Summary _[Why: ...]_
 
 > `/start-ticket KEY` to begin | `/start-ticket KEY --speckit` for spec-driven
 
@@ -133,62 +131,66 @@ the full data so the user can evaluate it. Structure it exactly like this:
 **[M] In Progress | [M] To Do / Selected | [M] Backlog | [M] Overdue**
 
 #### In Progress
+
 _Finish these before starting new work. Context switching is expensive._
 
 | Key | Summary | Priority | Due | Labels | Updated |
-|-----|---------|----------|-----|--------|---------|
-| ... | ... | ... | ... | ... | ... |
+| --- | ------- | -------- | --- | ------ | ------- |
+| ... | ...     | ...      | ... | ...    | ...     |
 
 #### Overdue
+
 _Past due date — address or reschedule._
 
 | Key | Summary | Due | Days Late | Priority |
-|-----|---------|-----|-----------|----------|
-| ... | ... | ... | ... | ... |
+| --- | ------- | --- | --------- | -------- |
+| ... | ...     | ... | ...       | ...      |
 
 _(If none: "None — you're current on deadlines.")_
 
 #### To Do + Selected for Development
+
 _Ready to start. Sorted by priority then recency._
 
 | Key | Summary | Priority | Type | Labels | Updated |
-|-----|---------|----------|------|--------|---------|
-| ... | ... | ... | ... | ... | ... |
+| --- | ------- | -------- | ---- | ------ | ------- |
+| ... | ...     | ...      | ...  | ...    | ...     |
 
 #### Backlog (To be assigned status / Low priority)
+
 _Parked. Don't start these unless the above sections are empty._
 
 | Key | Summary | Type | Labels | Updated |
-|-----|---------|------|--------|---------|
-| ... | ... | ... | ... | ... |
+| --- | ------- | ---- | ------ | ------- |
+| ... | ...     | ...  | ...    | ...     |
 
 ---
 
 ### Unassigned Pool ([N] tickets without an owner)
 
-_These are open tickets across OGC, MG, OEDIGI, HAITI with no assignee.
-Items here may need your attention or could be claimed for the sprint._
+_These are open tickets across OGC, MG, OEDIGI, HAITI with no assignee. Items
+here may need your attention or could be claimed for the sprint._
 
 #### Needs Attention (recently created, high priority, or production issues)
 
 | Key | Summary | Priority | Status | Project | Updated |
-|-----|---------|----------|--------|---------|---------|
-| ... | ... | ... | ... | ... | ... |
+| --- | ------- | -------- | ------ | ------- | ------- |
+| ... | ...     | ...      | ...    | ...     | ...     |
 
 _(Flag: crash reports, "Down" in title, Highest/High priority, created today)_
 
 #### Unassigned In Progress (orphaned — someone started but no owner)
 
 | Key | Summary | Status | Project | Labels | Updated |
-|-----|---------|--------|---------|--------|---------|
-| ... | ... | ... | ... | ... | ... |
+| --- | ------- | ------ | ------- | ------ | ------- |
+| ... | ...     | ...    | ...     | ...    | ...     |
 
 _(If none: skip this section)_
 
 #### Unassigned Backlog (informational)
 
-**[N] more unassigned tickets** in backlog across OGC ([n]), MG ([n]),
-HAITI ([n]), OEDIGI ([n]).
+**[N] more unassigned tickets** in backlog across OGC ([n]), MG ([n]), HAITI
+([n]), OEDIGI ([n]).
 
 [Top 5-10 by recency, then "and N more..."]
 
@@ -224,8 +226,8 @@ After the report, offer these actions:
 - **Surface anomalies.** Orphaned In Progress tickets, stale items, test junk,
   broken due dates — these are the things a human would miss scanning Jira
   boards.
-- **Country labels = urgency.** Madagascar, Indonesia, PNG labels indicate
-  real deployments. Always factor these into suggestions.
+- **Country labels = urgency.** Madagascar, Indonesia, PNG labels indicate real
+  deployments. Always factor these into suggestions.
 - **Counts everywhere.** Header counts let the user gut-check scope instantly:
   "23 assigned, 50 unassigned, 0 overdue" tells a story before reading any
   table.

--- a/.specify/oe/commands/finish-ticket.md
+++ b/.specify/oe/commands/finish-ticket.md
@@ -40,8 +40,8 @@ git status --porcelain             # Uncommitted changes
 gh pr view --json number,title,baseRefName,url,isDraft  # PR info
 ```
 
-- Extract **Jira key** from branch name (pattern: `<type>/<KEY>-<slug>`) or
-  from the `$ARGUMENTS`
+- Extract **Jira key** from branch name (pattern: `<type>/<KEY>-<slug>`) or from
+  the `$ARGUMENTS`
 - If uncommitted changes exist, **warn and ask**: commit first or continue?
 - If no PR exists, warn but continue (user may want to create one after)
 
@@ -103,8 +103,8 @@ If tests fail → stop and report.
 
 **Skip if `--quick`.**
 
-Run the `/audit-branch` command logic (Tier 1+2 by default, Tier 3 if
-`--deep` was passed).
+Run the `/audit-branch` command logic (Tier 1+2 by default, Tier 3 if `--deep`
+was passed).
 
 This checks for:
 
@@ -113,11 +113,11 @@ This checks for:
 - Constitution violations (layered architecture, Carbon DS, i18n)
 - Scope creep, over-engineering, unused imports
 
-**If CRITICAL or HIGH findings exist:** Stop and present findings. The user
-must address them before proceeding.
+**If CRITICAL or HIGH findings exist:** Stop and present findings. The user must
+address them before proceeding.
 
-**If only MEDIUM/LOW/INFO findings:** Present findings as advisory but
-continue. Ask: "Address these now, or proceed to PR?"
+**If only MEDIUM/LOW/INFO findings:** Present findings as advisory but continue.
+Ask: "Address these now, or proceed to PR?"
 
 ### Step 5: PR Readiness
 

--- a/.specify/oe/commands/start-ticket.md
+++ b/.specify/oe/commands/start-ticket.md
@@ -1,8 +1,8 @@
 # Start Ticket
 
 Set up a development environment for a Jira ticket: fetch details, create
-branch, optionally create a draft PR and transition Jira status. Integrates
-with SpecKit for spec-driven development.
+branch, optionally create a draft PR and transition Jira status. Integrates with
+SpecKit for spec-driven development.
 
 ## User Input
 
@@ -31,8 +31,7 @@ First argument is the Jira issue key. Additional flags:
 ### Step 1: Fetch Jira Ticket
 
 Use `mcp__claude_ai_Atlassian__getJiraIssue` with cloud ID above. Fields:
-`["summary", "description", "status", "priority", "issuetype", "labels",
-"sprint", "parent", "issuelinks"]`
+`["summary", "description", "status", "priority", "issuetype", "labels", "sprint", "parent", "issuelinks"]`
 
 Display a brief summary:
 
@@ -46,13 +45,13 @@ Labels: Madagascar | Parent: OGC-49
 
 **Branch name pattern:** `<type>/<KEY>-<slug>`
 
-| Jira Type     | Prefix |
-| ------------- | ------ |
-| Bug           | fix    |
-| Story         | feat   |
-| Task          | chore  |
-| Epic          | epic   |
-| Sub-task      | feat   |
+| Jira Type | Prefix |
+| --------- | ------ |
+| Bug       | fix    |
+| Story     | feat   |
+| Task      | chore  |
+| Epic      | epic   |
+| Sub-task  | feat   |
 
 Slugify: lowercase, hyphens, truncate to ~50 chars at word boundary.
 
@@ -83,9 +82,9 @@ Push and create a draft PR:
 git push -u origin "$BRANCH_NAME"
 ```
 
-**PR title:** `<type>(<project>): <short summary> (<KEY>)`
-**PR body:** Generated from Jira description — summary bullets, link to Jira
-ticket, acceptance criteria if available.
+**PR title:** `<type>(<project>): <short summary> (<KEY>)` **PR body:**
+Generated from Jira description — summary bullets, link to Jira ticket,
+acceptance criteria if available.
 
 ```bash
 gh pr create --draft --title "$TITLE" --body "$BODY" --base "$BASE_BRANCH"
@@ -129,8 +128,8 @@ Started: OGC-337 — Implement Generic ASTM Plugin v1.1/1.2
 
 ## Lifecycle & Jira Sync
 
-This command is the **entry point** of the development cycle. It syncs Jira
-to "In Progress." Other commands handle later transitions:
+This command is the **entry point** of the development cycle. It syncs Jira to
+"In Progress." Other commands handle later transitions:
 
 ```
 /daily-priorities             ← Pick what to work on

--- a/specs/OGC-284-barcode-label-quantity-management/quickstart.md
+++ b/specs/OGC-284-barcode-label-quantity-management/quickstart.md
@@ -157,3 +157,40 @@ git submodule update --init --recursive
 cd dataexport && mvn clean install -DskipTests -Dmaven.test.skip=true && cd ..
 mvn test -Dtest="BarcodeConfigurationRestControllerTest,BarcodeInformationServiceTest"
 ```
+
+---
+
+## M2 execution evidence (2026-03-10)
+
+### Branch/workflow
+
+- Active milestone branch:
+  `feat/284-barcode-label-quantity-management-m2-persistence-upsert`
+- Branch created from current OGC-284 feature head to preserve remediated
+  artifacts.
+
+### FR-010 and persistence hardening evidence
+
+- Pathology supplied-only wiring added:
+  - `PathologySampleForm` includes optional pathology label count inputs.
+  - `PathologySampleServiceImpl` calls
+    `saveBarcodeInfoForSampleAndSampleItemsPathology(...)` only when all
+    pathology counts are supplied.
+- Generic sample order persistence hardening added:
+  - null-safe default fields fallback in `GenericSampleOrderServiceImpl`
+  - quantity fallback helper enforces default `1` for null/non-positive values
+  - `@Min(1)` validation annotations on generic sample label count form fields
+
+### Test execution evidence
+
+- Command:
+  `mvn -Dtest=GenericSampleOrderServiceImplTest,BarcodeInfoServiceImplTest,PathologySampleServiceImplTest,HibernateMappingValidationTest,BarcodeSchemaValidationTest test`
+- Result: PASS (21 tests, 0 failures, 0 errors)
+- Coverage highlights:
+  - Generic sample order default/explicit/null-safe persistence tests
+  - Pathology FR-010 supplied-only workflow wiring tests
+  - Barcode helper upsert/dedup pathology coverage (including no-sample-item
+    behavior)
+  - ORM mapping validation for barcode entities
+  - Liquibase/schema changeset verification for `base.xml`,
+    `028-barcode-info-tables.xml`, and `barcode_expansion.xml`

--- a/specs/OGC-284-barcode-label-quantity-management/tasks.md
+++ b/specs/OGC-284-barcode-label-quantity-management/tasks.md
@@ -117,7 +117,7 @@ inputs persist FR-010 specimen/block/slide/freezer quantities when supplied.
       changesets (`base.xml`, `028-barcode-info-tables.xml`,
       `barcode_expansion.xml`) in
       `src/test/java/org/openelisglobal/barcode/BarcodeSchemaValidationTest.java`
-- [ ] T020 Create milestone PR for M2 with verification details
+- [x] T020 Create milestone PR for M2 with verification details
 
 ---
 

--- a/specs/OGC-284-barcode-label-quantity-management/tasks.md
+++ b/specs/OGC-284-barcode-label-quantity-management/tasks.md
@@ -82,22 +82,29 @@ fallback safely; localized labels render correctly.
 **Stories**: US2  
 **Depends On**: M1  
 **Independent Test**: Generic sample order stores default/explicit quantities,
-updates existing barcode metadata without duplication, and persists sample-item
-metadata whenever sample items are created.
+updates existing barcode metadata without duplication, persists sample-item
+metadata whenever sample items are created, and pathology workflow/service
+inputs persist FR-010 specimen/block/slide/freezer quantities when supplied.
 
-- [ ] T013 Create milestone branch
+- [x] T013 Create milestone branch
       `feat/284-barcode-label-quantity-management-m2-persistence-upsert` from
       `develop` and add worktree at
       `/workspace-worktrees/ogc-284-m2-persistence-upsert`
-- [ ] T014 [P] [US2] Extend default-value and upsert/dedup tests in
+- [ ] T014 [P] [US2] Extend default-value and upsert/dedup tests, including
+      explicit FR-010 pathology helper coverage, in
       `src/test/java/org/openelisglobal/barcode/service/BarcodeInfoServiceImplTest.java`
 - [ ] T015 [P] [US2] Create service-level generic sample order persistence tests
       in
       `src/test/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImplTest.java`
 - [ ] T016 [US2] Ensure default quantity application and null-safe handling in
       `src/main/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImpl.java`
-- [ ] T017 [US2] Verify and harden sample and sample-item upsert behavior in
-      `src/main/java/org/openelisglobal/barcode/service/BarcodeInfoServiceImpl.java`
+- [x] T017 [US2] Verify and harden sample and sample-item upsert behavior,
+      including explicit FR-010 pathology workflow/service wiring (supplied-only
+      semantics), in
+      `src/main/java/org/openelisglobal/barcode/service/BarcodeInfoServiceImpl.java`,
+      `src/main/java/org/openelisglobal/program/service/PathologySampleServiceImpl.java`,
+      and
+      `src/main/java/org/openelisglobal/program/controller/pathology/PathologySampleForm.java`
 - [ ] T018 [US2] Align form contract for label quantity fields (optional + valid
       values) in
       `src/main/java/org/openelisglobal/genericsample/form/GenericSampleOrderForm.java`

--- a/specs/OGC-284-barcode-label-quantity-management/tasks.md
+++ b/specs/OGC-284-barcode-label-quantity-management/tasks.md
@@ -90,13 +90,13 @@ inputs persist FR-010 specimen/block/slide/freezer quantities when supplied.
       `feat/284-barcode-label-quantity-management-m2-persistence-upsert` from
       `develop` and add worktree at
       `/workspace-worktrees/ogc-284-m2-persistence-upsert`
-- [ ] T014 [P] [US2] Extend default-value and upsert/dedup tests, including
+- [x] T014 [P] [US2] Extend default-value and upsert/dedup tests, including
       explicit FR-010 pathology helper coverage, in
       `src/test/java/org/openelisglobal/barcode/service/BarcodeInfoServiceImplTest.java`
-- [ ] T015 [P] [US2] Create service-level generic sample order persistence tests
+- [x] T015 [P] [US2] Create service-level generic sample order persistence tests
       in
       `src/test/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImplTest.java`
-- [ ] T016 [US2] Ensure default quantity application and null-safe handling in
+- [x] T016 [US2] Ensure default quantity application and null-safe handling in
       `src/main/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImpl.java`
 - [x] T017 [US2] Verify and harden sample and sample-item upsert behavior,
       including explicit FR-010 pathology workflow/service wiring (supplied-only
@@ -105,15 +105,15 @@ inputs persist FR-010 specimen/block/slide/freezer quantities when supplied.
       `src/main/java/org/openelisglobal/program/service/PathologySampleServiceImpl.java`,
       and
       `src/main/java/org/openelisglobal/program/controller/pathology/PathologySampleForm.java`
-- [ ] T018 [US2] Align form contract for label quantity fields (optional + valid
+- [x] T018 [US2] Align form contract for label quantity fields (optional + valid
       values) in
       `src/main/java/org/openelisglobal/genericsample/form/GenericSampleOrderForm.java`
-- [ ] T019 [US2] Run milestone tests and record verification evidence in
+- [x] T019 [US2] Run milestone tests and record verification evidence in
       `specs/OGC-284-barcode-label-quantity-management/quickstart.md`
-- [ ] T041 [US2] Add ORM validation test for `SampleBarcodeInfo` and
+- [x] T041 [US2] Add ORM validation test for `SampleBarcodeInfo` and
       `SampleItemBarcodeInfo` mappings in
       `src/test/java/org/openelisglobal/barcode/HibernateMappingValidationTest.java`
-- [ ] T042 [US2] Add Liquibase/schema verification test for existing OGC-284
+- [x] T042 [US2] Add Liquibase/schema verification test for existing OGC-284
       changesets (`base.xml`, `028-barcode-info-tables.xml`,
       `barcode_expansion.xml`) in
       `src/test/java/org/openelisglobal/barcode/BarcodeSchemaValidationTest.java`

--- a/src/main/java/org/openelisglobal/genericsample/form/GenericSampleOrderForm.java
+++ b/src/main/java/org/openelisglobal/genericsample/form/GenericSampleOrderForm.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.genericsample.form;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.Min;
 import java.util.HashMap;
 import java.util.Map;
 import org.hl7.fhir.r4.model.Questionnaire;
@@ -29,8 +30,10 @@ public class GenericSampleOrderForm extends BaseForm {
         private String collectionDate;
         private String collectionTime;
         /** Number of order labels to print (OGC-284). */
+        @Min(1)
         private Integer numOrderLabels;
         /** Number of specimen labels to print per sample item (OGC-284). */
+        @Min(1)
         private Integer numSpecimenLabels;
 
         // Getters and setters

--- a/src/main/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImpl.java
+++ b/src/main/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImpl.java
@@ -141,6 +141,10 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
         Map<String, Object> result = new HashMap<>();
 
         GenericSampleOrderForm.DefaultFields defaultFields = form.getDefaultFields();
+        if (defaultFields == null) {
+            defaultFields = new GenericSampleOrderForm.DefaultFields();
+            form.setDefaultFields(defaultFields);
+        }
 
         // Create and save Sample
         Sample sample = createSample(defaultFields, sysUserId);
@@ -248,8 +252,8 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
                 "Additional fields saved successfully");
 
         // Save barcode label counts for order/specimen (OGC-284)
-        int numOrderLabels = defaultFields.getNumOrderLabels() != null ? defaultFields.getNumOrderLabels() : 1;
-        int numSpecimenLabels = defaultFields.getNumSpecimenLabels() != null ? defaultFields.getNumSpecimenLabels() : 1;
+        int numOrderLabels = resolveLabelQuantity(defaultFields.getNumOrderLabels());
+        int numSpecimenLabels = resolveLabelQuantity(defaultFields.getNumSpecimenLabels());
         barcodeInfoService.saveBarcodeInfoForSampleAndSampleItems(sample, numOrderLabels, numSpecimenLabels);
 
         // Save notebook sample and questionnaire response if notebook is selected
@@ -405,6 +409,10 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
         }
 
         // Note: "collector" is stored in SampleItem
+    }
+
+    private int resolveLabelQuantity(Integer quantity) {
+        return quantity != null && quantity > 0 ? quantity : 1;
     }
 
     private void saveProgramSample(Sample sample, GenericSampleOrderForm form, String sysUserId)

--- a/src/main/java/org/openelisglobal/program/controller/pathology/PathologySampleForm.java
+++ b/src/main/java/org/openelisglobal/program/controller/pathology/PathologySampleForm.java
@@ -47,6 +47,16 @@ public class PathologySampleForm {
 
     private List<PathologyReportForm> reports;
 
+    private Integer numOrderLabels;
+
+    private Integer numSpecimenLabels;
+
+    private Integer numBlockLabels;
+
+    private Integer numSlideLabels;
+
+    private Integer numFreezerLabels;
+
     public PathologyStatus getStatus() {
         return status;
     }
@@ -181,6 +191,46 @@ public class PathologySampleForm {
 
     public void setReports(List<PathologyReportForm> reports) {
         this.reports = reports;
+    }
+
+    public Integer getNumOrderLabels() {
+        return numOrderLabels;
+    }
+
+    public void setNumOrderLabels(Integer numOrderLabels) {
+        this.numOrderLabels = numOrderLabels;
+    }
+
+    public Integer getNumSpecimenLabels() {
+        return numSpecimenLabels;
+    }
+
+    public void setNumSpecimenLabels(Integer numSpecimenLabels) {
+        this.numSpecimenLabels = numSpecimenLabels;
+    }
+
+    public Integer getNumBlockLabels() {
+        return numBlockLabels;
+    }
+
+    public void setNumBlockLabels(Integer numBlockLabels) {
+        this.numBlockLabels = numBlockLabels;
+    }
+
+    public Integer getNumSlideLabels() {
+        return numSlideLabels;
+    }
+
+    public void setNumSlideLabels(Integer numSlideLabels) {
+        this.numSlideLabels = numSlideLabels;
+    }
+
+    public Integer getNumFreezerLabels() {
+        return numFreezerLabels;
+    }
+
+    public void setNumFreezerLabels(Integer numFreezerLabels) {
+        this.numFreezerLabels = numFreezerLabels;
     }
 
     public List<String> getImmunoHistoChemistryTestIds() {

--- a/src/main/java/org/openelisglobal/program/service/PathologySampleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/program/service/PathologySampleServiceImpl.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.barcode.service.BarcodeInfoService;
 import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.service.AuditableBaseObjectServiceImpl;
@@ -90,6 +91,9 @@ public class PathologySampleServiceImpl extends AuditableBaseObjectServiceImpl<P
 
     @Autowired
     private TestSectionService testSectionService;
+
+    @Autowired
+    private BarcodeInfoService barcodeInfoService;
 
     PathologySampleServiceImpl() {
         super(PathologySample.class);
@@ -201,10 +205,22 @@ public class PathologySampleServiceImpl extends AuditableBaseObjectServiceImpl<P
         }
         try {
             update(pathologySample);
+            persistPathologyBarcodeCountsIfSupplied(pathologySample, form);
         } catch (RuntimeException e) {
             LogEvent.logError(e);
             throw e;
         }
+    }
+
+    private void persistPathologyBarcodeCountsIfSupplied(PathologySample pathologySample, PathologySampleForm form) {
+        if (form.getNumOrderLabels() == null || form.getNumSpecimenLabels() == null || form.getNumBlockLabels() == null
+                || form.getNumSlideLabels() == null || form.getNumFreezerLabels() == null) {
+            return;
+        }
+
+        barcodeInfoService.saveBarcodeInfoForSampleAndSampleItemsPathology(pathologySample.getSample(),
+                form.getNumOrderLabels(), form.getNumSpecimenLabels(), form.getNumBlockLabels(),
+                form.getNumSlideLabels(), form.getNumFreezerLabels());
     }
 
     private void validatePathologySample(PathologySample pathologySample, PathologySampleForm form) {

--- a/src/test/java/org/openelisglobal/barcode/BarcodeSchemaValidationTest.java
+++ b/src/test/java/org/openelisglobal/barcode/BarcodeSchemaValidationTest.java
@@ -1,0 +1,51 @@
+package org.openelisglobal.barcode;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+
+/**
+ * Validates barcode schema expectations from existing OGC-284 Liquibase changes
+ * by checking changeset contents and inclusion wiring.
+ */
+public class BarcodeSchemaValidationTest {
+
+    @Test
+    public void testSampleBarcodeInfoSchemaColumnsExist() throws Exception {
+        Set<String> expectedColumns = new HashSet<>(Arrays.asList("id", "sample_id", "print_order_num"));
+        String changesetXml = readClassPathFile("liquibase/3.3.x.x/028-barcode-info-tables.xml");
+        for (String column : expectedColumns) {
+            assertTrue("028-barcode-info-tables.xml should define sample_barcode_info column " + column,
+                    changesetXml.contains("name=\"" + column + "\""));
+        }
+    }
+
+    @Test
+    public void testSampleItemBarcodeInfoSchemaColumnsExist() throws Exception {
+        Set<String> expectedColumns = new HashSet<>(Arrays.asList("id", "sample_item_id", "print_specimen_num",
+                "print_block_num", "print_slide_num", "print_freezer_num"));
+        String changesetXml = readClassPathFile("liquibase/3.3.x.x/028-barcode-info-tables.xml");
+        for (String column : expectedColumns) {
+            assertTrue("028-barcode-info-tables.xml should define sample_item_barcode_info column " + column,
+                    changesetXml.contains("name=\"" + column + "\""));
+        }
+    }
+
+    @Test
+    public void testBaseLiquibaseIncludesBarcodeChangesets() throws Exception {
+        String baseXml = readClassPathFile("liquibase/3.3.x.x/base.xml");
+        assertTrue("base.xml should include 028-barcode-info-tables.xml",
+                baseXml.contains("028-barcode-info-tables.xml"));
+        assertTrue("base.xml should include barcode_expansion.xml", baseXml.contains("barcode_expansion.xml"));
+    }
+
+    private String readClassPathFile(String path) throws Exception {
+        ClassPathResource resource = new ClassPathResource(path);
+        return StreamUtils.copyToString(resource.getInputStream(), java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/org/openelisglobal/barcode/HibernateMappingValidationTest.java
+++ b/src/test/java/org/openelisglobal/barcode/HibernateMappingValidationTest.java
@@ -1,0 +1,36 @@
+package org.openelisglobal.barcode;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+import org.junit.Test;
+import org.openelisglobal.barcode.valueholder.SampleBarcodeInfo;
+import org.openelisglobal.barcode.valueholder.SampleItemBarcodeInfo;
+import org.openelisglobal.localization.valueholder.Localization;
+import org.openelisglobal.localization.valueholder.LocalizationValue;
+
+/**
+ * Validates barcode ORM mappings without requiring a database connection.
+ */
+public class HibernateMappingValidationTest {
+
+    @Test
+    public void testBarcodeHibernateMappingsLoadSuccessfully() {
+        Configuration config = new Configuration();
+        config.addAnnotatedClass(SampleBarcodeInfo.class);
+        config.addAnnotatedClass(SampleItemBarcodeInfo.class);
+        config.addAnnotatedClass(Localization.class);
+        config.addAnnotatedClass(LocalizationValue.class);
+        config.addResource("hibernate/hbm/Sample.hbm.xml");
+        config.addResource("hibernate/hbm/SampleItem.hbm.xml");
+        config.addResource("hibernate/hbm/TypeOfSample.hbm.xml");
+        config.addResource("hibernate/hbm/UnitOfMeasure.hbm.xml");
+        config.setProperty("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
+        config.setProperty("hibernate.hbm2ddl.auto", "none");
+
+        SessionFactory sf = config.buildSessionFactory();
+        assertNotNull("Barcode Hibernate mappings should load successfully", sf);
+        sf.close();
+    }
+}

--- a/src/test/java/org/openelisglobal/barcode/service/BarcodeInfoServiceImplTest.java
+++ b/src/test/java/org/openelisglobal/barcode/service/BarcodeInfoServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -145,5 +146,16 @@ public class BarcodeInfoServiceImplTest {
 
         // Assert: second item inserted
         verify(sampleItemBarcodeInfoService).insert(any(SampleItemBarcodeInfo.class));
+    }
+
+    @Test
+    public void saveBarcodeInfoForSampleAndSampleItemsPathology_handlesNoSampleItems() {
+        when(sampleItemService.getSampleItemsBySampleId(sample.getId())).thenReturn(Collections.emptyList());
+
+        barcodeInfoService.saveBarcodeInfoForSampleAndSampleItemsPathology(sample, 2, 3, 4, 5, 6);
+
+        verify(sampleBarcodeInfoService).insert(any(SampleBarcodeInfo.class));
+        verify(sampleItemBarcodeInfoService, never()).insert(any(SampleItemBarcodeInfo.class));
+        verify(sampleItemBarcodeInfoService, never()).update(any(SampleItemBarcodeInfo.class));
     }
 }

--- a/src/test/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImplTest.java
+++ b/src/test/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImplTest.java
@@ -1,0 +1,172 @@
+package org.openelisglobal.genericsample.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.barcode.service.BarcodeInfoService;
+import org.openelisglobal.common.provider.validation.IAccessionNumberGenerator;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.OrderStatus;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.common.util.DefaultConfigurationProperties;
+import org.openelisglobal.genericsample.form.GenericSampleOrderForm;
+import org.openelisglobal.internationalization.MessageUtil;
+import org.openelisglobal.sample.dao.SampleDAO;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.sampleitem.service.SampleItemService;
+import org.openelisglobal.spring.util.SpringContext;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.MessageSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GenericSampleOrderServiceImplTest {
+
+    @Mock
+    private SampleService sampleService;
+
+    @Mock
+    private SampleItemService sampleItemService;
+
+    @Mock
+    private SampleDAO sampleDAO;
+
+    @Mock
+    private BarcodeInfoService barcodeInfoService;
+
+    @Mock
+    private IStatusService statusService;
+
+    @Mock
+    private AutowireCapableBeanFactory beanFactory;
+
+    @Mock
+    private IAccessionNumberGenerator accessionNumberGenerator;
+
+    @Mock
+    private DefaultConfigurationProperties configurationProperties;
+
+    @Mock
+    private MessageSource messageSource;
+
+    private GenericSampleOrderServiceImpl service;
+
+    @Before
+    public void setUp() {
+        service = new GenericSampleOrderServiceImpl();
+        ReflectionTestUtils.setField(service, "sampleService", sampleService);
+        ReflectionTestUtils.setField(service, "sampleItemService", sampleItemService);
+        ReflectionTestUtils.setField(service, "sampleDAO", sampleDAO);
+        ReflectionTestUtils.setField(service, "barcodeInfoService", barcodeInfoService);
+        ReflectionTestUtils.setField(service, "accessionNumberGenerator", accessionNumberGenerator);
+        ReflectionTestUtils.setField(SpringContext.class, "factory", beanFactory);
+
+        when(beanFactory.getBean(IStatusService.class)).thenReturn(statusService);
+        when(beanFactory.getBean(DefaultConfigurationProperties.class)).thenReturn(configurationProperties);
+        when(statusService.getStatusID(OrderStatus.Entered)).thenReturn("2");
+        when(configurationProperties.getPropertyValue(any(ConfigurationProperties.Property.class))).thenReturn("X");
+        when(configurationProperties.getPropertyValue(anyString())).thenReturn("human");
+        when(messageSource.getMessage(anyString(), any(), anyString(), any())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0);
+            if ("date.format".equals(key) || "date.format.formatKey".equals(key)) {
+                return "MM/dd/yyyy";
+            }
+            if ("dateTime.format".equals(key) || "timestamp.format.formatKey".equals(key)) {
+                return "MM/dd/yyyy HH:mm";
+            }
+            if ("time.format".equals(key) || "time.format.formatKey".equals(key)) {
+                return "HH:mm";
+            }
+            if ("timestamp.format.formatKey.12".equals(key)) {
+                return "MM/dd/yyyy hh:mm a";
+            }
+            return invocation.getArgument(2);
+        });
+        MessageUtil.setMessageSource(messageSource);
+
+        doAnswer(invocation -> {
+            Sample sample = invocation.getArgument(0);
+            if (sample.getId() == null) {
+                sample.setId("sample-1");
+            }
+            return null;
+        }).when(sampleService).insertDataWithAccessionNumber(any(Sample.class));
+    }
+
+    @After
+    public void tearDown() {
+        ReflectionTestUtils.setField(SpringContext.class, "factory", null);
+    }
+
+    @Test
+    public void saveGenericSampleOrderInternal_defaultsLabelCountsToOneWhenMissing() throws Exception {
+        GenericSampleOrderForm form = buildForm("M2-DEFAULT-001", null, null);
+
+        Sample saved = new Sample();
+        saved.setId("sample-1");
+        saved.setAccessionNumber("M2-DEFAULT-001");
+        when(sampleService.get("sample-1")).thenReturn(saved);
+
+        Map<String, Object> result = service.saveGenericSampleOrderInternal(form, "1001");
+
+        assertTrue("Save should report success", (Boolean) result.get("success"));
+        verify(barcodeInfoService).saveBarcodeInfoForSampleAndSampleItems(saved, 1, 1);
+    }
+
+    @Test
+    public void saveGenericSampleOrderInternal_usesExplicitLabelCountsWhenProvided() throws Exception {
+        GenericSampleOrderForm form = buildForm("M2-EXPLICIT-001", 3, 4);
+
+        Sample saved = new Sample();
+        saved.setId("sample-1");
+        saved.setAccessionNumber("M2-EXPLICIT-001");
+        when(sampleService.get("sample-1")).thenReturn(saved);
+
+        Map<String, Object> result = service.saveGenericSampleOrderInternal(form, "1001");
+
+        assertTrue("Save should report success", (Boolean) result.get("success"));
+        verify(barcodeInfoService).saveBarcodeInfoForSampleAndSampleItems(saved, 3, 4);
+    }
+
+    @Test
+    public void saveGenericSampleOrderInternal_handlesMissingDefaultFieldsByApplyingFallbacks() throws Exception {
+        GenericSampleOrderForm form = new GenericSampleOrderForm();
+        when(accessionNumberGenerator.getNextAccessionNumber(eq(null), eq(true))).thenReturn("AUTO-0001");
+        when(sampleService.getSampleByAccessionNumber("AUTO-0001")).thenReturn(null);
+
+        Sample saved = new Sample();
+        saved.setId("sample-1");
+        saved.setAccessionNumber("AUTO-0001");
+        when(sampleService.get("sample-1")).thenReturn(saved);
+
+        Map<String, Object> result = service.saveGenericSampleOrderInternal(form, "1001");
+
+        assertTrue("Save should report success when default fields are missing", (Boolean) result.get("success"));
+        assertNotNull("Generated accession number should be returned", result.get("accessionNumber"));
+        verify(barcodeInfoService).saveBarcodeInfoForSampleAndSampleItems(saved, 1, 1);
+    }
+
+    private GenericSampleOrderForm buildForm(String labNo, Integer numOrderLabels, Integer numSpecimenLabels) {
+        GenericSampleOrderForm form = new GenericSampleOrderForm();
+        GenericSampleOrderForm.DefaultFields defaultFields = new GenericSampleOrderForm.DefaultFields();
+        defaultFields.setLabNo(labNo);
+        defaultFields.setNumOrderLabels(numOrderLabels);
+        defaultFields.setNumSpecimenLabels(numSpecimenLabels);
+        form.setDefaultFields(defaultFields);
+        return form;
+    }
+}

--- a/src/test/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImplTest.java
+++ b/src/test/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImplTest.java
@@ -64,9 +64,13 @@ public class GenericSampleOrderServiceImplTest {
     private MessageSource messageSource;
 
     private GenericSampleOrderServiceImpl service;
+    private AutowireCapableBeanFactory previousFactory;
+    private Object previousMessageUtilInstance;
 
     @Before
     public void setUp() {
+        previousFactory = (AutowireCapableBeanFactory) ReflectionTestUtils.getField(SpringContext.class, "factory");
+        previousMessageUtilInstance = ReflectionTestUtils.getField(MessageUtil.class, "instance");
         service = new GenericSampleOrderServiceImpl();
         ReflectionTestUtils.setField(service, "sampleService", sampleService);
         ReflectionTestUtils.setField(service, "sampleItemService", sampleItemService);
@@ -109,7 +113,8 @@ public class GenericSampleOrderServiceImplTest {
 
     @After
     public void tearDown() {
-        ReflectionTestUtils.setField(SpringContext.class, "factory", null);
+        ReflectionTestUtils.setField(SpringContext.class, "factory", previousFactory);
+        ReflectionTestUtils.setField(MessageUtil.class, "instance", previousMessageUtilInstance);
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/program/service/PathologySampleServiceImplTest.java
+++ b/src/test/java/org/openelisglobal/program/service/PathologySampleServiceImplTest.java
@@ -1,0 +1,88 @@
+package org.openelisglobal.program.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.barcode.service.BarcodeInfoService;
+import org.openelisglobal.program.controller.pathology.PathologySampleForm;
+import org.openelisglobal.program.valueholder.pathology.PathologySample;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PathologySampleServiceImplTest {
+
+    @Mock
+    private BarcodeInfoService barcodeInfoService;
+
+    private PathologySampleServiceImpl pathologySampleService;
+    private PathologySample existingPathologySample;
+
+    @Before
+    public void setUp() {
+        pathologySampleService = org.mockito.Mockito.spy(new PathologySampleServiceImpl());
+        ReflectionTestUtils.setField(pathologySampleService, "barcodeInfoService", barcodeInfoService);
+
+        existingPathologySample = new PathologySample();
+        existingPathologySample.setId(2);
+        existingPathologySample.setBlocks(new ArrayList<>());
+        existingPathologySample.setSlides(new ArrayList<>());
+        existingPathologySample.setRequests(new ArrayList<>());
+        existingPathologySample.setTechniques(new ArrayList<>());
+        existingPathologySample.setConclusions(new ArrayList<>());
+        existingPathologySample.setReports(new ArrayList<>());
+
+        Sample sample = new Sample();
+        sample.setId("1");
+        existingPathologySample.setSample(sample);
+
+        doReturn(existingPathologySample).when(pathologySampleService).get(eq(2));
+        doReturn(existingPathologySample).when(pathologySampleService).update(any(PathologySample.class));
+    }
+
+    @Test
+    public void updateWithFormValues_persistsPathologyBarcodeCountsWhenSupplied() {
+        PathologySampleForm form = baseForm();
+        form.setNumOrderLabels(2);
+        form.setNumSpecimenLabels(3);
+        form.setNumBlockLabels(4);
+        form.setNumSlideLabels(5);
+        form.setNumFreezerLabels(6);
+
+        pathologySampleService.updateWithFormValues(2, form);
+
+        verify(barcodeInfoService).saveBarcodeInfoForSampleAndSampleItemsPathology(existingPathologySample.getSample(),
+                2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void updateWithFormValues_doesNotPersistPathologyBarcodeCountsWhenMissing() {
+        PathologySampleForm form = baseForm();
+
+        pathologySampleService.updateWithFormValues(2, form);
+
+        verify(barcodeInfoService, never()).saveBarcodeInfoForSampleAndSampleItemsPathology(
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.anyInt());
+    }
+
+    private PathologySampleForm baseForm() {
+        PathologySampleForm form = new PathologySampleForm();
+        form.setSystemUserId("2");
+        form.setStatus(PathologySample.PathologyStatus.GROSSING);
+        form.setBlocks(new ArrayList<>());
+        form.setSlides(new ArrayList<>());
+        form.setReports(new ArrayList<>());
+        return form;
+    }
+}


### PR DESCRIPTION
## Summary
- complete remaining M2 persistence tasks by hardening generic sample label count handling (null-safe defaults + positive validation) and extending barcode helper test coverage
- wire and verify FR-010 supplied-only pathology persistence end-to-end in service/form plus dedicated unit coverage
- add barcode ORM and Liquibase/schema verification tests, and record M2 execution evidence in quickstart/tasks

## Test plan
- [x] `mvn -Dtest=GenericSampleOrderServiceImplTest,BarcodeInfoServiceImplTest,PathologySampleServiceImplTest,HibernateMappingValidationTest,BarcodeSchemaValidationTest test`
- [x] `mvn -Dtest=PathologySampleServiceImplTest,BarcodeInfoServiceImplTest test`
- [ ] CI validation on PR branch


Made with [Cursor](https://cursor.com)