### PR TITLE
chore: track OE workflow commands and ignore Claude artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ volume/lucene/*
 # AI Agent command directories (populated by scripts/install-speckit-commands.py)
 # These are compiled from .specify/core/commands/ and .specify/oe/commands/ and should not be tracked
 .cursor/commands/
+.claude/
 .claude/commands/
 
 # Ignore .cursor/ except for worktrees.json (Cursor worktree setup config)

--- a/.specify/oe/commands/daily-priorities.md
+++ b/.specify/oe/commands/daily-priorities.md
@@ -1,0 +1,245 @@
+# Daily Priorities
+
+Query DIGI Jira via the Atlassian MCP to build a prioritized daily work plan.
+The report has two parts: **suggested priorities** (the recommendation) and
+**full context** (everything you need to evaluate whether the suggestions are
+right and what else is on the docket).
+
+After presenting, suggest `/start-ticket <KEY>` to begin work.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+**Flags:**
+
+- `/daily-priorities` → Your tickets + unassigned across main projects
+- `/daily-priorities --project OGC` → Filter to one project
+- `/daily-priorities --mine-only` → Skip unassigned query
+- `/daily-priorities --confluence` → Also pull recent Confluence context
+- `/daily-priorities --deep` → Fetch full descriptions for top tickets
+
+## Atlassian Config
+
+- **Cloud ID:** `57b4e32d-23d4-4a71-8985-82ac0274d145`
+- **Site:** `uwdigi.atlassian.net`
+- **Main projects:** OGC, MG, OEDIGI, HAITI (used for unassigned query)
+
+## Workflow
+
+### Step 1: Fetch Tickets
+
+Run **three** JQL queries in parallel using
+`mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql` (cloud ID above).
+
+**Query A — Your assigned open tickets:**
+
+```
+assignee = currentUser() AND status != Done ORDER BY status DESC, priority ASC, updated DESC
+```
+
+Fields:
+`["summary", "status", "priority", "issuetype", "duedate", "labels", "sprint", "updated"]`
+Max: 50
+
+**Query B — Your overdue tickets:**
+
+```
+assignee = currentUser() AND status != Done AND duedate < now() ORDER BY duedate ASC
+```
+
+Fields: same. Max: 20
+
+**Query C — Unassigned tickets across main projects** (skip if `--mine-only`):
+
+```
+assignee is EMPTY AND status != Done AND project in (OGC, MG, OEDIGI, HAITI) ORDER BY priority ASC, updated DESC
+```
+
+Fields: same. Max: 50
+
+If `--project` is specified, append `AND project = "<KEY>"` to queries A and B,
+and use only that project for query C.
+
+### Step 1b: Confluence (only with `--confluence`)
+
+Use `mcp__claude_ai_Atlassian__search` with query:
+`"sprint planning" OR "weekly priorities" OR "standup"`
+
+Read the top 1-2 relevant pages for context.
+
+### Step 1c: Deep Fetch (only with `--deep`)
+
+For the top 5 highest-priority tickets from queries A+C, use
+`mcp__claude_ai_Atlassian__getJiraIssue` to get full descriptions and comments.
+
+### Step 2: Process Results
+
+**Because Jira descriptions can be very large**, extract results using a
+lightweight approach — pipe the JSON through Python or jq to pull only the
+fields needed for the report tables. Do NOT try to read the full raw JSON
+inline.
+
+Example extraction (adapt path to actual result file):
+
+```bash
+cat $RESULT_FILE | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for i in data['issues']['nodes']:
+    f = i['fields']
+    print('|'.join([
+        i['key'],
+        f['issuetype']['name'],
+        f['priority']['name'],
+        f['status']['name'],
+        f.get('duedate') or '-',
+        ', '.join(f.get('labels') or []),
+        f.get('updated','')[:10],
+        f['summary'][:80]
+    ]))
+"
+```
+
+Deduplicate by issue key across all queries.
+
+### Step 3: Build the Report
+
+The report has **two major sections**: a short recommendation up front, then
+the full data so the user can evaluate it. Structure it exactly like this:
+
+```markdown
+## Daily Priorities — [Date]
+
+### Suggested Focus (top 3)
+
+1. **KEY** — Summary
+   _[Why: deadline in N days / only High priority / active momentum / unblocks N other tickets / production issue]_
+
+2. **KEY** — Summary
+   _[Why: ...]_
+
+3. **KEY** — Summary
+   _[Why: ...]_
+
+> `/start-ticket KEY` to begin | `/start-ticket KEY --speckit` for spec-driven
+
+---
+
+### Your Tickets ([N] assigned to you)
+
+**[M] In Progress | [M] To Do / Selected | [M] Backlog | [M] Overdue**
+
+#### In Progress
+_Finish these before starting new work. Context switching is expensive._
+
+| Key | Summary | Priority | Due | Labels | Updated |
+|-----|---------|----------|-----|--------|---------|
+| ... | ... | ... | ... | ... | ... |
+
+#### Overdue
+_Past due date — address or reschedule._
+
+| Key | Summary | Due | Days Late | Priority |
+|-----|---------|-----|-----------|----------|
+| ... | ... | ... | ... | ... |
+
+_(If none: "None — you're current on deadlines.")_
+
+#### To Do + Selected for Development
+_Ready to start. Sorted by priority then recency._
+
+| Key | Summary | Priority | Type | Labels | Updated |
+|-----|---------|----------|------|--------|---------|
+| ... | ... | ... | ... | ... | ... |
+
+#### Backlog (To be assigned status / Low priority)
+_Parked. Don't start these unless the above sections are empty._
+
+| Key | Summary | Type | Labels | Updated |
+|-----|---------|------|--------|---------|
+| ... | ... | ... | ... | ... |
+
+---
+
+### Unassigned Pool ([N] tickets without an owner)
+
+_These are open tickets across OGC, MG, OEDIGI, HAITI with no assignee.
+Items here may need your attention or could be claimed for the sprint._
+
+#### Needs Attention (recently created, high priority, or production issues)
+
+| Key | Summary | Priority | Status | Project | Updated |
+|-----|---------|----------|--------|---------|---------|
+| ... | ... | ... | ... | ... | ... |
+
+_(Flag: crash reports, "Down" in title, Highest/High priority, created today)_
+
+#### Unassigned In Progress (orphaned — someone started but no owner)
+
+| Key | Summary | Status | Project | Labels | Updated |
+|-----|---------|--------|---------|--------|---------|
+| ... | ... | ... | ... | ... | ... |
+
+_(If none: skip this section)_
+
+#### Unassigned Backlog (informational)
+
+**[N] more unassigned tickets** in backlog across OGC ([n]), MG ([n]),
+HAITI ([n]), OEDIGI ([n]).
+
+[Top 5-10 by recency, then "and N more..."]
+
+---
+
+### Flags & Observations
+
+- **Stale tickets:** [Any assigned tickets with no update in 14+ days]
+- **Junk/test tickets:** [Any obvious test data that should be deleted]
+- **Past-due dates:** [Tickets with due dates in the past that aren't overdue
+  status — Jira metadata mismatch]
+- **Dependency chains:** [If ticket X unblocks Y, Z — note it]
+- **Deployment labels:** Country labels (Madagascar, Indonesia, PNG) = active
+  deployments with real users. Note these as higher urgency.
+```
+
+### Step 4: Offer Follow-ups
+
+After the report, offer these actions:
+
+- "Want details on a specific ticket? I can fetch the full description."
+- "Ready to start one? `/start-ticket OGC-337`"
+- "Want to claim an unassigned ticket? I can assign it to you in Jira."
+- "Need Confluence context? Re-run with `--confluence`"
+
+## Report Design Principles
+
+- **Suggestions up front, context below.** The user should see the
+  recommendation in 5 seconds, then have everything they need to challenge it
+  without asking follow-up questions.
+- **Make assignment crystal clear.** Every table should make it obvious whether
+  tickets are yours or unassigned. Never mix them in the same table.
+- **Surface anomalies.** Orphaned In Progress tickets, stale items, test junk,
+  broken due dates — these are the things a human would miss scanning Jira
+  boards.
+- **Country labels = urgency.** Madagascar, Indonesia, PNG labels indicate
+  real deployments. Always factor these into suggestions.
+- **Counts everywhere.** Header counts let the user gut-check scope instantly:
+  "23 assigned, 50 unassigned, 0 overdue" tells a story before reading any
+  table.
+
+## Lifecycle & Jira Sync
+
+This command is the **triage step** — read-only against Jira. The full
+development cycle syncs Jira status at key milestones:
+
+```
+/daily-priorities             ← YOU ARE HERE: read tickets from Jira
+/start-ticket OGC-337        ← Jira → "In Progress"
+  /speckit.* pipeline         ← Spec → Plan → Tasks → Implement
+  /fix-ci                     ← Fix CI failures
+/finish-ticket                ← Jira → "In Review"
+  /address-pr-comments        ← Handle reviewer feedback
+```

--- a/.specify/oe/commands/daily-priorities.md
+++ b/.specify/oe/commands/daily-priorities.md
@@ -107,22 +107,20 @@ Deduplicate by issue key across all queries.
 
 ### Step 3: Build the Report
 
-The report has **two major sections**: a short recommendation up front, then
-the full data so the user can evaluate it. Structure it exactly like this:
+The report has **two major sections**: a short recommendation up front, then the
+full data so the user can evaluate it. Structure it exactly like this:
 
 ```markdown
 ## Daily Priorities — [Date]
 
 ### Suggested Focus (top 3)
 
-1. **KEY** — Summary
-   _[Why: deadline in N days / only High priority / active momentum / unblocks N other tickets / production issue]_
+1. **KEY** — Summary _[Why: deadline in N days / only High priority / active
+   momentum / unblocks N other tickets / production issue]_
 
-2. **KEY** — Summary
-   _[Why: ...]_
+2. **KEY** — Summary _[Why: ...]_
 
-3. **KEY** — Summary
-   _[Why: ...]_
+3. **KEY** — Summary _[Why: ...]_
 
 > `/start-ticket KEY` to begin | `/start-ticket KEY --speckit` for spec-driven
 
@@ -133,62 +131,66 @@ the full data so the user can evaluate it. Structure it exactly like this:
 **[M] In Progress | [M] To Do / Selected | [M] Backlog | [M] Overdue**
 
 #### In Progress
+
 _Finish these before starting new work. Context switching is expensive._
 
 | Key | Summary | Priority | Due | Labels | Updated |
-|-----|---------|----------|-----|--------|---------|
-| ... | ... | ... | ... | ... | ... |
+| --- | ------- | -------- | --- | ------ | ------- |
+| ... | ...     | ...      | ... | ...    | ...     |
 
 #### Overdue
+
 _Past due date — address or reschedule._
 
 | Key | Summary | Due | Days Late | Priority |
-|-----|---------|-----|-----------|----------|
-| ... | ... | ... | ... | ... |
+| --- | ------- | --- | --------- | -------- |
+| ... | ...     | ... | ...       | ...      |
 
 _(If none: "None — you're current on deadlines.")_
 
 #### To Do + Selected for Development
+
 _Ready to start. Sorted by priority then recency._
 
 | Key | Summary | Priority | Type | Labels | Updated |
-|-----|---------|----------|------|--------|---------|
-| ... | ... | ... | ... | ... | ... |
+| --- | ------- | -------- | ---- | ------ | ------- |
+| ... | ...     | ...      | ...  | ...    | ...     |
 
 #### Backlog (To be assigned status / Low priority)
+
 _Parked. Don't start these unless the above sections are empty._
 
 | Key | Summary | Type | Labels | Updated |
-|-----|---------|------|--------|---------|
-| ... | ... | ... | ... | ... |
+| --- | ------- | ---- | ------ | ------- |
+| ... | ...     | ...  | ...    | ...     |
 
 ---
 
 ### Unassigned Pool ([N] tickets without an owner)
 
-_These are open tickets across OGC, MG, OEDIGI, HAITI with no assignee.
-Items here may need your attention or could be claimed for the sprint._
+_These are open tickets across OGC, MG, OEDIGI, HAITI with no assignee. Items
+here may need your attention or could be claimed for the sprint._
 
 #### Needs Attention (recently created, high priority, or production issues)
 
 | Key | Summary | Priority | Status | Project | Updated |
-|-----|---------|----------|--------|---------|---------|
-| ... | ... | ... | ... | ... | ... |
+| --- | ------- | -------- | ------ | ------- | ------- |
+| ... | ...     | ...      | ...    | ...     | ...     |
 
 _(Flag: crash reports, "Down" in title, Highest/High priority, created today)_
 
 #### Unassigned In Progress (orphaned — someone started but no owner)
 
 | Key | Summary | Status | Project | Labels | Updated |
-|-----|---------|--------|---------|--------|---------|
-| ... | ... | ... | ... | ... | ... |
+| --- | ------- | ------ | ------- | ------ | ------- |
+| ... | ...     | ...    | ...     | ...    | ...     |
 
 _(If none: skip this section)_
 
 #### Unassigned Backlog (informational)
 
-**[N] more unassigned tickets** in backlog across OGC ([n]), MG ([n]),
-HAITI ([n]), OEDIGI ([n]).
+**[N] more unassigned tickets** in backlog across OGC ([n]), MG ([n]), HAITI
+([n]), OEDIGI ([n]).
 
 [Top 5-10 by recency, then "and N more..."]
 
@@ -224,8 +226,8 @@ After the report, offer these actions:
 - **Surface anomalies.** Orphaned In Progress tickets, stale items, test junk,
   broken due dates — these are the things a human would miss scanning Jira
   boards.
-- **Country labels = urgency.** Madagascar, Indonesia, PNG labels indicate
-  real deployments. Always factor these into suggestions.
+- **Country labels = urgency.** Madagascar, Indonesia, PNG labels indicate real
+  deployments. Always factor these into suggestions.
 - **Counts everywhere.** Header counts let the user gut-check scope instantly:
   "23 assigned, 50 unassigned, 0 overdue" tells a story before reading any
   table.

--- a/.specify/oe/commands/finish-ticket.md
+++ b/.specify/oe/commands/finish-ticket.md
@@ -1,0 +1,212 @@
+# Finish Ticket
+
+Final polish, audit, and validation before marking a ticket ready for review.
+Chains existing commands (`/audit-branch`, formatting, tests) and syncs Jira
+status to "In Review."
+
+This is the **exit gate** of the development cycle — run it when you believe
+your work is complete and you want a thorough check before requesting review.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+**Flags:**
+
+- `/finish-ticket` → Full audit + format + test + Jira sync + PR ready
+- `/finish-ticket --quick` → Format + compile only (skip audit and tests)
+- `/finish-ticket --no-jira` → Skip Jira status transition
+- `/finish-ticket --no-pr` → Skip PR readiness marking
+- `/finish-ticket --deep` → Pass `--deep` to audit-branch (Tier 3 semantic)
+- `/finish-ticket OGC-337` → Explicit Jira key (otherwise auto-detected from
+  branch name)
+
+## Atlassian Config
+
+- **Cloud ID:** `57b4e32d-23d4-4a71-8985-82ac0274d145`
+- **Site:** `uwdigi.atlassian.net`
+
+## Workflow
+
+### Step 1: Preflight
+
+Gather context (all parallel):
+
+```bash
+git branch --show-current          # Branch name
+git status --porcelain             # Uncommitted changes
+gh pr view --json number,title,baseRefName,url,isDraft  # PR info
+```
+
+- Extract **Jira key** from branch name (pattern: `<type>/<KEY>-<slug>`) or
+  from the `$ARGUMENTS`
+- If uncommitted changes exist, **warn and ask**: commit first or continue?
+- If no PR exists, warn but continue (user may want to create one after)
+
+Report:
+
+```
+Branch:  feat/OGC-337-implement-generic-astm-plugin-v1
+PR:      #42 (draft) → develop
+Jira:    OGC-337
+Status:  2 uncommitted files (warn)
+```
+
+### Step 2: Format (mandatory)
+
+Run formatting per CLAUDE.md rules — this is non-negotiable before any audit.
+
+**Backend (if Java files changed in branch):**
+
+```bash
+mvn spotless:apply
+```
+
+**Frontend (if JS/JSX/TS/TSX files changed in branch):**
+
+```bash
+cd frontend && npm run format && cd ..
+```
+
+Check if formatting produced changes:
+
+```bash
+git diff --stat
+```
+
+If formatting changed files, **stage and commit them** with message:
+`style: apply formatting (spotless + prettier)`
+
+### Step 3: Compile & Unit Tests
+
+**Skip if `--quick` and no test files changed.**
+
+**Backend:**
+
+```bash
+mvn test
+```
+
+If tests fail → stop and report. Don't proceed to audit with failing tests.
+
+**Frontend (if frontend files changed):**
+
+```bash
+cd frontend && npm test -- --watchAll=false --coverage=false && cd ..
+```
+
+If tests fail → stop and report.
+
+### Step 4: Audit Branch
+
+**Skip if `--quick`.**
+
+Run the `/audit-branch` command logic (Tier 1+2 by default, Tier 3 if
+`--deep` was passed).
+
+This checks for:
+
+- Debug statements, TODOs, placeholder code
+- Merge conflict markers, swallowed exceptions
+- Constitution violations (layered architecture, Carbon DS, i18n)
+- Scope creep, over-engineering, unused imports
+
+**If CRITICAL or HIGH findings exist:** Stop and present findings. The user
+must address them before proceeding.
+
+**If only MEDIUM/LOW/INFO findings:** Present findings as advisory but
+continue. Ask: "Address these now, or proceed to PR?"
+
+### Step 5: PR Readiness
+
+**Skip if `--no-pr` or no PR exists.**
+
+Check PR is up to date with base branch:
+
+```bash
+git fetch origin
+git log --oneline origin/$BASE_BRANCH..HEAD  # Commits ahead
+git log --oneline HEAD..origin/$BASE_BRANCH  # Commits behind
+```
+
+If behind base branch, suggest:
+
+- `/careful-rebase` to bring up to date
+
+If PR is currently draft, offer to mark as ready:
+
+```bash
+gh pr ready
+```
+
+Ensure PR description includes a link to the Jira ticket. If missing, update:
+
+```bash
+gh pr edit --body "..."   # Append Jira link if not present
+```
+
+### Step 6: Jira Transition
+
+**Skip if `--no-jira` or no Jira key detected.**
+
+Use `mcp__claude_ai_Atlassian__getTransitionsForJiraIssue` (cloud ID:
+`57b4e32d-23d4-4a71-8985-82ac0274d145`) to find a transition to "In Review",
+"Review", or "Code Review" (try common variants).
+
+If found, use `mcp__claude_ai_Atlassian__transitionJiraIssue` to move it.
+
+If no review-like transition exists, list available transitions and ask the user
+which one to use (or skip).
+
+### Step 7: Summary
+
+```
+## Finish Ticket — OGC-337
+
+| Check         | Result                     |
+| ------------- | -------------------------- |
+| Formatting    | Applied (1 file changed)   |
+| Unit tests    | 142 passed, 0 failed       |
+| Branch audit  | 0 critical, 1 medium       |
+| PR #42        | Marked ready for review    |
+| Jira OGC-337  | Transitioned to In Review  |
+
+### Audit Findings (advisory)
+- [M4] LOW: Hedging language in comment (ServiceImpl.java:89)
+
+### What's Next
+- Wait for reviewer feedback
+- When comments arrive: `/address-pr-comments`
+- If CI fails after push: `/fix-ci`
+- After merge: Jira ticket will need manual transition to Done
+  (or set up automation in Jira)
+```
+
+## Lifecycle Reference
+
+This command is part of the DIGI development workflow:
+
+```
+/daily-priorities             ← Pick what to work on (Jira → you)
+/start-ticket OGC-337        ← Branch + PR + Jira "In Progress"
+  /speckit.specify            ← Define the feature
+  /speckit.plan               ← Design approach
+  /speckit.tasks              ← Break into tasks
+  /speckit.implement          ← Code with TDD
+  /fix-ci                     ← Fix CI failures
+  /careful-rebase             ← Stay current with base
+/finish-ticket                ← YOU ARE HERE: audit + Jira "In Review"
+  /address-pr-comments        ← Handle reviewer feedback
+  /fix-ci                     ← Fix post-review CI issues
+/finish-ticket                ← Re-run after addressing comments
+```
+
+## Safety
+
+- Never force-push
+- Never skip formatting
+- Stop on CRITICAL audit findings — don't mark PR ready with known issues
+- Ask before transitioning Jira status
+- Ask before marking PR as ready (removing draft)

--- a/.specify/oe/commands/finish-ticket.md
+++ b/.specify/oe/commands/finish-ticket.md
@@ -40,8 +40,8 @@ git status --porcelain             # Uncommitted changes
 gh pr view --json number,title,baseRefName,url,isDraft  # PR info
 ```
 
-- Extract **Jira key** from branch name (pattern: `<type>/<KEY>-<slug>`) or
-  from the `$ARGUMENTS`
+- Extract **Jira key** from branch name (pattern: `<type>/<KEY>-<slug>`) or from
+  the `$ARGUMENTS`
 - If uncommitted changes exist, **warn and ask**: commit first or continue?
 - If no PR exists, warn but continue (user may want to create one after)
 
@@ -103,8 +103,8 @@ If tests fail → stop and report.
 
 **Skip if `--quick`.**
 
-Run the `/audit-branch` command logic (Tier 1+2 by default, Tier 3 if
-`--deep` was passed).
+Run the `/audit-branch` command logic (Tier 1+2 by default, Tier 3 if `--deep`
+was passed).
 
 This checks for:
 
@@ -113,11 +113,11 @@ This checks for:
 - Constitution violations (layered architecture, Carbon DS, i18n)
 - Scope creep, over-engineering, unused imports
 
-**If CRITICAL or HIGH findings exist:** Stop and present findings. The user
-must address them before proceeding.
+**If CRITICAL or HIGH findings exist:** Stop and present findings. The user must
+address them before proceeding.
 
-**If only MEDIUM/LOW/INFO findings:** Present findings as advisory but
-continue. Ask: "Address these now, or proceed to PR?"
+**If only MEDIUM/LOW/INFO findings:** Present findings as advisory but continue.
+Ask: "Address these now, or proceed to PR?"
 
 ### Step 5: PR Readiness
 

--- a/.specify/oe/commands/start-ticket.md
+++ b/.specify/oe/commands/start-ticket.md
@@ -1,8 +1,8 @@
 # Start Ticket
 
 Set up a development environment for a Jira ticket: fetch details, create
-branch, optionally create a draft PR and transition Jira status. Integrates
-with SpecKit for spec-driven development.
+branch, optionally create a draft PR and transition Jira status. Integrates with
+SpecKit for spec-driven development.
 
 ## User Input
 
@@ -31,8 +31,7 @@ First argument is the Jira issue key. Additional flags:
 ### Step 1: Fetch Jira Ticket
 
 Use `mcp__claude_ai_Atlassian__getJiraIssue` with cloud ID above. Fields:
-`["summary", "description", "status", "priority", "issuetype", "labels",
-"sprint", "parent", "issuelinks"]`
+`["summary", "description", "status", "priority", "issuetype", "labels", "sprint", "parent", "issuelinks"]`
 
 Display a brief summary:
 
@@ -46,13 +45,13 @@ Labels: Madagascar | Parent: OGC-49
 
 **Branch name pattern:** `<type>/<KEY>-<slug>`
 
-| Jira Type     | Prefix |
-| ------------- | ------ |
-| Bug           | fix    |
-| Story         | feat   |
-| Task          | chore  |
-| Epic          | epic   |
-| Sub-task      | feat   |
+| Jira Type | Prefix |
+| --------- | ------ |
+| Bug       | fix    |
+| Story     | feat   |
+| Task      | chore  |
+| Epic      | epic   |
+| Sub-task  | feat   |
 
 Slugify: lowercase, hyphens, truncate to ~50 chars at word boundary.
 
@@ -83,9 +82,9 @@ Push and create a draft PR:
 git push -u origin "$BRANCH_NAME"
 ```
 
-**PR title:** `<type>(<project>): <short summary> (<KEY>)`
-**PR body:** Generated from Jira description — summary bullets, link to Jira
-ticket, acceptance criteria if available.
+**PR title:** `<type>(<project>): <short summary> (<KEY>)` **PR body:**
+Generated from Jira description — summary bullets, link to Jira ticket,
+acceptance criteria if available.
 
 ```bash
 gh pr create --draft --title "$TITLE" --body "$BODY" --base "$BASE_BRANCH"
@@ -129,8 +128,8 @@ Started: OGC-337 — Implement Generic ASTM Plugin v1.1/1.2
 
 ## Lifecycle & Jira Sync
 
-This command is the **entry point** of the development cycle. It syncs Jira
-to "In Progress." Other commands handle later transitions:
+This command is the **entry point** of the development cycle. It syncs Jira to
+"In Progress." Other commands handle later transitions:
 
 ```
 /daily-priorities             ← Pick what to work on

--- a/.specify/oe/commands/start-ticket.md
+++ b/.specify/oe/commands/start-ticket.md
@@ -1,0 +1,150 @@
+# Start Ticket
+
+Set up a development environment for a Jira ticket: fetch details, create
+branch, optionally create a draft PR and transition Jira status. Integrates
+with SpecKit for spec-driven development.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+First argument is the Jira issue key. Additional flags:
+
+- `/start-ticket OGC-337` → Create branch, draft PR, transition to In Progress
+- `/start-ticket OGC-337 --speckit` → Also bootstrap SpecKit spec from ticket
+- `/start-ticket OGC-337 --worktree` → Use a git worktree (parallel dev)
+- `/start-ticket OGC-337 --no-pr` → Skip PR creation
+- `/start-ticket OGC-337 --no-transition` → Don't move Jira status
+- `/start-ticket OGC-337 --base demo/madagascar` → Branch from non-default base
+
+**Default base branch:** `develop`
+
+## Atlassian Config
+
+- **Cloud ID:** `57b4e32d-23d4-4a71-8985-82ac0274d145`
+- **Site:** `uwdigi.atlassian.net`
+
+## Workflow
+
+### Step 1: Fetch Jira Ticket
+
+Use `mcp__claude_ai_Atlassian__getJiraIssue` with cloud ID above. Fields:
+`["summary", "description", "status", "priority", "issuetype", "labels",
+"sprint", "parent", "issuelinks"]`
+
+Display a brief summary:
+
+```
+OGC-337 | Story | Medium | Selected for Development
+Implement Generic ASTM Plugin v1.1/1.2
+Labels: Madagascar | Parent: OGC-49
+```
+
+### Step 2: Create Branch
+
+**Branch name pattern:** `<type>/<KEY>-<slug>`
+
+| Jira Type     | Prefix |
+| ------------- | ------ |
+| Bug           | fix    |
+| Story         | feat   |
+| Task          | chore  |
+| Epic          | epic   |
+| Sub-task      | feat   |
+
+Slugify: lowercase, hyphens, truncate to ~50 chars at word boundary.
+
+Example: `feat/OGC-337-implement-generic-astm-plugin-v1`
+
+**Confirm** the branch name with the user before creating.
+
+```bash
+git fetch origin $BASE_BRANCH
+git checkout -b "$BRANCH_NAME" "origin/$BASE_BRANCH"
+```
+
+**If `--worktree`:**
+
+```bash
+WORKTREE_DIR="../worktrees/$(basename $(pwd))-$TICKET_KEY"
+mkdir -p "$(dirname $WORKTREE_DIR)"
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" "origin/$BASE_BRANCH"
+```
+
+Report the worktree path so the user can `cd` there.
+
+### Step 3: Draft PR (unless `--no-pr`)
+
+Push and create a draft PR:
+
+```bash
+git push -u origin "$BRANCH_NAME"
+```
+
+**PR title:** `<type>(<project>): <short summary> (<KEY>)`
+**PR body:** Generated from Jira description — summary bullets, link to Jira
+ticket, acceptance criteria if available.
+
+```bash
+gh pr create --draft --title "$TITLE" --body "$BODY" --base "$BASE_BRANCH"
+```
+
+### Step 4: Transition Jira (unless `--no-transition`)
+
+Use `mcp__claude_ai_Atlassian__getTransitionsForJiraIssue` to find "In Progress"
+transition. If available, use `mcp__claude_ai_Atlassian__transitionJiraIssue`.
+
+If already In Progress, skip silently.
+
+### Step 5: SpecKit Bootstrap (only with `--speckit`)
+
+Determine the next spec number from `specs/` directory. Then invoke
+`/speckit.specify` using the Jira ticket description as the feature input.
+
+This creates `specs/NNN-<feature>/spec.md` seeded from the Jira ticket.
+
+After SpecKit completes, remind the user of the next steps:
+
+```
+SpecKit pipeline:
+  /speckit.plan      → Design the implementation
+  /speckit.tasks     → Generate task breakdown
+  /speckit.implement → Execute tasks with TDD
+```
+
+### Step 6: Summary
+
+```
+Started: OGC-337 — Implement Generic ASTM Plugin v1.1/1.2
+
+  Branch:  feat/OGC-337-implement-generic-astm-plugin-v1
+  PR:      #42 (draft) — https://github.com/...
+  Jira:    Transitioned to In Progress
+  SpecKit: specs/012-astm-plugin-v1/spec.md created
+
+  Next: /speckit.plan
+```
+
+## Lifecycle & Jira Sync
+
+This command is the **entry point** of the development cycle. It syncs Jira
+to "In Progress." Other commands handle later transitions:
+
+```
+/daily-priorities             ← Pick what to work on
+/start-ticket OGC-337        ← YOU ARE HERE: Jira → "In Progress"
+  /speckit.* pipeline         ← Spec → Plan → Tasks → Implement
+  /fix-ci                     ← Fix CI failures
+  /careful-rebase             ← Stay current with base
+/finish-ticket                ← Audit + Jira → "In Review"
+  /address-pr-comments        ← Handle reviewer feedback
+```
+
+## Safety
+
+- Never force-push or push to protected branches
+- Always create **draft** PRs
+- Confirm branch name before creating
+- If branch exists, offer to check it out instead


### PR DESCRIPTION
## Summary

- Add three SpecKit OE command definitions (`daily-priorities`, `start-ticket`, `finish-ticket`) used in daily workflow
- Add `.claude/` to `.gitignore` to keep local Claude artifacts out of version control
- Apply Spotless formatting to the markdown command files

Re-introduction of `6597b0f` (accidentally direct-committed to develop) with formatting fixed.


Made with [Cursor](https://cursor.com)