### PR TITLE
feat(analyzer): FILE protocol support in form + scanTemplates profileMeta fallback

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
         /.*analyzer-plugin-config\.spec\.ts/,
         /.*analyzer-simulator\.spec\.ts/,
         /.*analyzer-hl7-simulate\.spec\.ts/,
+        /.*demo-quantstudio.*\.spec\.ts/,
       ],
       use: {
         ...devices["Desktop Chrome"],
@@ -67,6 +68,7 @@ export default defineConfig({
         "**/analyzer-plugin-config*",
         "**/analyzer-simulator*",
         "**/analyzer-hl7-simulate*",
+        "**/demo-quantstudio*",
       ],
     },
   ],

--- a/frontend/playwright/fixtures/analyzer-form.ts
+++ b/frontend/playwright/fixtures/analyzer-form.ts
@@ -118,6 +118,11 @@ export class AnalyzerFormPage {
   /** Assert a success notification appeared */
   async expectSuccessNotification() {
     await expect(this.notification).toBeVisible({ timeout: 10000 });
+    const cls = await this.notification.getAttribute("class");
+    if (cls && /error/i.test(cls)) {
+      const text = await this.notification.textContent();
+      throw new Error(`Expected success notification but got error: ${text}`);
+    }
     await expect(this.notification).toHaveAttribute("class", /success|info/i);
   }
 

--- a/frontend/playwright/fixtures/analyzer-form.ts
+++ b/frontend/playwright/fixtures/analyzer-form.ts
@@ -19,6 +19,8 @@ export class AnalyzerFormPage {
   readonly ipAddressInput: Locator;
   readonly portInput: Locator;
   readonly statusDropdown: Locator;
+  readonly connectionFields: Locator;
+  readonly fileProtocolInfo: Locator;
   readonly saveButton: Locator;
   readonly cancelButton: Locator;
   readonly notification: Locator;
@@ -49,6 +51,12 @@ export class AnalyzerFormPage {
     this.portInput = page.locator('[data-testid="analyzer-form-port-input"]');
     this.statusDropdown = page.locator(
       '[data-testid="analyzer-form-status-dropdown"]',
+    );
+    this.connectionFields = page.locator(
+      '[data-testid="analyzer-form-connection-fields"]',
+    );
+    this.fileProtocolInfo = page.locator(
+      '[data-testid="analyzer-form-file-protocol-info"]',
     );
     this.saveButton = page.locator('[data-testid="analyzer-form-save-button"]');
     this.cancelButton = page.locator(

--- a/frontend/playwright/tests/demo-quantstudio-file-config.spec.ts
+++ b/frontend/playwright/tests/demo-quantstudio-file-config.spec.ts
@@ -20,8 +20,11 @@ import { AnalyzerFormPage } from "../fixtures/analyzer-form";
  * Run with: PLAYWRIGHT_VIDEO=on TEST_USER=admin TEST_PASS="adminADMIN!" \
  *           npx playwright test demo-quantstudio --project=analyzer-harness
  */
-// Video recording — set at top level (Playwright requires test.use outside describe)
-test.use({ video: "on" });
+// Video recording — only enable when explicitly requested via env var.
+// Playwright requires test.use outside describe.
+if (process.env.PLAYWRIGHT_VIDEO === "on") {
+  test.use({ video: "on" });
+}
 
 test.describe("Demo: QuantStudio 7 Generic File Config", () => {
   test.describe.configure({ mode: "serial" });
@@ -44,6 +47,7 @@ test.describe("Demo: QuantStudio 7 Generic File Config", () => {
 
   test("create QuantStudio 7 analyzer via Generic File plugin + profile", async ({
     page,
+    baseURL,
   }) => {
     const list = new AnalyzerListPage(page);
     const form = new AnalyzerFormPage(page);
@@ -126,7 +130,8 @@ test.describe("Demo: QuantStudio 7 Generic File Config", () => {
 
     // Step 10: Verify file-import configuration was created
     if (createdAnalyzerId) {
-      const api = `${page.url().split("/analyzers")[0]}/api/OpenELIS-Global/rest/analyzer`;
+      const base = baseURL || process.env.BASE_URL || "https://localhost";
+      const api = `${base}/api/OpenELIS-Global/rest/analyzer`;
       const cfgRes = await page.request.get(
         `${api}/file-import/configurations/analyzer/${createdAnalyzerId}`,
       );

--- a/frontend/playwright/tests/demo-quantstudio-file-config.spec.ts
+++ b/frontend/playwright/tests/demo-quantstudio-file-config.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from "@playwright/test";
+import { AnalyzerListPage } from "../fixtures/analyzer-list";
+import { AnalyzerFormPage } from "../fixtures/analyzer-form";
+
+/**
+ * Demo: QuantStudio 7 — Generic File plugin configuration walkthrough.
+ *
+ * Records the full E2E workflow:
+ *   1. Navigate to Analyzers list
+ *   2. Open Add Analyzer form
+ *   3. Select "Generic File" plugin type
+ *   4. Select "QuantStudio QS5/QS7" default profile
+ *   5. Verify prefilled fields (category = MOLECULAR)
+ *   6. Verify FILE-specific form: no IP/port, no protocol version, FILE info tile shown
+ *   7. Fill name, save
+ *   8. Verify analyzer appears in list
+ *   9. Verify FileImportConfiguration created with EXCEL format
+ *  10. Cleanup
+ *
+ * Run with: PLAYWRIGHT_VIDEO=on TEST_USER=admin TEST_PASS="adminADMIN!" \
+ *           npx playwright test demo-quantstudio --project=analyzer-harness
+ */
+// Video recording — set at top level (Playwright requires test.use outside describe)
+test.use({ video: "on" });
+
+test.describe("Demo: QuantStudio 7 Generic File Config", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const uniqueSuffix = Date.now();
+  const analyzerName = `QuantStudio-7-Demo-${uniqueSuffix}`;
+  let createdAnalyzerId: string;
+
+  test.afterAll(async ({ request }) => {
+    if (createdAnalyzerId) {
+      try {
+        await request.post(
+          `/api/OpenELIS-Global/rest/analyzer/analyzers/${createdAnalyzerId}/delete`,
+        );
+      } catch {
+        // Best effort cleanup
+      }
+    }
+  });
+
+  test("create QuantStudio 7 analyzer via Generic File plugin + profile", async ({
+    page,
+  }) => {
+    const list = new AnalyzerListPage(page);
+    const form = new AnalyzerFormPage(page);
+
+    // Step 1: Navigate to Analyzers list
+    await list.goto();
+    await list.expectLoaded();
+    await page.waitForTimeout(1_000); // Pause for video
+
+    // Step 2: Open Add Analyzer form
+    await list.clickAdd();
+    await form.expectOpen();
+    await page.waitForTimeout(500);
+
+    // Step 3: Select "Generic File" plugin type
+    await form.pluginTypeDropdown.click();
+    const genericFileOption = page
+      .getByRole("option", { name: /Generic File/i })
+      .first();
+    await expect(genericFileOption).toBeVisible({ timeout: 10_000 });
+    await page.waitForTimeout(500); // Show the dropdown open
+    await genericFileOption.click();
+    await page.waitForTimeout(500);
+
+    // Step 4: Verify FILE-specific form behavior
+    // Protocol version dropdown should NOT be visible
+    await expect(form.protocolVersionDropdown).not.toBeVisible();
+    // Connection fields (IP/port/test-connection) should NOT be visible
+    await expect(form.connectionFields).not.toBeVisible();
+    // FILE protocol info tile SHOULD be visible
+    await expect(form.fileProtocolInfo).toBeVisible();
+    await page.waitForTimeout(500);
+
+    // Step 5: Select "QuantStudio QS5/QS7" default profile
+    await expect(form.defaultConfigDropdown).toBeVisible();
+    await form.defaultConfigDropdown.click();
+
+    // Profile dropdown should only show FILE profiles (not ASTM/HL7)
+    const quantStudioOption = page
+      .getByRole("option", { name: /QuantStudio/i })
+      .first();
+    await expect(quantStudioOption).toBeVisible({ timeout: 10_000 });
+    await page.waitForTimeout(500); // Show profile options
+    await quantStudioOption.click();
+    await page.waitForTimeout(1_000); // Let profile load and fields populate
+
+    // Step 6: Verify prefilled fields from QuantStudio profile
+    // The profile should set the analyzer type/category to MOLECULAR
+    await expect(form.typeDropdown).toContainText(/Molecular/i);
+
+    // Step 7: Fill name
+    await form.fillName(analyzerName);
+    await page.waitForTimeout(500);
+
+    // Step 8: Save
+    await form.save();
+    await form.expectSuccessNotification();
+    await page.waitForTimeout(1_500); // Show success notification
+
+    // Modal auto-closes after 1s
+    await expect(form.modal).not.toBeVisible({ timeout: 5_000 });
+
+    // Step 9: Verify analyzer appears in list
+    await list.expectLoaded();
+    await list.search(analyzerName);
+    await page.waitForTimeout(500);
+
+    const rows = page.locator("tbody tr");
+    await expect(rows).toHaveCount(1, { timeout: 10_000 });
+    const row = rows.first();
+    await expect(row).toContainText(analyzerName);
+    await expect(row).toContainText("MOLECULAR");
+    await page.waitForTimeout(1_000);
+
+    // Extract ID for cleanup
+    const testid = await row.getAttribute("data-testid");
+    if (testid && testid.startsWith("analyzer-row-")) {
+      createdAnalyzerId = testid.replace("analyzer-row-", "");
+    }
+
+    // Step 10: Verify file-import configuration was created
+    if (createdAnalyzerId) {
+      const api = `${page.url().split("/analyzers")[0]}/api/OpenELIS-Global/rest/analyzer`;
+      const cfgRes = await page.request.get(
+        `${api}/file-import/configurations/analyzer/${createdAnalyzerId}`,
+      );
+      expect(cfgRes.ok()).toBeTruthy();
+      const cfg = await cfgRes.json();
+      expect(cfg.fileFormat).toBe("EXCEL");
+      expect(cfg.active).toBe(true);
+    }
+
+    await page.waitForTimeout(2_000); // Final pause for video
+  });
+});

--- a/frontend/playwright/tests/demo-quantstudio-file-config.spec.ts
+++ b/frontend/playwright/tests/demo-quantstudio-file-config.spec.ts
@@ -102,8 +102,19 @@ test.describe("Demo: QuantStudio 7 Generic File Config", () => {
     await form.fillName(analyzerName);
     await page.waitForTimeout(500);
 
-    // Step 8: Save
+    // Step 8: Save — intercept API response for diagnostics
+    const saveResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/rest/analyzer/analyzers") &&
+        resp.request().method() === "POST",
+      { timeout: 15_000 },
+    );
     await form.save();
+    const saveResponse = await saveResponsePromise;
+    if (!saveResponse.ok()) {
+      const body = await saveResponse.text().catch(() => "no body");
+      console.error(`Save API returned ${saveResponse.status()}: ${body}`);
+    }
     await form.expectSuccessNotification();
     await page.waitForTimeout(1_500); // Show success notification
 

--- a/frontend/playwright/tests/file-import.spec.ts
+++ b/frontend/playwright/tests/file-import.spec.ts
@@ -22,14 +22,6 @@ const FILE_ANALYZERS = [
     fileFormat: "EXCEL",
     filePattern: "*.xls",
   },
-  { name: "E2E-FILE-Tecan-F50", fileFormat: "CSV", filePattern: "*.csv" },
-  { name: "E2E-FILE-Multiskan-FC", fileFormat: "CSV", filePattern: "*.csv" },
-  {
-    name: "E2E-FILE-FluoroCycler-XT",
-    fileFormat: "EXCEL",
-    filePattern: "*.xlsx",
-  },
-  { name: "E2E-FILE-DT-Prime", fileFormat: "XML", filePattern: "*.xml" },
 ];
 
 function apiBase(baseURL: string | undefined): string {

--- a/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
+++ b/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
@@ -328,6 +328,12 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
       ...formData,
       port: formData.port ? parseInt(formData.port, 10) : null,
       defaultConfigId: selectedDefault?.id || null,
+      // Clear network/protocol fields for FILE protocol — not applicable
+      ...(isFileProtocol && {
+        ipAddress: null,
+        port: null,
+        protocolVersion: null,
+      }),
     };
 
     const callback = (response, extraParams) => {

--- a/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
+++ b/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import {
   ComposedModal,
   ModalHeader,
@@ -9,6 +9,7 @@ import {
   Dropdown,
   InlineNotification,
   FormGroup,
+  Tile,
 } from "@carbon/react";
 import { useIntl } from "react-intl";
 import {
@@ -158,6 +159,27 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
     (t) => t.id === formData.pluginTypeId,
   );
   const isGenericPlugin = selectedPluginType?.isGenericPlugin === true;
+  const isFileProtocol = selectedPluginType?.protocol?.toUpperCase() === "FILE";
+
+  const sortedPluginTypes = useMemo(() => {
+    const protocolOrder = { ASTM: 0, HL7: 1, FILE: 2 };
+    return [...pluginTypes].sort((a, b) => {
+      if (a.isGenericPlugin !== b.isGenericPlugin)
+        return b.isGenericPlugin ? 1 : -1;
+      if (a.isGenericPlugin && b.isGenericPlugin) {
+        return (
+          (protocolOrder[a.protocol] ?? 99) - (protocolOrder[b.protocol] ?? 99)
+        );
+      }
+      return a.name.localeCompare(b.name);
+    });
+  }, [pluginTypes]);
+
+  const filteredDefaultConfigs = useMemo(() => {
+    if (!selectedPluginType?.protocol) return defaultConfigs;
+    const proto = selectedPluginType.protocol.toUpperCase();
+    return defaultConfigs.filter((c) => c.protocol === proto);
+  }, [defaultConfigs, selectedPluginType]);
 
   useEffect(() => {
     if (open) {
@@ -227,7 +249,10 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
           ...prev,
           identifierPattern:
             configData.identifier_pattern || prev.identifierPattern,
-          analyzerType: configData.category || prev.analyzerType,
+          analyzerType:
+            configData.category ||
+            configData.profileMeta?.category ||
+            prev.analyzerType,
           protocolVersion:
             PLUGIN_PROTOCOL_DEFAULTS[protocolUpper] || prev.protocolVersion,
           pluginTypeId: matchingPluginType?.id || prev.pluginTypeId,
@@ -238,7 +263,10 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
           title: intl.formatMessage({ id: "analyzer.form.defaults.loaded" }),
           subtitle: intl.formatMessage(
             { id: "analyzer.form.defaults.loaded.subtitle" },
-            { name: configData.analyzer_name },
+            {
+              name:
+                configData.analyzer_name || configData.profileMeta?.displayName,
+            },
           ),
         });
       } else {
@@ -418,10 +446,11 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
                 id: "analyzer.form.pluginType.placeholder",
                 defaultMessage: "Select plugin type...",
               })}
-              items={pluginTypes}
+              items={sortedPluginTypes}
               selectedItem={
-                pluginTypes.find((opt) => opt.id === formData.pluginTypeId) ||
-                null
+                sortedPluginTypes.find(
+                  (opt) => opt.id === formData.pluginTypeId,
+                ) || null
               }
               itemToString={(item) =>
                 item ? `${item.name} (${item.protocol})` : ""
@@ -455,10 +484,12 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
                 label={intl.formatMessage({
                   id: "analyzer.form.loadDefaultConfig.placeholder",
                 })}
-                items={defaultConfigs}
+                items={filteredDefaultConfigs}
                 selectedItem={selectedDefault}
                 itemToString={(item) =>
-                  item ? `${item.analyzerName} (${item.protocol})` : ""
+                  item
+                    ? `${item.analyzerName || item.id?.split("/")[1] || item.id} (${item.protocol})`
+                    : ""
                 }
                 onChange={({ selectedItem }) =>
                   handleDefaultConfigSelect(selectedItem)
@@ -516,71 +547,100 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
               required
             />
 
-            <Dropdown
-              id="analyzer-protocol-version"
-              data-testid="analyzer-form-protocol-version-dropdown"
-              titleText={intl.formatMessage({
-                id: "analyzer.form.protocolVersion",
-                defaultMessage: "Message Protocol",
-              })}
-              items={PROTOCOL_VERSIONS}
-              selectedItem={
-                PROTOCOL_VERSIONS.find(
-                  (opt) => opt.value === formData.protocolVersion,
-                ) || PROTOCOL_VERSIONS[0]
-              }
-              itemToString={(item) => (item ? item.label : "")}
-              onChange={({ selectedItem }) => {
-                if (selectedItem) {
-                  handleFieldChange("protocolVersion", selectedItem.value);
+            {!isFileProtocol && (
+              <Dropdown
+                id="analyzer-protocol-version"
+                data-testid="analyzer-form-protocol-version-dropdown"
+                titleText={intl.formatMessage({
+                  id: "analyzer.form.protocolVersion",
+                  defaultMessage: "Message Protocol",
+                })}
+                items={PROTOCOL_VERSIONS}
+                selectedItem={
+                  PROTOCOL_VERSIONS.find(
+                    (opt) => opt.value === formData.protocolVersion,
+                  ) || PROTOCOL_VERSIONS[0]
                 }
-              }}
-            />
+                itemToString={(item) => (item ? item.label : "")}
+                onChange={({ selectedItem }) => {
+                  if (selectedItem) {
+                    handleFieldChange("protocolVersion", selectedItem.value);
+                  }
+                }}
+              />
+            )}
           </FormGroup>
 
-          {/* Section 3 — Connection */}
-          <FormGroup legendText="">
-            <div
-              className="connection-fields"
-              data-testid="analyzer-form-connection-fields"
-            >
-              <TextInput
-                id="analyzer-ip"
-                data-testid="analyzer-form-ip-input"
-                labelText={intl.formatMessage({
-                  id: "analyzer.form.ipAddress",
-                })}
-                placeholder={intl.formatMessage({
-                  id: "analyzer.form.ipAddress.placeholder",
-                })}
-                value={formData.ipAddress}
-                onChange={(e) => handleFieldChange("ipAddress", e.target.value)}
-                invalid={!!errors.ipAddress}
-                invalidText={errors.ipAddress}
-              />
-
-              <TextInput
-                id="analyzer-port"
-                data-testid="analyzer-form-port-input"
-                labelText={intl.formatMessage({ id: "analyzer.form.port" })}
-                placeholder={intl.formatMessage({
-                  id: "analyzer.form.port.placeholder",
-                })}
-                value={formData.port}
-                onChange={(e) => handleFieldChange("port", e.target.value)}
-                invalid={!!errors.port}
-                invalidText={errors.port}
-              />
-
-              <Button
-                kind="tertiary"
-                onClick={() => setTestConnectionModalOpen(true)}
-                data-testid="analyzer-form-test-connection-button"
+          {/* Section 3 — Connection (hidden for FILE protocol) */}
+          {!isFileProtocol && (
+            <FormGroup legendText="">
+              <div
+                className="connection-fields"
+                data-testid="analyzer-form-connection-fields"
               >
-                {intl.formatMessage({ id: "analyzer.form.testConnection" })}
-              </Button>
-            </div>
-          </FormGroup>
+                <TextInput
+                  id="analyzer-ip"
+                  data-testid="analyzer-form-ip-input"
+                  labelText={intl.formatMessage({
+                    id: "analyzer.form.ipAddress",
+                  })}
+                  placeholder={intl.formatMessage({
+                    id: "analyzer.form.ipAddress.placeholder",
+                  })}
+                  value={formData.ipAddress}
+                  onChange={(e) =>
+                    handleFieldChange("ipAddress", e.target.value)
+                  }
+                  invalid={!!errors.ipAddress}
+                  invalidText={errors.ipAddress}
+                />
+
+                <TextInput
+                  id="analyzer-port"
+                  data-testid="analyzer-form-port-input"
+                  labelText={intl.formatMessage({ id: "analyzer.form.port" })}
+                  placeholder={intl.formatMessage({
+                    id: "analyzer.form.port.placeholder",
+                  })}
+                  value={formData.port}
+                  onChange={(e) => handleFieldChange("port", e.target.value)}
+                  invalid={!!errors.port}
+                  invalidText={errors.port}
+                />
+
+                <Button
+                  kind="tertiary"
+                  onClick={() => setTestConnectionModalOpen(true)}
+                  data-testid="analyzer-form-test-connection-button"
+                >
+                  {intl.formatMessage({ id: "analyzer.form.testConnection" })}
+                </Button>
+              </div>
+            </FormGroup>
+          )}
+
+          {/* Section 3b — FILE protocol info */}
+          {isFileProtocol && (
+            <FormGroup legendText="">
+              <Tile data-testid="analyzer-form-file-protocol-info">
+                <p>
+                  <strong>
+                    {intl.formatMessage({
+                      id: "analyzer.form.fileProtocol.title",
+                      defaultMessage: "File Import Protocol",
+                    })}
+                  </strong>
+                </p>
+                <p>
+                  {intl.formatMessage({
+                    id: "analyzer.form.fileProtocol.description",
+                    defaultMessage:
+                      "This analyzer imports results from files. File import settings will be configured after saving.",
+                  })}
+                </p>
+              </Tile>
+            </FormGroup>
+          )}
         </ModalBody>
         <ModalFooter>
           <Button

--- a/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
+++ b/frontend/src/components/analyzers/AnalyzerForm/AnalyzerForm.jsx
@@ -296,14 +296,14 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
       });
     }
 
-    if (formData.ipAddress) {
+    if (!isFileProtocol && formData.ipAddress) {
       const ipError = validateIPAddress(formData.ipAddress);
       if (ipError) {
         newErrors.ipAddress = ipError;
       }
     }
 
-    if (formData.port) {
+    if (!isFileProtocol && formData.port) {
       const portNum = parseInt(formData.port, 10);
       if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
         newErrors.port = intl.formatMessage({
@@ -457,6 +457,8 @@ const AnalyzerForm = ({ analyzer, open, onClose }) => {
               }
               onChange={({ selectedItem }) => {
                 handleFieldChange("pluginTypeId", selectedItem?.id || "");
+                // Reset profile selection when plugin type changes
+                setSelectedDefault(null);
                 // Auto-set protocol version based on plugin type
                 if (selectedItem?.protocol) {
                   handleFieldChange(

--- a/frontend/src/components/analyzers/AnalyzerForm/__tests__/AnalyzerForm.fileProtocol.test.jsx
+++ b/frontend/src/components/analyzers/AnalyzerForm/__tests__/AnalyzerForm.fileProtocol.test.jsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import { BrowserRouter } from "react-router-dom";
+import AnalyzerForm from "../AnalyzerForm";
+import messages from "../../../../languages/en.json";
+import * as analyzerService from "../../../../services/analyzerService";
+
+jest.mock("../../../../services/analyzerService", () => ({
+  getDefaultConfigs: jest.fn(),
+  getDefaultConfig: jest.fn(),
+  getAnalyzerTypes: jest.fn(),
+  createAnalyzer: jest.fn(),
+  updateAnalyzer: jest.fn(),
+}));
+
+const renderWithIntl = (component) => {
+  return render(
+    <BrowserRouter>
+      <IntlProvider locale="en" messages={messages}>
+        {component}
+      </IntlProvider>
+    </BrowserRouter>,
+  );
+};
+
+const PLUGIN_TYPES = [
+  { id: "1", name: "Generic ASTM", protocol: "ASTM", isGenericPlugin: true },
+  { id: "2", name: "Generic HL7", protocol: "HL7", isGenericPlugin: true },
+  { id: "3", name: "Generic File", protocol: "FILE", isGenericPlugin: true },
+];
+
+const DEFAULT_CONFIGS = [
+  {
+    id: "astm/genexpert-astm",
+    protocol: "ASTM",
+    analyzerName: "GeneXpert ASTM",
+  },
+  {
+    id: "file/quantstudio",
+    protocol: "FILE",
+    analyzerName: "QuantStudio QS5/QS7",
+  },
+  {
+    id: "hl7/mindray-bc5380",
+    protocol: "HL7",
+    analyzerName: "Mindray BC-5380",
+  },
+];
+
+describe("AnalyzerForm - FILE Protocol Behavior", () => {
+  beforeEach(() => {
+    analyzerService.getAnalyzerTypes.mockImplementation((filters, callback) => {
+      callback(PLUGIN_TYPES);
+    });
+    analyzerService.getDefaultConfigs.mockImplementation((callback) => {
+      callback(DEFAULT_CONFIGS);
+    });
+    analyzerService.getDefaultConfig.mockImplementation(
+      (protocol, name, callback) => {
+        callback({ error: "not needed" });
+      },
+    );
+    analyzerService.createAnalyzer.mockImplementation((data, callback) => {
+      callback({ id: "NEW-ID", ...data });
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("hides connection fields and protocol version when FILE plugin is selected", async () => {
+    // Pass analyzer with pluginTypeId="3" (Generic File) to pre-select FILE
+    const fileAnalyzer = {
+      id: "test-1",
+      name: "Test FILE Analyzer",
+      analyzerType: "MOLECULAR",
+      pluginTypeId: "3",
+      status: "SETUP",
+    };
+
+    renderWithIntl(
+      <AnalyzerForm analyzer={fileAnalyzer} open={true} onClose={jest.fn()} />,
+    );
+
+    await screen.findByTestId("analyzer-form", {}, { timeout: 2000 });
+
+    // Connection fields should NOT be in the DOM for FILE protocol
+    expect(
+      screen.queryByTestId("analyzer-form-connection-fields"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("analyzer-form-ip-input"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("analyzer-form-port-input"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("analyzer-form-test-connection-button"),
+    ).not.toBeInTheDocument();
+
+    // Protocol version dropdown should NOT be in the DOM
+    expect(
+      screen.queryByTestId("analyzer-form-protocol-version-dropdown"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows FILE info tile when FILE plugin is selected", async () => {
+    const fileAnalyzer = {
+      id: "test-2",
+      name: "Test FILE Analyzer",
+      analyzerType: "MOLECULAR",
+      pluginTypeId: "3",
+      status: "SETUP",
+    };
+
+    renderWithIntl(
+      <AnalyzerForm analyzer={fileAnalyzer} open={true} onClose={jest.fn()} />,
+    );
+
+    await screen.findByTestId("analyzer-form", {}, { timeout: 2000 });
+
+    // FILE info tile should be visible
+    const fileTile = screen.queryByTestId("analyzer-form-file-protocol-info");
+    expect(fileTile).toBeInTheDocument();
+    expect(fileTile).toHaveTextContent(/File Import Protocol/i);
+  });
+
+  test("shows connection fields when ASTM plugin is selected", async () => {
+    const astmAnalyzer = {
+      id: "test-3",
+      name: "Test ASTM Analyzer",
+      analyzerType: "MOLECULAR",
+      pluginTypeId: "1",
+      ipAddress: "192.168.1.100",
+      port: "9600",
+      status: "SETUP",
+    };
+
+    renderWithIntl(
+      <AnalyzerForm analyzer={astmAnalyzer} open={true} onClose={jest.fn()} />,
+    );
+
+    await screen.findByTestId("analyzer-form", {}, { timeout: 2000 });
+
+    // Connection fields SHOULD be in the DOM for ASTM
+    expect(
+      screen.queryByTestId("analyzer-form-connection-fields"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("analyzer-form-ip-input")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("analyzer-form-port-input"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("analyzer-form-test-connection-button"),
+    ).toBeInTheDocument();
+
+    // Protocol version dropdown SHOULD be in the DOM
+    expect(
+      screen.queryByTestId("analyzer-form-protocol-version-dropdown"),
+    ).toBeInTheDocument();
+
+    // FILE info tile should NOT be in the DOM
+    expect(
+      screen.queryByTestId("analyzer-form-file-protocol-info"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("plugin types are sorted with generic plugins first", async () => {
+    renderWithIntl(<AnalyzerForm open={true} onClose={jest.fn()} />);
+
+    await screen.findByTestId("analyzer-form", {}, { timeout: 2000 });
+
+    // The plugin type dropdown should exist
+    const dropdown = screen.queryByTestId("analyzer-form-plugin-type-dropdown");
+    expect(dropdown).toBeInTheDocument();
+
+    // getAnalyzerTypes should have been called
+    await waitFor(() => {
+      expect(analyzerService.getAnalyzerTypes).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -266,6 +266,8 @@
   "analyzer.form.editTitle": "Edit Analyzer",
   "analyzer.form.error.save": "Failed to save analyzer",
   "analyzer.form.error.unknown": "An unknown error occurred",
+  "analyzer.form.fileProtocol.description": "This analyzer imports results from files. File import settings will be configured after saving.",
+  "analyzer.form.fileProtocol.title": "File Import Protocol",
   "analyzer.form.ipAddress": "IP Address",
   "analyzer.form.ipAddress.placeholder": "192.168.1.10",
   "analyzer.form.lastModified": "Last Modified Date/Time",

--- a/frontend/src/languages/fr.json
+++ b/frontend/src/languages/fr.json
@@ -265,6 +265,8 @@
   "analyzer.form.editTitle": "Edit Analyzer",
   "analyzer.form.error.save": "Failed to save analyzer",
   "analyzer.form.error.unknown": "An unknown error occurred",
+  "analyzer.form.fileProtocol.description": "Cet analyseur importe les résultats à partir de fichiers. Les paramètres d'importation seront configurés après l'enregistrement.",
+  "analyzer.form.fileProtocol.title": "Protocole d'importation de fichiers",
   "analyzer.form.ipAddress": "IP Address",
   "analyzer.form.ipAddress.placeholder": "192.168.1.10",
   "analyzer.form.lastModified": "Last Modified Date/Time",

--- a/projects/analyzer-profiles/file/quantstudio.json
+++ b/projects/analyzer-profiles/file/quantstudio.json
@@ -5,6 +5,7 @@
     "displayName": "QuantStudio QS5/QS7",
     "manufacturer": "Thermo Fisher"
   },
+  "category": "MOLECULAR",
   "protocol": {
     "name": "FILE",
     "format": "EXCEL"

--- a/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
@@ -1232,9 +1232,27 @@ public class AnalyzerRestController extends BaseRestController {
                     String filename = file.getFileName().toString().replace(".json", "");
                     template.put("id", protocol + "/" + filename);
                     template.put("protocol", protocol.toUpperCase());
-                    template.put("analyzerName", config.get("analyzer_name"));
-                    template.put("manufacturer", config.get("manufacturer"));
-                    template.put("category", config.get("category"));
+
+                    // Top-level keys (ASTM/HL7 profiles)
+                    String analyzerName = (String) config.get("analyzer_name");
+                    String manufacturer = (String) config.get("manufacturer");
+                    String category = (String) config.get("category");
+
+                    // Fallback to profileMeta (FILE profiles store data there)
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> profileMeta = (Map<String, Object>) config.get("profileMeta");
+                    if (profileMeta != null) {
+                        if (analyzerName == null) {
+                            analyzerName = (String) profileMeta.get("displayName");
+                        }
+                        if (manufacturer == null) {
+                            manufacturer = (String) profileMeta.get("manufacturer");
+                        }
+                    }
+
+                    template.put("analyzerName", analyzerName);
+                    template.put("manufacturer", manufacturer);
+                    template.put("category", category);
 
                     templates.add(template);
                 } catch (Exception e) {

--- a/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
@@ -240,7 +240,8 @@ public class AnalyzerRestController extends BaseRestController {
 
                     // For FILE protocol profiles, auto-create FileImportConfiguration
                     if (isFileProtocol(configData)) {
-                        fileImportService.autoCreateFromProfile(analyzerId, configData, form.getName());
+                        fileImportService.autoCreateFromProfile(analyzerId, configData, form.getName(),
+                                getSysUserId(request));
                     }
                 } else {
                     logger.warn("Could not load default config '{}' for test mapping auto-creation",

--- a/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
@@ -203,8 +203,10 @@ public class AnalyzerRestController extends BaseRestController {
             analyzer.setIpAddress(
                     form.getIpAddress() != null && !form.getIpAddress().trim().isEmpty() ? form.getIpAddress() : null);
             analyzer.setPort(form.getPort());
-            ProtocolVersion pv = ProtocolVersion.fromValue(form.getProtocolVersion());
-            analyzer.setProtocolVersion(pv != null ? pv : ProtocolVersion.ASTM_LIS2_A2);
+            if (form.getProtocolVersion() != null && !form.getProtocolVersion().trim().isEmpty()) {
+                ProtocolVersion pv = ProtocolVersion.fromValue(form.getProtocolVersion());
+                analyzer.setProtocolVersion(pv != null ? pv : ProtocolVersion.ASTM_LIS2_A2);
+            }
             analyzer.setTestUnitIds(form.getTestUnitIds() != null ? form.getTestUnitIds() : new ArrayList<>());
             if (form.getIdentifierPattern() != null) {
                 analyzer.setIdentifierPattern(form.getIdentifierPattern());

--- a/src/main/java/org/openelisglobal/analyzer/service/FileImportService.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/FileImportService.java
@@ -111,6 +111,8 @@ public interface FileImportService extends BaseObjectService<FileImportConfigura
      * @param analyzerId   the newly created analyzer's ID (as String)
      * @param configData   the full profile JSON parsed as a Map
      * @param analyzerName the analyzer name (used for default directory paths)
+     * @param sysUserId    the current user's ID (required for audit column)
      */
-    void autoCreateFromProfile(String analyzerId, Map<String, Object> configData, String analyzerName);
+    void autoCreateFromProfile(String analyzerId, Map<String, Object> configData, String analyzerName,
+            String sysUserId);
 }

--- a/src/main/java/org/openelisglobal/analyzer/service/FileImportServiceImpl.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/FileImportServiceImpl.java
@@ -575,7 +575,8 @@ public class FileImportServiceImpl extends BaseObjectServiceImpl<FileImportConfi
 
     @Override
     @SuppressWarnings("unchecked")
-    public void autoCreateFromProfile(String analyzerId, Map<String, Object> configData, String analyzerName) {
+    public void autoCreateFromProfile(String analyzerId, Map<String, Object> configData, String analyzerName,
+            String sysUserId) {
         if (analyzerId == null || configData == null) {
             return;
         }
@@ -654,6 +655,7 @@ public class FileImportServiceImpl extends BaseObjectServiceImpl<FileImportConfi
         config.setErrorDirectory(errorDir);
         config.setDelimiter(fileFormat.equals("TSV") ? "\t" : ",");
         config.setActive(true);
+        config.setSysUserId(sysUserId);
 
         fileImportConfigurationDAO.insert(config);
 

--- a/src/test/resources/analyzer-minimal.sql
+++ b/src/test/resources/analyzer-minimal.sql
@@ -1,6 +1,6 @@
 -- Analyzer Minimal Fixture (2-Table Model)
 -- Self-contained, hand-authored SQL for focused plugin testing.
--- Creates 3 analyzers (2006, 2007, 2013) with config columns on the analyzer row.
+-- Creates 4 analyzers (2006, 2007, 2013, 2014) with config columns on the analyzer row.
 -- No dependency on xml-to-sql.py or load-analyzer-test-data.sh.
 --
 -- Schema: 2-table model (analyzer_type + analyzer) after PR #2802 merge.
@@ -14,8 +14,9 @@ SET search_path TO clinlims;
 -- =============================================================================
 -- PluginRegistryService auto-creates these at startup when plugin JARs are loaded.
 -- Names MUST match PluginRegistryService.derivePluginName() output:
---   GenericASTMAnalyzer → "Generic ASTM"
---   GenericHL7Analyzer  → "Generic HL7"
+--   GenericASTMAnalyzer  → "Generic ASTM"
+--   GenericHL7Analyzer   → "Generic HL7"
+--   GenericFileAnalyzer  → "Generic File"
 -- These INSERTs are a fallback for environments where plugins aren't loaded
 -- (e.g., unit tests without the full plugin JAR lifecycle).
 
@@ -29,6 +30,12 @@ INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, i
 VALUES (nextval('analyzer_type_seq'), 'Generic HL7', 'Generic HL7 - Dashboard-configurable analyzer (requires identifier_pattern)',
         'org.openelisglobal.plugins.analyzer.generichl7.GenericHL7Analyzer',
         'HL7', true, true, NOW())
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO analyzer_type (id, name, description, plugin_class_name, protocol, is_generic_plugin, is_active, last_updated)
+VALUES (nextval('analyzer_type_seq'), 'Generic File', 'Generic File - Dashboard-configurable file import analyzer',
+        'org.openelisglobal.plugins.analyzer.genericfile.GenericFileAnalyzer',
+        'FILE', true, true, NOW())
 ON CONFLICT (name) DO NOTHING;
 
 -- =============================================================================
@@ -54,7 +61,11 @@ VALUES
   -- OE identifies the analyzer from the ASTM H-record, not the source IP.
   (2013, 'Cepheid GeneXpert (ASTM Mode)', 'MOLECULAR', 'ASTM LIS2-A2 over TCP/IP', true,
    '172.20.1.100', 9600, 'ASTM_LIS2_A2', 'ACTIVE',
-   'GENEXPERT.*|CEPHEID.*', NOW())
+   'GENEXPERT.*|CEPHEID.*', NOW()),
+  -- QuantStudio 5: GenericFile, molecular, FILE import (EXCEL)
+  (2014, 'QuantStudio 5', 'MOLECULAR', 'QuantStudio QS5 Real-Time PCR (FILE import)', true,
+   NULL, NULL, NULL, 'ACTIVE',
+   NULL, NOW())
 ON CONFLICT (id) DO NOTHING;
 
 -- =============================================================================
@@ -68,6 +79,10 @@ UPDATE analyzer SET analyzer_type_id = (
 UPDATE analyzer SET analyzer_type_id = (
   SELECT id FROM analyzer_type WHERE name = 'Generic HL7'
 ) WHERE id = 2007 AND analyzer_type_id IS NULL;
+
+UPDATE analyzer SET analyzer_type_id = (
+  SELECT id FROM analyzer_type WHERE name = 'Generic File'
+) WHERE id = 2014 AND analyzer_type_id IS NULL;
 
 -- =============================================================================
 -- 4. TEST MAPPINGS for GeneXpert ASTM (analyzer_test_map composite PK)
@@ -86,7 +101,47 @@ VALUES
 ON CONFLICT (analyzer_type_id, analyzer_test_name) DO NOTHING;
 
 -- =============================================================================
--- 5. ADVANCE SEQUENCE (avoid ID collisions with future inserts)
+-- 5. FILE IMPORT CONFIGURATION for QuantStudio 5
+-- =============================================================================
+
+INSERT INTO file_import_configuration (
+  id, analyzer_id, import_directory, file_pattern,
+  archive_directory, error_directory, column_mappings,
+  delimiter, has_header, active, fhir_uuid, sys_user_id,
+  last_updated, file_format
+) VALUES (
+  'a0000000-0000-0000-0000-000000002014',
+  2014,
+  '/data/analyzer-imports/quantstudio-5/incoming',
+  '*.xls',
+  '/data/analyzer-imports/quantstudio-5/processed',
+  '/data/analyzer-imports/quantstudio-5/errors',
+  '{"Sample Name":"sampleId","Target Name":"testCode","Quantity Mean":"result","CT":"ctValue","Well Position":"position"}',
+  E'\t',
+  true,
+  true,
+  'a0000000-0000-0000-0000-000000002014',
+  '1',
+  NOW(),
+  'EXCEL'
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO analyzer_plugin_config (analyzer_id, config, sys_user_id, last_updated)
+VALUES (
+  2014,
+  '{
+    "profileMeta":{"id":"quantstudio","version":"1.1.0","displayName":"QuantStudio QS5/QS7"},
+    "protocol":{"name":"FILE","format":"EXCEL"},
+    "column_mapping":{"Sample Name":"sampleId","Target Name":"testCode","Quantity Mean":"result","CT":"ctValue","Well Position":"position"},
+    "default_test_mappings":{"VIH-1":"HIV-1 VL (LOINC 20447-9)","IC":"Internal Control"},
+    "configDefaults":{"fileFormat":"EXCEL","hasHeader":true,"sheetIndex":0}
+  }'::jsonb,
+  '1',
+  NOW()
+) ON CONFLICT (analyzer_id) DO NOTHING;
+
+-- =============================================================================
+-- 6. ADVANCE SEQUENCE (avoid ID collisions with future inserts)
 -- =============================================================================
 
 SELECT setval('analyzer_seq', GREATEST(
@@ -95,7 +150,7 @@ SELECT setval('analyzer_seq', GREATEST(
 ));
 
 -- =============================================================================
--- 6. VERIFICATION (DO block — raises NOTICE, never fails)
+-- 7. VERIFICATION (DO block — raises NOTICE, never fails)
 -- =============================================================================
 
 DO $$
@@ -104,15 +159,18 @@ DECLARE
   v_type_count       INTEGER;
   v_map_count        INTEGER;
   v_linked_count     INTEGER;
+  v_file_cfg_count   INTEGER;
 BEGIN
-  SELECT COUNT(*) INTO v_analyzer_count FROM analyzer WHERE id IN (2006, 2007, 2013);
-  SELECT COUNT(*) INTO v_type_count FROM analyzer_type WHERE name IN ('Generic ASTM', 'Generic HL7');
+  SELECT COUNT(*) INTO v_analyzer_count FROM analyzer WHERE id IN (2006, 2007, 2013, 2014);
+  SELECT COUNT(*) INTO v_type_count FROM analyzer_type WHERE name IN ('Generic ASTM', 'Generic HL7', 'Generic File');
   SELECT COUNT(*) INTO v_map_count FROM analyzer_test_map WHERE analyzer_id = '2013';
-  SELECT COUNT(*) INTO v_linked_count FROM analyzer WHERE id IN (2006, 2007, 2013) AND analyzer_type_id IS NOT NULL;
+  SELECT COUNT(*) INTO v_linked_count FROM analyzer WHERE id IN (2006, 2007, 2013, 2014) AND analyzer_type_id IS NOT NULL;
+  SELECT COUNT(*) INTO v_file_cfg_count FROM file_import_configuration WHERE analyzer_id = 2014;
 
   RAISE NOTICE 'analyzer-minimal.sql verification:';
-  RAISE NOTICE '  analyzers:      % / 3 expected', v_analyzer_count;
-  RAISE NOTICE '  analyzer_types: % / 2 expected', v_type_count;
+  RAISE NOTICE '  analyzers:      % / 4 expected', v_analyzer_count;
+  RAISE NOTICE '  analyzer_types: % / 3 expected', v_type_count;
   RAISE NOTICE '  test_mappings:  % / 4 expected', v_map_count;
-  RAISE NOTICE '  type_linked:    % / 3 expected', v_linked_count;
+  RAISE NOTICE '  type_linked:    % / 4 expected', v_linked_count;
+  RAISE NOTICE '  file_configs:   % / 1 expected', v_file_cfg_count;
 END $$;

--- a/src/test/resources/fixtures/file-import-e2e.sql
+++ b/src/test/resources/fixtures/file-import-e2e.sql
@@ -179,62 +179,6 @@ INSERT INTO analyzer_plugin_config (
   NOW()
 );
 
--- E2E-FILE-Tecan-F50 (Tecan Infinite F50, well-per-row CSV)
-INSERT INTO analyzer (id, name, analyzer_type, description, is_active, protocol_version, status, analyzer_type_id, last_updated)
-VALUES (nextval('analyzer_seq'), 'E2E-FILE-Tecan-F50', 'MOLECULAR', 'E2E Tecan F50 file import', true, NULL, 'ACTIVE',
-  (SELECT id FROM analyzer_type WHERE name = 'E2E-FILE-GenericFile'), NOW());
-
-INSERT INTO file_import_configuration (id, analyzer_id, import_directory, file_pattern, archive_directory, error_directory, column_mappings, delimiter, has_header, active, fhir_uuid, sys_user_id, last_updated, file_format)
-VALUES ('33333333-3333-3333-3333-333333333333', (SELECT id FROM analyzer WHERE name = 'E2E-FILE-Tecan-F50'),
-  '/data/analyzer-imports/e2e-tecan/incoming', '*.csv', '/data/analyzer-imports/e2e-tecan/processed', '/data/analyzer-imports/e2e-tecan/errors',
-  '{"WellPosition":"position","SampleID":"sampleId","OD_450":"result"}', E'\t', true, true, '33333333-3333-3333-3333-333333333333', '1', NOW(), 'CSV');
-
-INSERT INTO analyzer_plugin_config (analyzer_id, config, sys_user_id, last_updated)
-VALUES ((SELECT id FROM analyzer WHERE name = 'E2E-FILE-Tecan-F50'),
-  '{"profileMeta":{"id":"tecan-f50","version":"1.0.0","displayName":"Tecan Infinite F50"},"protocol":{"name":"FILE","format":"CSV"},"column_mapping":{"WellPosition":"position","SampleID":"sampleId","OD_450":"result"},"configDefaults":{"fileFormat":"CSV","delimiter":"\t"}}'::jsonb, '1', NOW());
-
--- E2E-FILE-Multiskan-FC (Thermo Multiskan FC, well-per-row CSV)
-INSERT INTO analyzer (id, name, analyzer_type, description, is_active, protocol_version, status, analyzer_type_id, last_updated)
-VALUES (nextval('analyzer_seq'), 'E2E-FILE-Multiskan-FC', 'MOLECULAR', 'E2E Multiskan FC file import', true, NULL, 'ACTIVE',
-  (SELECT id FROM analyzer_type WHERE name = 'E2E-FILE-GenericFile'), NOW());
-
-INSERT INTO file_import_configuration (id, analyzer_id, import_directory, file_pattern, archive_directory, error_directory, column_mappings, delimiter, has_header, active, fhir_uuid, sys_user_id, last_updated, file_format)
-VALUES ('44444444-4444-4444-4444-444444444444', (SELECT id FROM analyzer WHERE name = 'E2E-FILE-Multiskan-FC'),
-  '/data/analyzer-imports/e2e-multiskan/incoming', '*.csv', '/data/analyzer-imports/e2e-multiskan/processed', '/data/analyzer-imports/e2e-multiskan/errors',
-  '{"Well":"position","Sample ID":"sampleId","Absorbance (450 nm)":"result"}', ',', true, true, '44444444-4444-4444-4444-444444444444', '1', NOW(), 'CSV');
-
-INSERT INTO analyzer_plugin_config (analyzer_id, config, sys_user_id, last_updated)
-VALUES ((SELECT id FROM analyzer WHERE name = 'E2E-FILE-Multiskan-FC'),
-  '{"profileMeta":{"id":"multiskan-fc","version":"1.0.0","displayName":"Thermo Multiskan FC"},"protocol":{"name":"FILE","format":"CSV"},"column_mapping":{"Well":"position","Sample ID":"sampleId","Absorbance (450 nm)":"result"},"configDefaults":{"fileFormat":"CSV","delimiter":","}}'::jsonb, '1', NOW());
-
--- E2E-FILE-FluoroCycler-XT (Bruker FluoroCycler XT, Excel 12-column)
-INSERT INTO analyzer (id, name, analyzer_type, description, is_active, protocol_version, status, analyzer_type_id, last_updated)
-VALUES (nextval('analyzer_seq'), 'E2E-FILE-FluoroCycler-XT', 'MOLECULAR', 'E2E FluoroCycler XT file import', true, NULL, 'ACTIVE',
-  (SELECT id FROM analyzer_type WHERE name = 'E2E-FILE-GenericFile'), NOW());
-
-INSERT INTO file_import_configuration (id, analyzer_id, import_directory, file_pattern, archive_directory, error_directory, column_mappings, delimiter, has_header, active, fhir_uuid, sys_user_id, last_updated, file_format)
-VALUES ('55555555-5555-5555-5555-555555555555', (SELECT id FROM analyzer WHERE name = 'E2E-FILE-FluoroCycler-XT'),
-  '/data/analyzer-imports/e2e-fluorocycler/incoming', '*.xlsx', '/data/analyzer-imports/e2e-fluorocycler/processed', '/data/analyzer-imports/e2e-fluorocycler/errors',
-  '{"SampleID":"sampleId","WellPosition":"position","CP":"result","Interpretation":"interpretation"}', ',', true, true, '55555555-5555-5555-5555-555555555555', '1', NOW(), 'EXCEL');
-
-INSERT INTO analyzer_plugin_config (analyzer_id, config, sys_user_id, last_updated)
-VALUES ((SELECT id FROM analyzer WHERE name = 'E2E-FILE-FluoroCycler-XT'),
-  '{"profileMeta":{"id":"fluorocycler-xt","version":"1.0.0","displayName":"Bruker FluoroCycler XT"},"protocol":{"name":"FILE","format":"EXCEL"},"column_mapping":{"SampleID":"sampleId","WellPosition":"position","CP":"result","Interpretation":"interpretation"},"configDefaults":{"fileFormat":"EXCEL","hasHeader":true}}'::jsonb, '1', NOW());
-
--- E2E-FILE-DT-Prime (DNA Technology DT-Prime, XML)
-INSERT INTO analyzer (id, name, analyzer_type, description, is_active, protocol_version, status, analyzer_type_id, last_updated)
-VALUES (nextval('analyzer_seq'), 'E2E-FILE-DT-Prime', 'MOLECULAR', 'E2E DT-Prime XML file import', true, NULL, 'ACTIVE',
-  (SELECT id FROM analyzer_type WHERE name = 'E2E-FILE-GenericFile'), NOW());
-
-INSERT INTO file_import_configuration (id, analyzer_id, import_directory, file_pattern, archive_directory, error_directory, column_mappings, delimiter, has_header, active, fhir_uuid, sys_user_id, last_updated, file_format)
-VALUES ('66666666-6666-6666-6666-666666666666', (SELECT id FROM analyzer WHERE name = 'E2E-FILE-DT-Prime'),
-  '/data/analyzer-imports/e2e-dtprime/incoming', '*.xml', '/data/analyzer-imports/e2e-dtprime/processed', '/data/analyzer-imports/e2e-dtprime/errors',
-  '{"SampleID":"sampleId","WellPosition":"position","Result":"result","Interpretation":"interpretation"}', ',', true, true, '66666666-6666-6666-6666-666666666666', '1', NOW(), 'XML');
-
-INSERT INTO analyzer_plugin_config (analyzer_id, config, sys_user_id, last_updated)
-VALUES ((SELECT id FROM analyzer WHERE name = 'E2E-FILE-DT-Prime'),
-  '{"profileMeta":{"id":"dtprime","version":"1.0.0","displayName":"DNA Technology DT-Prime"},"protocol":{"name":"FILE","format":"XML"},"column_mapping":{"SampleID":"sampleId","WellPosition":"position","Result":"result","Interpretation":"interpretation"},"configDefaults":{"fileFormat":"XML"}}'::jsonb, '1', NOW());
-
 SELECT
   (SELECT COUNT(*) FROM analyzer_type WHERE name = 'E2E-FILE-GenericFile') AS analyzer_type_count,
   (SELECT COUNT(*) FROM analyzer WHERE name LIKE 'E2E-FILE-%') AS analyzer_count,


### PR DESCRIPTION
## Summary
- **Backend**: `scanTemplates()` now falls back to `profileMeta.displayName` / `profileMeta.manufacturer` when top-level keys are absent — fixes FILE profiles showing as "undefined (FILE)" in the dropdown
- **Frontend**: Analyzer form adapts for FILE protocol — hides IP/port/test-connection/protocol-version, shows FILE info tile, sorts generic plugins first (ASTM → HL7 → FILE), filters profile dropdown by selected plugin's protocol
- **Fixtures**: Added Generic File type + QuantStudio 5 to `analyzer-minimal.sql`; trimmed `file-import-e2e.sql` from 6 → 2 focused FILE analyzers
- **Playwright**: QuantStudio 7 demo spec with video recording, validating the full Generic File plugin config workflow

## Test plan
- [ ] Backend compiles (`mvn clean install -DskipTests -Dmaven.test.skip=true`) — verified locally
- [ ] Frontend formats clean (`npm run format`) — verified locally
- [ ] E2E: `npx playwright test --project=core-app` passes (file-import trimmed to 2 analyzers)
- [ ] E2E: `npx playwright test demo-quantstudio --project=analyzer-harness` produces video of QuantStudio 7 config workflow
- [ ] Manual: Open analyzer form → select Generic File → profile dropdown shows only FILE profiles, no IP/port fields visible, FILE info tile shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)