### PR TITLE
fix(ci): analyzer harness parity — same fixtures + seed as local

### DIFF
--- a/.github/workflows/analyzer-e2e.yml
+++ b/.github/workflows/analyzer-e2e.yml
@@ -93,10 +93,8 @@ jobs:
           timeout 120 bash -c 'until curl -s -f http://localhost:8442/actuator/health > /dev/null; do sleep 2; done'
           timeout 120 bash -c 'until curl -s -f http://localhost:8085/health > /dev/null; do sleep 2; done'
 
-      - name: Load analyzer harness fixture dataset (types + cleanup only)
-        run: |
-          docker exec -i openelisglobal-database psql -U clinlims -d clinlims < src/test/resources/analyzer-harness-e2e.sql
-          docker exec -i openelisglobal-database psql -U clinlims -d clinlims < src/test/resources/fixtures/file-import-e2e.sql
+      - name: Load test fixtures (parity with local: foundational + analyzer types + cleanup + storage)
+        run: ./src/test/resources/load-test-fixtures.sh --analyzers=full --no-verify
 
       - name: Seed analyzers via REST API (profile-based test mappings + bridge registration)
         run: bash projects/analyzer-harness/seed-analyzers.sh

--- a/.specify/oe/commands/restart-analyzer-harness.md
+++ b/.specify/oe/commands/restart-analyzer-harness.md
@@ -5,7 +5,8 @@ perform an analyzer harness environment restart workflow with:
 
 - **Container restart** with force-recreate for harness services
 - **Optional database reset** (drop volumes with `--full-reset`)
-- **Analyzer fixture loading** (from canonical `analyzer-e2e.generated.sql`)
+- **Fixture loading** (`load-test-fixtures.sh --analyzers=full`) and **analyzer
+  seeding** (`seed-analyzers.sh`)
 - **Analyzer infrastructure verification** (ASTM bridge, simulator, virtual
   serial)
 
@@ -267,19 +268,34 @@ export DB_PORT=15432
 export DB_HOST=localhost
 
 if [ "$FULL_RESET" = true ]; then
-    ./src/test/resources/load-test-fixtures.sh --no-verify
+    ./src/test/resources/load-test-fixtures.sh --analyzers=full --no-verify
 else
-    ./src/test/resources/load-test-fixtures.sh --reset --no-verify
+    ./src/test/resources/load-test-fixtures.sh --analyzers=full --reset --no-verify
 fi
 ```
 
 This loads:
 
 - Foundational data (e2e-foundational-data.sql)
+- Analyzer types + cleanup (analyzer-minimal.sql, file-import-e2e.sql)
 - Storage fixtures (storage-e2e.generated.sql from DBUnit)
-- **Analyzer fixtures** (analyzer-e2e.generated.sql - 12 analyzers 2000-2012)
 
-Report: "Loaded fixtures (foundational + storage + analyzers)"
+Report: "Loaded fixtures (foundational + analyzer types + storage)"
+
+### 6b) Seed analyzers via REST API (checkpoint #6b)
+
+**Skip if `--skip-fixtures` was passed.**
+
+Create the four harness analyzers (GeneXpert ASTM, QuantStudio 5/7, FluoroCycler
+XT) so Playwright and manual tests see the same set as CI:
+
+```bash
+cd $REPO_ROOT
+# TEST_USER and TEST_PASS from .env (loaded in preflight)
+BASE_URL=https://localhost bash projects/analyzer-harness/seed-analyzers.sh
+```
+
+Report: "Seeded 4 analyzers via REST API"
 
 ### 7) Verify analyzer infrastructure (checkpoint #7)
 
@@ -308,7 +324,7 @@ Print summary:
   Login: admin (credentials from .env)
 
   Database: localhost:15432
-  Analyzers: 12 loaded (IDs 2000-2012)
+  Analyzers: 4 seeded via seed-analyzers.sh (GeneXpert ASTM, QuantStudio 5/7, FluoroCycler XT)
   Defaults: 11 templates at /data/analyzer-defaults (host path: projects/analyzer-defaults)
 
   Analyzer Infrastructure:
@@ -367,9 +383,10 @@ Where:
 
 - Harness compose files:
   `projects/analyzer-harness/docker-compose.{dev,analyzer-test,letsencrypt}.yml`
-- Fixture loader: `src/test/resources/load-test-fixtures.sh`
-- Analyzer fixtures: `src/test/resources/testdata/analyzer-e2e.generated.sql`
-  (canonical)
+- Fixture loader: `src/test/resources/load-test-fixtures.sh` (use
+  `--analyzers=full`)
+- Analyzer seeding: `projects/analyzer-harness/seed-analyzers.sh` (4 analyzers
+  via REST API)
 - Build script: `projects/analyzer-harness/build.sh` (WAR + harness images)
 - Reset script: `projects/analyzer-harness/reset-env.sh` (implements this
   workflow)

--- a/projects/analyzer-harness/reset-env.sh
+++ b/projects/analyzer-harness/reset-env.sh
@@ -156,12 +156,19 @@ else
     export DB_HOST="${DB_HOST:-localhost}"
 
     if [ "$FULL_RESET" = true ]; then
-        ./src/test/resources/load-test-fixtures.sh --no-verify
+        ./src/test/resources/load-test-fixtures.sh --analyzers=full --no-verify
     else
-        ./src/test/resources/load-test-fixtures.sh --reset --no-verify
+        ./src/test/resources/load-test-fixtures.sh --analyzers=full --reset --no-verify
     fi
-    # 011 dataset is loaded by load-test-fixtures.sh (once); no separate call to avoid duplicate INSERT.
 
+    # Seed 4 harness analyzers via REST API (parity with CI and /restart-analyzer-harness)
+    set -a && [ -f .env ] && . ./.env && set +a
+    if [ -n "${TEST_PASS:-}" ]; then
+        BASE_URL=https://localhost bash projects/analyzer-harness/seed-analyzers.sh
+        echo -e "  ${GREEN}✓ Analyzers seeded${NC}"
+    else
+        echo -e "  ${YELLOW}⚠ TEST_PASS not set; run seed-analyzers.sh manually after adding to .env${NC}"
+    fi
     echo -e "  ${GREEN}✓ Fixtures loaded${NC}"
 fi
 


### PR DESCRIPTION
## Summary
Align CI analyzer E2E with local harness: same fixture loader and seed step.

## Changes
- **CI** (`.github/workflows/analyzer-e2e.yml`): Replace manual `docker exec psql` with `load-test-fixtures.sh --analyzers=full --no-verify` (foundational + analyzer types + cleanup + storage). Seed step unchanged.
- **restart-analyzer-harness** (command doc): Step 6 uses `--analyzers=full`; new step 6b runs `seed-analyzers.sh` after fixtures. Final report and reference updated.
- **reset-env.sh**: Use `--analyzers=full` and run `seed-analyzers.sh` after loading fixtures (when `TEST_PASS` is set).

## Goal
- Parity: local and CI use the same fixture contract and 4 API-seeded analyzers.
- Green CI under the same harness bootup contract as `/restart-analyzer-harness --full-reset` (fixtures + seed).

## How to verify
- CI will run on this PR (Analyzer E2E workflow).
- Locally: `/restart-analyzer-harness --full-reset` then run demo Playwright; same data path as CI.

Made with [Cursor](https://cursor.com)