### PR TITLE
issue-3078: add integration tests for alert notification config REST controller

### DIFF
--- a/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java
@@ -1,11 +1,10 @@
 package org.openelisglobal.alert.controller.rest;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -56,7 +55,7 @@ public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWe
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("Alert notification configuration saved successfully")));
+            .andExpect(jsonPath("$.message").value("Alert notification configuration saved successfully"));
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java
@@ -14,9 +14,11 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
+@Rollback
 public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWebContextSensitiveTest {
 
     private static final String BASE_PATH = "/rest/alert-notification-config";
@@ -27,11 +29,17 @@ public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWe
         super.setUp();
         objectMapper = new ObjectMapper();
         executeDataSetWithStateManagement("testdata/alert_notification_config.xml");
-        cleanRowsInCurrentConnection(new String[] { "notification_config_option", "site_information" });
     }
 
     @Test
     public void getAlertNotificationConfig_ShouldReturnAllExpectedAlertTypes() throws Exception {
+        Map<String, Object> payload = createConfigPayload(false, true, false, 20, "get@lab.com");
+
+        mockMvc.perform(post(BASE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload)))
+            .andExpect(status().isOk());
+
         MvcResult result = mockMvc.perform(get(BASE_PATH).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andReturn();
@@ -45,6 +53,18 @@ public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWe
             root.path("alertConfigs").get("FREEZER_TEMPERATURE_ALERT"));
         assertNotNull("EQUIPMENT_ALERT should exist", root.path("alertConfigs").get("EQUIPMENT_ALERT"));
         assertNotNull("INVENTORY_ALERT should exist", root.path("alertConfigs").get("INVENTORY_ALERT"));
+
+        assertEquals(
+            "FREEZER_TEMPERATURE_ALERT email should match saved config",
+            false,
+            root.path("alertConfigs").path("FREEZER_TEMPERATURE_ALERT").path("email").asBoolean());
+        assertEquals(
+            "FREEZER_TEMPERATURE_ALERT sms should match saved config",
+            true,
+            root.path("alertConfigs").path("FREEZER_TEMPERATURE_ALERT").path("sms").asBoolean());
+        assertEquals("Escalation should match saved config", false, root.path("escalationEnabled").asBoolean());
+        assertEquals("Escalation delay should match saved config", 20, root.path("escalationDelayMinutes").asInt());
+        assertEquals("Supervisor email should match saved config", "get@lab.com", root.path("supervisorEmail").asText());
     }
 
     @Test
@@ -55,7 +75,7 @@ public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWe
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk())
-            .andExpect(jsonPath("$.message").value("Alert notification configuration saved successfully"));
+            .andExpect(jsonPath("$.message").exists());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java
@@ -1,0 +1,124 @@
+package org.openelisglobal.alert.controller.rest;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWebContextSensitiveTest {
+
+    private static final String BASE_PATH = "/rest/alert-notification-config";
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        objectMapper = new ObjectMapper();
+        executeDataSetWithStateManagement("testdata/alert_notification_config.xml");
+        cleanRowsInCurrentConnection(new String[] { "notification_config_option", "site_information" });
+    }
+
+    @Test
+    public void getAlertNotificationConfig_ShouldReturnAllExpectedAlertTypes() throws Exception {
+        MvcResult result = mockMvc.perform(get(BASE_PATH).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        assertNotNull("Response body should exist", root);
+        assertNotNull("alertConfigs should exist", root.get("alertConfigs"));
+        assertNotNull(
+            "FREEZER_TEMPERATURE_ALERT should exist",
+            root.path("alertConfigs").get("FREEZER_TEMPERATURE_ALERT"));
+        assertNotNull("EQUIPMENT_ALERT should exist", root.path("alertConfigs").get("EQUIPMENT_ALERT"));
+        assertNotNull("INVENTORY_ALERT should exist", root.path("alertConfigs").get("INVENTORY_ALERT"));
+    }
+
+    @Test
+    public void saveAlertNotificationConfig_ShouldReturnSuccessMessage() throws Exception {
+        String requestBody = objectMapper.writeValueAsString(createConfigPayload(true, false, true, 30, "lab@openelis.org"));
+
+        mockMvc.perform(post(BASE_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Alert notification configuration saved successfully")));
+    }
+
+    @Test
+    public void saveThenGetAlertNotificationConfig_ShouldPersistUpdatedValues() throws Exception {
+        Map<String, Object> payload = createConfigPayload(true, false, true, 45, "alerts@openelis.org");
+
+        mockMvc.perform(post(BASE_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk());
+
+        MvcResult result = mockMvc.perform(get(BASE_PATH).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        assertEquals(
+                "FREEZER_TEMPERATURE_ALERT email should be true",
+                true,
+                root.path("alertConfigs").path("FREEZER_TEMPERATURE_ALERT").path("email").asBoolean());
+        assertEquals(
+                "FREEZER_TEMPERATURE_ALERT sms should be false",
+                false,
+                root.path("alertConfigs").path("FREEZER_TEMPERATURE_ALERT").path("sms").asBoolean());
+        assertEquals("Escalation should be enabled", true, root.path("escalationEnabled").asBoolean());
+        assertEquals("Escalation delay should be updated", 45, root.path("escalationDelayMinutes").asInt());
+        assertEquals("Supervisor email should be updated", "alerts@openelis.org", root.path("supervisorEmail").asText());
+    }
+
+    private Map<String, Object> createConfigPayload(
+            boolean enableEmail,
+            boolean enableSms,
+            boolean escalationEnabled,
+            int escalationDelayMinutes,
+            String supervisorEmail) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("alertConfigs", createAlertConfigs(enableEmail, enableSms));
+        payload.put("escalationEnabled", escalationEnabled);
+        payload.put("escalationDelayMinutes", escalationDelayMinutes);
+        payload.put("supervisorEmail", supervisorEmail);
+        return payload;
+    }
+
+    private Map<String, Map<String, Boolean>> createAlertConfigs(boolean enableEmail, boolean enableSms) {
+        Map<String, Map<String, Boolean>> alertConfigs = new HashMap<>();
+
+        Map<String, Boolean> freezerTemperatureConfig = new HashMap<>();
+        freezerTemperatureConfig.put("email", enableEmail);
+        freezerTemperatureConfig.put("sms", enableSms);
+        alertConfigs.put("FREEZER_TEMPERATURE_ALERT", freezerTemperatureConfig);
+
+        Map<String, Boolean> equipmentConfig = new HashMap<>();
+        equipmentConfig.put("email", false);
+        equipmentConfig.put("sms", false);
+        alertConfigs.put("EQUIPMENT_ALERT", equipmentConfig);
+
+        Map<String, Boolean> inventoryConfig = new HashMap<>();
+        inventoryConfig.put("email", false);
+        inventoryConfig.put("sms", false);
+        alertConfigs.put("INVENTORY_ALERT", inventoryConfig);
+
+        return alertConfigs;
+    }
+}

--- a/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java
@@ -32,19 +32,9 @@ public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWe
     }
 
     @Test
-    public void getAlertNotificationConfig_ShouldReturnAllExpectedAlertTypes() throws Exception {
+    public void saveThenGetAlertNotificationConfig_ShouldReturnAllExpectedAlertTypes() throws Exception {
         Map<String, Object> payload = createConfigPayload(false, true, false, 20, "get@lab.com");
-
-        mockMvc.perform(post(BASE_PATH)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(payload)))
-            .andExpect(status().isOk());
-
-        MvcResult result = mockMvc.perform(get(BASE_PATH).accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode root = saveAndFetchConfig(payload);
 
         assertNotNull("Response body should exist", root);
         assertNotNull("alertConfigs should exist", root.get("alertConfigs"));
@@ -81,17 +71,7 @@ public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWe
     @Test
     public void saveThenGetAlertNotificationConfig_ShouldPersistUpdatedValues() throws Exception {
         Map<String, Object> payload = createConfigPayload(true, false, true, 45, "alerts@openelis.org");
-
-        mockMvc.perform(post(BASE_PATH)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(payload)))
-                .andExpect(status().isOk());
-
-        MvcResult result = mockMvc.perform(get(BASE_PATH).accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode root = saveAndFetchConfig(payload);
 
         assertEquals(
                 "FREEZER_TEMPERATURE_ALERT email should be true",
@@ -104,6 +84,19 @@ public class AlertNotificationConfigRestControllerIntegrationTest extends BaseWe
         assertEquals("Escalation should be enabled", true, root.path("escalationEnabled").asBoolean());
         assertEquals("Escalation delay should be updated", 45, root.path("escalationDelayMinutes").asInt());
         assertEquals("Supervisor email should be updated", "alerts@openelis.org", root.path("supervisorEmail").asText());
+    }
+
+    private JsonNode saveAndFetchConfig(Map<String, Object> payload) throws Exception {
+        mockMvc.perform(post(BASE_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk());
+
+        MvcResult result = mockMvc.perform(get(BASE_PATH).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString());
     }
 
     private Map<String, Object> createConfigPayload(

--- a/src/test/resources/testdata/alert_notification_config.xml
+++ b/src/test/resources/testdata/alert_notification_config.xml
@@ -4,7 +4,4 @@
     <system_user id="1" login_name="testuser" last_name="User"
         first_name="Test" is_active="Y" is_employee="Y" />
 
-    <!-- Empty tables to ensure truncation before tests -->
-    <!-- notification_config_option will be truncated -->
-    <!-- site_information will be truncated -->
 </dataset>

--- a/src/test/resources/testdata/alert_notification_config.xml
+++ b/src/test/resources/testdata/alert_notification_config.xml
@@ -4,4 +4,7 @@
     <system_user id="1" login_name="testuser" last_name="User"
         first_name="Test" is_active="Y" is_employee="Y" />
 
+    <notification_config_option />
+    <site_information />
+
 </dataset>


### PR DESCRIPTION
- [x] The PR title includes a brief description of the work done, including the Issue number.
- [ ] The PR includes a video showing the changes for the work done. (N/A: backend-only test change)
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and Design documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary
Adds controller integration coverage for `/rest/alert-notification-config`.

New test class:
`src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerIntegrationTest.java`

Included scenarios:
1. GET returns expected config structure.
2. POST returns success message.
3. POST then GET returns updated persisted values.

## Screenshots
N/A (backend test-only change)

## Related Issue
Closes #3078

## Other
Validation command:
`mvn -Dtest=org.openelisglobal.alert.controller.rest.AlertNotificationConfigRestControllerIntegrationTest test`

Result:
`Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`
`BUILD SUCCESS`