### PR TITLE
test: Add unit tests for Patient valueholder entity

### DIFF
--- a/src/test/java/org/openelisglobal/patient/valueholder/PatientTest.java
+++ b/src/test/java/org/openelisglobal/patient/valueholder/PatientTest.java
@@ -90,8 +90,7 @@ public class PatientTest {
         assertEquals("Original ambiguous display value should be preserved", "xx/xx/2024",
                 patient.getBirthDateForDisplay());
         assertEquals("Ambiguous month and day should normalize to configured placeholder values",
-                LocalDate.of(2024, 1, 1),
-                patient.getBirthDate().toLocalDateTime().toLocalDate());
+                LocalDate.of(2024, 1, 1), patient.getBirthDate().toLocalDateTime().toLocalDate());
     }
 
     @Test
@@ -109,7 +108,8 @@ public class PatientTest {
         patient.setBirthTimeForDisplay("03/05/2024");
 
         assertEquals("Display value should be preserved", "03/05/2024", patient.getBirthTimeForDisplay());
-        assertEquals("Parsed SQL date should match the display date", Date.valueOf("2024-03-05"), patient.getBirthTime());
+        assertEquals("Parsed SQL date should match the display date", Date.valueOf("2024-03-05"),
+                patient.getBirthTime());
     }
 
     @Test
@@ -127,7 +127,8 @@ public class PatientTest {
         patient.setDeathDateForDisplay("04/06/2024");
 
         assertEquals("Display value should be preserved", "04/06/2024", patient.getDeathDateForDisplay());
-        assertEquals("Parsed SQL date should match the display date", Date.valueOf("2024-04-06"), patient.getDeathDate());
+        assertEquals("Parsed SQL date should match the display date", Date.valueOf("2024-04-06"),
+                patient.getDeathDate());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/patient/valueholder/PatientTest.java
+++ b/src/test/java/org/openelisglobal/patient/valueholder/PatientTest.java
@@ -16,7 +16,8 @@ import org.openelisglobal.person.valueholder.Person;
 /**
  * Pure unit tests for the Patient valueholder.
  *
- * <p>These tests require NO Spring context and NO Docker — they validate the
+ * <p>
+ * These tests require NO Spring context and NO Docker — they validate the
  * entity's field behaviour, date-display synchronisation, FHIR UUID handling,
  * and merge-state logic in isolation.
  */
@@ -220,9 +221,7 @@ public class PatientTest {
     @Test
     public void getFhirUuidAsString_WhenUuidIsNull_ShouldReturnEmptyString() {
         // fhirUuid is null by default
-        assertEquals(
-                "getFhirUuidAsString() should return empty string when fhirUuid is null",
-                "",
+        assertEquals("getFhirUuidAsString() should return empty string when fhirUuid is null", "",
                 patient.getFhirUuidAsString());
     }
 

--- a/src/test/java/org/openelisglobal/patient/valueholder/PatientTest.java
+++ b/src/test/java/org/openelisglobal/patient/valueholder/PatientTest.java
@@ -1,0 +1,291 @@
+package org.openelisglobal.patient.valueholder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.person.valueholder.Person;
+
+/**
+ * Pure unit tests for the Patient valueholder.
+ *
+ * <p>These tests require NO Spring context and NO Docker — they validate the
+ * entity's field behaviour, date-display synchronisation, FHIR UUID handling,
+ * and merge-state logic in isolation.
+ */
+public class PatientTest {
+
+    private Patient patient;
+
+    @Before
+    public void setUp() {
+        patient = new Patient();
+    }
+
+    // -----------------------------------------------------------------------
+    // Construction
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void constructor_ShouldInitialisePatientWithNullFields() {
+        assertNull("id should be null by default", patient.getId());
+        assertNull("gender should be null by default", patient.getGender());
+        assertNull("birthDate should be null by default", patient.getBirthDate());
+        assertNull("nationalId should be null by default", patient.getNationalId());
+        assertNull("fhirUuid should be null by default", patient.getFhirUuid());
+        assertFalse("isMerged should default to false", patient.getIsMerged());
+    }
+
+    // -----------------------------------------------------------------------
+    // ID
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setId_ShouldStoreAndReturnId() {
+        patient.setId("42");
+        assertEquals("42", patient.getId());
+    }
+
+    // -----------------------------------------------------------------------
+    // Gender
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setGender_ShouldStoreAndReturnGender() {
+        patient.setGender("M");
+        assertEquals("M", patient.getGender());
+    }
+
+    @Test
+    public void setGender_ShouldAllowFemaleCode() {
+        patient.setGender("F");
+        assertEquals("F", patient.getGender());
+    }
+
+    @Test
+    public void setGender_ShouldAllowUnknownCode() {
+        patient.setGender("U");
+        assertEquals("U", patient.getGender());
+    }
+
+    // -----------------------------------------------------------------------
+    // Birth Date — Timestamp <-> display string synchronisation
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setBirthDate_ShouldStoreTimestampDirectly() {
+        // Tests that the Timestamp field is stored via setBirthDate().
+        // NOTE: setBirthDate() also calls DateUtil.convertTimestampToStringDate()
+        // which requires Spring. We therefore set the display string explicitly
+        // first so the static block is never triggered.
+        Timestamp dob = Timestamp.valueOf("1990-06-15 00:00:00");
+        // Use the raw field path: set display then overwrite only the timestamp
+        // by directly verifying the Timestamp roundtrip without touching DateUtil.
+        assertNull("birthDate starts null", patient.getBirthDate());
+        // Directly set the private backing field via reflection to avoid DateUtil
+        try {
+            java.lang.reflect.Field f = Patient.class.getDeclaredField("birthDate");
+            f.setAccessible(true);
+            f.set(patient, dob);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        assertEquals(dob, patient.getBirthDate());
+    }
+
+    @Test
+    public void setBirthDateForDisplay_ShouldStoreDisplayString() {
+        // We only test that the display string is stored. Back-population of the
+        // Timestamp field calls DateUtil.convertAmbiguousStringDateToTimestamp()
+        // which requires Spring, so we only assert the getter returns what we set.
+        try {
+            java.lang.reflect.Field f = Patient.class.getDeclaredField("birthDateForDisplay");
+            f.setAccessible(true);
+            f.set(patient, "15/06/1990");
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        assertEquals("15/06/1990", patient.getBirthDateForDisplay());
+    }
+
+    @Test
+    public void getBirthDateForDisplay_WhenNeverSet_ShouldReturnNull() {
+        // birthDateForDisplay is null until explicitly set
+        assertNull(patient.getBirthDateForDisplay());
+    }
+
+    // -----------------------------------------------------------------------
+    // Birth Time
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setBirthTime_ShouldStoreSqlDateDirectly() {
+        // setBirthTime() also calls DateUtil — bypass via reflection
+        Date birthTime = Date.valueOf("1990-06-15");
+        try {
+            java.lang.reflect.Field f = Patient.class.getDeclaredField("birthTime");
+            f.setAccessible(true);
+            f.set(patient, birthTime);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        assertEquals(birthTime, patient.getBirthTime());
+    }
+
+    // -----------------------------------------------------------------------
+    // Death Date
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setDeathDate_ShouldStoreSqlDateDirectly() {
+        // setDeathDate() also calls DateUtil — bypass via reflection
+        Date deathDate = Date.valueOf("2020-12-31");
+        try {
+            java.lang.reflect.Field f = Patient.class.getDeclaredField("deathDate");
+            f.setAccessible(true);
+            f.set(patient, deathDate);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        assertEquals(deathDate, patient.getDeathDate());
+    }
+
+    // -----------------------------------------------------------------------
+    // EPI Name Fields
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void epiNameFields_ShouldBeSettableAndRetrievable() {
+        patient.setEpiFirstName("John");
+        patient.setEpiMiddleName("Arthur");
+        patient.setEpiLastName("Doe");
+
+        assertEquals("John", patient.getEpiFirstName());
+        assertEquals("Arthur", patient.getEpiMiddleName());
+        assertEquals("Doe", patient.getEpiLastName());
+    }
+
+    // -----------------------------------------------------------------------
+    // National ID / External ID / UPID
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setNationalId_ShouldStoreAndReturnNationalId() {
+        patient.setNationalId("NAT-20240001");
+        assertEquals("NAT-20240001", patient.getNationalId());
+    }
+
+    @Test
+    public void setExternalId_ShouldStoreAndReturnExternalId() {
+        patient.setExternalId("EXT-9876");
+        assertEquals("EXT-9876", patient.getExternalId());
+    }
+
+    @Test
+    public void setUpidCode_ShouldStoreAndReturnUpidCode() {
+        patient.setUpidCode("UPID-001");
+        assertEquals("UPID-001", patient.getUpidCode());
+    }
+
+    // -----------------------------------------------------------------------
+    // Chart Number
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setChartNumber_ShouldStoreAndReturnChartNumber() {
+        patient.setChartNumber("CHART-2024-0099");
+        assertEquals("CHART-2024-0099", patient.getChartNumber());
+    }
+
+    // -----------------------------------------------------------------------
+    // FHIR UUID
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setFhirUuid_ShouldStoreAndReturnUuid() {
+        UUID uuid = UUID.randomUUID();
+        patient.setFhirUuid(uuid);
+
+        assertEquals(uuid, patient.getFhirUuid());
+        assertEquals(uuid.toString(), patient.getFhirUuidAsString());
+    }
+
+    @Test
+    public void getFhirUuidAsString_WhenUuidIsNull_ShouldReturnEmptyString() {
+        // fhirUuid is null by default
+        assertEquals(
+                "getFhirUuidAsString() should return empty string when fhirUuid is null",
+                "",
+                patient.getFhirUuidAsString());
+    }
+
+    // -----------------------------------------------------------------------
+    // Merge State
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void isMerged_ShouldDefaultToFalse() {
+        assertFalse(patient.getIsMerged());
+    }
+
+    @Test
+    public void setIsMerged_ShouldUpdateMergeFlag() {
+        patient.setIsMerged(true);
+        assertTrue(patient.getIsMerged());
+    }
+
+    @Test
+    public void setMergedIntoPatientId_ShouldStoreAndReturnId() {
+        patient.setMergedIntoPatientId("99");
+        assertEquals("99", patient.getMergedIntoPatientId());
+    }
+
+    @Test
+    public void setMergeDate_ShouldStoreAndReturnTimestamp() {
+        Timestamp mergeDate = Timestamp.valueOf("2024-01-01 12:00:00");
+        patient.setMergeDate(mergeDate);
+        assertEquals(mergeDate, patient.getMergeDate());
+    }
+
+    // -----------------------------------------------------------------------
+    // Person association
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void setPerson_ShouldStoreAndReturnPerson() {
+        Person person = new Person();
+        person.setId("10");
+        patient.setPerson(person);
+
+        assertNotNull(patient.getPerson());
+        assertEquals("10", patient.getPerson().getId());
+    }
+
+    // -----------------------------------------------------------------------
+    // Demographic fields
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void demographicFields_ShouldBeSettableAndRetrievable() {
+        patient.setRace("Asian");
+        patient.setEthnicity("Non-Hispanic");
+        patient.setBirthPlace("Nairobi");
+        patient.setSchoolAttend("University");
+        patient.setMedicareId("MCR-001");
+        patient.setMedicaidId("MCD-001");
+
+        assertEquals("Asian", patient.getRace());
+        assertEquals("Non-Hispanic", patient.getEthnicity());
+        assertEquals("Nairobi", patient.getBirthPlace());
+        assertEquals("University", patient.getSchoolAttend());
+        assertEquals("MCR-001", patient.getMedicareId());
+        assertEquals("MCD-001", patient.getMedicaidId());
+    }
+}

--- a/src/test/java/org/openelisglobal/patient/valueholder/PatientTest.java
+++ b/src/test/java/org/openelisglobal/patient/valueholder/PatientTest.java
@@ -2,289 +2,168 @@ package org.openelisglobal.patient.valueholder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.UUID;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.openelisglobal.common.util.ConfigurationProperties.Property;
+import org.openelisglobal.common.util.DefaultConfigurationProperties;
+import org.openelisglobal.internationalization.MessageUtil;
 import org.openelisglobal.person.valueholder.Person;
+import org.openelisglobal.spring.util.SpringContext;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ResourceBundleMessageSource;
 
-/**
- * Pure unit tests for the Patient valueholder.
- *
- * <p>
- * These tests require NO Spring context and NO Docker — they validate the
- * entity's field behaviour, date-display synchronisation, FHIR UUID handling,
- * and merge-state logic in isolation.
- */
 public class PatientTest {
 
     private Patient patient;
+
+    @BeforeClass
+    public static void configureDateUtilDependencies() {
+        DefaultConfigurationProperties configuration = mock(DefaultConfigurationProperties.class);
+        when(configuration.getPropertyValue(Property.AmbiguousDateHolder)).thenReturn("x");
+        when(configuration.getPropertyValue(Property.AmbiguousDateValue)).thenReturn("01");
+        when(configuration.getPropertyValue(Property.DEFAULT_DATE_LOCALE)).thenReturn("en-US");
+        when(configuration.getPropertyValue(Property.DEFAULT_LANG_LOCALE)).thenReturn("en-US");
+        when(configuration.getPropertyValue(Property.StringContext)).thenReturn(null);
+
+        AutowireCapableBeanFactory beanFactory = mock(AutowireCapableBeanFactory.class);
+        when(beanFactory.getBean(DefaultConfigurationProperties.class)).thenReturn(configuration);
+
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(beanFactory);
+
+        new SpringContext().setApplicationContext(applicationContext);
+
+        ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("languages/message");
+        messageSource.setDefaultEncoding("UTF-8");
+        MessageUtil.setMessageSource(messageSource);
+    }
 
     @Before
     public void setUp() {
         patient = new Patient();
     }
 
-    // -----------------------------------------------------------------------
-    // Construction
-    // -----------------------------------------------------------------------
-
     @Test
-    public void constructor_ShouldInitialisePatientWithNullFields() {
-        assertNull("id should be null by default", patient.getId());
-        assertNull("gender should be null by default", patient.getGender());
-        assertNull("birthDate should be null by default", patient.getBirthDate());
-        assertNull("nationalId should be null by default", patient.getNationalId());
-        assertNull("fhirUuid should be null by default", patient.getFhirUuid());
-        assertFalse("isMerged should default to false", patient.getIsMerged());
-    }
-
-    // -----------------------------------------------------------------------
-    // ID
-    // -----------------------------------------------------------------------
-
-    @Test
-    public void setId_ShouldStoreAndReturnId() {
-        patient.setId("42");
-        assertEquals("42", patient.getId());
-    }
-
-    // -----------------------------------------------------------------------
-    // Gender
-    // -----------------------------------------------------------------------
-
-    @Test
-    public void setGender_ShouldStoreAndReturnGender() {
-        patient.setGender("M");
-        assertEquals("M", patient.getGender());
+    public void newPatient_ShouldExposeSafeDefaults() {
+        assertNull("A new patient should not have an id", patient.getId());
+        assertNull("A new patient should not have a person", patient.getPerson());
+        assertFalse("A new patient must not be marked as merged", patient.getIsMerged());
+        assertEquals("A missing FHIR UUID should render as an empty string", "", patient.getFhirUuidAsString());
     }
 
     @Test
-    public void setGender_ShouldAllowFemaleCode() {
-        patient.setGender("F");
-        assertEquals("F", patient.getGender());
+    public void setBirthDate_ShouldUpdateStoredTimestampAndDisplayValue() {
+        Timestamp birthDate = Timestamp.valueOf("2024-03-05 14:30:00");
+
+        patient.setBirthDate(birthDate);
+
+        assertEquals("Birth date should be stored exactly", birthDate, patient.getBirthDate());
+        assertEquals("Birth date should be formatted for display", "03/05/2024", patient.getBirthDateForDisplay());
     }
 
     @Test
-    public void setGender_ShouldAllowUnknownCode() {
-        patient.setGender("U");
-        assertEquals("U", patient.getGender());
-    }
+    public void setBirthDateForDisplay_ShouldParseDisplayDateIntoTimestamp() {
+        patient.setBirthDateForDisplay("03/05/2024");
 
-    // -----------------------------------------------------------------------
-    // Birth Date — Timestamp <-> display string synchronisation
-    // -----------------------------------------------------------------------
-
-    @Test
-    public void setBirthDate_ShouldStoreTimestampDirectly() {
-        // Tests that the Timestamp field is stored via setBirthDate().
-        // NOTE: setBirthDate() also calls DateUtil.convertTimestampToStringDate()
-        // which requires Spring. We therefore set the display string explicitly
-        // first so the static block is never triggered.
-        Timestamp dob = Timestamp.valueOf("1990-06-15 00:00:00");
-        // Use the raw field path: set display then overwrite only the timestamp
-        // by directly verifying the Timestamp roundtrip without touching DateUtil.
-        assertNull("birthDate starts null", patient.getBirthDate());
-        // Directly set the private backing field via reflection to avoid DateUtil
-        try {
-            java.lang.reflect.Field f = Patient.class.getDeclaredField("birthDate");
-            f.setAccessible(true);
-            f.set(patient, dob);
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-        assertEquals(dob, patient.getBirthDate());
+        assertEquals("Display value should be preserved", "03/05/2024", patient.getBirthDateForDisplay());
+        assertEquals("Parsed timestamp should keep the same calendar day", LocalDate.of(2024, 3, 5),
+                patient.getBirthDate().toLocalDateTime().toLocalDate());
     }
 
     @Test
-    public void setBirthDateForDisplay_ShouldStoreDisplayString() {
-        // We only test that the display string is stored. Back-population of the
-        // Timestamp field calls DateUtil.convertAmbiguousStringDateToTimestamp()
-        // which requires Spring, so we only assert the getter returns what we set.
-        try {
-            java.lang.reflect.Field f = Patient.class.getDeclaredField("birthDateForDisplay");
-            f.setAccessible(true);
-            f.set(patient, "15/06/1990");
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-        assertEquals("15/06/1990", patient.getBirthDateForDisplay());
+    public void setBirthDateForDisplay_WithAmbiguousDate_ShouldNormalizeMissingMonthAndDay() {
+        patient.setBirthDateForDisplay("xx/xx/2024");
+
+        assertEquals("Original ambiguous display value should be preserved", "xx/xx/2024",
+                patient.getBirthDateForDisplay());
+        assertEquals("Ambiguous month and day should normalize to configured placeholder values",
+                LocalDate.of(2024, 1, 1),
+                patient.getBirthDate().toLocalDateTime().toLocalDate());
     }
 
     @Test
-    public void getBirthDateForDisplay_WhenNeverSet_ShouldReturnNull() {
-        // birthDateForDisplay is null until explicitly set
-        assertNull(patient.getBirthDateForDisplay());
-    }
+    public void setBirthTime_ShouldUpdateStoredDateAndDisplayValue() {
+        Date birthTime = Date.valueOf("2024-03-05");
 
-    // -----------------------------------------------------------------------
-    // Birth Time
-    // -----------------------------------------------------------------------
+        patient.setBirthTime(birthTime);
 
-    @Test
-    public void setBirthTime_ShouldStoreSqlDateDirectly() {
-        // setBirthTime() also calls DateUtil — bypass via reflection
-        Date birthTime = Date.valueOf("1990-06-15");
-        try {
-            java.lang.reflect.Field f = Patient.class.getDeclaredField("birthTime");
-            f.setAccessible(true);
-            f.set(patient, birthTime);
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-        assertEquals(birthTime, patient.getBirthTime());
-    }
-
-    // -----------------------------------------------------------------------
-    // Death Date
-    // -----------------------------------------------------------------------
-
-    @Test
-    public void setDeathDate_ShouldStoreSqlDateDirectly() {
-        // setDeathDate() also calls DateUtil — bypass via reflection
-        Date deathDate = Date.valueOf("2020-12-31");
-        try {
-            java.lang.reflect.Field f = Patient.class.getDeclaredField("deathDate");
-            f.setAccessible(true);
-            f.set(patient, deathDate);
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-        assertEquals(deathDate, patient.getDeathDate());
-    }
-
-    // -----------------------------------------------------------------------
-    // EPI Name Fields
-    // -----------------------------------------------------------------------
-
-    @Test
-    public void epiNameFields_ShouldBeSettableAndRetrievable() {
-        patient.setEpiFirstName("John");
-        patient.setEpiMiddleName("Arthur");
-        patient.setEpiLastName("Doe");
-
-        assertEquals("John", patient.getEpiFirstName());
-        assertEquals("Arthur", patient.getEpiMiddleName());
-        assertEquals("Doe", patient.getEpiLastName());
-    }
-
-    // -----------------------------------------------------------------------
-    // National ID / External ID / UPID
-    // -----------------------------------------------------------------------
-
-    @Test
-    public void setNationalId_ShouldStoreAndReturnNationalId() {
-        patient.setNationalId("NAT-20240001");
-        assertEquals("NAT-20240001", patient.getNationalId());
+        assertEquals("Birth time should be stored exactly", birthTime, patient.getBirthTime());
+        assertEquals("Birth time should be formatted for display", "03/05/2024", patient.getBirthTimeForDisplay());
     }
 
     @Test
-    public void setExternalId_ShouldStoreAndReturnExternalId() {
-        patient.setExternalId("EXT-9876");
-        assertEquals("EXT-9876", patient.getExternalId());
+    public void setBirthTimeForDisplay_ShouldParseDisplayDateIntoSqlDate() {
+        patient.setBirthTimeForDisplay("03/05/2024");
+
+        assertEquals("Display value should be preserved", "03/05/2024", patient.getBirthTimeForDisplay());
+        assertEquals("Parsed SQL date should match the display date", Date.valueOf("2024-03-05"), patient.getBirthTime());
     }
 
     @Test
-    public void setUpidCode_ShouldStoreAndReturnUpidCode() {
-        patient.setUpidCode("UPID-001");
-        assertEquals("UPID-001", patient.getUpidCode());
+    public void setDeathDate_ShouldUpdateStoredDateAndDisplayValue() {
+        Date deathDate = Date.valueOf("2024-04-06");
+
+        patient.setDeathDate(deathDate);
+
+        assertEquals("Death date should be stored exactly", deathDate, patient.getDeathDate());
+        assertEquals("Death date should be formatted for display", "04/06/2024", patient.getDeathDateForDisplay());
     }
 
-    // -----------------------------------------------------------------------
-    // Chart Number
-    // -----------------------------------------------------------------------
-
     @Test
-    public void setChartNumber_ShouldStoreAndReturnChartNumber() {
-        patient.setChartNumber("CHART-2024-0099");
-        assertEquals("CHART-2024-0099", patient.getChartNumber());
+    public void setDeathDateForDisplay_ShouldParseDisplayDateIntoSqlDate() {
+        patient.setDeathDateForDisplay("04/06/2024");
+
+        assertEquals("Display value should be preserved", "04/06/2024", patient.getDeathDateForDisplay());
+        assertEquals("Parsed SQL date should match the display date", Date.valueOf("2024-04-06"), patient.getDeathDate());
     }
 
-    // -----------------------------------------------------------------------
-    // FHIR UUID
-    // -----------------------------------------------------------------------
-
     @Test
-    public void setFhirUuid_ShouldStoreAndReturnUuid() {
-        UUID uuid = UUID.randomUUID();
+    public void setFhirUuid_ShouldExposeCanonicalUuidString() {
+        UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
         patient.setFhirUuid(uuid);
 
-        assertEquals(uuid, patient.getFhirUuid());
-        assertEquals(uuid.toString(), patient.getFhirUuidAsString());
-    }
-
-    @Test
-    public void getFhirUuidAsString_WhenUuidIsNull_ShouldReturnEmptyString() {
-        // fhirUuid is null by default
-        assertEquals("getFhirUuidAsString() should return empty string when fhirUuid is null", "",
+        assertSame("FHIR UUID getter should return the same UUID instance", uuid, patient.getFhirUuid());
+        assertEquals("FHIR UUID string should use canonical format", "550e8400-e29b-41d4-a716-446655440000",
                 patient.getFhirUuidAsString());
     }
 
-    // -----------------------------------------------------------------------
-    // Merge State
-    // -----------------------------------------------------------------------
-
     @Test
-    public void isMerged_ShouldDefaultToFalse() {
-        assertFalse(patient.getIsMerged());
+    public void setPerson_ShouldReplaceCurrentPersonAssociation() {
+        Person first = new Person();
+        Person second = new Person();
+        second.setId("person-2");
+
+        patient.setPerson(first);
+        patient.setPerson(second);
+
+        assertSame("Patient should expose the most recently assigned person", second, patient.getPerson());
+        assertEquals("Replacement person details should remain accessible", "person-2", patient.getPerson().getId());
     }
 
     @Test
-    public void setIsMerged_ShouldUpdateMergeFlag() {
+    public void mergeFields_ShouldRetainMergeStateMetadata() {
+        Timestamp mergeDate = Timestamp.valueOf("2024-05-01 09:15:00");
+
         patient.setIsMerged(true);
-        assertTrue(patient.getIsMerged());
-    }
-
-    @Test
-    public void setMergedIntoPatientId_ShouldStoreAndReturnId() {
         patient.setMergedIntoPatientId("99");
-        assertEquals("99", patient.getMergedIntoPatientId());
-    }
-
-    @Test
-    public void setMergeDate_ShouldStoreAndReturnTimestamp() {
-        Timestamp mergeDate = Timestamp.valueOf("2024-01-01 12:00:00");
         patient.setMergeDate(mergeDate);
-        assertEquals(mergeDate, patient.getMergeDate());
-    }
 
-    // -----------------------------------------------------------------------
-    // Person association
-    // -----------------------------------------------------------------------
-
-    @Test
-    public void setPerson_ShouldStoreAndReturnPerson() {
-        Person person = new Person();
-        person.setId("10");
-        patient.setPerson(person);
-
-        assertNotNull(patient.getPerson());
-        assertEquals("10", patient.getPerson().getId());
-    }
-
-    // -----------------------------------------------------------------------
-    // Demographic fields
-    // -----------------------------------------------------------------------
-
-    @Test
-    public void demographicFields_ShouldBeSettableAndRetrievable() {
-        patient.setRace("Asian");
-        patient.setEthnicity("Non-Hispanic");
-        patient.setBirthPlace("Nairobi");
-        patient.setSchoolAttend("University");
-        patient.setMedicareId("MCR-001");
-        patient.setMedicaidId("MCD-001");
-
-        assertEquals("Asian", patient.getRace());
-        assertEquals("Non-Hispanic", patient.getEthnicity());
-        assertEquals("Nairobi", patient.getBirthPlace());
-        assertEquals("University", patient.getSchoolAttend());
-        assertEquals("MCR-001", patient.getMedicareId());
-        assertEquals("MCD-001", patient.getMedicaidId());
+        assertTrue("Merged patients should report merged state", patient.getIsMerged());
+        assertEquals("Merged target patient id should be retained", "99", patient.getMergedIntoPatientId());
+        assertEquals("Merge date should be retained", mergeDate, patient.getMergeDate());
     }
 }


### PR DESCRIPTION
# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [X] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Adds 

PatientTest.java
 — a comprehensive set of pure unit tests for the 

Patient
 valueholder entity (

patient/valueholder/Patient.java
), which previously had zero test coverage.

These tests run entirely in-memory with no Spring context and no Docker required, making them fast and CI-friendly.

## Screenshots


## Related Issue
[ https://github.com/DIGI-UW/OpenELIS-Global-2/issues/3255 ]

## Other

