### PR TITLE
fix: patient search uses wrong parameter for external ID

### DIFF
--- a/src/main/java/org/openelisglobal/sample/daoimpl/LuceneSearchResultsDAOImpl.java
+++ b/src/main/java/org/openelisglobal/sample/daoimpl/LuceneSearchResultsDAOImpl.java
@@ -73,7 +73,7 @@ public class LuceneSearchResultsDAOImpl implements SearchResultsDAO {
             query.setParameter(NATIONAL_ID_PARAM, nationalID);
         }
         if (!GenericValidator.isBlankOrNull(externalID)) {
-            query.setParameter(EXTERNAL_ID_PARAM, nationalID);
+            query.setParameter(EXTERNAL_ID_PARAM, externalID);
         }
         if (!GenericValidator.isBlankOrNull(STNumber)) {
             query.setParameter(ST_NUMBER_PARAM, STNumber);
@@ -159,7 +159,7 @@ public class LuceneSearchResultsDAOImpl implements SearchResultsDAO {
             query.setParameter(NATIONAL_ID_PARAM, nationalID);
         }
         if (!GenericValidator.isBlankOrNull(externalID)) {
-            query.setParameter(EXTERNAL_ID_PARAM, nationalID);
+            query.setParameter(EXTERNAL_ID_PARAM, externalID);
         }
         if (!GenericValidator.isBlankOrNull(STNumber)) {
             query.setParameter(ST_NUMBER_PARAM, STNumber);


### PR DESCRIPTION
## PR DESCRIPTION:
Was digging into the patient search code and found that external ID search
was silently using nationalID as the bind parameter in both query methods
inside LuceneSearchResultsDAOImpl. So searching by external ID was actually
filtering by national ID the whole time. Changed both occurrences to bind
externalID instead.

One file changed, no new logic added.

## Related Issue
Closes #3082 
