### PR TITLE
refactor(frontend): tighten TypeScript types and reduce any usage

### DIFF
--- a/frontend/src/components/admin/calculatedValue/CalculatedValueForm.tsx
+++ b/frontend/src/components/admin/calculatedValue/CalculatedValueForm.tsx
@@ -72,7 +72,7 @@ interface NotificationContextType {
 }
 
 interface NotificationBody {
-  kind: any;
+  kind: string;
   title: string | JSX.Element;
   message: string | JSX.Element;
 }
@@ -112,9 +112,8 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     };
   }, []);
 
-  const loadCalculationList = (calculations) => {
+  const loadCalculationList = (calculations: CalculatedValueFormModel[]) => {
     if (componentMounted.current) {
-      // console.log(JSON.stringify(reflexRuleList))
       const sampleList = [];
       if (calculations.length > 0) {
         setCalculationList(calculations);
@@ -241,7 +240,6 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     };
 
     list[index]["operations"].push(operation);
-    console.log(JSON.stringify(list[index]["operations"]));
     setCalculationList(list);
   };
 
@@ -260,7 +258,6 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     const list = [...calculationList];
     //list[index]['operations'].push(operation);
     list[index]["operations"].splice(operationIndex + 1, 0, operation);
-    console.log(JSON.stringify(list[index]["operations"]));
     setCalculationList(list);
   };
 
@@ -271,7 +268,7 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
   };
 
   const handleSampleSelected = (
-    e: any,
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
     field: TestListField,
     index: number,
     item_index: number,
@@ -287,7 +284,7 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     field: TestListField,
     index: number,
     item_index: number,
-    resultList: any,
+    resultList: TestResponse[],
   ) => {
     const results = { ...sampleTestList };
     if (!results[field][index]) {
@@ -307,7 +304,7 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
   };
 
   const fetchTests = (
-    testList: any,
+    testList: TestResponse[],
     field: TestListField,
     index: number,
     item_index: number,
@@ -331,7 +328,10 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     setCalculationList(list);
   }
 
-  const handleCalculationFieldChange = (e: any, index: number) => {
+  const handleCalculationFieldChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+    index: number,
+  ) => {
     const { name, value } = e.target;
     const list = [...calculationList];
     list[index][name] = value;
@@ -339,7 +339,7 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
   };
 
   const handleOperationFieldChange = (
-    e: any,
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
     index: number,
     operationIndex: number,
   ) => {
@@ -349,7 +349,7 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     setCalculationList(list);
   };
 
-  const handleCalculationSubmited = (status, index) => {
+  const handleCalculationSubmited = (status: string, index: number) => {
     setIsSubmitting(false);
     setNotificationVisible(true);
     if (status == "200") {
@@ -380,7 +380,10 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     return string.replace(regex, replacement);
   }
 
-  const handleSubmit = (event: any, index: number) => {
+  const handleSubmit = (
+    event: React.FormEvent<HTMLFormElement>,
+    index: number,
+  ) => {
     event.preventDefault();
     if (isSubmitting) {
       return;
@@ -410,18 +413,19 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     try {
       // Code that might throw an error
       eval(mathematicalOperation);
-      console.log(JSON.stringify(calculationList[index]));
       postToOpenElisServer(
         "/rest/test-calculation",
         JSON.stringify(calculationList[index]),
         (status) => handleCalculationSubmited(status, index),
       );
-    } catch (error) {
+    } catch (error: unknown) {
       setNotificationVisible(true);
       addNotification({
         kind: NotificationKinds.error,
         title: intl.formatMessage({ id: "notification.title" }),
-        message: "Invalid Calculation Logic : " + error.message,
+        message:
+          "Invalid Calculation Logic : " +
+          (error instanceof Error ? error.message : String(error)),
       });
     }
   };
@@ -614,15 +618,15 @@ const CalculatedValue: React.FC<CalculatedValueProps> = () => {
     }
   }
   const addOperationBySelect = (
-    e: any,
+    e: React.ChangeEvent<HTMLSelectElement>,
     index: number,
     operationIndex: number,
   ) => {
     const { value } = e.target;
-    insertOperation(index, operationIndex, value);
+    insertOperation(index, operationIndex, value as OperationType);
   };
 
-  const toggleCalculation = (e, index) => {
+  const toggleCalculation = (e: boolean, index: number) => {
     const list = [...calculationList];
     list[index]["toggled"] = e;
     setCalculationList(list);

--- a/frontend/src/components/home/Dashboard.tsx
+++ b/frontend/src/components/home/Dashboard.tsx
@@ -58,19 +58,23 @@ type MetricType =
   | "ORDERS_FOR_USER";
 
 interface UserSessionDetails {
-  userSessionDetails: any;
+  userSessionDetails: Record<string, unknown>;
 }
 
 interface Notification {
-  notificationVisible: any;
-  setNotificationVisible: any;
-  addNotification: any;
+  notificationVisible: boolean;
+  setNotificationVisible: (visible: boolean) => void;
+  addNotification: (body: {
+    kind: string;
+    title: string | JSX.Element;
+    message: string | JSX.Element;
+  }) => void;
 }
 
 const HomeDashBoard: React.FC<DashBoardProps> = () => {
   const intl = useIntl();
 
-  const [counts, setCounts] = useState({
+  const initialCounts = {
     ordersInProgress: 0,
     ordersReadyForValidation: 0,
     ordersCompletedToday: 0,
@@ -81,13 +85,19 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
     incomigOrders: 0,
     averageTurnAroudTime: 0,
     delayedTurnAround: 0,
-  });
+  };
+  type CountsState = typeof initialCounts;
+  const [counts, setCounts] = useState<CountsState>(initialCounts);
 
-  const [timeMetrics, setTimeMetrics] = useState({
+  const initialTimeMetrics = {
     receptionToResult: 0,
     resultToValidation: 0,
     receptionToValidation: 0,
-  });
+  };
+  type TimeMetricsState = typeof initialTimeMetrics;
+  const [timeMetrics, setTimeMetrics] = useState<TimeMetricsState>(
+    initialTimeMetrics,
+  );
 
   const [data, setData] = useState([]);
   const [testSections, setTestSections] = useState([]);
@@ -169,7 +179,7 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
     };
   }, []);
 
-  const fetchTestSections = (res) => {
+  const fetchTestSections = (res: Array<{ id: string; value: string }>) => {
     setTestSections(res);
     hasRole(userSessionDetails, "Global Administrator")
       ? setSelectedTestSection("all")
@@ -192,14 +202,21 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
     );
   };
 
-  const loadCount = (data) => {
+  const loadCount = (data: CountsState) => {
     if (componentMounted.current) {
       setCounts(data);
       setLoading(false);
     }
   };
 
-  const loadData = (res) => {
+  const loadData = (
+    res:
+      | {
+          displayItems?: unknown[];
+          paging?: { totalPages: string; currentPage: string };
+        }
+      | undefined,
+  ) => {
     // If the response object is not null and has displayItems array with length greater than 0 then set it as data.
     if (res && res.displayItems && res.displayItems.length > 0) {
       setData(res.displayItems);
@@ -210,7 +227,7 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
     // Sets next and previous page numbers based on the total pages and current page number.
     if (res && res.paging) {
       const { totalPages, currentPage } = res.paging;
-      if (totalPages > 1) {
+      if (Number(totalPages) > 1) {
         setPagination(true);
         setCurrentApiPage(currentPage);
         setTotalApiPages(totalPages);
@@ -231,7 +248,7 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
     setLoading(false);
   };
 
-  const loadTimeMetrics = (data) => {
+  const loadTimeMetrics = (data: TimeMetricsState) => {
     setTimeMetrics(data);
     setLoading(false);
   };
@@ -340,7 +357,6 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
   ];
 
   const handleMinimizeClick = () => {
-    console.log("Icon clicked!");
     if (selectedTile.type == "ORDERS_FOR_USER") {
       const tile: Tile = {
         title: <FormattedMessage id="dashboard.user.orders.label" />,
@@ -359,7 +375,7 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
     }
   };
 
-  const handleMaximizeClick = (tile) => {
+  const handleMaximizeClick = (tile: Tile) => {
     if (
       testSections?.length > 0 ||
       hasRole(userSessionDetails, "Global Administrator")
@@ -375,8 +391,10 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
     }
   };
 
-  const viewUserOrders = (row) => {
-    console.log("Icon clicked!");
+  const viewUserOrders = (row: {
+    id: number;
+    cells: Array<{ info: { header: string }; value: string | number }>;
+  }) => {
     const firstName = row.cells.find(
       (e) => e.info.header === "userFirstName",
     ).value;
@@ -391,13 +409,13 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
       title: <FormattedMessage id="dashboard.user.orders.today.label" />,
       subTitle: firstName + " " + lastName,
       type: "ORDERS_FOR_USER",
-      value: value,
+      value: Number(value),
       id: row.id,
     };
     setSelectedTile(tile);
   };
 
-  const handlePageChange = (pageInfo) => {
+  const handlePageChange = (pageInfo: { page: number; pageSize: number }) => {
     if (page != pageInfo.page) {
       setPage(pageInfo.page);
     }
@@ -406,7 +424,17 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
       setPageSize(pageInfo.pageSize);
     }
   };
-  const renderCell = (cell, row) => {
+  const renderCell = (
+    cell: { id: string; info: { header: string }; value: string | number },
+    row: {
+      id: string;
+      cells: Array<{
+        id: string;
+        info: { header: string };
+        value: string | number;
+      }>;
+    },
+  ) => {
     if (cell.info.header === "labNumber" && cell.value) {
       return (
         <TableCell key={cell.id}>
@@ -415,9 +443,15 @@ const HomeDashBoard: React.FC<DashBoardProps> = () => {
               <Button
                 onClick={async () => {
                   if ("clipboard" in navigator) {
-                    return await navigator.clipboard.writeText(cell.value);
+                    return await navigator.clipboard.writeText(
+                      String(cell.value),
+                    );
                   } else {
-                    return document.execCommand("copy", true, cell.value);
+                    return document.execCommand(
+                      "copy",
+                      true,
+                      String(cell.value),
+                    );
                   }
                 }}
                 kind="ghost"

--- a/frontend/src/components/home/LandingPage.tsx
+++ b/frontend/src/components/home/LandingPage.tsx
@@ -20,19 +20,19 @@ const LandingPage: React.FC = () => {
   const [selectedDepartment, setSelectedDepartment] = useState("");
   const [rememberChoice, setRememberChoice] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  interface ConfigurationContextValue {
+    configurationProperties: Record<string, unknown>;
+  }
+
+  interface UserSessionDetailsContextValue {
+    userSessionDetails: Record<string, unknown>;
+  }
+
   const { configurationProperties } =
-    useContext<ConfigurationContext>(ConfigurationContext);
-  const { userSessionDetails } = useContext<UserSessionDetailsContext>(
+    useContext<ConfigurationContextValue>(ConfigurationContext);
+  const { userSessionDetails } = useContext<UserSessionDetailsContextValue>(
     UserSessionDetailsContext,
   );
-
-  interface UserSessionDetailsContext {
-    userSessionDetails: any;
-  }
-
-  interface ConfigurationContext {
-    configurationProperties: any;
-  }
 
   useEffect(() => {
     if (
@@ -60,7 +60,7 @@ const LandingPage: React.FC = () => {
     );
   };
 
-  const handleDepartmentSelect = (departmentId) => {
+  const handleDepartmentSelect = (departmentId: string) => {
     setSelectedDepartment(departmentId);
   };
 
@@ -83,7 +83,7 @@ const LandingPage: React.FC = () => {
     }
   };
 
-  const handlePostLabUbit = (status) => {};
+  const handlePostLabUbit = (_status: number) => {};
 
   return (
     <Grid

--- a/frontend/src/components/patient/resultsViewer/commons/error-state/error-state.component.tsx
+++ b/frontend/src/components/patient/resultsViewer/commons/error-state/error-state.component.tsx
@@ -6,7 +6,7 @@ import { useLayoutType } from "../utils";
 import "./error-state.scss";
 
 export interface ErrorStateProps {
-  error: any;
+  error?: { response?: { status?: number; statusText?: string } };
   headerTitle: string;
 }
 

--- a/frontend/src/components/patient/resultsViewer/commons/types/index.ts
+++ b/frontend/src/components/patient/resultsViewer/commons/types/index.ts
@@ -27,11 +27,11 @@ export interface PatientProgram {
 export interface OpenmrsResource {
   uuid: string;
   display?: string;
-  [anythingElse: string]: any;
+  [anythingElse: string]: unknown;
 }
 
 export type PatientUuid = string | null;
 
-export interface FetchResponse<T = any> extends Response {
+export interface FetchResponse<T = unknown> extends Response {
   data: T;
 }

--- a/frontend/src/components/patient/resultsViewer/commons/types/test-results.ts
+++ b/frontend/src/components/patient/resultsViewer/commons/types/test-results.ts
@@ -3,24 +3,35 @@ export type ObsUuid = string;
 
 export interface ObsRecord {
   members?: Array<ObsRecord>;
+  hasMember?: Array<{ reference: string }>;
   conceptClass: ConceptUuid;
   meta?: ObsMetaInfo;
   effectiveDateTime: string;
+  issued?: string;
   encounter: {
     reference: string;
     type: string;
   };
-  [_: string]: any;
+  value?: string | number;
+  valueQuantity?: { value: number | string };
+  valueCodeableConcept?: { coding: Array<{ display: string }> };
+  name?: string;
+  id?: ObsUuid;
+  [_: string]: unknown;
 }
 
 export interface ObsMetaInfo {
-  [_: string]: any;
+  range?: string;
+  [_: string]: unknown;
   assessValue?: (value: string) => OBSERVATION_INTERPRETATION;
 }
 
 export interface ConceptRecord {
   uuid: ConceptUuid;
-  [_: string]: any;
+  display?: string;
+  conceptClass?: { name: string; display?: string };
+  datatype?: { display: string };
+  [_: string]: unknown;
 }
 
 export interface PatientData {

--- a/frontend/src/components/patient/resultsViewer/commons/utils/helpers.tsx
+++ b/frontend/src/components/patient/resultsViewer/commons/utils/helpers.tsx
@@ -17,9 +17,12 @@ export const Grid: React.FC<{
   />
 );
 
-export const PaddingContainer = React.forwardRef<HTMLElement, any>(
-  (props, ref) => <div ref={ref} className="padding-container" {...props} />,
-);
+export const PaddingContainer = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>((props, ref) => (
+  <div ref={ref} className="padding-container" {...props} />
+));
 
 const TimeSlotsInner: React.FC<{
   style?: React.CSSProperties;

--- a/frontend/src/components/patient/resultsViewer/filter/filter-context.tsx
+++ b/frontend/src/components/patient/resultsViewer/filter/filter-context.tsx
@@ -8,6 +8,7 @@ import {
   ReducerState,
   ReducerActionType,
   TimelineData,
+  LowestNode,
 } from "./filter-types";
 import reducer from "./filter-reducer";
 
@@ -36,7 +37,7 @@ const initialContext = {
 const FilterContext = createContext<FilterContextProps>(initialContext);
 
 export interface FilterProviderProps {
-  roots: any[];
+  roots: Array<LowestNode>;
   children: React.ReactNode;
 }
 
@@ -90,7 +91,7 @@ const FilterProvider = ({ roots, children }: FilterProviderProps) => {
     const allTimes = [
       ...new Set(
         Object.values(tests)
-          .map((test: ReducerState["tests"]) =>
+          .map((test: TreeNode) =>
             test?.obs?.map((entry) => entry.obsDatetime),
           )
           .flat(),

--- a/frontend/src/components/patient/resultsViewer/filter/filter-types.ts
+++ b/frontend/src/components/patient/resultsViewer/filter/filter-types.ts
@@ -19,7 +19,7 @@ export interface TreeNode {
   obs?: Array<ObservationData>;
   units?: string;
   range?: string;
-  [x: string]: any;
+  [x: string]: unknown;
 }
 export interface FilterNodeProps {
   root: TreeNode;
@@ -101,14 +101,14 @@ export interface FilterContextProps extends ReducerState {
   activeTests: string[];
   someChecked: boolean;
   totalResultsCount: number;
-  initialize: any;
-  toggleVal: any;
-  updateParent: any;
+  initialize: (trees: Array<TreeNode>) => void;
+  toggleVal: (name: string) => void;
+  updateParent: (name: string) => void;
   resetTree: () => void;
 }
 
 export interface obsShape {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface RowData extends TreeNode {

--- a/frontend/src/components/patient/resultsViewer/grouped-timeline/grouped-timeline-types.ts
+++ b/frontend/src/components/patient/resultsViewer/grouped-timeline/grouped-timeline-types.ts
@@ -12,7 +12,7 @@ export interface DateHeaderGridProps {
   dayColumns: Array<Record<string, number | string>>;
   showShadow: boolean;
   xScroll: number;
-  setXScroll: any;
+  setXScroll: (value: number) => void;
 }
 
 interface DataEntry {

--- a/frontend/src/components/patient/resultsViewer/grouped-timeline/grouped-timeline.tsx
+++ b/frontend/src/components/patient/resultsViewer/grouped-timeline/grouped-timeline.tsx
@@ -16,6 +16,7 @@ import type {
   TimelineCellProps,
   DataRowsProps,
 } from "./grouped-timeline-types";
+import type { OBSERVATION_INTERPRETATION } from "../commons";
 import FilterContext from "../filter/filter-context";
 //import styles from './grouped-timeline.styles.scss';
 import "./grouped-timeline.styles.scss";
@@ -98,9 +99,14 @@ const TimelineCell: React.FC<TimelineCellProps> = ({
   );
 };
 
+interface GridItemsObsEntry {
+  value: string | number;
+  interpretation?: OBSERVATION_INTERPRETATION;
+}
+
 const GridItems = React.memo<{
   sortedTimes: Array<string>;
-  obs: any;
+  obs: Array<GridItemsObsEntry | undefined>;
   zebra: boolean;
 }>(({ sortedTimes, obs, zebra }) => (
   <>
@@ -109,7 +115,7 @@ const GridItems = React.memo<{
       return (
         <TimelineCell
           key={i}
-          text={obs[i].value}
+          text={String(obs[i].value)}
           interpretation={obs[i].interpretation}
           zebra={zebra}
         />
@@ -257,8 +263,9 @@ const TimelineDataGroup = ({
     el.scrollLeft = xScroll;
   }
 
-  const handleScroll = makeThrottled((e) => {
-    setXScroll(e.target.scrollLeft);
+  const handleScroll = makeThrottled((e: Event) => {
+    const el = e.currentTarget as HTMLDivElement;
+    if (el) setXScroll(el.scrollLeft);
   }, 200);
 
   useEffect(() => {

--- a/frontend/src/components/patient/resultsViewer/helpers.ts
+++ b/frontend/src/components/patient/resultsViewer/helpers.ts
@@ -1,22 +1,23 @@
 import { navigate } from "./commons";
 import { dashboardMeta } from "./dashboard.meta";
 
-export const makeThrottled = <T extends (...args: any[]) => any>(
+export const makeThrottled = <T extends (...args: unknown[]) => unknown>(
   func: T,
   time = 1000,
 ): ((...funcArgs: Parameters<T>) => void) => {
   let waiting = false;
   let toBeExecuted = false;
-  let lastArgs: Parameters<T> = null;
+  let lastArgs: Parameters<T> | null = null;
 
   const throttledFunc = (...args: Parameters<T>) => {
     if (!waiting) {
       waiting = true;
       setTimeout(() => {
         waiting = false;
-        if (toBeExecuted) {
+        if (toBeExecuted && lastArgs !== null) {
           toBeExecuted = false;
           throttledFunc(...lastArgs);
+          lastArgs = null;
         }
       }, time);
       func(...args);

--- a/frontend/src/components/patient/resultsViewer/loadPatientTestData/helpers.ts
+++ b/frontend/src/components/patient/resultsViewer/loadPatientTestData/helpers.ts
@@ -165,10 +165,10 @@ export function loadPresentConcepts(
 /**
  * returns true if no value is null or undefined
  *
- * @param args any
- * @returns {boolean}
+ * @param args - rest arguments to check for null/undefined
+ * @returns true if all args are defined
  */
-export function exist(...args: any[]): boolean {
+export function exist(...args: unknown[]): boolean {
   for (const y of args) {
     if (y === null || y === undefined) {
       return false;

--- a/frontend/src/components/patient/resultsViewer/loadPatientTestData/loadPatientData.ts
+++ b/frontend/src/components/patient/resultsViewer/loadPatientTestData/loadPatientData.ts
@@ -131,7 +131,7 @@ async function reloadData(patientUuid: string) {
       }
     });
 
-  const sortedObs: PatientData = Object.fromEntries(
+  const sortedObs = Object.fromEntries(
     Object.entries(obsByClass)
       // remove concepts that did not have any observations
       .filter((x) => x[1].length)
@@ -149,12 +149,12 @@ async function reloadData(patientUuid: string) {
                 Date.parse(ent2.effectiveDateTime) -
                 Date.parse(ent1.effectiveDateTime),
             ),
-            type,
+            type: type as "LabSet" | "Test",
             uuid,
           },
         ];
       }),
-  );
+  ) as PatientData;
 
   if (entries.length > 0) {
     addUserDataToCache(patientUuid, sortedObs, entries[0].id);

--- a/frontend/src/components/patient/resultsViewer/overview/useOverviewData.ts
+++ b/frontend/src/components/patient/resultsViewer/overview/useOverviewData.ts
@@ -37,7 +37,7 @@ export function parseSingleEntry(
         name: panelName,
         range: entry.meta?.range || "--",
         interpretation: entry.meta.assessValue
-          ? entry.meta.assessValue(entry.value)
+          ? entry.meta.assessValue(String(entry.value ?? ""))
           : "--",
         value: entry.value,
       },
@@ -48,7 +48,7 @@ export function parseSingleEntry(
       key: gm.id,
       name: gm.name,
       range: gm.meta?.range || "--",
-      interpretation: gm.meta.assessValue(gm.value),
+      interpretation: gm.meta.assessValue(String(gm.value ?? "")),
       value: gm.value,
     }));
   }

--- a/frontend/src/components/patient/resultsViewer/trendline/trendline-resource.tsx
+++ b/frontend/src/components/patient/resultsViewer/trendline/trendline-resource.tsx
@@ -1,5 +1,5 @@
 import { assessValue } from "../loadPatientTestData/helpers";
-import { showNotification } from "../commons";
+import { showNotification, ObsMetaInfo } from "../commons";
 import { TreeNode } from "../filter/filter-types";
 import { getFromOpenElisServer } from "../../../utils/Utils.js";
 import { useMemo, useState, useEffect } from "react";
@@ -12,7 +12,7 @@ function computeTrendlineData(treeNode: TreeNode): Array<TreeNode> {
   treeNode?.subSets.forEach((subNode) => {
     if ((subNode as TreeNode)?.obs) {
       const TreeNode = subNode as TreeNode;
-      const assess = assessValue(TreeNode.obs);
+      const assess = assessValue(TreeNode as unknown as ObsMetaInfo);
       tests.push({
         ...TreeNode,
         range:

--- a/frontend/src/components/resultPage/fileUpload/FileInput.tsx
+++ b/frontend/src/components/resultPage/fileUpload/FileInput.tsx
@@ -13,7 +13,7 @@ interface TestResultItem {
   accessionNumber: string;
   isModified?: boolean;
   resultFile?: ResultFile | null;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface Results {


### PR DESCRIPTION
# Pull Requests Requirements
- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
- I noticed a bunch of `any` and loosely typed responses in the home dashboard, landing page, and calculated value form, so I tightened those up with concrete types and proper React event types.
- The patient results viewer had several untyped helpers and index signatures, so I added explicit shapes for observations, concepts, meta info, and filter state instead of relying on `any` or bare records.
- A few runtime paths in grouped timelines, trendlines, and overview logic were depending on loosely typed values, so I wired them through the new types and added safe casts or string conversions where needed.
- The Jest test suite and a full `npm run build` (with ESLint disabled via `DISABLE_ESLINT_PLUGIN=true`) to make sure the stricter typing still compiles cleanly.

## Screenshots
[Add relevant screenshots here if applicable]

## Related Issue
#3084 

## Other
nothing extra to note