### PR TITLE
test(NoteService): add missing tests for date range match and blank text guard

### DIFF
--- a/src/test/java/org/openelisglobal/note/NoteServiceTest.java
+++ b/src/test/java/org/openelisglobal/note/NoteServiceTest.java
@@ -294,6 +294,30 @@ public class NoteServiceTest extends BaseWebContextSensitiveTest {
         assertEquals("I", notes.get(0).getNoteType());
     }
 
+    @Test
+    public void getTestNotesInDateRangeByType_shouldReturnMatchingNotesForValidRange() throws Exception {
+        java.sql.Date lowDate = java.sql.Date.valueOf("2024-02-01");
+        java.sql.Date highDate = java.sql.Date.valueOf("2024-02-28");
+        NoteServiceImpl.NoteType noteType = NoteServiceImpl.NoteType.INTERNAL;
+
+        List<Note> notes = noteService.getTestNotesInDateRangeByType(lowDate, highDate, noteType);
+
+        assertNotNull("Returned notes list should not be null", notes);
+        assertTrue(
+                "Should return empty list since dataset notes are bound to a sample table, not an analysis table",
+                notes.isEmpty());
+    }
+
+    @Test
+    public void createSavableNote_shouldReturnNullWhenTextIsBlank() throws Exception {
+        Note note = noteService.createSavableNote(
+                createTestNoteObject(REF_ID, REF_TABLE_ID),
+                NoteServiceImpl.NoteType.INTERNAL,
+                "", "Test Subject", "1");
+
+        assertNull("createSavableNote should return null when note text is blank", note);
+    }
+
     private NoteObject createTestNoteObject(String refId, String tableId) {
         return new NoteObject() {
             @Override


### PR DESCRIPTION
## Summary

This PR adds two missing test cases to the existing `NoteServiceTest` that 
were not covered by the current test suite.

## Changes

### 1. `getTestNotesInDateRangeByType_shouldReturnMatchingNotesForValidRange`

The existing date range tests only covered cases where **no notes were returned** 
(year 2023 range and an inverted date range). There was no test verifying 
behaviour when the date range actually overlaps the dataset.

This test covers a valid date range (`2024-02-01` to `2024-02-28`) that 
matches the notes in the dataset, and documents that `getTestNotesInDateRangeByType` 
only returns notes bound to **analysis** records (via `AnalysisServiceImpl
.getTableReferenceId()`), not sample-bound notes — an important behavioural 
distinction that was previously undocumented in the test suite.

### 2. `createSavableNote_shouldReturnNullWhenTextIsBlank`

The existing `createSavableNote_shouldCreateNoteWithCorrectProperties` test 
only covered the happy path. The guard clause at the top of 
`NoteServiceImpl.createSavableNote()` that returns `null` when text is blank 
was completely untested.

This test covers that guard clause directly, ensuring blank text never 
produces a savable note object.

## Testing
```bash
mvn test -Dtest=NoteServiceTest
```

All 23 tests pass.

## Related

Contributes to the GSoC 2026 goal of improving integration test coverage 
for the service layer.