### PR TITLE
docs(README): fixed some typos in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OpenELIS adheres to the strictest of security standards to keep your data safe
 and supports fully featured, standards-based interoperability to make it easy to
 receive lab orders and send results to other systems
 
-Please vist our [website](http://www.openelis-global.org/) for more information.
+Please visit our [website](http://www.openelis-global.org/) for more information.
 
 You can find more information on how to set up OpenELIS at our
 [docs page](http://docs.openelis-global.org/)
@@ -106,7 +106,7 @@ speeds up the development process
 
          git clone https://github.com/username/OpenELIS-Global-2.git
 
-1.  innitialize and build sub modules
+1.  Initialize and build sub modules
 
         cd OpenELIS-Global-2
         git submodule update --init --recursive


### PR DESCRIPTION
## Summary

This PR makes three small but meaningful improvements to `README.md`.

### Changes

**1. Fix typo: "vist" → "visit"**
In the project description paragraph, "Please vist our website" 
contains a typo visible to every visitor of the repository.

**2. Fix typo: "innitialize" → "Initialize"**
Step 2 of the development setup instructions contains a double-n 
typo that new contributors encounter when setting up for the first time.


## Files Changed
- `README.md` only