### PR TITLE
fix: NumberFormatException parsing "NEGATIVE" as significant digits

### DIFF
--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -120,6 +120,22 @@ jobs:
           TEST_USER: ${{ vars.TEST_USER || 'admin' }}
           TEST_PASS: ${{ secrets.TEST_PASS }}
 
+      - name: Verify analyzer test mappings exist (prevent unmapped-result race)
+        run: |
+          for analyzer in "Cepheid GeneXpert (ASTM Mode)" "QuantStudio 5" "QuantStudio 7" "FluoroCycler XT"; do
+            MAPPINGS=$(curl -sk -u "$TEST_USER:$TEST_PASS" \
+              "$BASE_URL/api/OpenELIS-Global/rest/analyzer/analyzers" | \
+              python3 -c "import json,sys; data=json.load(sys.stdin); a=[x for x in data if x.get('name')=='$analyzer']; print(len(a[0].get('testMappings',[])) if a else 0)" 2>/dev/null || echo "0")
+            echo "$analyzer: $MAPPINGS test mappings"
+            if [ "$MAPPINGS" = "0" ]; then
+              echo "::warning::Analyzer '$analyzer' has no test mappings — results will be unmapped"
+            fi
+          done
+        env:
+          BASE_URL: https://localhost
+          TEST_USER: ${{ vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ secrets.TEST_PASS }}
+
       - name: Run analyzer Playwright harness-demo shard
         run: npm run pw:test -- --project=harness-demo --workers=1 --shard=${{ matrix.shard_index }}/${{ matrix.shard_total }}
         working-directory: frontend

--- a/src/main/java/org/openelisglobal/result/controller/AnalyzerResultsController.java
+++ b/src/main/java/org/openelisglobal/result/controller/AnalyzerResultsController.java
@@ -619,13 +619,13 @@ public class AnalyzerResultsController extends BaseController {
 
     private String getSignificantDigitsFromAnalyzerResults(AnalyzerResults result) {
         if (result.getTestId() == null) {
-            return result.getResult();
+            return null;
         }
 
         List<TestResult> testResults = testResultService.getActiveTestResultsByTest(result.getTestId());
 
         if (GenericValidator.isBlankOrNull(result.getResult()) || testResults.isEmpty()) {
-            return result.getResult();
+            return null;
         }
 
         TestResult testResult = testResults.get(0);
@@ -1357,7 +1357,11 @@ public class AnalyzerResultsController extends BaseController {
         // the results table is not autmatically updated with the significant digits
         // from TestResult so we must do this
         if (!GenericValidator.isBlankOrNull(resultItem.getSignificantDigits())) {
-            result.setSignificantDigits(Integer.parseInt(resultItem.getSignificantDigits()));
+            try {
+                result.setSignificantDigits(Integer.parseInt(resultItem.getSignificantDigits()));
+            } catch (NumberFormatException e) {
+                // significantDigits may contain non-numeric text if test mapping was missing
+            }
         }
 
         addMinMaxNormal(result, resultItem, patient);

--- a/src/main/java/org/openelisglobal/result/controller/AnalyzerResultsController.java
+++ b/src/main/java/org/openelisglobal/result/controller/AnalyzerResultsController.java
@@ -1357,10 +1357,11 @@ public class AnalyzerResultsController extends BaseController {
         // the results table is not autmatically updated with the significant digits
         // from TestResult so we must do this
         if (!GenericValidator.isBlankOrNull(resultItem.getSignificantDigits())) {
-            try {
+            if (StringUtil.isInteger(resultItem.getSignificantDigits())) {
                 result.setSignificantDigits(Integer.parseInt(resultItem.getSignificantDigits()));
-            } catch (NumberFormatException e) {
-                // significantDigits may contain non-numeric text if test mapping was missing
+            } else {
+                LogEvent.logWarn(AnalyzerResultsController.class.getSimpleName(), "createNewResult",
+                        "Invalid significantDigits value for testId '" + resultItem.getTestId() + "'");
             }
         }
 


### PR DESCRIPTION
## Summary
- `getSignificantDigitsFromAnalyzerResults()` returns `result.getResult()` (e.g. "NEGATIVE") when `testId` is null — leaking the result value into `significantDigits`
- `createNewResult()` then calls `Integer.parseInt("NEGATIVE")` → `NumberFormatException`
- Fix: return `null` instead of the result value; add try/catch guard at the parseInt call site

## Why PR CI passes but develop push fails
The ASTM message delivery timing differs between `pull_request` and `push` events. On push to develop, the bridge re-delivers the ASTM message during Liquibase migration restart. The staged `AnalyzerResults` record has `testId=null` because test mappings haven't been auto-created yet by `seed-analyzers.sh`. On PR, the timing is favorable and `testId` is populated.

## Root cause trace
1. Bridge delivers ASTM message → staged in `analyzer_results` with `testId=null`
2. `analyzerResultsToAnalyzerResultItem()` calls `getSignificantDigitsFromAnalyzerResults()` 
3. `testId == null` → returns `result.getResult()` = `"NEGATIVE"` (line 622)
4. Stored as `resultItem.significantDigits = "NEGATIVE"`
5. `createNewResult()` calls `Integer.parseInt("NEGATIVE")` (line 1360) → NFE
6. Exception propagates outside original try block → HTTP 500

## Test plan
- [ ] CI E2E passes — Analyzer Harness Demo 2/2 specifically
- [ ] Verified locally: harness-demo shard 2/2 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)