### PR TITLE
fix(e2e): remediate Playwright anti-patterns and add agent guardrails

### DIFF
--- a/.ai/skills/playwright/SKILL.md
+++ b/.ai/skills/playwright/SKILL.md
@@ -49,7 +49,8 @@ For AI-assisted development, prefer this sequence:
 - NEVER use `response.ok()` as the test pass/fail signal. Use `waitForResponse`
   for sync, assert on visible UI.
 - NEVER use `{ force: true }` on Carbon inputs. Click the `<label>` instead.
-- NEVER use `.catch(() => false)` on `isVisible()` — it returns boolean directly.
+- NEVER use `.catch(() => false)` on `isVisible()` — it returns boolean
+  directly.
 - ALWAYS include at least one `expect()` assertion per test.
 
 ## Execution Invariants

--- a/.ai/skills/playwright/SKILL.md
+++ b/.ai/skills/playwright/SKILL.md
@@ -46,6 +46,11 @@ For AI-assisted development, prefer this sequence:
   waits.
 - Do not create new Cypress tests. Cypress is deprecated; all new E2E work must
   use Playwright.
+- NEVER use `response.ok()` as the test pass/fail signal. Use `waitForResponse`
+  for sync, assert on visible UI.
+- NEVER use `{ force: true }` on Carbon inputs. Click the `<label>` instead.
+- NEVER use `.catch(() => false)` on `isVisible()` — it returns boolean directly.
+- ALWAYS include at least one `expect()` assertion per test.
 
 ## Execution Invariants
 

--- a/.ai/skills/playwright/commands/audit-playwright.md
+++ b/.ai/skills/playwright/commands/audit-playwright.md
@@ -42,6 +42,15 @@ Interpret input best-effort:
    - Use `videoPause()` for demo pacing, not `waitForTimeout()`.
    - Keep tests focused and avoid multi-concern mega-tests when possible.
 
+6. **Anti-pattern detection**
+   - Flag `response.ok()` or `response.status()` used as pass/fail signal
+   - Flag `{ force: true }` without a justifying comment about Carbon
+   - Flag `.catch(() => false)` on `isVisible()` calls (dead code)
+   - Flag `isVisible({ timeout: N })` — timeout param is deprecated
+   - Flag tests with no `expect()` calls
+   - Flag `page.getByLabel("text").check()` on Carbon inputs (targets hidden
+     element)
+
 ## Required References
 
 - `.ai/skills/playwright/reference/selector-policy.md`

--- a/.ai/skills/playwright/commands/audit-playwright.md
+++ b/.ai/skills/playwright/commands/audit-playwright.md
@@ -39,6 +39,7 @@ Interpret input best-effort:
    - Confirm helpers keep deterministic behavior.
 
 5. **Repo policy alignment**
+
    - Use `videoPause()` for demo pacing, not `waitForTimeout()`.
    - Keep tests focused and avoid multi-concern mega-tests when possible.
 

--- a/.ai/skills/playwright/commands/write-playwright-test.md
+++ b/.ai/skills/playwright/commands/write-playwright-test.md
@@ -37,6 +37,13 @@ Interpret input best-effort:
    - Keep `testInfo` and `videoPause()` conventions.
    - Prefer `getByRole` / `getByLabel` / `data-testid` selectors.
    - Add debug-context capture hooks for fragile or async-heavy workflows.
+   - NEVER use `response.ok()` as assertion — use `waitForResponse` for sync
+     only, then assert on visible UI
+   - For Carbon checkboxes/radios, click the `<label>` (NEVER `{ force: true }`)
+   - For autocomplete fields, wait for suggestion dropdown and click (do NOT
+     just type + Tab)
+   - Use `test.step()` for multi-step workflows
+   - Call `isVisible()` directly — never add `.catch(() => false)`
 
 4. **Register spec in Playwright config**
 

--- a/.ai/skills/playwright/reference/selector-policy.md
+++ b/.ai/skills/playwright/reference/selector-policy.md
@@ -29,9 +29,10 @@ Use this priority order:
 
 - NEVER use `{ force: true }` without documented justification.
 - For Carbon `<input type="checkbox">` and `<input type="radio">`: ALWAYS click
-  the associated `<label>` element or use `input.locator('..').locator('label').click()`.
-  Carbon applies `visually-hidden` to these inputs.
-- `page.getByLabel("text")` targets the hidden input — DO NOT call `.check()`
-  or `.click()` on it without force. Click the label directly instead.
+  the associated `<label>` element or use
+  `input.locator('..').locator('label').click()`. Carbon applies
+  `visually-hidden` to these inputs.
+- `page.getByLabel("text")` targets the hidden input — DO NOT call `.check()` or
+  `.click()` on it without force. Click the label directly instead.
 - For Carbon `ComboBox` / `Dropdown`: click the trigger button
   (`button[role="combobox"]` or `.cds--list-box__field`), not the wrapper div.

--- a/.ai/skills/playwright/reference/selector-policy.md
+++ b/.ai/skills/playwright/reference/selector-policy.md
@@ -24,3 +24,14 @@ Use this priority order:
 - Use event/response waits for async transitions.
 - Avoid `page.waitForTimeout()` except controlled demo pacing handled by
   `videoPause()`.
+
+## Actionability Rules
+
+- NEVER use `{ force: true }` without documented justification.
+- For Carbon `<input type="checkbox">` and `<input type="radio">`: ALWAYS click
+  the associated `<label>` element or use `input.locator('..').locator('label').click()`.
+  Carbon applies `visually-hidden` to these inputs.
+- `page.getByLabel("text")` targets the hidden input — DO NOT call `.check()`
+  or `.click()` on it without force. Click the label directly instead.
+- For Carbon `ComboBox` / `Dropdown`: click the trigger button
+  (`button[role="combobox"]` or `.cds--list-box__field`), not the wrapper div.

--- a/.ai/skills/playwright/reference/selector-policy.md
+++ b/.ai/skills/playwright/reference/selector-policy.md
@@ -30,7 +30,7 @@ Use this priority order:
 - NEVER use `{ force: true }` without documented justification.
 - For Carbon `<input type="checkbox">` and `<input type="radio">`: ALWAYS click
   the associated `<label>` element or use
-  `input.locator('..').locator('label').click()`. Carbon applies
+  `input.locator('xpath=..').locator('label').click()`. Carbon applies
   `visually-hidden` to these inputs.
 - `page.getByLabel("text")` targets the hidden input — DO NOT call `.check()` or
   `.click()` on it without force. Click the label directly instead.

--- a/.ai/skills/playwright/templates/PlaywrightE2E.spec.ts.template
+++ b/.ai/skills/playwright/templates/PlaywrightE2E.spec.ts.template
@@ -11,6 +11,8 @@ test.describe("Feature Name", () => {
     page.on("pageerror", (err) => {
       consoleErrors.push(`PAGE ERROR: ${err.message}`);
     });
+    // NOTE: console/pageerror listeners are for diagnostic tests only.
+    // Demo specs (core-demo, harness-demo) should omit these listeners.
 
     // Arrange
     // Selector priority: getByRole -> getByLabel -> data-testid -> text -> CSS(last resort)
@@ -24,6 +26,11 @@ test.describe("Feature Name", () => {
     // Assert
     const result = page.locator('[data-testid="expected-result"]');
     await expect(result).toBeVisible();
+
+    // For multi-step workflows, use test.step() to organize sections:
+    // await test.step('Step description', async () => {
+    //   // actions + at least one expect() per step
+    // });
 
     // Optional debug context capture pattern for unstable async flows
     // try {

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "WebSearch",
+      "Read(*)",
+      "WebFetch(*)",
+      "mcp__claude_ai_Atlassian__getAccessibleAtlassianResources",
+      "mcp__claude_ai_Atlassian__atlassianUserInfo",
+      "mcp__claude_ai_Atlassian__getVisibleJiraProjects",
+      "mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql",
+      "mcp__claude_ai_Atlassian__getJiraIssue",
+      "mcp__claude_ai_Atlassian__getTransitionsForJiraIssue",
+      "mcp__claude_ai_Atlassian__transitionJiraIssue",
+      "mcp__claude_ai_Atlassian__editJiraIssue",
+      "mcp__claude_ai_Atlassian__addCommentToJiraIssue",
+      "mcp__work-tools__jira_search"
+    ]
+  },
+  "outputStyle": "Explanatory"
+}

--- a/.specify/guides/playwright-best-practices.md
+++ b/.specify/guides/playwright-best-practices.md
@@ -498,15 +498,123 @@ python .ai/skills/playwright/scripts/validate-playwright-project.py playwright/t
 
 ## Anti-Patterns
 
-| ❌ Avoid                        | ✅ Instead                          |
-| ------------------------------- | ----------------------------------- |
-| `page.waitForTimeout(ms)`       | Auto-retrying `expect()` assertions |
-| `.first()` / `.nth(0)`          | More specific selectors             |
-| Hardcoded credentials in tests  | Environment variables               |
-| Testing CSS classes for state   | Role/ARIA attributes                |
-| Long tests with many assertions | Focused single-concern tests        |
-| Repeated login in each test     | Setup project with storageState     |
-| Raw CSS selectors               | Semantic `getByRole`, `getByLabel`  |
+### Critical Anti-Patterns (Hard Rules)
+
+These patterns MUST NOT appear in Playwright tests. Apply as DO/DO NOT rules
+during code review.
+
+| DO NOT | WHY | DO INSTEAD |
+|---|---|---|
+| `response.ok()` as pass/fail | Backend 500 throws before UI renders error; CI screenshots show stale state | `waitForResponse` for sync only, then `expect(ui).toBeVisible()` |
+| `{ force: true }` on Carbon inputs | Carbon uses `visually-hidden` on `<input>`; force bypasses actionability | Click the `<label>`: `page.locator('label[for="id"]').click()` |
+| `.catch(() => false)` on `isVisible()` | `isVisible()` returns boolean — catch is dead code hiding real errors | Call `isVisible()` directly |
+| `isVisible({ timeout: N })` | Timeout param is deprecated and ignored | Use `expect(el).toBeVisible({ timeout: N })` for auto-retry |
+| `page.getByLabel("text").check()` on Carbon | Targets the hidden `<input>` — fails actionability | Click the `<label>` element |
+| `isChecked()` on optional elements (no guard) | Throws if element not in DOM | `(await el.count()) > 0 && (await el.isChecked())` |
+| Type + Tab to replace autocomplete selection | `onSelect` sets server-side IDs that `onChange` does not | Wait for suggestion, click it; Tab only as fallback |
+| Tests with zero `expect()` calls | Pure navigation provides no regression protection | At least one `expect()` per test |
+
+### Structural Anti-Patterns
+
+| DO NOT | DO INSTEAD |
+|---|---|
+| `page.waitForTimeout(ms)` | Auto-retrying `expect()` assertions |
+| `.first()` / `.nth(0)` blindly | More specific selectors |
+| Hardcoded credentials in tests | `TEST_USER`/`TEST_PASS` environment variables |
+| CSS classes for state assertions | Role/ARIA attribute assertions |
+| Long tests with many concerns | Focused tests with `test.step()` sections |
+| Repeated login in each test | Setup project with `storageState` |
+| Raw CSS selectors | Semantic `getByRole`, `getByLabel` |
+
+### Correct `waitForResponse` Pattern
+
+```typescript
+// Synchronize on network, then assert on UI
+const responsePromise = page.waitForResponse('**/api/save');
+await saveButton.click();
+await responsePromise; // sync only — do not check .ok()
+
+// This is the real assertion
+await expect(page.getByText('Saved successfully')).toBeVisible();
+```
+
+### Correct Carbon Checkbox/Radio Pattern
+
+```typescript
+// DO: Click the label — the visible, clickable element
+await page.locator('label[for="saveallresults"]').click();
+
+// DO: For dynamic IDs, navigate to the parent wrapper
+await radioInput.locator('..').locator('label').click();
+
+// DO NOT: page.getByLabel("text").check() — targets hidden input
+// DO NOT: checkbox.check({ force: true }) — bypasses actionability
+```
+
+### Correct Autocomplete Pattern
+
+```typescript
+// Wait for suggestion dropdown, click the first match
+const suggestion = page.locator('[data-cy="auto-suggestion"]').first();
+try {
+  await expect(suggestion).toBeVisible({ timeout: 5_000 });
+  await suggestion.click();
+} catch {
+  // No suggestions (empty DB, no match) — accept free text via Tab
+  await page.keyboard.press("Tab");
+}
+```
+
+### Correct Optional Element Check
+
+```typescript
+// isVisible() returns boolean directly — no catch needed
+if (await element.isVisible()) {
+  await element.click();
+}
+
+// For isChecked() on optional elements — guard with count()
+const isChecked =
+  (await element.count()) > 0 && (await element.isChecked());
+```
+
+## Multi-Step Workflow Pattern
+
+Use `test.step()` to organize long workflows. Each step should have at least one
+assertion.
+
+```typescript
+test('complete sample order workflow', async ({ page }) => {
+  await test.step('Search and select patient', async () => {
+    await page.goto('/SamplePatientEntry');
+    await page.locator('input#lastName').fill('TEST-Smith');
+    await page.locator('button#local_search').click();
+    await expect(page.locator('[data-cy="radioButton"]').first()).toBeVisible();
+  });
+
+  await test.step('Fill sample details', async () => {
+    // ... fill sample type, tests, etc.
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+  });
+
+  await test.step('Submit and verify success', async () => {
+    await page.getByRole('button', { name: 'Submit' }).click();
+    await expect(page.locator('.orderEntrySuccessMsg')).toBeVisible();
+  });
+});
+```
+
+## Soft Assertions for Transient Notifications
+
+Toasts and notifications may disappear before assertions run. Use soft
+assertions with descriptive messages:
+
+```typescript
+await expect.soft(
+  page.getByRole('alert'),
+  'Success notification should appear after save'
+).toBeVisible({ timeout: 10_000 });
+```
 
 ---
 
@@ -521,5 +629,5 @@ python .ai/skills/playwright/scripts/validate-playwright-project.py playwright/t
 
 ---
 
-**Last Updated:** 2026-03-14  
+**Last Updated:** 2026-03-20
 **Applies To:** `frontend/playwright/`

--- a/.specify/guides/playwright-best-practices.md
+++ b/.specify/guides/playwright-best-practices.md
@@ -503,39 +503,39 @@ python .ai/skills/playwright/scripts/validate-playwright-project.py playwright/t
 These patterns MUST NOT appear in Playwright tests. Apply as DO/DO NOT rules
 during code review.
 
-| DO NOT | WHY | DO INSTEAD |
-|---|---|---|
-| `response.ok()` as pass/fail | Backend 500 throws before UI renders error; CI screenshots show stale state | `waitForResponse` for sync only, then `expect(ui).toBeVisible()` |
-| `{ force: true }` on Carbon inputs | Carbon uses `visually-hidden` on `<input>`; force bypasses actionability | Click the `<label>`: `page.locator('label[for="id"]').click()` |
-| `.catch(() => false)` on `isVisible()` | `isVisible()` returns boolean — catch is dead code hiding real errors | Call `isVisible()` directly |
-| `isVisible({ timeout: N })` | Timeout param is deprecated and ignored | Use `expect(el).toBeVisible({ timeout: N })` for auto-retry |
-| `page.getByLabel("text").check()` on Carbon | Targets the hidden `<input>` — fails actionability | Click the `<label>` element |
-| `isChecked()` on optional elements (no guard) | Throws if element not in DOM | `(await el.count()) > 0 && (await el.isChecked())` |
-| Type + Tab to replace autocomplete selection | `onSelect` sets server-side IDs that `onChange` does not | Wait for suggestion, click it; Tab only as fallback |
-| Tests with zero `expect()` calls | Pure navigation provides no regression protection | At least one `expect()` per test |
+| DO NOT                                        | WHY                                                                         | DO INSTEAD                                                       |
+| --------------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `response.ok()` as pass/fail                  | Backend 500 throws before UI renders error; CI screenshots show stale state | `waitForResponse` for sync only, then `expect(ui).toBeVisible()` |
+| `{ force: true }` on Carbon inputs            | Carbon uses `visually-hidden` on `<input>`; force bypasses actionability    | Click the `<label>`: `page.locator('label[for="id"]').click()`   |
+| `.catch(() => false)` on `isVisible()`        | `isVisible()` returns boolean — catch is dead code hiding real errors       | Call `isVisible()` directly                                      |
+| `isVisible({ timeout: N })`                   | Timeout param is deprecated and ignored                                     | Use `expect(el).toBeVisible({ timeout: N })` for auto-retry      |
+| `page.getByLabel("text").check()` on Carbon   | Targets the hidden `<input>` — fails actionability                          | Click the `<label>` element                                      |
+| `isChecked()` on optional elements (no guard) | Throws if element not in DOM                                                | `(await el.count()) > 0 && (await el.isChecked())`               |
+| Type + Tab to replace autocomplete selection  | `onSelect` sets server-side IDs that `onChange` does not                    | Wait for suggestion, click it; Tab only as fallback              |
+| Tests with zero `expect()` calls              | Pure navigation provides no regression protection                           | At least one `expect()` per test                                 |
 
 ### Structural Anti-Patterns
 
-| DO NOT | DO INSTEAD |
-|---|---|
-| `page.waitForTimeout(ms)` | Auto-retrying `expect()` assertions |
-| `.first()` / `.nth(0)` blindly | More specific selectors |
-| Hardcoded credentials in tests | `TEST_USER`/`TEST_PASS` environment variables |
-| CSS classes for state assertions | Role/ARIA attribute assertions |
-| Long tests with many concerns | Focused tests with `test.step()` sections |
-| Repeated login in each test | Setup project with `storageState` |
-| Raw CSS selectors | Semantic `getByRole`, `getByLabel` |
+| DO NOT                           | DO INSTEAD                                    |
+| -------------------------------- | --------------------------------------------- |
+| `page.waitForTimeout(ms)`        | Auto-retrying `expect()` assertions           |
+| `.first()` / `.nth(0)` blindly   | More specific selectors                       |
+| Hardcoded credentials in tests   | `TEST_USER`/`TEST_PASS` environment variables |
+| CSS classes for state assertions | Role/ARIA attribute assertions                |
+| Long tests with many concerns    | Focused tests with `test.step()` sections     |
+| Repeated login in each test      | Setup project with `storageState`             |
+| Raw CSS selectors                | Semantic `getByRole`, `getByLabel`            |
 
 ### Correct `waitForResponse` Pattern
 
 ```typescript
 // Synchronize on network, then assert on UI
-const responsePromise = page.waitForResponse('**/api/save');
+const responsePromise = page.waitForResponse("**/api/save");
 await saveButton.click();
 await responsePromise; // sync only — do not check .ok()
 
 // This is the real assertion
-await expect(page.getByText('Saved successfully')).toBeVisible();
+await expect(page.getByText("Saved successfully")).toBeVisible();
 ```
 
 ### Correct Carbon Checkbox/Radio Pattern
@@ -545,7 +545,7 @@ await expect(page.getByText('Saved successfully')).toBeVisible();
 await page.locator('label[for="saveallresults"]').click();
 
 // DO: For dynamic IDs, navigate to the parent wrapper
-await radioInput.locator('..').locator('label').click();
+await radioInput.locator("..").locator("label").click();
 
 // DO NOT: page.getByLabel("text").check() — targets hidden input
 // DO NOT: checkbox.check({ force: true }) — bypasses actionability
@@ -574,8 +574,7 @@ if (await element.isVisible()) {
 }
 
 // For isChecked() on optional elements — guard with count()
-const isChecked =
-  (await element.count()) > 0 && (await element.isChecked());
+const isChecked = (await element.count()) > 0 && (await element.isChecked());
 ```
 
 ## Multi-Step Workflow Pattern
@@ -584,22 +583,22 @@ Use `test.step()` to organize long workflows. Each step should have at least one
 assertion.
 
 ```typescript
-test('complete sample order workflow', async ({ page }) => {
-  await test.step('Search and select patient', async () => {
-    await page.goto('/SamplePatientEntry');
-    await page.locator('input#lastName').fill('TEST-Smith');
-    await page.locator('button#local_search').click();
+test("complete sample order workflow", async ({ page }) => {
+  await test.step("Search and select patient", async () => {
+    await page.goto("/SamplePatientEntry");
+    await page.locator("input#lastName").fill("TEST-Smith");
+    await page.locator("button#local_search").click();
     await expect(page.locator('[data-cy="radioButton"]').first()).toBeVisible();
   });
 
-  await test.step('Fill sample details', async () => {
+  await test.step("Fill sample details", async () => {
     // ... fill sample type, tests, etc.
-    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Next" })).toBeEnabled();
   });
 
-  await test.step('Submit and verify success', async () => {
-    await page.getByRole('button', { name: 'Submit' }).click();
-    await expect(page.locator('.orderEntrySuccessMsg')).toBeVisible();
+  await test.step("Submit and verify success", async () => {
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expect(page.locator(".orderEntrySuccessMsg")).toBeVisible();
   });
 });
 ```
@@ -610,10 +609,12 @@ Toasts and notifications may disappear before assertions run. Use soft
 assertions with descriptive messages:
 
 ```typescript
-await expect.soft(
-  page.getByRole('alert'),
-  'Success notification should appear after save'
-).toBeVisible({ timeout: 10_000 });
+await expect
+  .soft(
+    page.getByRole("alert"),
+    "Success notification should appear after save"
+  )
+  .toBeVisible({ timeout: 10_000 });
 ```
 
 ---
@@ -629,5 +630,4 @@ await expect.soft(
 
 ---
 
-**Last Updated:** 2026-03-20
-**Applies To:** `frontend/playwright/`
+**Last Updated:** 2026-03-20 **Applies To:** `frontend/playwright/`

--- a/.specify/guides/playwright-best-practices.md
+++ b/.specify/guides/playwright-best-practices.md
@@ -545,7 +545,7 @@ await expect(page.getByText("Saved successfully")).toBeVisible();
 await page.locator('label[for="saveallresults"]').click();
 
 // DO: For dynamic IDs, navigate to the parent wrapper
-await radioInput.locator("..").locator("label").click();
+await radioInput.locator("xpath=..").locator("label").click();
 
 // DO NOT: page.getByLabel("text").check() — targets hidden input
 // DO NOT: checkbox.check({ force: true }) — bypasses actionability

--- a/.specify/guides/playwright-e2e-quality-report.md
+++ b/.specify/guides/playwright-e2e-quality-report.md
@@ -1,9 +1,9 @@
 # Playwright E2E Quality Report
 
-> **Date:** 2026-03-20
-> **Scope:** All files in `frontend/playwright/` (tests, helpers, fixtures)
-> **Purpose:** Identify anti-patterns, establish modern best practices, and
-> recommend tooling improvements for OpenELIS Playwright E2E tests.
+> **Date:** 2026-03-20 **Scope:** All files in `frontend/playwright/` (tests,
+> helpers, fixtures) **Purpose:** Identify anti-patterns, establish modern best
+> practices, and recommend tooling improvements for OpenELIS Playwright E2E
+> tests.
 
 ---
 
@@ -27,7 +27,7 @@ const saveResponsePromise = page.waitForResponse(
   (res) =>
     res.url().includes("/rest/AnalyzerResults") &&
     res.request().method() === "POST",
-  { timeout: 60_000 },
+  { timeout: 60_000 }
 );
 await saveButton.click();
 // ... then checks saveResponse.ok() and throws if not
@@ -46,10 +46,10 @@ UI tell the story.
 **File:** `frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts` (lines
 18-32)
 
-The `pickFirstAutosuggestOptional` function uses `expect.poll()` with a 12-second
-timeout and custom intervals to wait for autocomplete dropdown suggestions to
-appear, then clicks the first one. If the dropdown never appears, it falls back
-to pressing Tab.
+The `pickFirstAutosuggestOptional` function uses `expect.poll()` with a
+12-second timeout and custom intervals to wait for autocomplete dropdown
+suggestions to appear, then clicks the first one. If the dropdown never appears,
+it falls back to pressing Tab.
 
 ```typescript
 // ogc-284-barcode-workflow.spec.ts lines 18-32
@@ -68,11 +68,11 @@ async function pickFirstAutosuggestOptional(page: Page, pause: PauseFn) {
 }
 ```
 
-**Why it matters:** This is called twice in `fillOrderDetails` (for site name and
-requester lookup), adding up to 24 seconds of potential polling time per order.
-The `[data-cy="auto-suggestion"]` selector is a Cypress-era attribute being used
-in Playwright tests. The try/catch silently swallows failures, masking real
-issues.
+**Why it matters:** This is called twice in `fillOrderDetails` (for site name
+and requester lookup), adding up to 24 seconds of potential polling time per
+order. The `[data-cy="auto-suggestion"]` selector is a Cypress-era attribute
+being used in Playwright tests. The try/catch silently swallows failures,
+masking real issues.
 
 **Better approach:** For known values in E2E fixtures, type the full value and
 press Tab. Autocomplete is a UX convenience, not the interaction path tests
@@ -82,13 +82,13 @@ should exercise.
 
 Multiple files use `{ force: true }` on click and check operations:
 
-| File | Line | Usage |
-|------|------|-------|
-| `ogc-284-barcode-workflow.spec.ts` | 163 | `await firstRadio.check({ force: true })` |
-| `ogc-284-barcode-workflow.spec.ts` | 199 | `await genderMale.check({ force: true })` |
-| `ogc-284-labels-ui.spec.ts` | 9 | `.click({ force: true })` |
-| `accept-results.ts` | 53 | `await acceptAllCheckbox.check({ force: true })` |
-| `barcode-configuration.spec.ts` | 60 | `await collectionDateCheckbox.setChecked(false, { force: true })` |
+| File                               | Line | Usage                                                             |
+| ---------------------------------- | ---- | ----------------------------------------------------------------- |
+| `ogc-284-barcode-workflow.spec.ts` | 163  | `await firstRadio.check({ force: true })`                         |
+| `ogc-284-barcode-workflow.spec.ts` | 199  | `await genderMale.check({ force: true })`                         |
+| `ogc-284-labels-ui.spec.ts`        | 9    | `.click({ force: true })`                                         |
+| `accept-results.ts`                | 53   | `await acceptAllCheckbox.check({ force: true })`                  |
+| `barcode-configuration.spec.ts`    | 60   | `await collectionDateCheckbox.setChecked(false, { force: true })` |
 
 **Why it matters:** `{ force: true }` bypasses Playwright's actionability checks
 (visibility, enabled state, not intercepted by overlay). This means the test may
@@ -109,9 +109,13 @@ assertions. For example:
 **File:** `ogc-284-barcode-workflow.spec.ts` -- "US3" test (lines 597-713)
 
 Large portions of US3 are purely navigational with no assertions:
-- Lines 651-665: Scrolls to print dialog elements, checks visibility with `.catch(() => false)`, but never asserts on outcome
-- Lines 676-679: Checks for Done button visibility with `.catch(() => false)` but no assertion
-- Lines 693-703: Navigates to Print Barcode page and scrolls around with no assertions
+
+- Lines 651-665: Scrolls to print dialog elements, checks visibility with
+  `.catch(() => false)`, but never asserts on outcome
+- Lines 676-679: Checks for Done button visibility with `.catch(() => false)`
+  but no assertion
+- Lines 693-703: Navigates to Print Barcode page and scrolls around with no
+  assertions
 
 **Why it matters:** A test without assertions is a "fire-and-forget" navigation
 script. It provides no regression protection. If the feature breaks, the test
@@ -141,7 +145,7 @@ injection, proper setup/teardown lifecycle, and composability.
 **Better approach:** Define POMs as Playwright fixtures:
 
 ```typescript
-import { test as base } from '@playwright/test';
+import { test as base } from "@playwright/test";
 const test = base.extend<{ analyzerList: AnalyzerListPage }>({
   analyzerList: async ({ page }, use) => {
     const list = new AnalyzerListPage(page);
@@ -175,17 +179,17 @@ belong in backend integration tests or a separate API test suite.
 Multiple files use `.catch(() => false)` or `.catch(() => {})` to silently
 swallow errors:
 
-| File | Line | Pattern |
-|------|------|---------|
-| `accept-results.ts` | 82 | `}).catch(() => { /* Some runs complete quickly */ })` |
-| `ogc-284-barcode-workflow.spec.ts` | 84 | `.isVisible({ timeout: 2_000 }).catch(() => false)` |
-| `ogc-284-barcode-workflow.spec.ts` | 124 | `.isVisible({ timeout: 3000 }).catch(() => false)` |
-| `ogc-284-barcode-workflow.spec.ts` | 188 | `.isVisible({ timeout: 5000 }).catch(() => false)` |
-| `ogc-284-barcode-workflow.spec.ts` | 197-198 | `.isChecked().catch(() => false)` |
-| `ogc-284-barcode-workflow.spec.ts` | 199 | `.isVisible().catch(() => false)` |
-| `ogc-284-barcode-workflow.spec.ts` | 205 | `.isVisible().catch(() => false)` |
-| `analyzer-plugin-config.spec.ts` | 32 | `.catch(() => {})` |
-| `analyzer-plugin-config.spec.ts` | 60 | `.catch(() => {})` |
+| File                               | Line    | Pattern                                                |
+| ---------------------------------- | ------- | ------------------------------------------------------ |
+| `accept-results.ts`                | 82      | `}).catch(() => { /* Some runs complete quickly */ })` |
+| `ogc-284-barcode-workflow.spec.ts` | 84      | `.isVisible({ timeout: 2_000 }).catch(() => false)`    |
+| `ogc-284-barcode-workflow.spec.ts` | 124     | `.isVisible({ timeout: 3000 }).catch(() => false)`     |
+| `ogc-284-barcode-workflow.spec.ts` | 188     | `.isVisible({ timeout: 5000 }).catch(() => false)`     |
+| `ogc-284-barcode-workflow.spec.ts` | 197-198 | `.isChecked().catch(() => false)`                      |
+| `ogc-284-barcode-workflow.spec.ts` | 199     | `.isVisible().catch(() => false)`                      |
+| `ogc-284-barcode-workflow.spec.ts` | 205     | `.isVisible().catch(() => false)`                      |
+| `analyzer-plugin-config.spec.ts`   | 32      | `.catch(() => {})`                                     |
+| `analyzer-plugin-config.spec.ts`   | 60      | `.catch(() => {})`                                     |
 
 **Why it matters:** Silent error swallowing creates invisible failures. When a
 DOM element is unexpectedly missing, the test silently skips the interaction
@@ -208,12 +212,13 @@ Playwright auto-waiting.
 
 ### 9. Network Interception Used as Assertion
 
-**File:** `frontend/playwright/tests/barcode-configuration.spec.ts` (lines 28-45)
+**File:** `frontend/playwright/tests/barcode-configuration.spec.ts` (lines
+28-45)
 
 This test intercepts `**/rest/BarcodeConfiguration` to mock the API, then
 asserts on the mock's state. While API mocking is a valid technique, this test
-never verifies the actual network call happened -- it only verifies the mock
-was set up correctly.
+never verifies the actual network call happened -- it only verifies the mock was
+set up correctly.
 
 ---
 
@@ -227,12 +232,12 @@ with a visible UI state assertion.
 
 ```typescript
 // Synchronize on network completion
-const responsePromise = page.waitForResponse('**/api/save');
+const responsePromise = page.waitForResponse("**/api/save");
 await saveButton.click();
 await responsePromise; // Wait for network, but don't assert on it
 
 // Assert on visible UI state
-await expect(page.getByText('Saved successfully')).toBeVisible();
+await expect(page.getByText("Saved successfully")).toBeVisible();
 ```
 
 ### 2. Type Full Text + Tab for Known Values
@@ -243,8 +248,8 @@ Tab out. Never poll for autocomplete dropdown suggestions in tests.
 ```typescript
 // BAD: Poll for autocomplete dropdown
 await input.fill("CAMES");
-await expect.poll(() => page.locator('.suggestion').count()).toBeGreaterThan(0);
-await page.locator('.suggestion').first().click();
+await expect.poll(() => page.locator(".suggestion").count()).toBeGreaterThan(0);
+await page.locator(".suggestion").first().click();
 
 // GOOD: Type full value and move on
 await input.fill("CAMES MAN");
@@ -271,16 +276,16 @@ Instead of long sequential test bodies, use `test.step()` to create named
 sections. This improves trace readability and failure diagnostics.
 
 ```typescript
-test('complete order workflow', async ({ page }) => {
-  await test.step('Select patient', async () => {
+test("complete order workflow", async ({ page }) => {
+  await test.step("Select patient", async () => {
     // ...
   });
 
-  await test.step('Fill sample details', async () => {
+  await test.step("Fill sample details", async () => {
     // ...
   });
 
-  await test.step('Submit order', async () => {
+  await test.step("Submit order", async () => {
     // ...
   });
 });
@@ -293,8 +298,8 @@ navigating through the UI. This is 10x faster and more reliable.
 
 ```typescript
 test.beforeAll(async ({ request }) => {
-  await request.post('/api/test-data/patients', {
-    data: { lastName: 'TEST-Smith', firstName: 'John' },
+  await request.post("/api/test-data/patients", {
+    data: { lastName: "TEST-Smith", firstName: "John" },
   });
 });
 ```
@@ -306,7 +311,7 @@ tree of a component. This is ideal for Carbon Design System forms where the
 accessible structure is well-defined.
 
 ```typescript
-await expect(page.getByTestId('order-form')).toMatchAriaSnapshot(`
+await expect(page.getByTestId("order-form")).toMatchAriaSnapshot(`
   - form "Add Order":
     - textbox "Patient Name"
     - combobox "Sample Type"
@@ -320,10 +325,12 @@ Use soft assertions with custom error messages for elements like toast
 notifications that may disappear quickly.
 
 ```typescript
-await expect.soft(
-  page.getByRole('alert'),
-  'Success notification should appear after save'
-).toBeVisible({ timeout: 10_000 });
+await expect
+  .soft(
+    page.getByRole("alert"),
+    "Success notification should appear after save"
+  )
+  .toBeVisible({ timeout: 10_000 });
 ```
 
 ---
@@ -344,28 +351,28 @@ cd frontend && npm install -D eslint-plugin-playwright
 
 ```javascript
 module.exports = {
-  extends: ['plugin:playwright/recommended'],
+  extends: ["plugin:playwright/recommended"],
   rules: {
-    'playwright/no-wait-for-timeout': 'error',
-    'playwright/prefer-web-first-assertions': 'warn',
-    'playwright/no-force-option': 'warn',
-    'playwright/no-page-pause': 'error',
-    'playwright/expect-expect': 'warn',
-    'playwright/no-conditional-expect': 'warn',
-    'playwright/no-conditional-in-test': 'warn',
+    "playwright/no-wait-for-timeout": "error",
+    "playwright/prefer-web-first-assertions": "warn",
+    "playwright/no-force-option": "warn",
+    "playwright/no-page-pause": "error",
+    "playwright/expect-expect": "warn",
+    "playwright/no-conditional-expect": "warn",
+    "playwright/no-conditional-in-test": "warn",
   },
 };
 ```
 
 **Key rules:**
 
-| Rule | Purpose | Current Violations |
-|------|---------|-------------------|
-| `no-wait-for-timeout` | Prevents `page.waitForTimeout()` | title-card.ts (2), video-pause.ts (1), results-ui retry loop |
-| `prefer-web-first-assertions` | Enforces auto-retrying assertions | Multiple `.isVisible()` one-shot checks |
-| `no-force-option` | Flags `{ force: true }` | 5 instances across 3 files |
-| `expect-expect` | Requires assertions in tests | Demo test steps with no expects |
-| `no-conditional-expect` | Flags `expect` inside try/catch | accept-results.ts, analyzer-test-connection.spec.ts |
+| Rule                          | Purpose                           | Current Violations                                           |
+| ----------------------------- | --------------------------------- | ------------------------------------------------------------ |
+| `no-wait-for-timeout`         | Prevents `page.waitForTimeout()`  | title-card.ts (2), video-pause.ts (1), results-ui retry loop |
+| `prefer-web-first-assertions` | Enforces auto-retrying assertions | Multiple `.isVisible()` one-shot checks                      |
+| `no-force-option`             | Flags `{ force: true }`           | 5 instances across 3 files                                   |
+| `expect-expect`               | Requires assertions in tests      | Demo test steps with no expects                              |
+| `no-conditional-expect`       | Flags `expect` inside try/catch   | accept-results.ts, analyzer-test-connection.spec.ts          |
 
 ### 2. Playwright MCP Server
 
@@ -375,8 +382,8 @@ Enable AI-assisted test development with the Playwright MCP server:
 claude mcp add playwright npx @playwright/mcp@latest
 ```
 
-This provides the LLM with direct browser interaction capabilities for
-debugging and understanding DOM state during test development.
+This provides the LLM with direct browser interaction capabilities for debugging
+and understanding DOM state during test development.
 
 ### 3. Playwright Test Agents
 
@@ -387,6 +394,7 @@ npx playwright init-agents --loop=claude
 ```
 
 This enables three-phase test generation:
+
 1. **Planner**: Analyzes the page and creates a test plan
 2. **Generator**: Writes the test code from the plan
 3. **Healer**: Fixes broken selectors automatically on failure
@@ -408,11 +416,13 @@ This catches flaky tests before they enter the CI pipeline.
 ### CLAUDE.md
 
 **Current Playwright guidance (lines 105-109):**
+
 - Points to AGENTS.md for full details
 - Mentions `npm run pw:test` invariant
 - No anti-pattern warnings
 
 **Gaps:**
+
 - No mention of the top 3 anti-patterns to avoid
 - No pointer to `.specify/guides/playwright-best-practices.md`
 - No mention of `eslint-plugin-playwright`
@@ -420,12 +430,14 @@ This catches flaky tests before they enter the CI pipeline.
 ### AGENTS.md
 
 **Current Playwright section (lines 1543-1685):**
+
 - Comprehensive project structure documentation
 - Good CI workflow documentation
 - Good local execution examples
 - Lists `videoPause()` pattern
 
 **Gaps:**
+
 - No anti-pattern list specific to Playwright (only has Cypress anti-patterns)
 - No mention of `waitForResponse` misuse
 - No mention of `{ force: true }` risks
@@ -437,12 +449,14 @@ This catches flaky tests before they enter the CI pipeline.
 ### `.specify/guides/playwright-best-practices.md`
 
 **Current content:**
+
 - Good selector strategy table
 - Good POM pattern
 - Good authentication strategy
 - Anti-patterns table at line 499-510
 
 **Gaps:**
+
 - Anti-pattern table is generic (copied from Playwright docs)
 - No mention of `waitForResponse` misuse pattern
 - No mention of autocomplete polling
@@ -458,11 +472,13 @@ This catches flaky tests before they enter the CI pipeline.
 ### `.ai/skills/playwright/SKILL.md`
 
 **Current content:**
+
 - Good lifecycle sequence
 - Good non-negotiables list
 - Good execution invariants
 
 **Gaps:**
+
 - No anti-pattern list
 - No mention of `waitForResponse` vs UI assertion pattern
 - No mention of `{ force: true }` risks
@@ -470,46 +486,55 @@ This catches flaky tests before they enter the CI pipeline.
 ### `.ai/skills/playwright/commands/*.md`
 
 **audit-playwright.md:**
+
 - Has 5-point checklist but all are generic
 - No specific anti-patterns to flag
 - No mention of `waitForResponse`, `force: true`, or autocomplete polling
 
 **write-playwright-test.md:**
+
 - Good source-first workflow
 - No mention of avoiding `waitForResponse` as assertion
 - No mention of avoiding autocomplete polling
 - No mention of `test.step()` for workflows
 
 **debug-playwright.md:**
+
 - Good source-first, evidence-first workflow
 - No mention of checking for `waitForResponse` masking real failures
 
 **plan-record-playwright.md:**
+
 - Good planning workflow
 - No quality criteria for what makes a test "ready to record"
 
 ### `.ai/skills/playwright/reference/*.md`
 
 **selector-policy.md:**
+
 - Good selector priority order
 - Good wait strategy rules
 - No mention of `{ force: true }` as a selector-adjacent concern
 
 **write-workflow.md:**
+
 - Good 6-step workflow
 - No anti-pattern checklist at the end
 
 **debug-workflow.md:**
+
 - Good 5-step diagnostic workflow
 - No mention of `waitForResponse` masking failures
 
 ### `.ai/skills/playwright/templates/PlaywrightE2E.spec.ts.template`
 
 **Current content:**
+
 - Good debug context capture pattern
 - Good `videoPause()` usage
 
 **Gaps:**
+
 - Uses `console`/`pageerror` listeners that are flagged as inappropriate for
   demo specs in playwright-best-practices.md -- template should have a note
 - No `test.step()` example for multi-step workflows
@@ -519,13 +544,13 @@ This catches flaky tests before they enter the CI pipeline.
 
 ## Summary of Findings
 
-| Category | Count | Severity |
-|----------|-------|----------|
-| `waitForResponse` as primary assertion | 1 file (accept-results.ts) | High -- masks backend failures |
-| Autocomplete polling (12s timeout) | 1 file (ogc-284-barcode-workflow.spec.ts) | High -- adds 24s flaky wait |
-| `{ force: true }` bypasses | 5 instances in 3 files | Medium -- masks actionability issues |
-| Tests with no assertions | Parts of 3 demo tests | Medium -- no regression protection |
-| Silent `.catch(() => false/{})`  | 15+ instances in 4 files | Medium -- invisible failures |
-| Pure API tests in E2E suite | 1 file (file-import.spec.ts) | Low -- wrong test type |
-| Manual POM construction | 10+ test files | Low -- boilerplate |
-| `page.waitForTimeout()` in helpers | 3 helpers (title-card, video-pause, results-ui) | Low -- most are video-only |
+| Category                               | Count                                           | Severity                             |
+| -------------------------------------- | ----------------------------------------------- | ------------------------------------ |
+| `waitForResponse` as primary assertion | 1 file (accept-results.ts)                      | High -- masks backend failures       |
+| Autocomplete polling (12s timeout)     | 1 file (ogc-284-barcode-workflow.spec.ts)       | High -- adds 24s flaky wait          |
+| `{ force: true }` bypasses             | 5 instances in 3 files                          | Medium -- masks actionability issues |
+| Tests with no assertions               | Parts of 3 demo tests                           | Medium -- no regression protection   |
+| Silent `.catch(() => false/{})`        | 15+ instances in 4 files                        | Medium -- invisible failures         |
+| Pure API tests in E2E suite            | 1 file (file-import.spec.ts)                    | Low -- wrong test type               |
+| Manual POM construction                | 10+ test files                                  | Low -- boilerplate                   |
+| `page.waitForTimeout()` in helpers     | 3 helpers (title-card, video-pause, results-ui) | Low -- most are video-only           |

--- a/.specify/guides/playwright-e2e-quality-report.md
+++ b/.specify/guides/playwright-e2e-quality-report.md
@@ -1,0 +1,531 @@
+# Playwright E2E Quality Report
+
+> **Date:** 2026-03-20
+> **Scope:** All files in `frontend/playwright/` (tests, helpers, fixtures)
+> **Purpose:** Identify anti-patterns, establish modern best practices, and
+> recommend tooling improvements for OpenELIS Playwright E2E tests.
+
+---
+
+## Anti-Patterns Found in OpenELIS Tests
+
+### 1. `waitForResponse` as Primary Assertion
+
+**File:** `frontend/playwright/helpers/accept-results.ts` (lines 68-92)
+
+The `acceptAndVerifyResults` helper uses `page.waitForResponse()` to intercept
+the POST to `/rest/AnalyzerResults` and then checks `saveResponse.ok()` as the
+primary success signal. While the helper does follow up with UI assertions
+(waiting for the page to reload and verifying staged rows disappear), the
+`waitForResponse` acts as the critical gate -- if the server returns 500, the
+helper throws a programmatic error with body text rather than letting the UI
+failure manifest naturally.
+
+```typescript
+// accept-results.ts lines 68-92
+const saveResponsePromise = page.waitForResponse(
+  (res) =>
+    res.url().includes("/rest/AnalyzerResults") &&
+    res.request().method() === "POST",
+  { timeout: 60_000 },
+);
+await saveButton.click();
+// ... then checks saveResponse.ok() and throws if not
+```
+
+**Why it matters:** When the backend returns HTTP 500, this throws a generic
+error before the UI has a chance to render an error notification. CI screenshots
+capture a stale page state, making diagnosis impossible.
+
+**Better approach:** Use `waitForResponse` purely for synchronization (knowing
+the POST completed), then assert on the visible success/error UI state. Let the
+UI tell the story.
+
+### 2. Autocomplete Polling with 12s Timeout
+
+**File:** `frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts` (lines
+18-32)
+
+The `pickFirstAutosuggestOptional` function uses `expect.poll()` with a 12-second
+timeout and custom intervals to wait for autocomplete dropdown suggestions to
+appear, then clicks the first one. If the dropdown never appears, it falls back
+to pressing Tab.
+
+```typescript
+// ogc-284-barcode-workflow.spec.ts lines 18-32
+async function pickFirstAutosuggestOptional(page: Page, pause: PauseFn) {
+  try {
+    await expect
+      .poll(async () => page.locator('[data-cy="auto-suggestion"]').count(), {
+        timeout: 12_000,
+        intervals: [400, 800, 1500],
+      })
+      .toBeGreaterThan(0);
+    await page.locator('[data-cy="auto-suggestion"]').first().click();
+  } catch {
+    await page.keyboard.press("Tab");
+  }
+}
+```
+
+**Why it matters:** This is called twice in `fillOrderDetails` (for site name and
+requester lookup), adding up to 24 seconds of potential polling time per order.
+The `[data-cy="auto-suggestion"]` selector is a Cypress-era attribute being used
+in Playwright tests. The try/catch silently swallows failures, masking real
+issues.
+
+**Better approach:** For known values in E2E fixtures, type the full value and
+press Tab. Autocomplete is a UX convenience, not the interaction path tests
+should exercise.
+
+### 3. `{ force: true }` Bypassing Actionability Checks
+
+Multiple files use `{ force: true }` on click and check operations:
+
+| File | Line | Usage |
+|------|------|-------|
+| `ogc-284-barcode-workflow.spec.ts` | 163 | `await firstRadio.check({ force: true })` |
+| `ogc-284-barcode-workflow.spec.ts` | 199 | `await genderMale.check({ force: true })` |
+| `ogc-284-labels-ui.spec.ts` | 9 | `.click({ force: true })` |
+| `accept-results.ts` | 53 | `await acceptAllCheckbox.check({ force: true })` |
+| `barcode-configuration.spec.ts` | 60 | `await collectionDateCheckbox.setChecked(false, { force: true })` |
+
+**Why it matters:** `{ force: true }` bypasses Playwright's actionability checks
+(visibility, enabled state, not intercepted by overlay). This means the test may
+"pass" even when the element is not actually interactable by a real user. In the
+Carbon Design System, checkboxes and radio buttons have overlaid label elements
+that intentionally receive pointer events -- `force: true` works around this but
+masks real actionability regressions.
+
+**Better approach:** Click the associated `<label>` element instead of forcing
+the hidden `<input>`. For Carbon checkboxes/radios, this is the correct user
+interaction path.
+
+### 4. No Assertions in Demo/Video Test Steps
+
+Several demo tests contain long sequences of UI interactions with no `expect()`
+assertions. For example:
+
+**File:** `ogc-284-barcode-workflow.spec.ts` -- "US3" test (lines 597-713)
+
+Large portions of US3 are purely navigational with no assertions:
+- Lines 651-665: Scrolls to print dialog elements, checks visibility with `.catch(() => false)`, but never asserts on outcome
+- Lines 676-679: Checks for Done button visibility with `.catch(() => false)` but no assertion
+- Lines 693-703: Navigates to Print Barcode page and scrolls around with no assertions
+
+**Why it matters:** A test without assertions is a "fire-and-forget" navigation
+script. It provides no regression protection. If the feature breaks, the test
+still passes.
+
+**Better approach:** Even demo tests should have at least one meaningful
+assertion per logical step using `test.step()` annotations.
+
+### 5. Manual POM Construction Instead of Fixture Injection
+
+Most tests that use Page Objects construct them manually:
+
+```typescript
+// Common pattern across tests
+const list = new AnalyzerListPage(page);
+const form = new AnalyzerFormPage(page);
+```
+
+While some tests use POMs well (analyzer-list.spec.ts, analyzer-form.spec.ts,
+error-dashboard.spec.ts), others bypass POMs entirely and use raw locators
+(ogc-284-barcode-workflow.spec.ts, file-import-ui.spec.ts, navbar.spec.ts).
+
+**Why it matters:** Manual construction is boilerplate-heavy and error-prone.
+Playwright's `test.extend()` fixture system provides automatic dependency
+injection, proper setup/teardown lifecycle, and composability.
+
+**Better approach:** Define POMs as Playwright fixtures:
+
+```typescript
+import { test as base } from '@playwright/test';
+const test = base.extend<{ analyzerList: AnalyzerListPage }>({
+  analyzerList: async ({ page }, use) => {
+    const list = new AnalyzerListPage(page);
+    await use(list);
+  },
+});
+```
+
+### 6. Pure API Tests Without UI Interaction
+
+**File:** `frontend/playwright/tests/file-import.spec.ts` (entire file)
+
+This test file contains three test groups that exclusively use `page.request.*`
+API calls with zero UI interactions. No page navigation, no DOM assertions.
+
+```typescript
+// file-import.spec.ts lines 48-69 (representative)
+const listRes = await page.request.get(`${api}/analyzers`);
+expect(listRes.ok()).toBeTruthy();
+const { analyzers } = (await listRes.json()) as { ... };
+const found = analyzers.find((a) => a.name === analyzer.name);
+expect(found).toBeDefined();
+```
+
+**Why it matters:** These are API integration tests masquerading as E2E tests.
+They inflate E2E suite runtime without testing any user-facing behavior. They
+belong in backend integration tests or a separate API test suite.
+
+### 7. Catching and Ignoring Errors
+
+Multiple files use `.catch(() => false)` or `.catch(() => {})` to silently
+swallow errors:
+
+| File | Line | Pattern |
+|------|------|---------|
+| `accept-results.ts` | 82 | `}).catch(() => { /* Some runs complete quickly */ })` |
+| `ogc-284-barcode-workflow.spec.ts` | 84 | `.isVisible({ timeout: 2_000 }).catch(() => false)` |
+| `ogc-284-barcode-workflow.spec.ts` | 124 | `.isVisible({ timeout: 3000 }).catch(() => false)` |
+| `ogc-284-barcode-workflow.spec.ts` | 188 | `.isVisible({ timeout: 5000 }).catch(() => false)` |
+| `ogc-284-barcode-workflow.spec.ts` | 197-198 | `.isChecked().catch(() => false)` |
+| `ogc-284-barcode-workflow.spec.ts` | 199 | `.isVisible().catch(() => false)` |
+| `ogc-284-barcode-workflow.spec.ts` | 205 | `.isVisible().catch(() => false)` |
+| `analyzer-plugin-config.spec.ts` | 32 | `.catch(() => {})` |
+| `analyzer-plugin-config.spec.ts` | 60 | `.catch(() => {})` |
+
+**Why it matters:** Silent error swallowing creates invisible failures. When a
+DOM element is unexpectedly missing, the test silently skips the interaction
+instead of failing. This means broken features can pass CI green.
+
+### 8. `page.waitForTimeout()` in Non-Video Helpers
+
+**File:** `frontend/playwright/helpers/title-card.ts` (lines 63, 107)
+
+The `showTitleCard` and `showStepCard` functions use `page.waitForTimeout()` for
+their display duration. While these are no-op outside video projects (gated by
+`isVideoProject`), the pattern normalizes `waitForTimeout` usage.
+
+**File:** `frontend/playwright/helpers/results-ui.ts` (lines 78-106)
+
+The `navigateUntilVisible` function implements a retry loop that navigates to a
+URL and waits for a locator to become visible, retrying on failure. This is a
+polling pattern that works around timing issues rather than using proper
+Playwright auto-waiting.
+
+### 9. Network Interception Used as Assertion
+
+**File:** `frontend/playwright/tests/barcode-configuration.spec.ts` (lines 28-45)
+
+This test intercepts `**/rest/BarcodeConfiguration` to mock the API, then
+asserts on the mock's state. While API mocking is a valid technique, this test
+never verifies the actual network call happened -- it only verifies the mock
+was set up correctly.
+
+---
+
+## Modern Best Practices (2025-2026)
+
+### 1. Use `waitForResponse` ONLY for Synchronization
+
+`waitForResponse` should synchronize test flow (wait for a network call to
+complete before proceeding), never serve as the primary assertion. Always follow
+with a visible UI state assertion.
+
+```typescript
+// Synchronize on network completion
+const responsePromise = page.waitForResponse('**/api/save');
+await saveButton.click();
+await responsePromise; // Wait for network, but don't assert on it
+
+// Assert on visible UI state
+await expect(page.getByText('Saved successfully')).toBeVisible();
+```
+
+### 2. Type Full Text + Tab for Known Values
+
+For autocomplete fields with known test data values, type the complete value and
+Tab out. Never poll for autocomplete dropdown suggestions in tests.
+
+```typescript
+// BAD: Poll for autocomplete dropdown
+await input.fill("CAMES");
+await expect.poll(() => page.locator('.suggestion').count()).toBeGreaterThan(0);
+await page.locator('.suggestion').first().click();
+
+// GOOD: Type full value and move on
+await input.fill("CAMES MAN");
+await input.press("Tab");
+```
+
+### 3. Use Web-First Assertions
+
+Playwright's `expect()` assertions auto-retry. Never use one-shot checks like
+`isVisible()` for assertions.
+
+```typescript
+// BAD: One-shot check (no retry)
+const visible = await element.isVisible();
+expect(visible).toBeTruthy();
+
+// GOOD: Web-first assertion (auto-retries)
+await expect(element).toBeVisible();
+```
+
+### 4. Use `test.step()` for Multi-Step Workflows
+
+Instead of long sequential test bodies, use `test.step()` to create named
+sections. This improves trace readability and failure diagnostics.
+
+```typescript
+test('complete order workflow', async ({ page }) => {
+  await test.step('Select patient', async () => {
+    // ...
+  });
+
+  await test.step('Fill sample details', async () => {
+    // ...
+  });
+
+  await test.step('Submit order', async () => {
+    // ...
+  });
+});
+```
+
+### 5. API-First Test Data Setup
+
+Use REST API calls in `beforeAll` or fixtures to create test data instead of
+navigating through the UI. This is 10x faster and more reliable.
+
+```typescript
+test.beforeAll(async ({ request }) => {
+  await request.post('/api/test-data/patients', {
+    data: { lastName: 'TEST-Smith', firstName: 'John' },
+  });
+});
+```
+
+### 6. ARIA Snapshot Testing for Carbon Forms
+
+Playwright 1.49+ supports ARIA snapshot testing, which captures the accessible
+tree of a component. This is ideal for Carbon Design System forms where the
+accessible structure is well-defined.
+
+```typescript
+await expect(page.getByTestId('order-form')).toMatchAriaSnapshot(`
+  - form "Add Order":
+    - textbox "Patient Name"
+    - combobox "Sample Type"
+    - button "Submit"
+`);
+```
+
+### 7. Soft Assertions for Transient Notifications
+
+Use soft assertions with custom error messages for elements like toast
+notifications that may disappear quickly.
+
+```typescript
+await expect.soft(
+  page.getByRole('alert'),
+  'Success notification should appear after save'
+).toBeVisible({ timeout: 10_000 });
+```
+
+---
+
+## Tooling Recommendations
+
+### 1. `eslint-plugin-playwright`
+
+**Status:** Not installed (confirmed by checking `frontend/package.json`).
+
+**Install:**
+
+```bash
+cd frontend && npm install -D eslint-plugin-playwright
+```
+
+**Configure** (add to `.eslintrc` or create `frontend/.eslintrc.playwright.js`):
+
+```javascript
+module.exports = {
+  extends: ['plugin:playwright/recommended'],
+  rules: {
+    'playwright/no-wait-for-timeout': 'error',
+    'playwright/prefer-web-first-assertions': 'warn',
+    'playwright/no-force-option': 'warn',
+    'playwright/no-page-pause': 'error',
+    'playwright/expect-expect': 'warn',
+    'playwright/no-conditional-expect': 'warn',
+    'playwright/no-conditional-in-test': 'warn',
+  },
+};
+```
+
+**Key rules:**
+
+| Rule | Purpose | Current Violations |
+|------|---------|-------------------|
+| `no-wait-for-timeout` | Prevents `page.waitForTimeout()` | title-card.ts (2), video-pause.ts (1), results-ui retry loop |
+| `prefer-web-first-assertions` | Enforces auto-retrying assertions | Multiple `.isVisible()` one-shot checks |
+| `no-force-option` | Flags `{ force: true }` | 5 instances across 3 files |
+| `expect-expect` | Requires assertions in tests | Demo test steps with no expects |
+| `no-conditional-expect` | Flags `expect` inside try/catch | accept-results.ts, analyzer-test-connection.spec.ts |
+
+### 2. Playwright MCP Server
+
+Enable AI-assisted test development with the Playwright MCP server:
+
+```bash
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+This provides the LLM with direct browser interaction capabilities for
+debugging and understanding DOM state during test development.
+
+### 3. Playwright Test Agents
+
+Playwright's experimental test agent support (planner/generator/healer pattern):
+
+```bash
+npx playwright init-agents --loop=claude
+```
+
+This enables three-phase test generation:
+1. **Planner**: Analyzes the page and creates a test plan
+2. **Generator**: Writes the test code from the plan
+3. **Healer**: Fixes broken selectors automatically on failure
+
+### 4. Flakiness Detection
+
+Before merging any new or modified Playwright test, run with `--repeat-each=3`:
+
+```bash
+cd frontend && npm run pw:test -- --repeat-each=3 --project=core-app
+```
+
+This catches flaky tests before they enter the CI pipeline.
+
+---
+
+## Guardrail Document Audit
+
+### CLAUDE.md
+
+**Current Playwright guidance (lines 105-109):**
+- Points to AGENTS.md for full details
+- Mentions `npm run pw:test` invariant
+- No anti-pattern warnings
+
+**Gaps:**
+- No mention of the top 3 anti-patterns to avoid
+- No pointer to `.specify/guides/playwright-best-practices.md`
+- No mention of `eslint-plugin-playwright`
+
+### AGENTS.md
+
+**Current Playwright section (lines 1543-1685):**
+- Comprehensive project structure documentation
+- Good CI workflow documentation
+- Good local execution examples
+- Lists `videoPause()` pattern
+
+**Gaps:**
+- No anti-pattern list specific to Playwright (only has Cypress anti-patterns)
+- No mention of `waitForResponse` misuse
+- No mention of `{ force: true }` risks
+- No mention of autocomplete polling anti-pattern
+- No mention of `eslint-plugin-playwright`
+- Section V.5 of constitution references Playwright but anti-patterns are
+  generic (not Playwright-specific)
+
+### `.specify/guides/playwright-best-practices.md`
+
+**Current content:**
+- Good selector strategy table
+- Good POM pattern
+- Good authentication strategy
+- Anti-patterns table at line 499-510
+
+**Gaps:**
+- Anti-pattern table is generic (copied from Playwright docs)
+- No mention of `waitForResponse` misuse pattern
+- No mention of autocomplete polling
+- No mention of `{ force: true }` for Carbon checkboxes
+- No mention of `test.step()` for workflow tests
+- No API-first test data setup guidance
+- No ARIA snapshot testing guidance
+- No soft assertion guidance for transient notifications
+- No `eslint-plugin-playwright` integration
+- Template in "Authentication Strategy" section shows outdated UI-based login
+  (the actual auth.setup.ts uses API-based login -- docs should match)
+
+### `.ai/skills/playwright/SKILL.md`
+
+**Current content:**
+- Good lifecycle sequence
+- Good non-negotiables list
+- Good execution invariants
+
+**Gaps:**
+- No anti-pattern list
+- No mention of `waitForResponse` vs UI assertion pattern
+- No mention of `{ force: true }` risks
+
+### `.ai/skills/playwright/commands/*.md`
+
+**audit-playwright.md:**
+- Has 5-point checklist but all are generic
+- No specific anti-patterns to flag
+- No mention of `waitForResponse`, `force: true`, or autocomplete polling
+
+**write-playwright-test.md:**
+- Good source-first workflow
+- No mention of avoiding `waitForResponse` as assertion
+- No mention of avoiding autocomplete polling
+- No mention of `test.step()` for workflows
+
+**debug-playwright.md:**
+- Good source-first, evidence-first workflow
+- No mention of checking for `waitForResponse` masking real failures
+
+**plan-record-playwright.md:**
+- Good planning workflow
+- No quality criteria for what makes a test "ready to record"
+
+### `.ai/skills/playwright/reference/*.md`
+
+**selector-policy.md:**
+- Good selector priority order
+- Good wait strategy rules
+- No mention of `{ force: true }` as a selector-adjacent concern
+
+**write-workflow.md:**
+- Good 6-step workflow
+- No anti-pattern checklist at the end
+
+**debug-workflow.md:**
+- Good 5-step diagnostic workflow
+- No mention of `waitForResponse` masking failures
+
+### `.ai/skills/playwright/templates/PlaywrightE2E.spec.ts.template`
+
+**Current content:**
+- Good debug context capture pattern
+- Good `videoPause()` usage
+
+**Gaps:**
+- Uses `console`/`pageerror` listeners that are flagged as inappropriate for
+  demo specs in playwright-best-practices.md -- template should have a note
+- No `test.step()` example for multi-step workflows
+- No example of assertion-only pattern (no `waitForResponse` example to copy)
+
+---
+
+## Summary of Findings
+
+| Category | Count | Severity |
+|----------|-------|----------|
+| `waitForResponse` as primary assertion | 1 file (accept-results.ts) | High -- masks backend failures |
+| Autocomplete polling (12s timeout) | 1 file (ogc-284-barcode-workflow.spec.ts) | High -- adds 24s flaky wait |
+| `{ force: true }` bypasses | 5 instances in 3 files | Medium -- masks actionability issues |
+| Tests with no assertions | Parts of 3 demo tests | Medium -- no regression protection |
+| Silent `.catch(() => false/{})`  | 15+ instances in 4 files | Medium -- invisible failures |
+| Pure API tests in E2E suite | 1 file (file-import.spec.ts) | Low -- wrong test type |
+| Manual POM construction | 10+ test files | Low -- boilerplate |
+| `page.waitForTimeout()` in helpers | 3 helpers (title-card, video-pause, results-ui) | Low -- most are video-only |

--- a/.specify/oe/commands/download-ci-logs.md
+++ b/.specify/oe/commands/download-ci-logs.md
@@ -12,6 +12,18 @@ specify a target.
   run the shim with **current branch** and **failed-only** (so the downloader is
   invoked with `--branch <current-branch>` and `--failed`).
 
+**Before downloading logs, ALWAYS run a holistic status check first:**
+
+```bash
+# Show ALL workflows at a glance (same view as GitHub PR UI)
+gh pr checks $(gh pr view --json number -q '.number') 2>/dev/null || \
+  gh run list --branch "$(git branch --show-current)" --limit 10
+```
+
+This ensures you identify ALL failing workflows (Backend, Frontend, E2E, etc.)
+before downloading logs for just one. A formatting failure in `01 - Backend` is
+just as blocking as an E2E failure in `03 - E2E`.
+
 ## Invocation
 
 The agent should parse user arguments and construct a safe command call. Only

--- a/.specify/oe/commands/fix-ci.md
+++ b/.specify/oe/commands/fix-ci.md
@@ -142,6 +142,29 @@ Determine:
 branch → BREAK immediately. Tell the user: "Cannot run /fix-ci on a protected
 branch. Please switch to a feature branch first."
 
+**Holistic CI status check (MANDATORY):**
+
+Before diving into specific failures, get the full picture across ALL workflows
+— not just E2E. This matches what the user sees in the GitHub PR UI:
+
+```bash
+# If PR exists, use gh pr checks for the same view as the GitHub UI
+gh pr checks $PR_NUMBER 2>/dev/null || \
+  gh run list --branch $BRANCH --limit 10 --json name,status,conclusion,workflowName \
+    --jq '.[] | "\(.workflowName) / \(.name): \(.conclusion // .status)"'
+```
+
+**Check ALL workflows**, not just the one you expect to fail:
+
+- `01 - Backend` (formatting, compilation, unit tests)
+- `02 - Frontend` (static analysis, image build)
+- `03 - E2E` (Playwright, Analyzer Harness, Cypress)
+- `Automation / Merge Conflicts`
+- `Validation / SpecKit`, `Validation / i18n`
+
+**Any failing workflow is in scope.** A formatting failure in Backend is just as
+blocking as an E2E test failure. Triage ALL failures before fixing any.
+
 Check project knowledge for known CI failure patterns:
 
 1. `.specify/memory/` — project-scoped memory (shared across all agents)
@@ -149,7 +172,7 @@ Check project knowledge for known CI failure patterns:
 3. Agent-specific memory (e.g., `$HOME/.claude/projects/*/memory/MEMORY.md`) if
    available
 
-Report the detected state before proceeding.
+Report the detected state (including all workflow statuses) before proceeding.
 
 ---
 
@@ -459,6 +482,19 @@ git push
 - Files changed
 - Summary of fix
 - Expected CI outcome
+
+**Post-push holistic check (MANDATORY):**
+
+After pushing, immediately check ALL workflow statuses — not just the one you
+fixed:
+
+```bash
+gh pr checks $PR_NUMBER 2>/dev/null || \
+  gh run list --branch $BRANCH --limit 5
+```
+
+This catches cascading failures (e.g., a test fix that breaks formatting) before
+waiting 30 minutes for E2E to report back.
 
 #### Parallel tracks: Local E2E + CI monitoring
 

--- a/.specify/plans/playwright-quality-remediation.md
+++ b/.specify/plans/playwright-quality-remediation.md
@@ -1,0 +1,519 @@
+# Playwright Quality Remediation Plan
+
+> **Date:** 2026-03-20
+> **Status:** DRAFT
+> **Research Report:** `.specify/guides/playwright-e2e-quality-report.md`
+> **Scope:** Prevent new anti-patterns, fix existing ones, improve architecture
+
+---
+
+## Phase 1: Guardrails (Prevent New Anti-Patterns)
+
+### 1.1 CLAUDE.md Additions
+
+Add the following section after the existing "Playwright E2E -- RECOMMENDED"
+block (after line 109):
+
+```markdown
+### Playwright Anti-Patterns (CRITICAL)
+
+**Top 3 anti-patterns that cause flaky tests -- MUST AVOID:**
+
+1. **`waitForResponse` as assertion** -- Use it for sync only, then assert on
+   visible UI state (`toBeVisible`, `toBeEnabled`, `toHaveText`)
+2. **Autocomplete polling** -- Type the full known value + Tab; never poll for
+   dropdown suggestions with `expect.poll()`
+3. **`{ force: true }`** -- Click the `<label>` instead of forcing hidden Carbon
+   inputs; `force` masks real actionability regressions
+
+**Full guide:** `.specify/guides/playwright-best-practices.md`
+**Quality report:** `.specify/guides/playwright-e2e-quality-report.md`
+```
+
+### 1.2 AGENTS.md Additions
+
+Add the following block inside the "E2E Tests (Playwright) -- RECOMMENDED"
+section, after the "Key Patterns" subsection (after line 1606):
+
+```markdown
+#### Playwright Anti-Patterns (MUST AVOID)
+
+These patterns cause flaky tests and invisible failures:
+
+- **`waitForResponse` as primary assertion** -- Use `waitForResponse` for
+  synchronization only. Always follow with a visible UI assertion
+  (`toBeVisible`, `toHaveText`). Never check `response.ok()` as the pass/fail
+  signal.
+- **Autocomplete polling** -- For known fixture values, type the full value +
+  Tab. Never use `expect.poll()` to wait for autocomplete dropdowns.
+- **`{ force: true }`** -- Carbon overlays labels on hidden inputs. Click the
+  `<label>` element instead of forcing the hidden `<input>`. `force` bypasses
+  actionability checks and masks real regressions.
+- **Silent `.catch(() => {})`** -- Never swallow errors silently. If an element
+  may not exist, use conditional logic with `isVisible()` followed by an
+  explicit code path, not a blanket catch.
+- **Tests without assertions** -- Every test (including demo tests) must have at
+  least one `expect()` call. Use `test.step()` for multi-step workflows.
+
+**Full guide:** `.specify/guides/playwright-best-practices.md`
+```
+
+### 1.3 Updates to `.specify/guides/playwright-best-practices.md`
+
+Add the following sections to the best practices guide:
+
+**A) Replace the "Anti-Patterns" table (line 499-510) with an expanded version:**
+
+```markdown
+## Anti-Patterns
+
+### Critical Anti-Patterns (Cause Flaky Tests)
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| `waitForResponse` as assertion | Backend 500 throws before UI renders error notification | Use for sync only, assert on UI |
+| `expect.poll()` for autocomplete | 12s polling adds flakiness; dropdown timing is non-deterministic | Type full value + Tab |
+| `{ force: true }` on Carbon inputs | Bypasses actionability; masks overlay/focus regressions | Click the `<label>` element |
+| `.catch(() => false)` silently | Swallows real failures; broken features pass green | Use explicit conditional paths |
+| No `expect()` in test body | Test provides zero regression protection | Add at least one assertion per step |
+
+### Structural Anti-Patterns
+
+| Anti-Pattern | Fix |
+|---|---|
+| `page.waitForTimeout(ms)` | Use auto-retrying `expect()` assertions |
+| Manual POM construction | Use `test.extend()` fixture injection |
+| Pure API tests in E2E suite | Move to backend integration tests |
+| Long tests with many concerns | Split into focused single-concern tests with `test.step()` |
+| Hardcoded credentials | Use `TEST_USER`/`TEST_PASS` environment variables |
+| CSS class assertions for state | Use ARIA role/attribute assertions |
+
+### Correct `waitForResponse` Pattern
+
+```typescript
+// Synchronize on network, then assert on UI
+const responsePromise = page.waitForResponse('**/api/save');
+await saveButton.click();
+await responsePromise; // sync only -- do not check .ok()
+
+// This is the real assertion
+await expect(page.getByText('Saved successfully')).toBeVisible();
+```
+
+### Correct Autocomplete Pattern
+
+```typescript
+// For known test data values -- type and move on
+await siteInput.fill("CAMES MAN");
+await siteInput.press("Tab");
+// Assert the field retained its value
+await expect(siteInput).toHaveValue("CAMES MAN");
+```
+
+### Correct Carbon Checkbox Pattern
+
+```typescript
+// Click the label, not the hidden input
+const label = page.locator('label[for="saveallresults"]');
+await label.click();
+// Or use getByLabel
+await page.getByLabel('Accept All').check();
+```
+```
+
+**B) Add a "Multi-Step Workflow Pattern" section:**
+
+```markdown
+## Multi-Step Workflow Pattern
+
+Use `test.step()` to organize long workflows. Each step should have at least one
+assertion.
+
+```typescript
+test('complete sample order workflow', async ({ page }) => {
+  await test.step('Search and select patient', async () => {
+    await page.goto('/SamplePatientEntry');
+    await page.locator('input#lastName').fill('TEST-Smith');
+    await page.locator('button#local_search').click();
+    await expect(page.locator('[data-cy="radioButton"]').first()).toBeVisible();
+  });
+
+  await test.step('Fill sample details', async () => {
+    // ... fill sample type, tests, etc.
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+  });
+
+  await test.step('Submit and verify success', async () => {
+    await page.getByRole('button', { name: 'Submit' }).click();
+    await expect(page.locator('.orderEntrySuccessMsg')).toBeVisible();
+  });
+});
+```
+```
+
+**C) Add "Soft Assertions for Transient UI" section:**
+
+```markdown
+## Soft Assertions for Transient Notifications
+
+Toasts and notifications may disappear before assertions run. Use soft
+assertions with descriptive messages:
+
+```typescript
+await expect.soft(
+  page.getByRole('alert'),
+  'Success notification should appear after save'
+).toBeVisible({ timeout: 10_000 });
+```
+```
+
+**D) Update the Authentication Strategy section** to match the actual
+`auth.setup.ts` implementation (API-based login, not UI-based).
+
+### 1.4 Updates to `.ai/skills/playwright/` Files
+
+**A) `SKILL.md` -- Add to "Core Non-Negotiables" list:**
+
+```markdown
+- Never use `waitForResponse` as the primary pass/fail signal. Use it for sync,
+  assert on visible UI.
+- Never poll for autocomplete dropdowns. Type the full known value and Tab.
+- Never use `{ force: true }` on Carbon inputs. Click the label instead.
+- Every test must contain at least one `expect()` assertion.
+```
+
+**B) `commands/audit-playwright.md` -- Add to Audit Checklist:**
+
+```markdown
+6. **Anti-pattern detection**
+   - Flag `waitForResponse` used as primary assertion (checking `.ok()` or
+     `.status()` as pass/fail)
+   - Flag `expect.poll()` for autocomplete/dropdown waiting
+   - Flag `{ force: true }` on input/checkbox/radio elements
+   - Flag tests with no `expect()` calls
+   - Flag `.catch(() => false)` or `.catch(() => {})` patterns
+```
+
+**C) `commands/write-playwright-test.md` -- Add to step 3 "Write from template":**
+
+```markdown
+   - Never use `waitForResponse` as assertion; use for sync only
+   - For autocomplete fields, type full value + Tab (never poll for suggestions)
+   - For Carbon checkboxes/radios, click the label (never `{ force: true }`)
+   - Use `test.step()` for multi-step workflows
+```
+
+**D) `reference/selector-policy.md` -- Add "Actionability" section:**
+
+```markdown
+## Actionability Rules
+
+- Never use `{ force: true }` unless documented and justified.
+- For Carbon `<input type="checkbox">` and `<input type="radio">`: click the
+  associated `<label>` element or use `page.getByLabel()`.
+- For Carbon `ComboBox` / `Dropdown`: click the trigger button
+  (`button[role="combobox"]` or `.cds--list-box__field`), not the wrapper div.
+```
+
+**E) `templates/PlaywrightE2E.spec.ts.template` -- Add `test.step()` example:**
+
+Add a commented example of `test.step()` usage and a note about when to use
+console/pageerror listeners (non-demo tests only).
+
+### 1.5 `eslint-plugin-playwright` Installation
+
+**Install:**
+
+```bash
+cd frontend && npm install -D eslint-plugin-playwright
+```
+
+**Create** `frontend/.eslintrc.playwright.js`:
+
+```javascript
+module.exports = {
+  extends: ['plugin:playwright/recommended'],
+  files: ['playwright/**/*.ts'],
+  rules: {
+    'playwright/no-wait-for-timeout': 'error',
+    'playwright/prefer-web-first-assertions': 'warn',
+    'playwright/no-force-option': 'warn',
+    'playwright/no-page-pause': 'error',
+    'playwright/expect-expect': 'warn',
+    'playwright/no-conditional-expect': 'warn',
+  },
+};
+```
+
+**Add npm script** to `frontend/package.json`:
+
+```json
+"pw:lint": "eslint --config .eslintrc.playwright.js playwright/"
+```
+
+### 1.6 Playwright MCP Server Setup
+
+Add to project setup documentation:
+
+```bash
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+---
+
+## Phase 2: Existing Test Fixes (Fix Current Anti-Patterns)
+
+Priority ordering: highest flakiness risk first.
+
+### P1 (Critical -- Causes CI Flakes)
+
+#### 2.1 Fix `accept-results.ts` -- Remove `waitForResponse` as Assertion
+
+**File:** `frontend/playwright/helpers/accept-results.ts`
+**Lines:** 68-92
+**Risk:** HIGH -- Backend 500 causes generic error before UI notification renders
+
+**Changes needed:**
+1. Keep `waitForResponse` for synchronization (line 68-73) but remove the
+   `saveResponse.ok()` check and the programmatic throw (lines 86-92)
+2. Instead, after `await saveResponsePromise`, assert on visible UI state:
+   - Success: `await expect(page).toHaveURL(/AnalyzerResults/, { timeout: 45_000 })`
+   - Error: `await expect(page.getByRole('alert').or(page.locator('.cds--inline-notification--error'))).not.toBeVisible()`
+3. Keep the existing post-navigation UI assertions (lines 97-106) which are
+   already correct
+
+#### 2.2 Fix `ogc-284-barcode-workflow.spec.ts` -- Remove Autocomplete Polling
+
+**File:** `frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts`
+**Function:** `pickFirstAutosuggestOptional` (lines 18-32)
+**Risk:** HIGH -- 12s polling per call, 2 calls per order = up to 24s flake window
+
+**Changes needed:**
+1. Replace `pickFirstAutosuggestOptional` with a simple Tab press:
+   ```typescript
+   async function tabOutOfAutocomplete(page: Page) {
+     await page.keyboard.press("Tab");
+   }
+   ```
+2. In `fillOrderDetails` (lines 263-342), change the site/requester fill pattern:
+   - For `siteInput`: fill full value ("CAMES MAN"), press Tab
+   - For `requesterLookup`: fill full value ("Prime"), press Tab
+3. Remove the `[data-cy="auto-suggestion"]` locator usage entirely (Cypress-era
+   selector in Playwright tests)
+
+#### 2.3 Fix `accept-results.ts` -- Replace `{ force: true }`
+
+**File:** `frontend/playwright/helpers/accept-results.ts`
+**Line:** 53
+**Risk:** MEDIUM -- May mask actionability regression on Accept All checkbox
+
+**Changes needed:**
+1. Replace `await acceptAllCheckbox.check({ force: true })` with either:
+   - `await page.getByLabel('Select all results').check()` (if label exists)
+   - `await page.locator('label[for="saveallresults"]').click()` (click the label)
+
+### P2 (Medium -- Masks Real Failures)
+
+#### 2.4 Fix `ogc-284-barcode-workflow.spec.ts` -- Replace `{ force: true }`
+
+**Lines:** 163, 199
+**Changes needed:**
+1. Line 163: Replace `await firstRadio.check({ force: true })` with clicking
+   the Carbon radio label element
+2. Line 199: Replace `await genderMale.check({ force: true })` with
+   `await page.getByLabel('Male').check()` or clicking the label
+
+#### 2.5 Fix `ogc-284-labels-ui.spec.ts` -- Replace `{ force: true }`
+
+**Line:** 9
+**Changes needed:**
+Replace `.click({ force: true })` with a proper wait for the element to be
+actionable, then click without force.
+
+#### 2.6 Fix `barcode-configuration.spec.ts` -- Replace `{ force: true }`
+
+**Line:** 60
+**Changes needed:**
+Replace `await collectionDateCheckbox.setChecked(false, { force: true })` with
+`await page.getByLabel('Collection Date and Time').uncheck()`.
+
+#### 2.7 Fix `ogc-284-barcode-workflow.spec.ts` -- Remove Silent Error Swallowing
+
+**Lines:** 84, 124, 188, 197-199, 205
+**Changes needed:**
+Replace `.catch(() => false)` patterns with explicit conditional checks:
+```typescript
+// Instead of: if (await element.isVisible().catch(() => false))
+const isPresent = await element.count() > 0;
+if (isPresent) {
+  await expect(element).toBeVisible();
+  // ... proceed with interaction
+}
+```
+
+#### 2.8 Add Assertions to Demo Test Steps
+
+**File:** `ogc-284-barcode-workflow.spec.ts` -- US3 test (lines 597-713)
+**Changes needed:**
+1. Add `await expect(successArea).toBeVisible()` after order submission
+2. Add `await expect(page.getByRole('heading', { name: /print bar code labels/i })).toBeVisible()` in reprint section
+3. Wrap logical sections in `test.step()` blocks
+
+### P3 (Low -- Structural Improvements)
+
+#### 2.9 Move `file-import.spec.ts` to API Test Suite
+
+**File:** `frontend/playwright/tests/file-import.spec.ts`
+**Changes needed:**
+This file contains zero UI interactions. Either:
+- Move assertions into backend integration tests, or
+- Convert to use `page.goto()` + UI assertions to verify the configurations
+  are visible in the UI (making it a real E2E test)
+
+#### 2.10 Add `test.step()` to Long Workflow Tests
+
+**Files:**
+- `ogc-284-barcode-workflow.spec.ts` (3 tests, each 100+ lines)
+- `astm-genexpert-results.spec.ts` (1 test with multiple phases)
+- `file-import-results.spec.ts` (1 test with multiple phases)
+
+**Changes needed:**
+Wrap existing logical sections in `test.step()` blocks for better trace
+readability and failure diagnostics.
+
+---
+
+## Phase 3: Architecture Improvements
+
+### 3.1 Fixture Injection Migration
+
+**Current state:** 10+ test files manually construct POMs with
+`new AnalyzerListPage(page)`.
+
+**Target state:** POMs provided via Playwright `test.extend()` fixtures.
+
+**Migration plan:**
+1. Create `frontend/playwright/fixtures/index.ts` with extended test:
+   ```typescript
+   import { test as base } from '@playwright/test';
+   import { AnalyzerListPage } from './analyzer-list';
+   import { AnalyzerFormPage } from './analyzer-form';
+   import { ErrorDashboardPage } from './error-dashboard';
+   import { Sidenav } from './sidenav';
+
+   export const test = base.extend<{
+     analyzerList: AnalyzerListPage;
+     analyzerForm: AnalyzerFormPage;
+     errorDashboard: ErrorDashboardPage;
+     sidenav: Sidenav;
+   }>({
+     analyzerList: async ({ page }, use) => {
+       await use(new AnalyzerListPage(page));
+     },
+     analyzerForm: async ({ page }, use) => {
+       await use(new AnalyzerFormPage(page));
+     },
+     errorDashboard: async ({ page }, use) => {
+       await use(new ErrorDashboardPage(page));
+     },
+     sidenav: async ({ page }, use) => {
+       await use(new Sidenav(page));
+     },
+   });
+
+   export { expect } from '@playwright/test';
+   ```
+2. Update test files to import from `../fixtures` instead of `@playwright/test`
+3. Use destructured fixtures: `test('...', async ({ page, analyzerList }) => {})`
+
+### 3.2 API-First Test Data Setup
+
+**Current state:** Tests create data through UI navigation (slow, flaky) or
+rely on SQL fixtures loaded externally.
+
+**Target state:** Tests create required data via REST API in `beforeAll` hooks.
+
+**Migration plan:**
+1. Create `frontend/playwright/helpers/api-data.ts` with helper functions:
+   - `createPatient(request, data)` - creates test patient via API
+   - `createOrder(request, data)` - creates test order via API
+   - `createAnalyzer(request, data)` - creates test analyzer via API (already
+     exists in `ensure-analyzer.ts`)
+2. Create shared fixtures that use API setup:
+   ```typescript
+   export const test = base.extend<{}, { testPatient: PatientData }>({
+     testPatient: [async ({ request }, use) => {
+       const patient = await createPatient(request, { ... });
+       await use(patient);
+       await deletePatient(request, patient.id);
+     }, { scope: 'worker' }],
+   });
+   ```
+
+### 3.3 ARIA Snapshot Testing Adoption
+
+**Applicable to:** Carbon form components that have stable accessible structure.
+
+**Migration plan:**
+1. Start with `barcode-configuration.spec.ts` as a pilot -- the form has clear
+   ARIA structure
+2. Add ARIA snapshot tests alongside existing assertions (additive, not
+   replacement)
+3. Document the pattern in `.specify/guides/playwright-best-practices.md`
+
+### 3.4 Playwright Test Agents Integration
+
+**Timeline:** After Phase 1 and Phase 2 are complete.
+
+**Steps:**
+1. Install: `npx playwright init-agents --loop=claude`
+2. Configure for OpenELIS-specific patterns (Carbon selectors, auth setup)
+3. Document in CLAUDE.md as an optional development tool
+4. Use for new test generation, not for fixing existing tests
+
+---
+
+## Appendix: Draft CLAUDE.md Addition
+
+Insert after line 109 (after the "Playwright E2E -- RECOMMENDED" section):
+
+```markdown
+### Playwright Anti-Patterns (CRITICAL)
+
+**Top 3 anti-patterns that cause flaky tests -- MUST AVOID:**
+
+1. **`waitForResponse` as assertion** -- Use it for sync only, then assert on
+   visible UI state (`toBeVisible`, `toBeEnabled`, `toHaveText`)
+2. **Autocomplete polling** -- Type the full known value + Tab; never poll for
+   dropdown suggestions with `expect.poll()`
+3. **`{ force: true }`** -- Click the `<label>` instead of forcing hidden Carbon
+   inputs; `force` masks real actionability regressions
+
+**Full guide:** `.specify/guides/playwright-best-practices.md`
+**Quality report:** `.specify/guides/playwright-e2e-quality-report.md`
+```
+
+## Appendix: Draft AGENTS.md Addition
+
+Insert after line 1606 (after the "Key Patterns" subsection in the Playwright
+section):
+
+```markdown
+#### Playwright Anti-Patterns (MUST AVOID)
+
+These patterns cause flaky tests and invisible failures:
+
+- **`waitForResponse` as primary assertion** -- Use for sync only. Always follow
+  with a visible UI assertion. Never check `response.ok()` as the pass/fail
+  signal.
+- **Autocomplete polling** -- Type the full known value + Tab. Never use
+  `expect.poll()` to wait for dropdown suggestions.
+- **`{ force: true }`** -- Carbon overlays labels on hidden inputs. Click the
+  `<label>` element instead. `force` bypasses actionability checks.
+- **Silent `.catch(() => {})`** -- Never swallow errors. Use explicit
+  conditional paths.
+- **Tests without assertions** -- Every test must have `expect()`. Use
+  `test.step()` for multi-step workflows.
+
+**Full guide:** `.specify/guides/playwright-best-practices.md`
+```

--- a/.specify/plans/playwright-quality-remediation.md
+++ b/.specify/plans/playwright-quality-remediation.md
@@ -115,10 +115,9 @@ await expect(siteInput).toHaveValue("CAMES MAN");
 
 ```typescript
 // Click the label, not the hidden input
+// Carbon checkbox: click the visible label, not the hidden input
 const label = page.locator('label[for="saveallresults"]');
 await label.click();
-// Or use getByLabel
-await page.getByLabel("Accept All").check();
 ```
 
 ````
@@ -215,7 +214,8 @@ template":**
 
 - Never use `{ force: true }` unless documented and justified.
 - For Carbon `<input type="checkbox">` and `<input type="radio">`: click the
-  associated `<label>` element or use `page.getByLabel()`.
+  associated `<label>` element (e.g., `label[for="inputId"]`). Do NOT use
+  `getByLabel().check()` — Carbon hides inputs with `visually-hidden`.
 - For Carbon `ComboBox` / `Dropdown`: click the trigger button
   (`button[role="combobox"]` or `.cds--list-box__field`), not the wrapper div.
 ```

--- a/.specify/plans/playwright-quality-remediation.md
+++ b/.specify/plans/playwright-quality-remediation.md
@@ -1,9 +1,8 @@
 # Playwright Quality Remediation Plan
 
-> **Date:** 2026-03-20
-> **Status:** DRAFT
-> **Research Report:** `.specify/guides/playwright-e2e-quality-report.md`
-> **Scope:** Prevent new anti-patterns, fix existing ones, improve architecture
+> **Date:** 2026-03-20 **Status:** DRAFT **Research Report:** >
+> `.specify/guides/playwright-e2e-quality-report.md` > **Scope:** Prevent new
+> anti-patterns, fix existing ones, improve architecture
 
 ---
 
@@ -26,8 +25,8 @@ block (after line 109):
 3. **`{ force: true }`** -- Click the `<label>` instead of forcing hidden Carbon
    inputs; `force` masks real actionability regressions
 
-**Full guide:** `.specify/guides/playwright-best-practices.md`
-**Quality report:** `.specify/guides/playwright-e2e-quality-report.md`
+**Full guide:** `.specify/guides/playwright-best-practices.md` **Quality
+report:** `.specify/guides/playwright-e2e-quality-report.md`
 ```
 
 ### 1.2 AGENTS.md Additions
@@ -62,43 +61,45 @@ These patterns cause flaky tests and invisible failures:
 
 Add the following sections to the best practices guide:
 
-**A) Replace the "Anti-Patterns" table (line 499-510) with an expanded version:**
+**A) Replace the "Anti-Patterns" table (line 499-510) with an expanded
+version:**
 
-```markdown
+````markdown
 ## Anti-Patterns
 
 ### Critical Anti-Patterns (Cause Flaky Tests)
 
-| Anti-Pattern | Why It Fails | Fix |
-|---|---|---|
-| `waitForResponse` as assertion | Backend 500 throws before UI renders error notification | Use for sync only, assert on UI |
-| `expect.poll()` for autocomplete | 12s polling adds flakiness; dropdown timing is non-deterministic | Type full value + Tab |
-| `{ force: true }` on Carbon inputs | Bypasses actionability; masks overlay/focus regressions | Click the `<label>` element |
-| `.catch(() => false)` silently | Swallows real failures; broken features pass green | Use explicit conditional paths |
-| No `expect()` in test body | Test provides zero regression protection | Add at least one assertion per step |
+| Anti-Pattern                       | Why It Fails                                                     | Fix                                 |
+| ---------------------------------- | ---------------------------------------------------------------- | ----------------------------------- |
+| `waitForResponse` as assertion     | Backend 500 throws before UI renders error notification          | Use for sync only, assert on UI     |
+| `expect.poll()` for autocomplete   | 12s polling adds flakiness; dropdown timing is non-deterministic | Type full value + Tab               |
+| `{ force: true }` on Carbon inputs | Bypasses actionability; masks overlay/focus regressions          | Click the `<label>` element         |
+| `.catch(() => false)` silently     | Swallows real failures; broken features pass green               | Use explicit conditional paths      |
+| No `expect()` in test body         | Test provides zero regression protection                         | Add at least one assertion per step |
 
 ### Structural Anti-Patterns
 
-| Anti-Pattern | Fix |
-|---|---|
-| `page.waitForTimeout(ms)` | Use auto-retrying `expect()` assertions |
-| Manual POM construction | Use `test.extend()` fixture injection |
-| Pure API tests in E2E suite | Move to backend integration tests |
-| Long tests with many concerns | Split into focused single-concern tests with `test.step()` |
-| Hardcoded credentials | Use `TEST_USER`/`TEST_PASS` environment variables |
-| CSS class assertions for state | Use ARIA role/attribute assertions |
+| Anti-Pattern                   | Fix                                                        |
+| ------------------------------ | ---------------------------------------------------------- |
+| `page.waitForTimeout(ms)`      | Use auto-retrying `expect()` assertions                    |
+| Manual POM construction        | Use `test.extend()` fixture injection                      |
+| Pure API tests in E2E suite    | Move to backend integration tests                          |
+| Long tests with many concerns  | Split into focused single-concern tests with `test.step()` |
+| Hardcoded credentials          | Use `TEST_USER`/`TEST_PASS` environment variables          |
+| CSS class assertions for state | Use ARIA role/attribute assertions                         |
 
 ### Correct `waitForResponse` Pattern
 
 ```typescript
 // Synchronize on network, then assert on UI
-const responsePromise = page.waitForResponse('**/api/save');
+const responsePromise = page.waitForResponse("**/api/save");
 await saveButton.click();
 await responsePromise; // sync only -- do not check .ok()
 
 // This is the real assertion
-await expect(page.getByText('Saved successfully')).toBeVisible();
+await expect(page.getByText("Saved successfully")).toBeVisible();
 ```
+````
 
 ### Correct Autocomplete Pattern
 
@@ -117,9 +118,10 @@ await expect(siteInput).toHaveValue("CAMES MAN");
 const label = page.locator('label[for="saveallresults"]');
 await label.click();
 // Or use getByLabel
-await page.getByLabel('Accept All').check();
+await page.getByLabel("Accept All").check();
 ```
-```
+
+````
 
 **B) Add a "Multi-Step Workflow Pattern" section:**
 
@@ -148,8 +150,9 @@ test('complete sample order workflow', async ({ page }) => {
     await expect(page.locator('.orderEntrySuccessMsg')).toBeVisible();
   });
 });
-```
-```
+````
+
+````
 
 **C) Add "Soft Assertions for Transient UI" section:**
 
@@ -164,8 +167,9 @@ await expect.soft(
   page.getByRole('alert'),
   'Success notification should appear after save'
 ).toBeVisible({ timeout: 10_000 });
-```
-```
+````
+
+````
 
 **D) Update the Authentication Strategy section** to match the actual
 `auth.setup.ts` implementation (API-based login, not UI-based).
@@ -180,7 +184,7 @@ await expect.soft(
 - Never poll for autocomplete dropdowns. Type the full known value and Tab.
 - Never use `{ force: true }` on Carbon inputs. Click the label instead.
 - Every test must contain at least one `expect()` assertion.
-```
+````
 
 **B) `commands/audit-playwright.md` -- Add to Audit Checklist:**
 
@@ -194,13 +198,14 @@ await expect.soft(
    - Flag `.catch(() => false)` or `.catch(() => {})` patterns
 ```
 
-**C) `commands/write-playwright-test.md` -- Add to step 3 "Write from template":**
+**C) `commands/write-playwright-test.md` -- Add to step 3 "Write from
+template":**
 
 ```markdown
-   - Never use `waitForResponse` as assertion; use for sync only
-   - For autocomplete fields, type full value + Tab (never poll for suggestions)
-   - For Carbon checkboxes/radios, click the label (never `{ force: true }`)
-   - Use `test.step()` for multi-step workflows
+- Never use `waitForResponse` as assertion; use for sync only
+- For autocomplete fields, type full value + Tab (never poll for suggestions)
+- For Carbon checkboxes/radios, click the label (never `{ force: true }`)
+- Use `test.step()` for multi-step workflows
 ```
 
 **D) `reference/selector-policy.md` -- Add "Actionability" section:**
@@ -232,15 +237,15 @@ cd frontend && npm install -D eslint-plugin-playwright
 
 ```javascript
 module.exports = {
-  extends: ['plugin:playwright/recommended'],
-  files: ['playwright/**/*.ts'],
+  extends: ["plugin:playwright/recommended"],
+  files: ["playwright/**/*.ts"],
   rules: {
-    'playwright/no-wait-for-timeout': 'error',
-    'playwright/prefer-web-first-assertions': 'warn',
-    'playwright/no-force-option': 'warn',
-    'playwright/no-page-pause': 'error',
-    'playwright/expect-expect': 'warn',
-    'playwright/no-conditional-expect': 'warn',
+    "playwright/no-wait-for-timeout": "error",
+    "playwright/prefer-web-first-assertions": "warn",
+    "playwright/no-force-option": "warn",
+    "playwright/no-page-pause": "error",
+    "playwright/expect-expect": "warn",
+    "playwright/no-conditional-expect": "warn",
   },
 };
 ```
@@ -269,33 +274,38 @@ Priority ordering: highest flakiness risk first.
 
 #### 2.1 Fix `accept-results.ts` -- Remove `waitForResponse` as Assertion
 
-**File:** `frontend/playwright/helpers/accept-results.ts`
-**Lines:** 68-92
-**Risk:** HIGH -- Backend 500 causes generic error before UI notification renders
+**File:** `frontend/playwright/helpers/accept-results.ts` **Lines:** 68-92
+**Risk:** HIGH -- Backend 500 causes generic error before UI notification
+renders
 
 **Changes needed:**
+
 1. Keep `waitForResponse` for synchronization (line 68-73) but remove the
    `saveResponse.ok()` check and the programmatic throw (lines 86-92)
 2. Instead, after `await saveResponsePromise`, assert on visible UI state:
-   - Success: `await expect(page).toHaveURL(/AnalyzerResults/, { timeout: 45_000 })`
-   - Error: `await expect(page.getByRole('alert').or(page.locator('.cds--inline-notification--error'))).not.toBeVisible()`
+   - Success:
+     `await expect(page).toHaveURL(/AnalyzerResults/, { timeout: 45_000 })`
+   - Error:
+     `await expect(page.getByRole('alert').or(page.locator('.cds--inline-notification--error'))).not.toBeVisible()`
 3. Keep the existing post-navigation UI assertions (lines 97-106) which are
    already correct
 
 #### 2.2 Fix `ogc-284-barcode-workflow.spec.ts` -- Remove Autocomplete Polling
 
 **File:** `frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts`
-**Function:** `pickFirstAutosuggestOptional` (lines 18-32)
-**Risk:** HIGH -- 12s polling per call, 2 calls per order = up to 24s flake window
+**Function:** `pickFirstAutosuggestOptional` (lines 18-32) **Risk:** HIGH -- 12s
+polling per call, 2 calls per order = up to 24s flake window
 
 **Changes needed:**
+
 1. Replace `pickFirstAutosuggestOptional` with a simple Tab press:
    ```typescript
    async function tabOutOfAutocomplete(page: Page) {
      await page.keyboard.press("Tab");
    }
    ```
-2. In `fillOrderDetails` (lines 263-342), change the site/requester fill pattern:
+2. In `fillOrderDetails` (lines 263-342), change the site/requester fill
+   pattern:
    - For `siteInput`: fill full value ("CAMES MAN"), press Tab
    - For `requesterLookup`: fill full value ("Prime"), press Tab
 3. Remove the `[data-cy="auto-suggestion"]` locator usage entirely (Cypress-era
@@ -303,48 +313,46 @@ Priority ordering: highest flakiness risk first.
 
 #### 2.3 Fix `accept-results.ts` -- Replace `{ force: true }`
 
-**File:** `frontend/playwright/helpers/accept-results.ts`
-**Line:** 53
-**Risk:** MEDIUM -- May mask actionability regression on Accept All checkbox
+**File:** `frontend/playwright/helpers/accept-results.ts` **Line:** 53 **Risk:**
+MEDIUM -- May mask actionability regression on Accept All checkbox
 
 **Changes needed:**
+
 1. Replace `await acceptAllCheckbox.check({ force: true })` with either:
    - `await page.getByLabel('Select all results').check()` (if label exists)
-   - `await page.locator('label[for="saveallresults"]').click()` (click the label)
+   - `await page.locator('label[for="saveallresults"]').click()` (click the
+     label)
 
 ### P2 (Medium -- Masks Real Failures)
 
 #### 2.4 Fix `ogc-284-barcode-workflow.spec.ts` -- Replace `{ force: true }`
 
-**Lines:** 163, 199
-**Changes needed:**
-1. Line 163: Replace `await firstRadio.check({ force: true })` with clicking
-   the Carbon radio label element
+**Lines:** 163, 199 **Changes needed:**
+
+1. Line 163: Replace `await firstRadio.check({ force: true })` with clicking the
+   Carbon radio label element
 2. Line 199: Replace `await genderMale.check({ force: true })` with
    `await page.getByLabel('Male').check()` or clicking the label
 
 #### 2.5 Fix `ogc-284-labels-ui.spec.ts` -- Replace `{ force: true }`
 
-**Line:** 9
-**Changes needed:**
-Replace `.click({ force: true })` with a proper wait for the element to be
-actionable, then click without force.
+**Line:** 9 **Changes needed:** Replace `.click({ force: true })` with a proper
+wait for the element to be actionable, then click without force.
 
 #### 2.6 Fix `barcode-configuration.spec.ts` -- Replace `{ force: true }`
 
-**Line:** 60
-**Changes needed:**
-Replace `await collectionDateCheckbox.setChecked(false, { force: true })` with
+**Line:** 60 **Changes needed:** Replace
+`await collectionDateCheckbox.setChecked(false, { force: true })` with
 `await page.getByLabel('Collection Date and Time').uncheck()`.
 
 #### 2.7 Fix `ogc-284-barcode-workflow.spec.ts` -- Remove Silent Error Swallowing
 
-**Lines:** 84, 124, 188, 197-199, 205
-**Changes needed:**
-Replace `.catch(() => false)` patterns with explicit conditional checks:
+**Lines:** 84, 124, 188, 197-199, 205 **Changes needed:** Replace
+`.catch(() => false)` patterns with explicit conditional checks:
+
 ```typescript
 // Instead of: if (await element.isVisible().catch(() => false))
-const isPresent = await element.count() > 0;
+const isPresent = (await element.count()) > 0;
 if (isPresent) {
   await expect(element).toBeVisible();
   // ... proceed with interaction
@@ -355,31 +363,34 @@ if (isPresent) {
 
 **File:** `ogc-284-barcode-workflow.spec.ts` -- US3 test (lines 597-713)
 **Changes needed:**
+
 1. Add `await expect(successArea).toBeVisible()` after order submission
-2. Add `await expect(page.getByRole('heading', { name: /print bar code labels/i })).toBeVisible()` in reprint section
+2. Add
+   `await expect(page.getByRole('heading', { name: /print bar code labels/i })).toBeVisible()`
+   in reprint section
 3. Wrap logical sections in `test.step()` blocks
 
 ### P3 (Low -- Structural Improvements)
 
 #### 2.9 Move `file-import.spec.ts` to API Test Suite
 
-**File:** `frontend/playwright/tests/file-import.spec.ts`
-**Changes needed:**
+**File:** `frontend/playwright/tests/file-import.spec.ts` **Changes needed:**
 This file contains zero UI interactions. Either:
+
 - Move assertions into backend integration tests, or
-- Convert to use `page.goto()` + UI assertions to verify the configurations
-  are visible in the UI (making it a real E2E test)
+- Convert to use `page.goto()` + UI assertions to verify the configurations are
+  visible in the UI (making it a real E2E test)
 
 #### 2.10 Add `test.step()` to Long Workflow Tests
 
 **Files:**
+
 - `ogc-284-barcode-workflow.spec.ts` (3 tests, each 100+ lines)
 - `astm-genexpert-results.spec.ts` (1 test with multiple phases)
 - `file-import-results.spec.ts` (1 test with multiple phases)
 
-**Changes needed:**
-Wrap existing logical sections in `test.step()` blocks for better trace
-readability and failure diagnostics.
+**Changes needed:** Wrap existing logical sections in `test.step()` blocks for
+better trace readability and failure diagnostics.
 
 ---
 
@@ -393,13 +404,15 @@ readability and failure diagnostics.
 **Target state:** POMs provided via Playwright `test.extend()` fixtures.
 
 **Migration plan:**
+
 1. Create `frontend/playwright/fixtures/index.ts` with extended test:
+
    ```typescript
-   import { test as base } from '@playwright/test';
-   import { AnalyzerListPage } from './analyzer-list';
-   import { AnalyzerFormPage } from './analyzer-form';
-   import { ErrorDashboardPage } from './error-dashboard';
-   import { Sidenav } from './sidenav';
+   import { test as base } from "@playwright/test";
+   import { AnalyzerListPage } from "./analyzer-list";
+   import { AnalyzerFormPage } from "./analyzer-form";
+   import { ErrorDashboardPage } from "./error-dashboard";
+   import { Sidenav } from "./sidenav";
 
    export const test = base.extend<{
      analyzerList: AnalyzerListPage;
@@ -421,19 +434,22 @@ readability and failure diagnostics.
      },
    });
 
-   export { expect } from '@playwright/test';
+   export { expect } from "@playwright/test";
    ```
+
 2. Update test files to import from `../fixtures` instead of `@playwright/test`
-3. Use destructured fixtures: `test('...', async ({ page, analyzerList }) => {})`
+3. Use destructured fixtures:
+   `test('...', async ({ page, analyzerList }) => {})`
 
 ### 3.2 API-First Test Data Setup
 
-**Current state:** Tests create data through UI navigation (slow, flaky) or
-rely on SQL fixtures loaded externally.
+**Current state:** Tests create data through UI navigation (slow, flaky) or rely
+on SQL fixtures loaded externally.
 
 **Target state:** Tests create required data via REST API in `beforeAll` hooks.
 
 **Migration plan:**
+
 1. Create `frontend/playwright/helpers/api-data.ts` with helper functions:
    - `createPatient(request, data)` - creates test patient via API
    - `createOrder(request, data)` - creates test order via API
@@ -455,6 +471,7 @@ rely on SQL fixtures loaded externally.
 **Applicable to:** Carbon form components that have stable accessible structure.
 
 **Migration plan:**
+
 1. Start with `barcode-configuration.spec.ts` as a pilot -- the form has clear
    ARIA structure
 2. Add ARIA snapshot tests alongside existing assertions (additive, not
@@ -466,6 +483,7 @@ rely on SQL fixtures loaded externally.
 **Timeline:** After Phase 1 and Phase 2 are complete.
 
 **Steps:**
+
 1. Install: `npx playwright init-agents --loop=claude`
 2. Configure for OpenELIS-specific patterns (Carbon selectors, auth setup)
 3. Document in CLAUDE.md as an optional development tool
@@ -489,8 +507,8 @@ Insert after line 109 (after the "Playwright E2E -- RECOMMENDED" section):
 3. **`{ force: true }`** -- Click the `<label>` instead of forcing hidden Carbon
    inputs; `force` masks real actionability regressions
 
-**Full guide:** `.specify/guides/playwright-best-practices.md`
-**Quality report:** `.specify/guides/playwright-e2e-quality-report.md`
+**Full guide:** `.specify/guides/playwright-best-practices.md` **Quality
+report:** `.specify/guides/playwright-e2e-quality-report.md`
 ```
 
 ## Appendix: Draft AGENTS.md Addition

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1618,10 +1618,10 @@ state.
 
 ```typescript
 // DO: sync then assert on UI
-const responsePromise = page.waitForResponse('**/api/save');
+const responsePromise = page.waitForResponse("**/api/save");
 await saveButton.click();
 await responsePromise; // sync only — do not check .ok()
-await expect(page.getByText('Saved successfully')).toBeVisible();
+await expect(page.getByText("Saved successfully")).toBeVisible();
 ```
 
 **DO NOT: Use `{ force: true }` on Carbon inputs**
@@ -1634,11 +1634,11 @@ Carbon Design System applies `visually-hidden` to `<input type="checkbox">` and
 // DO: click the label
 await page.locator('label[for="saveallresults"]').click();
 // or for dynamic IDs:
-await input.locator('..').locator('label').click();
+await input.locator("..").locator("label").click();
 
 // DO NOT:
 await checkbox.check({ force: true }); // bypasses actionability checks
-await page.getByLabel('text').check(); // targets hidden input — will fail
+await page.getByLabel("text").check(); // targets hidden input — will fail
 ```
 
 **DO NOT: Use `.catch(() => false)` on `isVisible()`**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1604,6 +1604,70 @@ must be explicitly added to a project's `testMatch` allowlist in
 - **`CORE_DEMO_TESTS` / `HARNESS_DEMO_TESTS`**: Shared globs between each demo
   pair and its `*-demo-video` project — defined in `playwright.config.ts`.
 
+#### Playwright Anti-Patterns (MUST AVOID)
+
+These patterns cause flaky tests and invisible failures. Apply them as hard
+rules when writing or reviewing Playwright code.
+
+**DO NOT: Use `response.ok()` as test pass/fail**
+
+Use `waitForResponse` for synchronization only. The real assertion must be on
+visible UI state. When the backend returns HTTP 500, checking `response.ok()`
+throws before the UI renders its error notification — CI screenshots show stale
+state.
+
+```typescript
+// DO: sync then assert on UI
+const responsePromise = page.waitForResponse('**/api/save');
+await saveButton.click();
+await responsePromise; // sync only — do not check .ok()
+await expect(page.getByText('Saved successfully')).toBeVisible();
+```
+
+**DO NOT: Use `{ force: true }` on Carbon inputs**
+
+Carbon Design System applies `visually-hidden` to `<input type="checkbox">` and
+`<input type="radio">`. The visible, clickable element is the associated
+`<label>`. Click the label instead.
+
+```typescript
+// DO: click the label
+await page.locator('label[for="saveallresults"]').click();
+// or for dynamic IDs:
+await input.locator('..').locator('label').click();
+
+// DO NOT:
+await checkbox.check({ force: true }); // bypasses actionability checks
+await page.getByLabel('text').check(); // targets hidden input — will fail
+```
+
+**DO NOT: Use `.catch(() => false)` on `isVisible()`**
+
+`locator.isVisible()` returns `boolean` without throwing. The `.catch()` is dead
+code that hides real errors (like strict mode violations matching 2+ elements).
+The `timeout` parameter on `isVisible()` is deprecated and ignored.
+
+```typescript
+// DO:
+if (await element.isVisible()) { ... }
+// For waiting: use web-first assertion
+await expect(element).toBeVisible({ timeout: 5_000 });
+
+// DO NOT:
+if (await element.isVisible({ timeout: 3000 }).catch(() => false)) { ... }
+```
+
+**DO NOT: Replace autocomplete selection with type + Tab**
+
+The `AutoComplete` component's `onSelect` callback sets server-side IDs that
+`onChange` (typing) does not. Typing + Tab leaves `referringSiteId` empty. Wait
+for suggestion dropdown items, then click one. Provide a Tab fallback only for
+when no suggestions appear.
+
+**ALWAYS: Include at least one `expect()` assertion per test.**
+
+**Full guide:** `.specify/guides/playwright-best-practices.md`
+
 #### Available npm Scripts
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1634,7 +1634,7 @@ Carbon Design System applies `visually-hidden` to `<input type="checkbox">` and
 // DO: click the label
 await page.locator('label[for="saveallresults"]').click();
 // or for dynamic IDs:
-await input.locator("..").locator("label").click();
+await input.locator("xpath=..").locator("label").click();
 
 // DO NOT:
 await checkbox.check({ force: true }); // bypasses actionability checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,22 @@ When using `/speckit.implement`, follow **Red-Green-Refactor** cycle:
 > contract, scripts, and project descriptions. Key invariant: always use
 > `npm run pw:test` scripts, never raw `npx playwright test`.
 
+### Playwright Anti-Patterns (CRITICAL)
+
+**DO NOT** introduce these patterns — they cause flaky tests:
+
+1. **`response.ok()` as pass/fail** — Use `waitForResponse` for sync only, then
+   assert on visible UI state (`toBeVisible`, `toHaveURL`, `toHaveText`)
+2. **`{ force: true }` on Carbon inputs** — Click the `<label>` instead; Carbon
+   hides `<input>` elements with `visually-hidden`
+3. **`.catch(() => false)` on `isVisible()`** — `isVisible()` already returns
+   boolean; the catch hides real errors
+4. **`isVisible({ timeout: N })`** — The timeout parameter is deprecated and
+   ignored; use `expect(el).toBeVisible({ timeout: N })` for waiting
+
+**Full guide:** `.specify/guides/playwright-best-practices.md`
+**Quality report:** `.specify/guides/playwright-e2e-quality-report.md`
+
 ---
 
 ## Quick Links

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,8 @@ When using `/speckit.implement`, follow **Red-Green-Refactor** cycle:
 4. **`isVisible({ timeout: N })`** — The timeout parameter is deprecated and
    ignored; use `expect(el).toBeVisible({ timeout: N })` for waiting
 
-**Full guide:** `.specify/guides/playwright-best-practices.md`
-**Quality report:** `.specify/guides/playwright-e2e-quality-report.md`
+**Full guide:** `.specify/guides/playwright-best-practices.md` **Quality
+report:** `.specify/guides/playwright-e2e-quality-report.md`
 
 ---
 

--- a/frontend/playwright/helpers/accept-results.ts
+++ b/frontend/playwright/helpers/accept-results.ts
@@ -50,7 +50,8 @@ export async function acceptAndVerifyResults(
 
   const acceptAllCheckbox = page.locator("#saveallresults");
   await expect(acceptAllCheckbox).toBeAttached({ timeout: 5_000 });
-  await acceptAllCheckbox.check({ force: true });
+  // Carbon checkbox: click the visible label instead of forcing the hidden input
+  await page.locator('label[for="saveallresults"]').click();
   await presentation.pause(1_500);
 
   // ── Save ────────────────────────────────────────────────────────
@@ -83,20 +84,8 @@ export async function acceptAndVerifyResults(
     // Some runs complete quickly and can skip observable transition states.
   });
 
-  const saveResponse = await saveResponsePromise;
-  if (!saveResponse.ok()) {
-    // Wait for the Carbon error notification to render so it appears in CI screenshots
-    const errorNotification = page.locator(
-      ".cds--toast-notification--error, .cds--inline-notification--error",
-    );
-    await errorNotification
-      .waitFor({ state: "visible", timeout: 5_000 })
-      .catch(() => {});
-    const detail = (await saveResponse.text().catch(() => "")).slice(0, 500);
-    throw new Error(
-      `POST /rest/AnalyzerResults failed: HTTP ${saveResponse.status()} ${detail}`,
-    );
-  }
+  // Wait for POST completion (sync only — UI assertions below are the real pass/fail)
+  await saveResponsePromise;
 
   // Success path issues full page reload (AnalyserResults.js).
   await page.waitForURL(/AnalyzerResults[?]type=/, { timeout: 45_000 });

--- a/frontend/playwright/tests/barcode-configuration.spec.ts
+++ b/frontend/playwright/tests/barcode-configuration.spec.ts
@@ -57,10 +57,8 @@ test.describe("Barcode configuration", () => {
     await expect(collectionDateCheckbox).toBeChecked();
 
     await maxOrderInput.fill("22");
-    // Carbon checkbox: click the visible label instead of forcing the hidden input
-    await page
-      .locator("label", { hasText: "Collection Date and Time" })
-      .click();
+    // Carbon checkbox: click the specific associated label instead of forcing the hidden input
+    await page.locator('label[for="specimenCollectionDateCheck"]').click();
     await page.getByRole("button", { name: "Save" }).click();
 
     await page.reload();

--- a/frontend/playwright/tests/barcode-configuration.spec.ts
+++ b/frontend/playwright/tests/barcode-configuration.spec.ts
@@ -57,7 +57,10 @@ test.describe("Barcode configuration", () => {
     await expect(collectionDateCheckbox).toBeChecked();
 
     await maxOrderInput.fill("22");
-    await collectionDateCheckbox.setChecked(false, { force: true });
+    // Carbon checkbox: click the visible label instead of forcing the hidden input
+    await page
+      .locator("label", { hasText: "Collection Date and Time" })
+      .click();
     await page.getByRole("button", { name: "Save" }).click();
 
     await page.reload();

--- a/frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts
+++ b/frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts
@@ -138,7 +138,7 @@ async function selectPatient(
   await expect(firstRadio).toBeVisible({ timeout: 5000 });
   await scrollToAndPause(page, firstRadio, pause, 800);
   // Carbon radio: click the visible label sibling instead of forcing the hidden input
-  await firstRadio.locator("..").locator("label").click();
+  await firstRadio.locator("xpath=..").locator("label").click();
 
   // Wait for patient form hydration before moving to the next wizard step.
   await expect(page.locator('[data-cy="patientSelectionReady"]')).toBeVisible({
@@ -174,8 +174,11 @@ async function selectPatient(
     const hasGender =
       ((await genderMale.count()) > 0 && (await genderMale.isChecked())) ||
       ((await genderFemale.count()) > 0 && (await genderFemale.isChecked()));
-    if (!hasGender && (await genderMale.isVisible())) {
+    if (!hasGender && (await genderMale.count()) > 0) {
       // Carbon radio: click the visible label instead of forcing the hidden input
+      await expect(page.locator('label[for="radio-1"]')).toBeVisible({
+        timeout: 5_000,
+      });
       await page.locator('label[for="radio-1"]').click();
     }
 

--- a/frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts
+++ b/frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts
@@ -14,7 +14,19 @@ import { videoPause } from "../helpers/video-pause";
  */
 type PauseFn = (ms: number) => Promise<void>;
 
-/** Site/requester lookup: prefer autosuggest, but fall back to tabbing out. */
+/** Site/requester lookup: wait for suggestion dropdown, fall back to Tab if none appear. */
+async function pickFirstAutosuggestOptional(page: Page, pause: PauseFn) {
+  const suggestion = page.locator('[data-cy="auto-suggestion"]').first();
+  try {
+    await expect(suggestion).toBeVisible({ timeout: 5_000 });
+    await suggestion.click();
+    await pause(500);
+  } catch {
+    // No suggestions rendered (empty DB, no match) — accept free text via Tab
+    await page.keyboard.press("Tab");
+    await pause(200);
+  }
+}
 
 /** Visible success panel after SamplePatientEntry save (class from OrderSuccessMessage). */
 async function expectOrderEntrySaveSuccess(page: Page) {
@@ -59,24 +71,6 @@ async function scrollToAndPause(
   await pause(pauseMs);
 }
 
-async function waitForAutoSuggestion(page: Page, pattern?: RegExp) {
-  if (pattern) {
-    const matchingSuggestion = page
-      .locator('[data-cy="auto-suggestion"]')
-      .filter({ hasText: pattern })
-      .first();
-    if (
-      await matchingSuggestion.isVisible({ timeout: 2_000 }).catch(() => false)
-    ) {
-      return matchingSuggestion;
-    }
-  }
-
-  const suggestion = page.locator('[data-cy="auto-suggestion"]').first();
-  await expect(suggestion).toBeVisible({ timeout: 5_000 });
-  return suggestion;
-}
-
 async function waitForSampleStep(page: Page) {
   const sampleSelect = page.locator("select#sampleId_0");
   await expect(sampleSelect).toBeVisible({ timeout: 15_000 });
@@ -106,7 +100,7 @@ async function selectPatient(
 ) {
   // Ensure we're on the Search tab
   const searchTabBtn = page.locator('[data-cy="searchPatientTabButton"]');
-  if (await searchTabBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+  if (await searchTabBtn.isVisible()) {
     await searchTabBtn.click();
   }
 
@@ -143,9 +137,8 @@ async function selectPatient(
       : page.locator('[data-cy="radioButton"]').first();
   await expect(firstRadio).toBeVisible({ timeout: 5000 });
   await scrollToAndPause(page, firstRadio, pause, 800);
-  // Carbon overlays the visible label on top of the radio input, which can
-  // intercept pointer events in CI; forcing a radio check matches Cypress.
-  await firstRadio.check({ force: true });
+  // Carbon radio: click the visible label sibling instead of forcing the hidden input
+  await firstRadio.locator("..").locator("label").click();
 
   // Wait for patient form hydration before moving to the next wizard step.
   await expect(page.locator('[data-cy="patientSelectionReady"]')).toBeVisible({
@@ -170,7 +163,7 @@ async function selectPatient(
   // Search results can omit fields that the Add Order validation schema still
   // requires (national ID, gender, DOB). Backfill them before advancing.
   const nationalIdInput = page.locator("input#nationalId");
-  if (await nationalIdInput.isVisible({ timeout: 5000 }).catch(() => false)) {
+  if (await nationalIdInput.isVisible()) {
     if (!(await nationalIdInput.inputValue()).trim()) {
       await nationalIdInput.fill(`DEMO-${Date.now()}`);
       await nationalIdInput.press("Tab");
@@ -179,15 +172,16 @@ async function selectPatient(
     const genderMale = page.locator("input#radio-1");
     const genderFemale = page.locator("input#radio-2");
     const hasGender =
-      (await genderMale.isChecked().catch(() => false)) ||
-      (await genderFemale.isChecked().catch(() => false));
-    if (!hasGender && (await genderMale.isVisible().catch(() => false))) {
-      await genderMale.check({ force: true });
+      ((await genderMale.count()) > 0 && (await genderMale.isChecked())) ||
+      ((await genderFemale.count()) > 0 && (await genderFemale.isChecked()));
+    if (!hasGender && (await genderMale.isVisible())) {
+      // Carbon radio: click the visible label instead of forcing the hidden input
+      await page.locator('label[for="radio-1"]').click();
     }
 
     const birthDateInput = page.locator("input#date-picker-default-id");
     if (
-      (await birthDateInput.isVisible().catch(() => false)) &&
+      (await birthDateInput.isVisible()) &&
       !(await birthDateInput.inputValue()).trim()
     ) {
       await birthDateInput.fill("13/03/1990");
@@ -213,29 +207,29 @@ async function fillSampleStep(page: Page) {
   }
 
   const collectionDate = page.locator("input#collectionDate_0");
-  if (await collectionDate.isVisible().catch(() => false)) {
+  if (await collectionDate.isVisible()) {
     await collectionDate.fill("13/03/2026");
     await collectionDate.press("Tab");
   }
 
   const collectionTime = page.locator("input#collectionTime_0");
-  if (await collectionTime.isVisible().catch(() => false)) {
+  if (await collectionTime.isVisible()) {
     await collectionTime.fill("07:15");
     await collectionTime.press("Tab");
   }
 
   const collector = page.locator("input#collector_0");
-  if (await collector.isVisible().catch(() => false)) {
+  if (await collector.isVisible()) {
     await collector.fill("E2E Collector");
   }
 
   const quantity = page.locator("input#quantity");
-  if (await quantity.isVisible().catch(() => false)) {
+  if (await quantity.isVisible()) {
     await quantity.fill("1");
   }
 
   const uomSelect = page.locator("select#uomId_0");
-  if (await uomSelect.isVisible().catch(() => false)) {
+  if (await uomSelect.isVisible()) {
     await uomSelect.selectOption({ index: 1 });
   }
 
@@ -250,54 +244,54 @@ async function fillOrderDetails(page: Page, pause: PauseFn) {
 
   const labNoInput = page.locator("input#labNo");
   const generateBtn = page.locator("[data-cy='generate-labNumber']");
-  if (await generateBtn.isVisible({ timeout: 4000 }).catch(() => false)) {
+  if (await generateBtn.isVisible()) {
     await generateBtn.click();
     await expect(labNoInput).not.toHaveValue("", { timeout: 10_000 });
   }
 
   const requestDate = page.locator("input#order_requestDate");
-  if (await requestDate.isVisible().catch(() => false)) {
+  if (await requestDate.isVisible()) {
     await requestDate.fill("13/03/2026");
     await page.keyboard.press("Tab");
     await expect(requestDate).toHaveValue("13/03/2026");
   }
   const receivedDate = page.locator("input#order_receivedDate");
-  if (await receivedDate.isVisible().catch(() => false)) {
+  if (await receivedDate.isVisible()) {
     await receivedDate.fill("13/03/2026");
     await page.keyboard.press("Tab");
     await expect(receivedDate).toHaveValue("13/03/2026");
   }
 
   const siteInput = page.locator("input#siteName");
-  if (await siteInput.isVisible().catch(() => false)) {
+  if (await siteInput.isVisible()) {
     await siteInput.clear();
     await siteInput.fill("CAMES MAN");
-    await page.keyboard.press("Tab");
-    await pause(300);
+    await pause(1200);
+    await pickFirstAutosuggestOptional(page, pause);
   }
 
   const requesterLookup = page.locator("input#requesterId");
-  if (await requesterLookup.isVisible().catch(() => false)) {
+  if (await requesterLookup.isVisible()) {
     await requesterLookup.clear();
-    await requesterLookup.fill("Prime, Optimus");
-    await page.keyboard.press("Tab");
-    await pause(300);
+    await requesterLookup.fill("Prime");
+    await pause(800);
+    await pickFirstAutosuggestOptional(page, pause);
   }
 
   const requesterFirst = page.locator("input#requesterFirstName");
-  if (await requesterFirst.isVisible().catch(() => false)) {
+  if (await requesterFirst.isVisible()) {
     await requesterFirst.clear();
     await requesterFirst.fill("Optimus");
     await expect(requesterFirst).toHaveValue("Optimus");
   }
   const requesterLast = page.locator("input#requesterLastName");
-  if (await requesterLast.isVisible().catch(() => false)) {
+  if (await requesterLast.isVisible()) {
     await requesterLast.clear();
     await requesterLast.fill("Prime");
     await expect(requesterLast).toHaveValue("Prime");
   }
 
-  if (await requesterLookup.isVisible().catch(() => false)) {
+  if (await requesterLookup.isVisible()) {
     if (!(await requesterLookup.inputValue()).trim()) {
       await requesterLookup.fill("Prime, Optimus");
     }
@@ -308,7 +302,7 @@ async function fillOrderDetails(page: Page, pause: PauseFn) {
   const paymentStatus = page.getByRole("combobox", {
     name: "Patient payment status:",
   });
-  if (await paymentStatus.isVisible().catch(() => false)) {
+  if (await paymentStatus.isVisible()) {
     const current = await paymentStatus.inputValue();
     if (!current) {
       await paymentStatus.selectOption({ index: 1 });
@@ -318,7 +312,7 @@ async function fillOrderDetails(page: Page, pause: PauseFn) {
   const samplingPoint = page.getByRole("combobox", {
     name: "Sampling performed for analysis:",
   });
-  if (await samplingPoint.isVisible().catch(() => false)) {
+  if (await samplingPoint.isVisible()) {
     const current = await samplingPoint.inputValue();
     if (!current) {
       await samplingPoint.selectOption({ index: 1 });
@@ -441,7 +435,7 @@ test("US1 — Admin configures barcode label quantities", async ({
   await showSceneLabel(page, "US1 · FR-002c — Optional Elements", testInfo);
 
   const optionalCheckbox = page.locator("#orderPatientDobCheck");
-  if (await optionalCheckbox.isVisible({ timeout: 3000 }).catch(() => false)) {
+  if (await optionalCheckbox.isVisible()) {
     await scrollToAndPause(page, optionalCheckbox, pause, 2000);
   }
 
@@ -506,7 +500,7 @@ test("US2 — Capture label quantities during sample creation", async ({
 
   // Step 1: program selection — skip through (no required input)
   const next2 = page.getByRole("button", { name: "Next", exact: true });
-  if (await next2.isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (await next2.isVisible()) {
     await expect(next2).toBeEnabled({ timeout: 5_000 });
     await next2.click();
     await waitForSampleStep(page);
@@ -543,7 +537,7 @@ test("US2 — Capture label quantities during sample creation", async ({
 
   // Edit specimen labels
   const specimenInput = labelsSection.locator("#sample-row-1");
-  if (await specimenInput.isVisible().catch(() => false)) {
+  if (await specimenInput.isVisible()) {
     await scrollToAndPause(page, specimenInput, pause, 600);
     await specimenInput.fill("2");
     await pause(800);
@@ -551,7 +545,7 @@ test("US2 — Capture label quantities during sample creation", async ({
 
   // Running total
   const runningTotal = labelsSection.locator("p");
-  if (await runningTotal.isVisible().catch(() => false)) {
+  if (await runningTotal.isVisible()) {
     await scrollToAndPause(page, runningTotal, pause, 2000);
   }
 
@@ -599,7 +593,7 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
   await clickNext(page);
 
   const next2 = page.getByRole("button", { name: "Next", exact: true });
-  if (await next2.isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (await next2.isVisible()) {
     await expect(next2).toBeEnabled({ timeout: 5_000 });
     await next2.click();
     await waitForSampleStep(page);
@@ -609,7 +603,7 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
 
   // Show labels section briefly before moving on
   const labelsSection = page.getByTestId("labels-section-root");
-  if (await labelsSection.isVisible({ timeout: 5000 }).catch(() => false)) {
+  if (await labelsSection.isVisible()) {
     await scrollToAndPause(page, labelsSection, pause, 1500);
   }
 
@@ -634,11 +628,12 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
   await showSceneLabel(page, "US3 · FR-011 — Print Dialog", testInfo);
 
   const successArea = page.locator(".orderEntrySuccessMsg").first();
+  await expect(successArea).toBeVisible({ timeout: 10_000 });
   await scrollToAndPause(page, successArea, pause, 1000);
 
   // Scroll to print dialog
   const printTitle = page.getByText(/print labels/i).first();
-  if (await printTitle.isVisible({ timeout: 3000 }).catch(() => false)) {
+  if (await printTitle.isVisible()) {
     await scrollToAndPause(page, printTitle, pause, 1500);
   }
 
@@ -660,7 +655,7 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
   await showSceneLabel(page, "US3 · FR-013 — Done / Defer", testInfo);
 
   const doneButton = page.getByRole("button", { name: /^(done|skip)$/i });
-  if (await doneButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+  if (await doneButton.isVisible()) {
     await scrollToAndPause(page, doneButton, pause, 2000);
   }
 
@@ -679,13 +674,12 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
   const printBarcodeHeading = page.getByRole("heading", {
     name: /print bar code labels/i,
   });
-  if (await printBarcodeHeading.isVisible().catch(() => false)) {
-    await scrollToAndPause(page, printBarcodeHeading, pause, 1500);
+  await expect(printBarcodeHeading).toBeVisible({ timeout: 15_000 });
+  await scrollToAndPause(page, printBarcodeHeading, pause, 1500);
 
-    const siteSearch = page.getByLabel(/search site name/i);
-    if (await siteSearch.isVisible().catch(() => false)) {
-      await scrollToAndPause(page, siteSearch, pause, 2000);
-    }
+  const siteSearch = page.getByLabel(/search site name/i);
+  if (await siteSearch.isVisible()) {
+    await scrollToAndPause(page, siteSearch, pause, 2000);
   }
 
   await showTitleCard(

--- a/frontend/playwright/tests/ogc-284-labels-ui.spec.ts
+++ b/frontend/playwright/tests/ogc-284-labels-ui.spec.ts
@@ -4,9 +4,11 @@ test.describe("OGC-284 labels UI", () => {
   test("Add Order shows shared labels section", async ({ page }) => {
     await page.goto("/SamplePatientEntry");
 
-    await page
-      .getByRole("button", { name: /incomplete add sample/i })
-      .click({ force: true });
+    const addSampleBtn = page.getByRole("button", {
+      name: /incomplete add sample/i,
+    });
+    await expect(addSampleBtn).toBeVisible({ timeout: 10_000 });
+    await addSampleBtn.click();
     await expect(page.getByTestId("labels-section-root")).toBeVisible();
     await expect(page.getByLabel(/order labels/i)).toBeVisible();
     await expect(page.getByText(/running total/i)).toBeVisible();


### PR DESCRIPTION
## Summary

- **Remove `{ force: true }`** from all Carbon checkbox/radio interactions (5 instances across 3 files). Carbon applies `visually-hidden` to `<input>` elements — clicking the associated `<label>` is the correct interaction path
- **Remove `waitForResponse` as primary assertion** in `accept-results.ts` — kept for synchronization only; `waitForURL` and visible UI assertions are the real pass/fail signals
- **Clean up `.catch(() => false)` on `isVisible()`** — Playwright's `isVisible()` returns boolean without throwing; the catch was dead code hiding potential errors (18 instances)
- **Improve autocomplete helper** — replaced 12s `expect.poll()` with 5s web-first `expect().toBeVisible()`, keeping Tab fallback for when no suggestions appear
- **Add missing assertions** to US3 demo test (successArea, printBarcodeHeading)
- **Remove unused** `waitForAutoSuggestion` function
- **Add DO/DO NOT guardrail rules** to CLAUDE.md, AGENTS.md, playwright-best-practices.md, and all Playwright skill files (SKILL.md, audit, write, selector-policy, template)

## Research Validation

All fixes were validated against:
- **Playwright API**: Confirmed `isVisible()` returns boolean (never throws), timeout param is deprecated/ignored
- **Carbon Design System source**: Confirmed `visually-hidden` mixin on `<input>`, `<label>` is visible clickable element
- **AutoComplete component source**: Confirmed `onSelect` sets server-side IDs that `onChange` does not — "type + Tab" is NOT always safe (corrected from original plan)

## Files Changed

| Category | Files |
|---|---|
| Code fixes | `accept-results.ts`, `ogc-284-barcode-workflow.spec.ts`, `barcode-configuration.spec.ts`, `ogc-284-labels-ui.spec.ts` |
| Guardrails | `CLAUDE.md`, `AGENTS.md`, `playwright-best-practices.md` |
| Skill files | `SKILL.md`, `audit-playwright.md`, `write-playwright-test.md`, `selector-policy.md`, `PlaywrightE2E.spec.ts.template` |

## Test plan

- [ ] TypeScript compilation passes (`tsc --noEmit` ✅ verified locally)
- [ ] Prettier formatting passes (✅ verified locally)
- [ ] `core-app` Playwright project passes in CI
- [ ] `core-demo` Playwright project passes in CI
- [ ] `harness` + `harness-demo` Playwright projects pass in CI
- [ ] No regressions in accept-results helper (used by analyzer harness tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)