### PR TITLE
chore(coverage): issue-3134 add backend instruction coverage helper and README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ accessing any of these links, simply follow these steps:
 - `--skip-tests`: Skip tests (formatting only)
 - `--skip-e2e`: Skip E2E tests (frontend only)
 
+**Coverage helper script:**
+
+```bash
+# Report backend layer instruction coverage from JaCoCo CSV
+./scripts/layer-coverage-gate-all.sh
+
+# Use a custom JaCoCo CSV path
+./scripts/layer-coverage-gate-all.sh path/to/jacoco.csv
+```
+
 **Manual commands** (if you prefer to run steps individually):
 
 1.  Run Code Formatting Check (Backend). This command checks code formatting and

--- a/scripts/layer-coverage-gate-all.sh
+++ b/scripts/layer-coverage-gate-all.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CSV_PATH="${1:-target/site/jacoco/jacoco.csv}"
+
+if [[ ! -f "$CSV_PATH" ]]; then
+  echo "ERROR: JaCoCo CSV not found at $CSV_PATH"
+  echo "Run Maven tests first so JaCoCo generates reports."
+  exit 2
+fi
+
+awk -F, '
+  function pct(cov, total) {
+    if (total == 0) {
+      return 0
+    }
+    return (100 * cov) / total
+  }
+
+  function add_to_layer(layer, missed, covered) {
+    layer_miss[layer] += missed
+    layer_cov[layer] += covered
+    all_miss += missed
+    all_cov += covered
+  }
+
+  NR > 1 {
+    pkg = $2
+    missed = $4
+    covered = $5
+
+    if (index(pkg, ".controller") > 0) {
+      add_to_layer("controller", missed, covered)
+    } else if (index(pkg, ".service") > 0) {
+      add_to_layer("service", missed, covered)
+    } else if (index(pkg, ".dao") > 0) {
+      add_to_layer("dao", missed, covered)
+    } else if (index(pkg, ".valueholder") > 0) {
+      add_to_layer("valueholder", missed, covered)
+    } else if (index(pkg, ".form") > 0) {
+      add_to_layer("form", missed, covered)
+    } else {
+      add_to_layer("other", missed, covered)
+    }
+  }
+
+  END {
+    all_total = all_miss + all_cov
+    if (all_total == 0) {
+      print "ERROR: Unable to compute coverage from " ARGV[1]
+      exit 3
+    }
+
+    all_pct = pct(all_cov, all_total)
+
+    print "Backend layers coverage report (instruction coverage)"
+    print "-----------------------------------------"
+
+    n = split("controller service dao valueholder form other", ordered, " ")
+    for (i = 1; i <= n; i++) {
+      layer = ordered[i]
+      total = layer_miss[layer] + layer_cov[layer]
+      if (total > 0) {
+        layer_pct = pct(layer_cov[layer], total)
+        printf("%-12s : %6.2f%% (covered=%d,total=%d)\n", layer, layer_pct, layer_cov[layer], total)
+      }
+    }
+
+    printf("%-12s : %6.2f%% (covered=%d,total=%d)\n", "all", all_pct, all_cov, all_total)
+  }
+' "$CSV_PATH"


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 Styleguide and Design documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary
This PR adds a lightweight backend helper script to report JaCoCo instruction coverage by backend layer, and documents how to run it in the existing developer workflow documentation.

### What changed
- Added a backend helper script to print instruction coverage by layer
- Added usage documentation in README under the scripts/checks section
- Output explicitly states instruction coverage
- Output includes required groups:
  - controller
  - service
  - dao
  - valueholder
  - form
  - other
  - all

## Screenshots
Not applicable (no UI changes).

## Related Issue
Closes #3134

## Other
### Validation performed
- Script runs successfully with default JaCoCo CSV path
- Script runs successfully with a custom CSV path argument
- Output header explicitly states instruction coverage
- Output includes percentages and covered/total counts by layer and overall

### Commands used
- `./scripts/layer-coverage-gate-all.sh`
- `./scripts/layer-coverage-gate-all.sh target/site/jacoco/jacoco.csv`