### PR TITLE
fix: correct 'Martial Status' typo to 'Marital Status' in Patient Form (#2919)

### DIFF
--- a/db/dbInit/OpenELIS-Global.sql
+++ b/db/dbInit/OpenELIS-Global.sql
@@ -9828,10 +9828,10 @@ COPY clinlims.dictionary (id, is_active, dict_entry, lastupdated, local_abbrev, 
 1272	Y	Kaposi's Sarcoma?	2020-01-22 21:46:41.469132	sarcKapo	178	diseases.RTN.kaposisSarcoma	79800	\N
 1273	Y	Marital Status Divorced	2020-01-22 21:46:41.469132	divorced	78	marital.divorced	102000	\N
 1274	Y	Marital Status Single (for ARV)	2020-01-22 21:46:41.469132	celibate	78	marital.single	62400	\N
-1275	Y	Martial Status cohabiting (for ARV)	2020-01-22 21:46:41.469132	cohab	78	marital.cohabitating	62600	\N
-1276	Y	Martial Status Married (for ARV)	2020-01-22 21:46:41.469132	married	78	marital.married	62500	\N
-1277	Y	Martial Status N/A for children (for ARV)	2020-01-22 21:46:41.469132	NA	78	marital.n_a	62800	\N
-1278	Y	Martial Status window(er) (for ARV)	2020-01-22 21:46:41.469132	widow	78	marital.widow	62700	\N
+1275	Y	Marital Status cohabiting (for ARV)	2020-01-22 21:46:41.469132	cohab	78	marital.cohabitating	62600	\N
+1276	Y	Marital Status Married (for ARV)	2020-01-22 21:46:41.469132	married	78	marital.married	62500	\N
+1277	Y	Marital Status N/A for children (for ARV)	2020-01-22 21:46:41.469132	NA	78	marital.n_a	62800	\N
+1278	Y	Marital Status window(er) (for ARV)	2020-01-22 21:46:41.469132	widow	78	marital.widow	62700	\N
 1279	Y	N/A	2020-01-22 21:46:41.469132	na	242	answer.notApplicable	72500	\N
 1280	Y	No Schooling	2020-01-22 21:46:41.469132	NoSchool	240	education.noSchool	62000	\N
 1281	Y	Not applicable (AIDS Prophylaxis)	2020-01-22 21:46:41.469132	NA	83	answer.notApplicable	65800	\N

--- a/frontend/src/languages/am_ET.json
+++ b/frontend/src/languages/am_ET.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/ar.json
+++ b/frontend/src/languages/ar.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -2452,7 +2452,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/en_GB.json
+++ b/frontend/src/languages/en_GB.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/en_LK.json
+++ b/frontend/src/languages/en_LK.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/en_US.json
+++ b/frontend/src/languages/en_US.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/id_ID.json
+++ b/frontend/src/languages/id_ID.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/mg.json
+++ b/frontend/src/languages/mg.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/si.json
+++ b/frontend/src/languages/si.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/si_LK.json
+++ b/frontend/src/languages/si_LK.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/sw.json
+++ b/frontend/src/languages/sw.json
@@ -1275,7 +1275,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/ta.json
+++ b/frontend/src/languages/ta.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/frontend/src/languages/ta_LK.json
+++ b/frontend/src/languages/ta_LK.json
@@ -1983,7 +1983,7 @@
   "patient.emergency.additional.camp": "Enter Camp/Commune",
   "patient.emergency.additional.district": "Enter District",
   "patient.emergency.additional.education": "Enter Education",
-  "patient.emergency.additional.maritalstatus": "Enter Martial Status",
+  "patient.emergency.additional.maritalstatus": "Enter Marital Status",
   "patient.emergency.additional.nationnality": "Enter Nationality",
   "patient.emergency.additional.othernationality": "Enter Other Nationality",
   "patient.emergency.additional.region": "Enter Region",

--- a/install/installerTemplate/linux/initDB/OpenELIS-Global.sql
+++ b/install/installerTemplate/linux/initDB/OpenELIS-Global.sql
@@ -9829,10 +9829,10 @@ COPY clinlims.dictionary (id, is_active, dict_entry, lastupdated, local_abbrev, 
 1272	Y	Kaposi's Sarcoma?	2020-01-22 21:46:41.469132	sarcKapo	178	diseases.RTN.kaposisSarcoma	79800	\N
 1273	Y	Marital Status Divorced	2020-01-22 21:46:41.469132	divorced	78	marital.divorced	102000	\N
 1274	Y	Marital Status Single (for ARV)	2020-01-22 21:46:41.469132	celibate	78	marital.single	62400	\N
-1275	Y	Martial Status cohabiting (for ARV)	2020-01-22 21:46:41.469132	cohab	78	marital.cohabitating	62600	\N
-1276	Y	Martial Status Married (for ARV)	2020-01-22 21:46:41.469132	married	78	marital.married	62500	\N
-1277	Y	Martial Status N/A for children (for ARV)	2020-01-22 21:46:41.469132	NA	78	marital.n_a	62800	\N
-1278	Y	Martial Status window(er) (for ARV)	2020-01-22 21:46:41.469132	widow	78	marital.widow	62700	\N
+1275	Y	Marital Status cohabiting (for ARV)	2020-01-22 21:46:41.469132	cohab	78	marital.cohabitating	62600	\N
+1276	Y	Marital Status Married (for ARV)	2020-01-22 21:46:41.469132	married	78	marital.married	62500	\N
+1277	Y	Marital Status N/A for children (for ARV)	2020-01-22 21:46:41.469132	NA	78	marital.n_a	62800	\N
+1278	Y	Marital Status window(er) (for ARV)	2020-01-22 21:46:41.469132	widow	78	marital.widow	62700	\N
 1279	Y	N/A	2020-01-22 21:46:41.469132	na	242	answer.notApplicable	72500	\N
 1280	Y	No Schooling	2020-01-22 21:46:41.469132	NoSchool	240	education.noSchool	62000	\N
 1281	Y	Not applicable (AIDS Prophylaxis)	2020-01-22 21:46:41.469132	NA	83	answer.notApplicable	65800	\N

--- a/src/test/resources/postgre-db-init/OpenELIS-Global.sql
+++ b/src/test/resources/postgre-db-init/OpenELIS-Global.sql
@@ -9828,10 +9828,10 @@ COPY clinlims.dictionary (id, is_active, dict_entry, lastupdated, local_abbrev, 
 1272	Y	Kaposi's Sarcoma?	2020-01-22 21:46:41.469132	sarcKapo	178	diseases.RTN.kaposisSarcoma	79800	\N
 1273	Y	Marital Status Divorced	2020-01-22 21:46:41.469132	divorced	78	marital.divorced	102000	\N
 1274	Y	Marital Status Single (for ARV)	2020-01-22 21:46:41.469132	celibate	78	marital.single	62400	\N
-1275	Y	Martial Status cohabiting (for ARV)	2020-01-22 21:46:41.469132	cohab	78	marital.cohabitating	62600	\N
-1276	Y	Martial Status Married (for ARV)	2020-01-22 21:46:41.469132	married	78	marital.married	62500	\N
-1277	Y	Martial Status N/A for children (for ARV)	2020-01-22 21:46:41.469132	NA	78	marital.n_a	62800	\N
-1278	Y	Martial Status window(er) (for ARV)	2020-01-22 21:46:41.469132	widow	78	marital.widow	62700	\N
+1275	Y	Marital Status cohabiting (for ARV)	2020-01-22 21:46:41.469132	cohab	78	marital.cohabitating	62600	\N
+1276	Y	Marital Status Married (for ARV)	2020-01-22 21:46:41.469132	married	78	marital.married	62500	\N
+1277	Y	Marital Status N/A for children (for ARV)	2020-01-22 21:46:41.469132	NA	78	marital.n_a	62800	\N
+1278	Y	Marital Status window(er) (for ARV)	2020-01-22 21:46:41.469132	widow	78	marital.widow	62700	\N
 1279	Y	N/A	2020-01-22 21:46:41.469132	na	242	answer.notApplicable	72500	\N
 1280	Y	No Schooling	2020-01-22 21:46:41.469132	NoSchool	240	education.noSchool	62000	\N
 1281	Y	Not applicable (AIDS Prophylaxis)	2020-01-22 21:46:41.469132	NA	83	answer.notApplicable	65800	\N

--- a/volume/database/dbInit/OpenELIS-Global.sql
+++ b/volume/database/dbInit/OpenELIS-Global.sql
@@ -9828,10 +9828,10 @@ COPY clinlims.dictionary (id, is_active, dict_entry, lastupdated, local_abbrev, 
 1272	Y	Kaposi's Sarcoma?	2020-01-22 21:46:41.469132	sarcKapo	178	diseases.RTN.kaposisSarcoma	79800	\N
 1273	Y	Marital Status Divorced	2020-01-22 21:46:41.469132	divorced	78	marital.divorced	102000	\N
 1274	Y	Marital Status Single (for ARV)	2020-01-22 21:46:41.469132	celibate	78	marital.single	62400	\N
-1275	Y	Martial Status cohabiting (for ARV)	2020-01-22 21:46:41.469132	cohab	78	marital.cohabitating	62600	\N
-1276	Y	Martial Status Married (for ARV)	2020-01-22 21:46:41.469132	married	78	marital.married	62500	\N
-1277	Y	Martial Status N/A for children (for ARV)	2020-01-22 21:46:41.469132	NA	78	marital.n_a	62800	\N
-1278	Y	Martial Status window(er) (for ARV)	2020-01-22 21:46:41.469132	widow	78	marital.widow	62700	\N
+1275	Y	Marital Status cohabiting (for ARV)	2020-01-22 21:46:41.469132	cohab	78	marital.cohabitating	62600	\N
+1276	Y	Marital Status Married (for ARV)	2020-01-22 21:46:41.469132	married	78	marital.married	62500	\N
+1277	Y	Marital Status N/A for children (for ARV)	2020-01-22 21:46:41.469132	NA	78	marital.n_a	62800	\N
+1278	Y	Marital Status window(er) (for ARV)	2020-01-22 21:46:41.469132	widow	78	marital.widow	62700	\N
 1279	Y	N/A	2020-01-22 21:46:41.469132	na	242	answer.notApplicable	72500	\N
 1280	Y	No Schooling	2020-01-22 21:46:41.469132	NoSchool	240	education.noSchool	62000	\N
 1281	Y	Not applicable (AIDS Prophylaxis)	2020-01-22 21:46:41.469132	NA	83	answer.notApplicable	65800	\N


### PR DESCRIPTION
Fixes #2919

# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. (Not applicable for a typo)
- [x] The PR title follows conventional commit label standards.
- [x] The changes conform to the OpenELIS Global Styleguide and Design documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary

This PR corrects the typo "Martial Status" to "Marital Status" across the Patient Form.
The change affects SQL seed data and language files (JSON translations) to ensure
consistent terminology throughout the application.


## Related Issue

Fixes #2919

