### PR TITLE
fix(ui): replace index keys in pathology/IHC/cytology dynamic lists

### DIFF
--- a/frontend/src/components/cytology/CytologyCaseView.js
+++ b/frontend/src/components/cytology/CytologyCaseView.js
@@ -505,9 +505,13 @@ function CytologyCaseView() {
           >
             <SelectItem disabled value="placeholder" text="Status" />
 
-            {statuses.map((status, index) => {
+            {statuses.map((status) => {
               return (
-                <SelectItem key={index} text={status.value} value={status.id} />
+                <SelectItem
+                  key={status.id}
+                  text={status.value}
+                  value={status.id}
+                />
               );
             })}
           </Select>
@@ -527,9 +531,9 @@ function CytologyCaseView() {
             }}
           >
             <SelectItem />
-            {technicianUsers.map((user, index) => {
+            {technicianUsers.map((user) => {
               return (
-                <SelectItem key={index} text={user.value} value={user.id} />
+                <SelectItem key={user.id} text={user.value} value={user.id} />
               );
             })}
           </Select>
@@ -551,9 +555,9 @@ function CytologyCaseView() {
             }}
           >
             <SelectItem />
-            {pathologistUsers.map((user, index) => {
+            {pathologistUsers.map((user) => {
               return (
-                <SelectItem key={index} text={user.value} value={user.id} />
+                <SelectItem key={user.id} text={user.value} value={user.id} />
               );
             })}
           </Select>
@@ -779,10 +783,10 @@ function CytologyCaseView() {
                     id: "immunohistochemistry.label.addreport",
                   })}
                 />
-                {reportTypes.map((report, index) => {
+                {reportTypes.map((report) => {
                   return (
                     <SelectItem
-                      key={index}
+                      key={report.id}
                       text={report.value}
                       value={report.id}
                     />
@@ -960,10 +964,10 @@ function CytologyCaseView() {
                     }}
                   >
                     <SelectItem />
-                    {adequacySatisfactionList.map((user, index) => {
+                    {adequacySatisfactionList.map((user) => {
                       return (
                         <SelectItem
-                          key={index}
+                          key={user.id}
                           text={user.value}
                           value={user.id}
                         />
@@ -1004,8 +1008,8 @@ function CytologyCaseView() {
                       <Column lg={8} md={4} sm={2}>
                         {pathologySampleInfo.specimenAdequacy &&
                           pathologySampleInfo.specimenAdequacy.values.map(
-                            (adequacy, index) => (
-                              <Tag key={index} onClose={() => {}}>
+                            (adequacy) => (
+                              <Tag key={adequacy.id} onClose={() => {}}>
                                 {adequacy.value}
                               </Tag>
                             ),
@@ -1038,7 +1042,7 @@ function CytologyCaseView() {
                     >
                       {satisfactoryForEvaluation.map((adequacy, index) => (
                         <RadioButton
-                          key={index}
+                          key={adequacy.id}
                           index={index}
                           id={"adquacy" + index}
                           labelText={adequacy.value}
@@ -1162,9 +1166,9 @@ function CytologyCaseView() {
                                     (item) => item.id == result.id,
                                   ),
                                 )
-                                ?.map((result, index) => (
+                                ?.map((result) => (
                                   <Tag
-                                    key={index}
+                                    key={result.id}
                                     filter
                                     onClose={() => {
                                       var diagnosisResultsMap =
@@ -1226,9 +1230,9 @@ function CytologyCaseView() {
                                     (item) => item.id == result.id,
                                   ),
                                 )
-                                ?.map((result, index) => (
+                                ?.map((result) => (
                                   <Tag
-                                    key={index}
+                                    key={result.id}
                                     filter
                                     onClose={() => {
                                       var diagnosisResultsMap =
@@ -1405,7 +1409,7 @@ function CytologyCaseView() {
                           "DICTIONARY",
                         )?.results.map((result, index) => (
                           <Tag
-                            key={index}
+                            key={result.id}
                             filter
                             onClose={() => {
                               var diagnosisResultsMap =
@@ -1509,7 +1513,7 @@ function CytologyCaseView() {
                           "DICTIONARY",
                         )?.results.map((result, index) => (
                           <Tag
-                            key={index}
+                            key={result.id}
                             filter
                             onClose={() => {
                               var diagnosisResultsMap =
@@ -1609,7 +1613,7 @@ function CytologyCaseView() {
                           "DICTIONARY",
                         )?.results.map((result, index) => (
                           <Tag
-                            key={index}
+                            key={result.id}
                             filter
                             onClose={() => {
                               var diagnosisResultsMap =
@@ -1708,7 +1712,7 @@ function CytologyCaseView() {
                           "DICTIONARY",
                         )?.results.map((result, index) => (
                           <Tag
-                            key={index}
+                            key={result.id}
                             filter
                             onClose={() => {
                               var diagnosisResultsMap =

--- a/frontend/src/components/immunohistochemistry/ImmunohistochemistryCaseView.js
+++ b/frontend/src/components/immunohistochemistry/ImmunohistochemistryCaseView.js
@@ -338,10 +338,10 @@ function ImmunohistochemistryCaseView() {
                   >
                     <SelectItem disabled value="placeholder" text="Intensity" />
                     <SelectItem value="" text="" />
-                    {intensityList.map((status, index) => {
+                    {intensityList.map((status) => {
                       return (
                         <SelectItem
-                          key={index}
+                          key={status.id}
                           text={status.value}
                           value={status.value}
                         />
@@ -416,10 +416,10 @@ function ImmunohistochemistryCaseView() {
                   >
                     <SelectItem disabled value="placeholder" text="Intensity" />
                     <SelectItem value="" text="" />
-                    {intensityList.map((status, index) => {
+                    {intensityList.map((status) => {
                       return (
                         <SelectItem
-                          key={index}
+                          key={status.id}
                           text={status.value}
                           value={status.value}
                         />
@@ -618,10 +618,10 @@ function ImmunohistochemistryCaseView() {
                   >
                     <SelectItem disabled value="placeholder" text="" />
                     <SelectItem value="" text="" />
-                    {molecularSubTypeList.map((status, index) => {
+                    {molecularSubTypeList.map((status) => {
                       return (
                         <SelectItem
-                          key={index}
+                          key={status.id}
                           text={status.value}
                           value={status.value}
                         />
@@ -1104,10 +1104,10 @@ function ImmunohistochemistryCaseView() {
             >
               <SelectItem disabled value="placeholder" text="Status" />
 
-              {statuses.map((status, index) => {
+              {statuses.map((status) => {
                 return (
                   <SelectItem
-                    key={index}
+                    key={status.id}
                     text={status.value}
                     value={status.id}
                   />
@@ -1131,9 +1131,9 @@ function ImmunohistochemistryCaseView() {
               }}
             >
               <SelectItem />
-              {technicianUsers.map((user, index) => {
+              {technicianUsers.map((user) => {
                 return (
-                  <SelectItem key={index} text={user.value} value={user.id} />
+                  <SelectItem key={user.id} text={user.value} value={user.id} />
                 );
               })}
             </Select>
@@ -1154,9 +1154,9 @@ function ImmunohistochemistryCaseView() {
               }}
             >
               <SelectItem />
-              {pathologistUsers.map((user, index) => {
+              {pathologistUsers.map((user) => {
                 return (
-                  <SelectItem key={index} text={user.value} value={user.id} />
+                  <SelectItem key={user.id} text={user.value} value={user.id} />
                 );
               })}
             </Select>
@@ -1207,10 +1207,10 @@ function ImmunohistochemistryCaseView() {
                       id: "immunohistochemistry.label.addreport",
                     })}
                   />
-                  {reportTypes.map((report, index) => {
+                  {reportTypes.map((report) => {
                     return (
                       <SelectItem
-                        key={index}
+                        key={report.id}
                         text={report.value}
                         value={report.id}
                       />
@@ -1589,9 +1589,9 @@ function ImmunohistochemistryCaseView() {
                       <Column lg={14} md={4} sm={2}>
                         {immunohistochemistrySampleInfo.techniques &&
                           immunohistochemistrySampleInfo.techniques.map(
-                            (technique, index) => (
+                            (technique) => (
                               <>
-                                <Tag key={index}>{technique.value} </Tag>
+                                <Tag key={technique.id}>{technique.value} </Tag>
                               </>
                             ),
                           )}
@@ -1605,9 +1605,12 @@ function ImmunohistochemistryCaseView() {
                       <Column lg={14} md={4} sm={2}>
                         {immunohistochemistrySampleInfo.requests &&
                           immunohistochemistrySampleInfo.requests.map(
-                            (technique, index) => (
+                            (technique) => (
                               <>
-                                <Tag key={index}> {technique.value} </Tag>
+                                <Tag key={technique.id}>
+                                  {" "}
+                                  {technique.value}{" "}
+                                </Tag>
                               </>
                             ),
                           )}
@@ -1641,9 +1644,12 @@ function ImmunohistochemistryCaseView() {
                       <Column lg={14} md={4} sm={2}>
                         {immunohistochemistrySampleInfo.conclusions &&
                           immunohistochemistrySampleInfo.conclusions.map(
-                            (conclusion, index) => (
+                            (conclusion) => (
                               <>
-                                <Tag key={index}> {conclusion.value} </Tag>
+                                <Tag key={conclusion.id}>
+                                  {" "}
+                                  {conclusion.value}{" "}
+                                </Tag>
                               </>
                             ),
                           )}

--- a/frontend/src/components/pathology/PathologyCaseView.js
+++ b/frontend/src/components/pathology/PathologyCaseView.js
@@ -420,9 +420,13 @@ function PathologyCaseView() {
           >
             <SelectItem disabled value="placeholder" text="Status" />
 
-            {statuses.map((status, index) => {
+            {statuses.map((status) => {
               return (
-                <SelectItem key={index} text={status.value} value={status.id} />
+                <SelectItem
+                  key={status.id}
+                  text={status.value}
+                  value={status.id}
+                />
               );
             })}
           </Select>
@@ -443,9 +447,9 @@ function PathologyCaseView() {
             }}
           >
             <SelectItem />
-            {technicianUsers.map((user, index) => {
+            {technicianUsers.map((user) => {
               return (
-                <SelectItem key={index} text={user.value} value={user.id} />
+                <SelectItem key={user.id} text={user.value} value={user.id} />
               );
             })}
           </Select>
@@ -467,9 +471,9 @@ function PathologyCaseView() {
             }}
           >
             <SelectItem />
-            {pathologistUsers.map((user, index) => {
+            {pathologistUsers.map((user) => {
               return (
-                <SelectItem key={index} text={user.value} value={user.id} />
+                <SelectItem key={user.id} text={user.value} value={user.id} />
               );
             })}
           </Select>
@@ -993,7 +997,7 @@ function PathologyCaseView() {
                   {pathologySampleInfo.techniques &&
                     pathologySampleInfo.techniques.map((technique, index) => (
                       <Tag
-                        key={index}
+                        key={technique.id}
                         filter
                         onClose={() => {
                           var info = { ...pathologySampleInfo };
@@ -1038,7 +1042,7 @@ function PathologyCaseView() {
                     <>
                       <Column lg={2} md={4} sm={2}>
                         <Tag
-                          key={index}
+                          key={request.id}
                           filter
                           onClose={() => {
                             var info = { ...pathologySampleInfo };
@@ -1067,10 +1071,10 @@ function PathologyCaseView() {
                           }}
                         >
                           <SelectItem />
-                          {requestStatuses.map((status, index) => {
+                          {requestStatuses.map((status) => {
                             return (
                               <SelectItem
-                                key={index}
+                                key={status.id}
                                 text={status.value}
                                 value={status.id}
                               />
@@ -1173,7 +1177,7 @@ function PathologyCaseView() {
                   {pathologySampleInfo.conclusions &&
                     pathologySampleInfo.conclusions.map((conclusion, index) => (
                       <Tag
-                        key={index}
+                        key={conclusion.id}
                         filter
                         onClose={() => {
                           var info = { ...pathologySampleInfo };
@@ -1246,7 +1250,7 @@ function PathologyCaseView() {
                     pathologySampleInfo.immunoHistoChemistryTestIds.map(
                       (test, index) => (
                         <Tag
-                          key={index}
+                          key={test.id}
                           filter
                           onClose={() => {
                             var info = { ...pathologySampleInfo };


### PR DESCRIPTION
# Pull Requests Requirements
- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Details
I reviewed `programDashboard.jsx` plus pathology, immunohistochemistry, and cytology case view files, then only replaced `key={index}` / `key={idx}` where both conditions were true: the list is dynamic and each item has a stable unique ID.

Updated key usage to stable IDs in:
- Pathology case view: status/user selectors and ID-based selected-tag collections.
- Immunohistochemistry case view: selector options and selected-tag collections with item IDs.
- Cytology case view: selector options, adequacy values, and diagnosis result tag lists keyed by `id`.

I intentionally left index keys in places where stable ID is not guaranteed (for example,block/slide layout rows with temporary empty IDs) and in commented code.

Fixes #3139 