### PR TITLE
fix(e2e): centralize timeouts and remove Playwright anti-patterns

### DIFF
--- a/frontend/playwright/fixtures/analyzer-form.ts
+++ b/frontend/playwright/fixtures/analyzer-form.ts
@@ -1,4 +1,5 @@
 import { Page, expect, Locator } from "@playwright/test";
+import { UI_TIMEOUT } from "../helpers/timeouts";
 
 /**
  * AnalyzerForm Page Object
@@ -85,7 +86,7 @@ export class AnalyzerFormPage {
     const trigger = dropdown.locator(
       'button[role="combobox"], .cds--list-box__field',
     );
-    await expect(trigger).toBeEnabled({ timeout: 10_000 });
+    await expect(trigger).toBeEnabled({ timeout: UI_TIMEOUT });
     await trigger.click();
     const item = this.page.getByRole("option", { name: text });
     await item.first().click();
@@ -123,7 +124,7 @@ export class AnalyzerFormPage {
 
   /** Assert a success notification appeared */
   async expectSuccessNotification() {
-    await expect(this.notification).toBeVisible({ timeout: 10000 });
+    await expect(this.notification).toBeVisible({ timeout: UI_TIMEOUT });
     const cls = await this.notification.getAttribute("class");
     if (cls && /error/i.test(cls)) {
       const text = await this.notification.textContent();
@@ -134,7 +135,7 @@ export class AnalyzerFormPage {
 
   /** Assert a notification of any kind appeared */
   async expectNotification() {
-    await expect(this.notification).toBeVisible({ timeout: 10000 });
+    await expect(this.notification).toBeVisible({ timeout: UI_TIMEOUT });
   }
 
   /** Get the current value of the identifier pattern input */

--- a/frontend/playwright/fixtures/analyzer-list.ts
+++ b/frontend/playwright/fixtures/analyzer-list.ts
@@ -1,4 +1,5 @@
 import { Page, expect, Locator } from "@playwright/test";
+import { UI_TIMEOUT, LONG_TIMEOUT, NAV_TIMEOUT } from "../helpers/timeouts";
 
 /**
  * AnalyzersList Page Object
@@ -37,9 +38,9 @@ export class AnalyzerListPage {
   /** Assert the page has loaded (root + header + stats visible) */
   async expectLoaded() {
     // Wait for analyzers API to complete (stats grid populated)
-    await expect(this.root).toBeVisible({ timeout: 45_000 });
-    await expect(this.header).toBeVisible({ timeout: 10_000 });
-    await expect(this.statsGrid).toBeVisible({ timeout: 15_000 });
+    await expect(this.root).toBeVisible({ timeout: NAV_TIMEOUT });
+    await expect(this.header).toBeVisible({ timeout: UI_TIMEOUT });
+    await expect(this.statsGrid).toBeVisible({ timeout: LONG_TIMEOUT });
   }
 
   /** Get a stat tile value by testid suffix (total, active, inactive) */

--- a/frontend/playwright/fixtures/sidenav.ts
+++ b/frontend/playwright/fixtures/sidenav.ts
@@ -1,4 +1,5 @@
 import { Page, expect, Locator } from "@playwright/test";
+import { SHORT_TIMEOUT } from "../helpers/timeouts";
 
 /**
  * Sidenav Page Object - encapsulates sidenav interactions
@@ -130,7 +131,7 @@ export class Sidenav {
   async hasStorageSubnav(): Promise<boolean> {
     const btn = this.nav.getByRole("button", { name: "Storage", exact: true });
     try {
-      await btn.waitFor({ state: "visible", timeout: 3000 });
+      await btn.waitFor({ state: "visible", timeout: SHORT_TIMEOUT });
       return true;
     } catch {
       return false;

--- a/frontend/playwright/helpers/accept-results.ts
+++ b/frontend/playwright/helpers/accept-results.ts
@@ -85,18 +85,18 @@ export async function acceptAndVerifyResults(
   });
 
   // Success path issues full page reload (AnalyserResults.js).
-  await page.waitForURL(/AnalyzerResults[?]type=/, { timeout: LONG_TIMEOUT });
+  await page.waitForURL(/AnalyzerResults[?]type=/, { timeout: NAV_TIMEOUT });
 
   if (stagedCountBeforeSave > 0) {
     await expect
       .poll(async () => stagedRows.count(), {
-        timeout: UI_TIMEOUT,
+        timeout: LONG_TIMEOUT,
       })
       .toBe(0);
   }
 
-  await expect(saveInProgress).toBeHidden({ timeout: UI_TIMEOUT });
-  await expect(saveButton).toBeEnabled({ timeout: UI_TIMEOUT });
+  await expect(saveInProgress).toBeHidden({ timeout: LONG_TIMEOUT });
+  await expect(saveButton).toBeEnabled({ timeout: LONG_TIMEOUT });
 
   // ── Verify in OE results view, not on the staging page ───────────
   await presentation.step(stepOffset + 3, "View Accepted Results", 2000);

--- a/frontend/playwright/helpers/accept-results.ts
+++ b/frontend/playwright/helpers/accept-results.ts
@@ -5,6 +5,12 @@ import {
   locatorForAccessionNumber,
   openAccessionResultsAndWaitForText,
 } from "./results-ui";
+import {
+  SHORT_TIMEOUT,
+  UI_TIMEOUT,
+  LONG_TIMEOUT,
+  NAV_TIMEOUT,
+} from "./timeouts";
 
 /**
  * Accept all analyzer results on the staging page, verify they were saved,
@@ -49,7 +55,7 @@ export async function acceptAndVerifyResults(
   await presentation.step(stepOffset + 1, "Accept All Results", 2000);
 
   const acceptAllCheckbox = page.locator("#saveallresults");
-  await expect(acceptAllCheckbox).toBeAttached({ timeout: 5_000 });
+  await expect(acceptAllCheckbox).toBeAttached({ timeout: SHORT_TIMEOUT });
   // Carbon checkbox: click the visible label instead of forcing the hidden input
   await page.locator('label[for="saveallresults"]').click();
   await presentation.pause(1_500);
@@ -63,43 +69,34 @@ export async function acceptAndVerifyResults(
     .locator('[data-testid="LabNo"]')
     .filter({ hasText: accessionTextRegExp(stagedAccession.trim()) });
   const stagedCountBeforeSave = await stagedRows.count();
-  await expect(saveButton).toBeVisible({ timeout: 5_000 });
-  await expect(saveButton).toBeEnabled({ timeout: 5_000 });
+  await expect(saveButton).toBeVisible({ timeout: SHORT_TIMEOUT });
+  await expect(saveButton).toBeEnabled({ timeout: SHORT_TIMEOUT });
 
-  const saveResponsePromise = page.waitForResponse(
-    (res) =>
-      res.url().includes("/rest/AnalyzerResults") &&
-      res.request().method() === "POST",
-    { timeout: 60_000 },
-  );
   await saveButton.click();
 
   const saveInProgress = page.locator(
     '[data-testid="analyzer-results-save-in-progress"]',
   );
   await Promise.any([
-    expect(saveButton).toBeDisabled({ timeout: 5_000 }),
-    saveInProgress.waitFor({ state: "attached", timeout: 5_000 }),
+    expect(saveButton).toBeDisabled({ timeout: SHORT_TIMEOUT }),
+    saveInProgress.waitFor({ state: "attached", timeout: SHORT_TIMEOUT }),
   ]).catch(() => {
     // Some runs complete quickly and can skip observable transition states.
   });
 
-  // Wait for POST completion (sync only — UI assertions below are the real pass/fail)
-  await saveResponsePromise;
-
   // Success path issues full page reload (AnalyserResults.js).
-  await page.waitForURL(/AnalyzerResults[?]type=/, { timeout: 45_000 });
+  await page.waitForURL(/AnalyzerResults[?]type=/, { timeout: LONG_TIMEOUT });
 
   if (stagedCountBeforeSave > 0) {
     await expect
       .poll(async () => stagedRows.count(), {
-        timeout: 30_000,
+        timeout: UI_TIMEOUT,
       })
       .toBe(0);
   }
 
-  await expect(saveInProgress).toBeHidden({ timeout: 30_000 });
-  await expect(saveButton).toBeEnabled({ timeout: 20_000 });
+  await expect(saveInProgress).toBeHidden({ timeout: UI_TIMEOUT });
+  await expect(saveButton).toBeEnabled({ timeout: UI_TIMEOUT });
 
   // ── Verify in OE results view, not on the staging page ───────────
   await presentation.step(stepOffset + 3, "View Accepted Results", 2000);
@@ -108,12 +105,12 @@ export async function acceptAndVerifyResults(
     stagedAccession,
     stagedAccession,
     {
-      timeoutMs: 60_000,
-      perAttemptTimeoutMs: 15_000,
+      timeoutMs: NAV_TIMEOUT,
+      perAttemptTimeoutMs: UI_TIMEOUT,
     },
   );
   await expect(locatorForAccessionNumber(page, stagedAccession)).toBeVisible({
-    timeout: 15_000,
+    timeout: UI_TIMEOUT,
   });
   await presentation.pause(3_000);
 }

--- a/frontend/playwright/helpers/timeouts.ts
+++ b/frontend/playwright/helpers/timeouts.ts
@@ -1,3 +1,14 @@
+/** Conditional checks, dropdown options, negative assertions (element absent) */
+export const QUICK_TIMEOUT = 2_000;
+
+/** Element attachment, visibility, enabled checks */
 export const SHORT_TIMEOUT = 5_000;
+
+/** Post-action UI state assertions (state changes after clicks/saves) */
 export const UI_TIMEOUT = 10_000;
+
+/** Page navigation, cross-page verification, form submissions */
 export const LONG_TIMEOUT = 30_000;
+
+/** Full page load, auth flows, initial bootstrap */
+export const NAV_TIMEOUT = 45_000;

--- a/frontend/playwright/tests/analyzer-hl7-simulate.spec.ts
+++ b/frontend/playwright/tests/analyzer-hl7-simulate.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { AnalyzerListPage } from "../fixtures/analyzer-list";
+import { UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
 
 const HL7_ANALYZER_NAME = "Mindray BC-5380";
 
@@ -35,7 +36,7 @@ test.describe("Analyzer HL7 Simulator", () => {
       new RegExp(`/analyzers/${analyzer!.id}/mappings`),
     );
     await page.locator('[data-testid="field-mapping-test-button"]').click({
-      timeout: 10_000,
+      timeout: UI_TIMEOUT,
     });
     await expect(
       page.locator('[data-testid="test-mapping-modal"]'),
@@ -53,9 +54,9 @@ test.describe("Analyzer HL7 Simulator", () => {
 
     await page.locator('[data-testid="test-mapping-preview-button"]').click();
     const results = page.locator('[data-testid="test-mapping-results"]');
-    await expect(results).toBeVisible({ timeout: 15_000 });
+    await expect(results).toBeVisible({ timeout: LONG_TIMEOUT });
     await expect(results.locator("tbody tr").first()).toBeVisible({
-      timeout: 10_000,
+      timeout: UI_TIMEOUT,
     });
   });
 });

--- a/frontend/playwright/tests/analyzer-plugin-config.spec.ts
+++ b/frontend/playwright/tests/analyzer-plugin-config.spec.ts
@@ -5,6 +5,7 @@ import {
   ensureAnalyzerByName,
   GENEXPERT_DEFAULT_ANALYZER,
 } from "../helpers/ensure-analyzer";
+import { QUICK_TIMEOUT, SHORT_TIMEOUT, UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
 
 test.describe("Analyzer Plugin Config", () => {
   test("profile selection prefills implemented analyzer fields", async ({
@@ -25,13 +26,13 @@ test.describe("Analyzer Plugin Config", () => {
       await form.expectOpen();
 
       try {
-        await expect(form.pluginTypeDropdown).toBeVisible({ timeout: 5_000 });
+        await expect(form.pluginTypeDropdown).toBeVisible({ timeout: SHORT_TIMEOUT });
       } catch {
         // Modal may have closed — retry
-        if (await form.modal.isVisible()) {
-          await form.cancelButton.click().catch(() => {});
+        if (await form.modal.isVisible() && await form.cancelButton.isVisible()) {
+          await form.cancelButton.click();
         }
-        await expect(form.modal).not.toBeVisible({ timeout: 2_000 });
+        await expect(form.modal).not.toBeVisible({ timeout: QUICK_TIMEOUT });
         continue;
       }
 
@@ -44,22 +45,20 @@ test.describe("Analyzer Plugin Config", () => {
         const genericAstmOption = page
           .getByRole("option", { name: /Generic ASTM/i })
           .first();
-        if (await genericAstmOption.isVisible().catch(() => false)) {
+        if (await genericAstmOption.isVisible()) {
           await genericAstmOption.click();
           selectedPlugin = true;
           break;
         }
         await page.keyboard.press("Escape");
-        await expect(genericAstmOption).not.toBeVisible({ timeout: 2_000 });
+        await expect(genericAstmOption).not.toBeVisible({ timeout: QUICK_TIMEOUT });
       }
       if (selectedPlugin) break;
 
       // Close form and retry
       if (await form.modal.isVisible()) {
-        await form.cancelButton.click().catch(() => {});
-        await expect(form.modal)
-          .not.toBeVisible({ timeout: 2_000 })
-          .catch(() => {});
+        if (await form.cancelButton.isVisible()) await form.cancelButton.click();
+        await expect(form.modal).not.toBeVisible({ timeout: QUICK_TIMEOUT });
       }
     }
     expect(
@@ -76,7 +75,7 @@ test.describe("Analyzer Plugin Config", () => {
     const geneXpertProfile = page
       .getByRole("option", { name: /GeneXpert.*ASTM/i })
       .first();
-    await expect(geneXpertProfile).toBeVisible({ timeout: 10_000 });
+    await expect(geneXpertProfile).toBeVisible({ timeout: UI_TIMEOUT });
     await geneXpertProfile.click();
 
     // Selecting the profile should prefill key analyzer fields.
@@ -107,7 +106,7 @@ test.describe("Analyzer Plugin Config", () => {
     );
 
     const snapshotTile = page.locator('[data-testid="plugin-config-snapshot"]');
-    await expect(snapshotTile).toBeVisible({ timeout: 15_000 });
+    await expect(snapshotTile).toBeVisible({ timeout: LONG_TIMEOUT });
     await expect(snapshotTile).toContainText("{");
 
     await expect(

--- a/frontend/playwright/tests/analyzer-plugin-config.spec.ts
+++ b/frontend/playwright/tests/analyzer-plugin-config.spec.ts
@@ -5,7 +5,12 @@ import {
   ensureAnalyzerByName,
   GENEXPERT_DEFAULT_ANALYZER,
 } from "../helpers/ensure-analyzer";
-import { QUICK_TIMEOUT, SHORT_TIMEOUT, UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
+import {
+  QUICK_TIMEOUT,
+  SHORT_TIMEOUT,
+  UI_TIMEOUT,
+  LONG_TIMEOUT,
+} from "../helpers/timeouts";
 
 test.describe("Analyzer Plugin Config", () => {
   test("profile selection prefills implemented analyzer fields", async ({
@@ -26,10 +31,15 @@ test.describe("Analyzer Plugin Config", () => {
       await form.expectOpen();
 
       try {
-        await expect(form.pluginTypeDropdown).toBeVisible({ timeout: SHORT_TIMEOUT });
+        await expect(form.pluginTypeDropdown).toBeVisible({
+          timeout: SHORT_TIMEOUT,
+        });
       } catch {
         // Modal may have closed — retry
-        if (await form.modal.isVisible() && await form.cancelButton.isVisible()) {
+        if (
+          (await form.modal.isVisible()) &&
+          (await form.cancelButton.isVisible())
+        ) {
           await form.cancelButton.click();
         }
         await expect(form.modal).not.toBeVisible({ timeout: QUICK_TIMEOUT });
@@ -45,19 +55,31 @@ test.describe("Analyzer Plugin Config", () => {
         const genericAstmOption = page
           .getByRole("option", { name: /Generic ASTM/i })
           .first();
-        if (await genericAstmOption.isVisible()) {
+        let optionVisible = false;
+        try {
+          await expect(genericAstmOption).toBeVisible({
+            timeout: QUICK_TIMEOUT,
+          });
+          optionVisible = true;
+        } catch {
+          // Option not rendered in this attempt — retry
+        }
+        if (optionVisible) {
           await genericAstmOption.click();
           selectedPlugin = true;
           break;
         }
         await page.keyboard.press("Escape");
-        await expect(genericAstmOption).not.toBeVisible({ timeout: QUICK_TIMEOUT });
+        await expect(genericAstmOption).not.toBeVisible({
+          timeout: QUICK_TIMEOUT,
+        });
       }
       if (selectedPlugin) break;
 
       // Close form and retry
       if (await form.modal.isVisible()) {
-        if (await form.cancelButton.isVisible()) await form.cancelButton.click();
+        if (await form.cancelButton.isVisible())
+          await form.cancelButton.click();
         await expect(form.modal).not.toBeVisible({ timeout: QUICK_TIMEOUT });
       }
     }

--- a/frontend/playwright/tests/analyzer-simulator.spec.ts
+++ b/frontend/playwright/tests/analyzer-simulator.spec.ts
@@ -4,6 +4,7 @@ import {
   ensureAnalyzerByName,
   GENEXPERT_DEFAULT_ANALYZER,
 } from "../helpers/ensure-analyzer";
+import { UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
 
 /**
  * Analyzer Simulator E2E
@@ -35,7 +36,7 @@ test.describe("Analyzer Simulator", () => {
 
     await page
       .locator('[data-testid="field-mapping-test-button"]')
-      .click({ timeout: 10_000 });
+      .click({ timeout: UI_TIMEOUT });
     await expect(
       page.locator('[data-testid="test-mapping-modal"]'),
     ).toBeVisible();
@@ -48,11 +49,11 @@ test.describe("Analyzer Simulator", () => {
     await page.locator('[data-testid="test-mapping-preview-button"]').click();
 
     const results = page.locator('[data-testid="test-mapping-results"]');
-    await expect(results).toBeVisible({ timeout: 15_000 });
+    await expect(results).toBeVisible({ timeout: LONG_TIMEOUT });
 
     // Ensure preview produced actual parsed rows.
     await expect(results.locator("tbody tr").first()).toBeVisible({
-      timeout: 10_000,
+      timeout: UI_TIMEOUT,
     });
 
     // Plugin config details may render either in-modal (legacy test-id blocks)

--- a/frontend/playwright/tests/analyzer-test-connection.spec.ts
+++ b/frontend/playwright/tests/analyzer-test-connection.spec.ts
@@ -5,6 +5,7 @@ import {
   ensureAnalyzerByName,
   GENEXPERT_DEFAULT_ANALYZER,
 } from "../helpers/ensure-analyzer";
+import { SHORT_TIMEOUT, UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
 
 /**
  * Analyzer Test Connection E2E
@@ -34,7 +35,7 @@ test.describe("Analyzer Test Connection", () => {
     await list.expectLoaded();
 
     const row = list.getRow(GENEXPERT_ID);
-    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toBeVisible({ timeout: UI_TIMEOUT });
 
     await list.openOverflowMenu(GENEXPERT_ID);
     await list.clickAction(GENEXPERT_ID, "test-connection");
@@ -68,7 +69,7 @@ test.describe("Analyzer Test Connection", () => {
     for (let attempt = 1; attempt <= 3; attempt++) {
       await testButton.click();
       try {
-        await expect(successTag.first()).toBeVisible({ timeout: 20_000 });
+        await expect(successTag.first()).toBeVisible({ timeout: LONG_TIMEOUT });
         connected = true;
         break;
       } catch {
@@ -94,10 +95,10 @@ test.describe("Analyzer Test Connection", () => {
       // Wait for "Test Again" button before retrying
       if (attempt < 3) {
         try {
-          await expect(retryButton).toBeVisible({ timeout: 5_000 });
+          await expect(retryButton).toBeVisible({ timeout: SHORT_TIMEOUT });
           await retryButton.click();
         } catch {
-          await expect(successTag.or(errorTag)).toBeVisible({ timeout: 5_000 });
+          await expect(successTag.or(errorTag)).toBeVisible({ timeout: SHORT_TIMEOUT });
         }
       }
     }
@@ -179,7 +180,7 @@ test.describe("Real GeneXpert Test Connection", () => {
     // Plugin Type loads async — wait for options before selecting
     await form.pluginTypeDropdown.click();
     const pluginOption = page.getByRole("option", { name: /Generic ASTM/ });
-    await expect(pluginOption.first()).toBeVisible({ timeout: 10_000 });
+    await expect(pluginOption.first()).toBeVisible({ timeout: UI_TIMEOUT });
     await pluginOption.first().click();
 
     await form.selectType("Molecular");
@@ -241,7 +242,7 @@ test.describe("Real GeneXpert Test Connection", () => {
 
     // Real GeneXpert + contention handling may take longer than mock
     const successTag = page.locator('[data-testid="test-connection-success"]');
-    await expect(successTag).toBeVisible({ timeout: 30_000 });
+    await expect(successTag).toBeVisible({ timeout: LONG_TIMEOUT });
 
     const errorTag = page.locator('[data-testid="test-connection-error"]');
     await expect(errorTag).not.toBeVisible();

--- a/frontend/playwright/tests/analyzer-test-connection.spec.ts
+++ b/frontend/playwright/tests/analyzer-test-connection.spec.ts
@@ -98,7 +98,9 @@ test.describe("Analyzer Test Connection", () => {
           await expect(retryButton).toBeVisible({ timeout: SHORT_TIMEOUT });
           await retryButton.click();
         } catch {
-          await expect(successTag.or(errorTag)).toBeVisible({ timeout: SHORT_TIMEOUT });
+          await expect(successTag.or(errorTag)).toBeVisible({
+            timeout: SHORT_TIMEOUT,
+          });
         }
       }
     }

--- a/frontend/playwright/tests/astm-genexpert-results.spec.ts
+++ b/frontend/playwright/tests/astm-genexpert-results.spec.ts
@@ -11,7 +11,7 @@ import {
   accessionTextRegExp,
   openAnalyzerResultsAndWaitForText,
 } from "../helpers/results-ui";
-import { UI_TIMEOUT } from "../helpers/timeouts";
+import { SHORT_TIMEOUT, UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
 
 const SIMULATOR_URL = "http://localhost:8085";
 const BRIDGE_DESTINATION = "tcp://openelis-analyzer-bridge:12001";
@@ -39,11 +39,11 @@ async function testConnection(
   const testConnectionAction = page
     .locator('[data-testid*="analyzer-action-test-connection"]')
     .first();
-  await expect(testConnectionAction).toBeVisible({ timeout: 3_000 });
+  await expect(testConnectionAction).toBeVisible({ timeout: SHORT_TIMEOUT });
   await testConnectionAction.click();
 
   const connectionModal = page.locator('[data-testid="test-connection-modal"]');
-  await expect(connectionModal).toBeVisible({ timeout: 10_000 });
+  await expect(connectionModal).toBeVisible({ timeout: UI_TIMEOUT });
 
   const testButton = page.locator(
     '[data-testid="test-connection-test-button"]',
@@ -51,13 +51,13 @@ async function testConnection(
   await testButton.click();
 
   const successTag = page.locator('[data-testid="test-connection-success"]');
-  await expect(successTag).toBeVisible({ timeout: 15_000 });
+  await expect(successTag).toBeVisible({ timeout: LONG_TIMEOUT });
   await presentation.pause(1_500);
 
   await connectionModal
     .locator('[data-testid="test-connection-close-button"]')
     .click();
-  await expect(connectionModal).toBeHidden({ timeout: 10_000 });
+  await expect(connectionModal).toBeHidden({ timeout: UI_TIMEOUT });
 }
 
 async function pushAstmMessage(page: Page, presentation: DemoPresentation) {
@@ -76,7 +76,7 @@ async function verifyResults(
     page,
     analyzerName,
     EXPECTED_RESULTS[0].sampleId,
-    { timeoutMs: RESULTS_TIMEOUT, perAttemptTimeoutMs: 15_000 },
+    { timeoutMs: RESULTS_TIMEOUT, perAttemptTimeoutMs: LONG_TIMEOUT },
   );
 
   const resultsRegion = page.locator(".orderLegendBody, table").first();
@@ -90,7 +90,7 @@ async function verifyResults(
     const inputResult = resultsRegion
       .locator(`input[value*="${expected.result}"]`)
       .first();
-    if (await inputResult.isVisible().catch(() => false)) {
+    if (await inputResult.isVisible()) {
       await expect(inputResult).toBeVisible({ timeout: UI_TIMEOUT });
     } else {
       await expect(

--- a/frontend/playwright/tests/astm-genexpert-results.spec.ts
+++ b/frontend/playwright/tests/astm-genexpert-results.spec.ts
@@ -90,8 +90,15 @@ async function verifyResults(
     const inputResult = resultsRegion
       .locator(`input[value*="${expected.result}"]`)
       .first();
-    if (await inputResult.isVisible()) {
-      await expect(inputResult).toBeVisible({ timeout: UI_TIMEOUT });
+    let inputVisible = false;
+    try {
+      await expect(inputResult).toBeVisible({ timeout: SHORT_TIMEOUT });
+      inputVisible = true;
+    } catch {
+      // Input field not found — try text match instead
+    }
+    if (inputVisible) {
+      // Already verified visible above
     } else {
       await expect(
         resultsRegion.getByText(expected.result, { exact: false }).first(),

--- a/frontend/playwright/tests/auth.setup.ts
+++ b/frontend/playwright/tests/auth.setup.ts
@@ -1,4 +1,5 @@
 import { test as setup, expect } from "@playwright/test";
+import { SHORT_TIMEOUT, LONG_TIMEOUT, NAV_TIMEOUT } from "../helpers/timeouts";
 
 const AUTH_FILE = "playwright/.auth/user.json";
 
@@ -22,7 +23,7 @@ const AUTH_FILE = "playwright/.auth/user.json";
  *     and add it to the browser context with path=/ so all routes work.
  */
 setup("authenticate", async ({ page, request, context }, testInfo) => {
-  testInfo.setTimeout(60_000);
+  testInfo.setTimeout(NAV_TIMEOUT);
 
   const username = process.env.TEST_USER;
   const password = process.env.TEST_PASS;
@@ -40,14 +41,14 @@ setup("authenticate", async ({ page, request, context }, testInfo) => {
     .poll(
       async () => {
         try {
-          const health = await request.get("/health", { timeout: 5_000 });
+          const health = await request.get("/health", { timeout: SHORT_TIMEOUT });
           return health.ok();
         } catch {
           return false;
         }
       },
       {
-        timeout: 60_000,
+        timeout: NAV_TIMEOUT,
         intervals: [1_000, 2_000, 5_000],
         message: "Waiting for backend /health endpoint to become ready",
       },
@@ -134,7 +135,7 @@ setup("authenticate", async ({ page, request, context }, testInfo) => {
 
   // ── Step 4: Verify authenticated state ────────────────────────
   await page.goto("analyzers", { waitUntil: "domcontentloaded" });
-  await expect(page).not.toHaveURL(/\/login(?:\?|$)/, { timeout: 15_000 });
+  await expect(page).not.toHaveURL(/\/login(?:\?|$)/, { timeout: LONG_TIMEOUT });
 
   // ── Step 5: Save session ──────────────────────────────────────
   await page.context().storageState({ path: AUTH_FILE });

--- a/frontend/playwright/tests/auth.setup.ts
+++ b/frontend/playwright/tests/auth.setup.ts
@@ -41,7 +41,9 @@ setup("authenticate", async ({ page, request, context }, testInfo) => {
     .poll(
       async () => {
         try {
-          const health = await request.get("/health", { timeout: SHORT_TIMEOUT });
+          const health = await request.get("/health", {
+            timeout: SHORT_TIMEOUT,
+          });
           return health.ok();
         } catch {
           return false;
@@ -135,7 +137,9 @@ setup("authenticate", async ({ page, request, context }, testInfo) => {
 
   // ── Step 4: Verify authenticated state ────────────────────────
   await page.goto("analyzers", { waitUntil: "domcontentloaded" });
-  await expect(page).not.toHaveURL(/\/login(?:\?|$)/, { timeout: LONG_TIMEOUT });
+  await expect(page).not.toHaveURL(/\/login(?:\?|$)/, {
+    timeout: LONG_TIMEOUT,
+  });
 
   // ── Step 5: Save session ──────────────────────────────────────
   await page.context().storageState({ path: AUTH_FILE });

--- a/frontend/playwright/tests/demo-quantstudio-file-config.spec.ts
+++ b/frontend/playwright/tests/demo-quantstudio-file-config.spec.ts
@@ -3,6 +3,7 @@ import { AnalyzerListPage } from "../fixtures/analyzer-list";
 import { AnalyzerFormPage } from "../fixtures/analyzer-form";
 import { cleanupAnalyzerByName } from "../helpers/cleanup-analyzer";
 import { createDemoPresentation } from "../helpers/demo-presentation";
+import { SHORT_TIMEOUT, UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
 
 /**
  * Demo: QuantStudio 7 — Generic File profile walkthrough.
@@ -89,7 +90,7 @@ test.describe("Demo: QuantStudio 7 Generic File Config", () => {
     await presentation.step(4, "Save the analyzer");
     await form.save();
     await form.expectSuccessNotification();
-    await expect(form.modal).not.toBeVisible({ timeout: 15_000 });
+    await expect(form.modal).not.toBeVisible({ timeout: LONG_TIMEOUT });
     await presentation.pause(1_000);
 
     // Step 9: Verify analyzer appears in list
@@ -102,7 +103,7 @@ test.describe("Demo: QuantStudio 7 Generic File Config", () => {
       .locator("tbody tr")
       .filter({ hasText: createdAnalyzerName })
       .first();
-    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toBeVisible({ timeout: UI_TIMEOUT });
     await expect(row).toContainText(createdAnalyzerName);
     await expect(row).toContainText("MOLECULAR");
     await presentation.pause(1_000);
@@ -117,13 +118,13 @@ test.describe("Demo: QuantStudio 7 Generic File Config", () => {
     const fileImportAction = page
       .locator('[data-testid*="analyzer-action-file-import"]')
       .first();
-    await expect(fileImportAction).toBeVisible({ timeout: 5_000 });
+    await expect(fileImportAction).toBeVisible({ timeout: SHORT_TIMEOUT });
     await fileImportAction.click();
 
     const fileImportForm = page.locator(
       '[data-testid="file-import-configuration-form"]',
     );
-    await expect(fileImportForm).toBeVisible({ timeout: 10_000 });
+    await expect(fileImportForm).toBeVisible({ timeout: UI_TIMEOUT });
 
     const fileFormatDropdown = page.locator(
       '[data-testid="file-import-configuration-file-format-dropdown"]',
@@ -142,10 +143,10 @@ test.describe("Demo: QuantStudio 7 Generic File Config", () => {
     );
 
     await expect(fileFormatDropdown).toContainText(/Excel/i);
-    await expect(directoryInput).not.toHaveValue("", { timeout: 10_000 });
-    await expect(patternInput).not.toHaveValue("", { timeout: 10_000 });
-    await expect(archiveInput).not.toHaveValue("", { timeout: 10_000 });
-    await expect(errorInput).not.toHaveValue("", { timeout: 10_000 });
+    await expect(directoryInput).not.toHaveValue("", { timeout: UI_TIMEOUT });
+    await expect(patternInput).not.toHaveValue("", { timeout: UI_TIMEOUT });
+    await expect(archiveInput).not.toHaveValue("", { timeout: UI_TIMEOUT });
+    await expect(errorInput).not.toHaveValue("", { timeout: UI_TIMEOUT });
 
     await presentation.title(
       "Story Complete",

--- a/frontend/playwright/tests/file-import-ui.spec.ts
+++ b/frontend/playwright/tests/file-import-ui.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { videoPause } from "../helpers/video-pause";
 import { cleanupAnalyzerByName } from "../helpers/cleanup-analyzer";
+import { QUICK_TIMEOUT, SHORT_TIMEOUT, UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
 
 /**
  * QuantStudio 7 MVP Workflow E2E
@@ -45,20 +46,20 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
     await page.goto("analyzers", { waitUntil: "domcontentloaded" });
 
     const analyzerList = page.locator('[data-testid="analyzers-list"]');
-    await expect(analyzerList).toBeVisible({ timeout: 30_000 });
+    await expect(analyzerList).toBeVisible({ timeout: LONG_TIMEOUT });
     await expect(
       page.locator('[data-testid="analyzers-list-stats"]'),
-    ).toBeVisible({ timeout: 15_000 });
+    ).toBeVisible({ timeout: LONG_TIMEOUT });
 
     await videoPause(page, 1_500, testInfo);
 
     // ── Step 2: Click "Add Analyzer" ─────────────────────────────
     const addButton = page.locator('[data-testid="add-analyzer-button"]');
-    await expect(addButton).toBeVisible({ timeout: 5_000 });
+    await expect(addButton).toBeVisible({ timeout: SHORT_TIMEOUT });
     await addButton.click();
 
     const analyzerForm = page.locator('[data-testid="analyzer-form"]');
-    await expect(analyzerForm).toBeVisible({ timeout: 10_000 });
+    await expect(analyzerForm).toBeVisible({ timeout: UI_TIMEOUT });
     await videoPause(page, 1_000, testInfo);
 
     // ── Step 3: Fill in QuantStudio 7 details ────────────────────
@@ -78,10 +79,10 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
       '[role="listbox"]:visible [role="option"]',
     );
     const fileOption = dropdownOptions.filter({ hasText: /FILE/i }).first();
-    if (await fileOption.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    if (await fileOption.isVisible()) {
       await fileOption.click();
     } else {
-      await expect(dropdownOptions.first()).toBeVisible({ timeout: 2_000 });
+      await expect(dropdownOptions.first()).toBeVisible({ timeout: QUICK_TIMEOUT });
       await dropdownOptions.first().click();
     }
     await videoPause(page, 500, testInfo);
@@ -97,11 +98,11 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
       .filter({ hasText: /Molecular/i })
       .first();
     if (
-      await molecularOption.isVisible({ timeout: 2_000 }).catch(() => false)
+      await molecularOption.isVisible()
     ) {
       await molecularOption.click();
     } else {
-      await expect(dropdownOptions.first()).toBeVisible({ timeout: 2_000 });
+      await expect(dropdownOptions.first()).toBeVisible({ timeout: QUICK_TIMEOUT });
       await dropdownOptions.first().click();
     }
     await videoPause(page, 1_500, testInfo);
@@ -113,7 +114,7 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
     await saveButton.click();
 
     // Wait for modal to auto-close (1s delay on success)
-    await expect(analyzerForm).toBeHidden({ timeout: 15_000 });
+    await expect(analyzerForm).toBeHidden({ timeout: LONG_TIMEOUT });
     await videoPause(page, 1_500, testInfo);
 
     // ── Step 5: Find the new analyzer in the list ────────────────
@@ -125,7 +126,7 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
       hasText: new RegExp(escapeRegExp(createdAnalyzerName), "i"),
     });
     const analyzerRow = qsRow.first();
-    await expect(analyzerRow).toBeVisible({ timeout: 10_000 });
+    await expect(analyzerRow).toBeVisible({ timeout: UI_TIMEOUT });
     await videoPause(page, 1_000, testInfo);
 
     // ── Step 6: Configure File Import ────────────────────────────
@@ -138,13 +139,13 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
     const fileImportAction = page
       .locator('[data-testid*="analyzer-action-file-import"]')
       .first();
-    await expect(fileImportAction).toBeVisible({ timeout: 3_000 });
+    await expect(fileImportAction).toBeVisible({ timeout: SHORT_TIMEOUT });
     await fileImportAction.click();
 
     const fileImportForm = page.locator(
       '[data-testid="file-import-configuration-form"]',
     );
-    await expect(fileImportForm).toBeVisible({ timeout: 10_000 });
+    await expect(fileImportForm).toBeVisible({ timeout: UI_TIMEOUT });
     await videoPause(page, 1_000, testInfo);
 
     // Select file format — EXCEL for QuantStudio
@@ -155,10 +156,10 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
     await videoPause(page, 500, testInfo);
 
     const excelOption = dropdownOptions.filter({ hasText: /Excel/i }).first();
-    if (await excelOption.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    if (await excelOption.isVisible()) {
       await excelOption.click();
     } else {
-      await expect(dropdownOptions.first()).toBeVisible({ timeout: 2_000 });
+      await expect(dropdownOptions.first()).toBeVisible({ timeout: QUICK_TIMEOUT });
       await dropdownOptions.first().click();
     }
     await videoPause(page, 500, testInfo);
@@ -197,11 +198,11 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
       '[data-testid="file-import-configuration-form-save-button"]',
     );
     await fileImportSave.click();
-    await expect(fileImportForm).toBeHidden({ timeout: 15_000 });
+    await expect(fileImportForm).toBeHidden({ timeout: LONG_TIMEOUT });
     await videoPause(page, 1_500, testInfo);
 
     // ── Step 7: Test Connection ──────────────────────────────────
-    await expect(analyzerRow).toBeVisible({ timeout: 10_000 });
+    await expect(analyzerRow).toBeVisible({ timeout: UI_TIMEOUT });
     const overflowMenu2 = analyzerRow
       .locator('[data-testid^="analyzer-row-overflow-"]')
       .first();
@@ -211,25 +212,25 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
     const testConnectionAction = page
       .locator('[data-testid*="analyzer-action-test-connection"]')
       .first();
-    await expect(testConnectionAction).toBeVisible({ timeout: 3_000 });
+    await expect(testConnectionAction).toBeVisible({ timeout: SHORT_TIMEOUT });
     await testConnectionAction.click();
 
     const testConnectionModal = page.locator(
       '[data-testid="test-connection-modal"]',
     );
-    await expect(testConnectionModal).toBeVisible({ timeout: 10_000 });
+    await expect(testConnectionModal).toBeVisible({ timeout: UI_TIMEOUT });
     await videoPause(page, 1_000, testInfo);
 
     // Click "Test"
     const testButton = page.locator(
       '[data-testid="test-connection-test-button"]',
     );
-    await expect(testButton).toBeVisible({ timeout: 5_000 });
+    await expect(testButton).toBeVisible({ timeout: SHORT_TIMEOUT });
     await testButton.click();
 
     // Verify success
     const successTag = page.locator('[data-testid="test-connection-success"]');
-    await expect(successTag).toBeVisible({ timeout: 10_000 });
+    await expect(successTag).toBeVisible({ timeout: UI_TIMEOUT });
     await videoPause(page, 1_500, testInfo);
 
     // Close
@@ -239,7 +240,7 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
     await closeButton.click();
 
     // ── Step 8: Verify back at list ──────────────────────────────
-    await expect(analyzerList).toBeVisible({ timeout: 10_000 });
+    await expect(analyzerList).toBeVisible({ timeout: UI_TIMEOUT });
     await videoPause(page, 1_500, testInfo);
   });
 

--- a/frontend/playwright/tests/file-import-ui.spec.ts
+++ b/frontend/playwright/tests/file-import-ui.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from "@playwright/test";
 import { videoPause } from "../helpers/video-pause";
 import { cleanupAnalyzerByName } from "../helpers/cleanup-analyzer";
-import { QUICK_TIMEOUT, SHORT_TIMEOUT, UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
+import {
+  QUICK_TIMEOUT,
+  SHORT_TIMEOUT,
+  UI_TIMEOUT,
+  LONG_TIMEOUT,
+} from "../helpers/timeouts";
 
 /**
  * QuantStudio 7 MVP Workflow E2E
@@ -79,10 +84,19 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
       '[role="listbox"]:visible [role="option"]',
     );
     const fileOption = dropdownOptions.filter({ hasText: /FILE/i }).first();
-    if (await fileOption.isVisible()) {
+    let fileVisible = false;
+    try {
+      await expect(fileOption).toBeVisible({ timeout: QUICK_TIMEOUT });
+      fileVisible = true;
+    } catch {
+      // FILE option not available — fall back to first option
+    }
+    if (fileVisible) {
       await fileOption.click();
     } else {
-      await expect(dropdownOptions.first()).toBeVisible({ timeout: QUICK_TIMEOUT });
+      await expect(dropdownOptions.first()).toBeVisible({
+        timeout: QUICK_TIMEOUT,
+      });
       await dropdownOptions.first().click();
     }
     await videoPause(page, 500, testInfo);
@@ -97,12 +111,19 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
     const molecularOption = dropdownOptions
       .filter({ hasText: /Molecular/i })
       .first();
-    if (
-      await molecularOption.isVisible()
-    ) {
+    let molecularVisible = false;
+    try {
+      await expect(molecularOption).toBeVisible({ timeout: QUICK_TIMEOUT });
+      molecularVisible = true;
+    } catch {
+      // Molecular option not available — fall back to first option
+    }
+    if (molecularVisible) {
       await molecularOption.click();
     } else {
-      await expect(dropdownOptions.first()).toBeVisible({ timeout: QUICK_TIMEOUT });
+      await expect(dropdownOptions.first()).toBeVisible({
+        timeout: QUICK_TIMEOUT,
+      });
       await dropdownOptions.first().click();
     }
     await videoPause(page, 1_500, testInfo);
@@ -156,10 +177,19 @@ test.describe("QuantStudio 7 MVP Workflow", () => {
     await videoPause(page, 500, testInfo);
 
     const excelOption = dropdownOptions.filter({ hasText: /Excel/i }).first();
-    if (await excelOption.isVisible()) {
+    let excelVisible = false;
+    try {
+      await expect(excelOption).toBeVisible({ timeout: QUICK_TIMEOUT });
+      excelVisible = true;
+    } catch {
+      // Excel option not available — fall back to first option
+    }
+    if (excelVisible) {
       await excelOption.click();
     } else {
-      await expect(dropdownOptions.first()).toBeVisible({ timeout: QUICK_TIMEOUT });
+      await expect(dropdownOptions.first()).toBeVisible({
+        timeout: QUICK_TIMEOUT,
+      });
       await dropdownOptions.first().click();
     }
     await videoPause(page, 500, testInfo);

--- a/frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts
+++ b/frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, Page, Locator, TestInfo } from "@playwright/test";
 import { showSceneLabel, showTitleCard } from "../helpers/title-card";
 import { videoPause } from "../helpers/video-pause";
+import { SHORT_TIMEOUT, UI_TIMEOUT, LONG_TIMEOUT } from "../helpers/timeouts";
 
 /**
  * OGC-284 — Barcode label quantity workflow (user stories)
@@ -18,7 +19,7 @@ type PauseFn = (ms: number) => Promise<void>;
 async function pickFirstAutosuggestOptional(page: Page, pause: PauseFn) {
   const suggestion = page.locator('[data-cy="auto-suggestion"]').first();
   try {
-    await expect(suggestion).toBeVisible({ timeout: 5_000 });
+    await expect(suggestion).toBeVisible({ timeout: SHORT_TIMEOUT });
     await suggestion.click();
     await pause(500);
   } catch {
@@ -31,7 +32,7 @@ async function pickFirstAutosuggestOptional(page: Page, pause: PauseFn) {
 /** Visible success panel after SamplePatientEntry save (class from OrderSuccessMessage). */
 async function expectOrderEntrySaveSuccess(page: Page) {
   await expect(page.locator(".orderEntrySuccessMsg")).toBeVisible({
-    timeout: 20_000,
+    timeout: LONG_TIMEOUT,
   });
 }
 
@@ -73,16 +74,16 @@ async function scrollToAndPause(
 
 async function waitForSampleStep(page: Page) {
   const sampleSelect = page.locator("select#sampleId_0");
-  await expect(sampleSelect).toBeVisible({ timeout: 15_000 });
+  await expect(sampleSelect).toBeVisible({ timeout: LONG_TIMEOUT });
   await expect(
     sampleSelect.locator("option:not(:first-child)"),
-  ).not.toHaveCount(0, { timeout: 15_000 });
+  ).not.toHaveCount(0, { timeout: LONG_TIMEOUT });
 }
 
 async function waitForOrderDetailsStep(page: Page) {
-  await expect(page.locator("input#labNo")).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("input#labNo")).toBeVisible({ timeout: LONG_TIMEOUT });
   await expect(page.locator("input#order_requestDate")).toBeVisible({
-    timeout: 15_000,
+    timeout: LONG_TIMEOUT,
   });
 }
 
@@ -105,7 +106,7 @@ async function selectPatient(
   }
 
   const lastNameInput = page.locator("input#lastName");
-  await expect(lastNameInput).toBeVisible({ timeout: 8000 });
+  await expect(lastNameInput).toBeVisible({ timeout: UI_TIMEOUT });
   await lastNameInput.fill(lastName);
 
   const firstNameInput = page.locator("input#firstName");
@@ -118,7 +119,7 @@ async function selectPatient(
   await searchBtn.click();
 
   await expect(page.locator('[data-cy="radioButton"]').first()).toBeVisible({
-    timeout: 10_000,
+    timeout: UI_TIMEOUT,
   });
 
   const namedRow = page
@@ -135,29 +136,29 @@ async function selectPatient(
     (await namedRow.count()) > 0
       ? namedRow.locator('[data-cy="radioButton"]').first()
       : page.locator('[data-cy="radioButton"]').first();
-  await expect(firstRadio).toBeVisible({ timeout: 5000 });
+  await expect(firstRadio).toBeVisible({ timeout: SHORT_TIMEOUT });
   await scrollToAndPause(page, firstRadio, pause, 800);
   // Carbon radio: click the visible label sibling instead of forcing the hidden input
   await firstRadio.locator("xpath=..").locator("label").click();
 
   // Wait for patient form hydration before moving to the next wizard step.
   await expect(page.locator('[data-cy="patientSelectionReady"]')).toBeVisible({
-    timeout: 15_000,
+    timeout: LONG_TIMEOUT,
   });
   await expect(page.locator("input#lastName")).toHaveValue(
     new RegExp(lastName, "i"),
     {
-      timeout: 10_000,
+      timeout: UI_TIMEOUT,
     },
   );
   await expect(page.locator("input#firstName")).toHaveValue(
     new RegExp(firstName, "i"),
     {
-      timeout: 10_000,
+      timeout: UI_TIMEOUT,
     },
   );
   await expect(page.locator("input#primaryPhone")).toBeVisible({
-    timeout: 10_000,
+    timeout: UI_TIMEOUT,
   });
 
   // Search results can omit fields that the Add Order validation schema still
@@ -177,7 +178,7 @@ async function selectPatient(
     if (!hasGender && (await genderMale.count()) > 0) {
       // Carbon radio: click the visible label instead of forcing the hidden input
       await expect(page.locator('label[for="radio-1"]')).toBeVisible({
-        timeout: 5_000,
+        timeout: SHORT_TIMEOUT,
       });
       await page.locator('label[for="radio-1"]').click();
     }
@@ -249,7 +250,7 @@ async function fillOrderDetails(page: Page, pause: PauseFn) {
   const generateBtn = page.locator("[data-cy='generate-labNumber']");
   if (await generateBtn.isVisible()) {
     await generateBtn.click();
-    await expect(labNoInput).not.toHaveValue("", { timeout: 10_000 });
+    await expect(labNoInput).not.toHaveValue("", { timeout: UI_TIMEOUT });
   }
 
   const requestDate = page.locator("input#order_requestDate");
@@ -298,7 +299,7 @@ async function fillOrderDetails(page: Page, pause: PauseFn) {
     if (!(await requesterLookup.inputValue()).trim()) {
       await requesterLookup.fill("Prime, Optimus");
     }
-    await expect(requesterLookup).not.toHaveValue("", { timeout: 5_000 });
+    await expect(requesterLookup).not.toHaveValue("", { timeout: SHORT_TIMEOUT });
   }
 
   // Newer order-entry validation requires explicit selections here.
@@ -326,8 +327,8 @@ async function fillOrderDetails(page: Page, pause: PauseFn) {
 /** Click Next and wait for the next page to load. */
 async function clickNext(page: Page) {
   const btn = page.getByRole("button", { name: "Next", exact: true });
-  await expect(btn).toBeVisible({ timeout: 5000 });
-  await expect(btn).toBeEnabled({ timeout: 5_000 });
+  await expect(btn).toBeVisible({ timeout: SHORT_TIMEOUT });
+  await expect(btn).toBeEnabled({ timeout: SHORT_TIMEOUT });
   await btn.click();
 }
 
@@ -338,12 +339,12 @@ async function clickNext(page: Page) {
 async function selectPanelOrTest(page: Page) {
   // Carbon checkbox: the <input> is visually hidden; click the <label> instead.
   const label = page.locator('label:has-text("Bilan Biochimique")');
-  await expect(label).toBeVisible({ timeout: 10_000 });
+  await expect(label).toBeVisible({ timeout: UI_TIMEOUT });
   await label.scrollIntoViewIfNeeded();
-  await label.click({ timeout: 5000 });
+  await label.click({ timeout: SHORT_TIMEOUT });
   await expect(
     page.getByRole("button", { name: "Next", exact: true }),
-  ).toBeEnabled({ timeout: 10_000 });
+  ).toBeEnabled({ timeout: UI_TIMEOUT });
 }
 
 async function gotoBarcodeConfig(page: Page) {
@@ -351,14 +352,14 @@ async function gotoBarcodeConfig(page: Page) {
     waitUntil: "domcontentloaded",
   });
   await expect(page.getByRole("button", { name: "Save" })).toBeVisible({
-    timeout: 15_000,
+    timeout: LONG_TIMEOUT,
   });
 }
 
 async function gotoSamplePatientEntry(page: Page) {
   await page.goto("/SamplePatientEntry", { waitUntil: "domcontentloaded" });
   await expect(page.locator('[data-cy="searchPatientTabButton"]')).toBeVisible({
-    timeout: 15_000,
+    timeout: LONG_TIMEOUT,
   });
 }
 
@@ -367,7 +368,7 @@ async function gotoPrintBarcode(page: Page) {
   await expect(
     page.getByRole("heading", { name: /print bar code labels/i }),
   ).toBeVisible({
-    timeout: 15_000,
+    timeout: LONG_TIMEOUT,
   });
 }
 
@@ -453,16 +454,16 @@ test("US1 — Admin configures barcode label quantities", async ({
   await showSceneLabel(page, "US1 · FR-003 — Save + Reload", testInfo);
 
   const saveButton = page.getByRole("button", { name: "Save" });
-  await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+  await expect(saveButton).toBeEnabled({ timeout: UI_TIMEOUT });
   await scrollToAndPause(page, saveButton, pause, 800);
   await saveButton.click();
   await expect(
     page.getByText(/bar.?code configurations has been saved/i).first(),
-  ).toBeVisible({ timeout: 10_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
 
   await page.reload({ waitUntil: "domcontentloaded" });
   await expect(page.getByRole("button", { name: "Save" })).toBeVisible({
-    timeout: 15_000,
+    timeout: LONG_TIMEOUT,
   });
   await scrollToAndPause(page, defaultOrderInput, pause, 2000);
 
@@ -504,7 +505,7 @@ test("US2 — Capture label quantities during sample creation", async ({
   // Step 1: program selection — skip through (no required input)
   const next2 = page.getByRole("button", { name: "Next", exact: true });
   if (await next2.isVisible()) {
-    await expect(next2).toBeEnabled({ timeout: 5_000 });
+    await expect(next2).toBeEnabled({ timeout: SHORT_TIMEOUT });
     await next2.click();
     await waitForSampleStep(page);
   }
@@ -529,7 +530,7 @@ test("US2 — Capture label quantities during sample creation", async ({
   );
 
   const labelsSection = page.getByTestId("labels-section-root");
-  await expect(labelsSection).toBeVisible({ timeout: 8000 });
+  await expect(labelsSection).toBeVisible({ timeout: UI_TIMEOUT });
   await scrollToAndPause(page, labelsSection, pause, 2000);
 
   // Edit order labels
@@ -560,7 +561,7 @@ test("US2 — Capture label quantities during sample creation", async ({
   // Submit
   const submitBtn = page.getByRole("button", { name: "Submit" });
   await scrollToAndPause(page, submitBtn, pause, 1000);
-  await expect(submitBtn).toBeEnabled({ timeout: 10_000 });
+  await expect(submitBtn).toBeEnabled({ timeout: UI_TIMEOUT });
   await submitBtn.click();
   await expectOrderEntrySaveSuccess(page);
 
@@ -597,7 +598,7 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
 
   const next2 = page.getByRole("button", { name: "Next", exact: true });
   if (await next2.isVisible()) {
-    await expect(next2).toBeEnabled({ timeout: 5_000 });
+    await expect(next2).toBeEnabled({ timeout: SHORT_TIMEOUT });
     await next2.click();
     await waitForSampleStep(page);
   }
@@ -616,7 +617,7 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
 
   const submitBtn = page.getByRole("button", { name: "Submit" });
   await scrollToAndPause(page, submitBtn, pause, 800);
-  await expect(submitBtn).toBeEnabled({ timeout: 10_000 });
+  await expect(submitBtn).toBeEnabled({ timeout: UI_TIMEOUT });
   await submitBtn.click();
   await expectOrderEntrySaveSuccess(page);
 
@@ -631,7 +632,7 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
   await showSceneLabel(page, "US3 · FR-011 — Print Dialog", testInfo);
 
   const successArea = page.locator(".orderEntrySuccessMsg").first();
-  await expect(successArea).toBeVisible({ timeout: 10_000 });
+  await expect(successArea).toBeVisible({ timeout: UI_TIMEOUT });
   await scrollToAndPause(page, successArea, pause, 1000);
 
   // Scroll to print dialog
@@ -677,7 +678,7 @@ test("US3 — Post-save print dialog and reprint", async ({ page }, testInfo) =>
   const printBarcodeHeading = page.getByRole("heading", {
     name: /print bar code labels/i,
   });
-  await expect(printBarcodeHeading).toBeVisible({ timeout: 15_000 });
+  await expect(printBarcodeHeading).toBeVisible({ timeout: LONG_TIMEOUT });
   await scrollToAndPause(page, printBarcodeHeading, pause, 1500);
 
   const siteSearch = page.getByLabel(/search site name/i);

--- a/frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts
+++ b/frontend/playwright/tests/ogc-284-barcode-workflow.spec.ts
@@ -81,7 +81,9 @@ async function waitForSampleStep(page: Page) {
 }
 
 async function waitForOrderDetailsStep(page: Page) {
-  await expect(page.locator("input#labNo")).toBeVisible({ timeout: LONG_TIMEOUT });
+  await expect(page.locator("input#labNo")).toBeVisible({
+    timeout: LONG_TIMEOUT,
+  });
   await expect(page.locator("input#order_requestDate")).toBeVisible({
     timeout: LONG_TIMEOUT,
   });
@@ -299,7 +301,9 @@ async function fillOrderDetails(page: Page, pause: PauseFn) {
     if (!(await requesterLookup.inputValue()).trim()) {
       await requesterLookup.fill("Prime, Optimus");
     }
-    await expect(requesterLookup).not.toHaveValue("", { timeout: SHORT_TIMEOUT });
+    await expect(requesterLookup).not.toHaveValue("", {
+      timeout: SHORT_TIMEOUT,
+    });
   }
 
   // Newer order-entry validation requires explicit selections here.

--- a/frontend/playwright/tests/ogc-284-labels-ui.spec.ts
+++ b/frontend/playwright/tests/ogc-284-labels-ui.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { UI_TIMEOUT } from "../helpers/timeouts";
 
 test.describe("OGC-284 labels UI", () => {
   test("Add Order shows shared labels section", async ({ page }) => {
@@ -7,7 +8,7 @@ test.describe("OGC-284 labels UI", () => {
     const addSampleBtn = page.getByRole("button", {
       name: /incomplete add sample/i,
     });
-    await expect(addSampleBtn).toBeVisible({ timeout: 10_000 });
+    await expect(addSampleBtn).toBeVisible({ timeout: UI_TIMEOUT });
     await addSampleBtn.click();
     await expect(page.getByTestId("labels-section-root")).toBeVisible();
     await expect(page.getByLabel(/order labels/i)).toBeVisible();


### PR DESCRIPTION
## Summary

- **Root cause fix:** Remove `waitForResponse` gate in `accept-results.ts` that caused flaky "response not bound in connection" failure on develop ([run 23453448084](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/23453448084/job/68238663279), Demo 2/2 shard). The page reload raced Playwright's response tracker — pure timing flake, rerun passed.
- **Centralize timeouts:** Replace all 108 hardcoded timeout values across 15 files with 5 named constants from `timeouts.ts` (`QUICK_TIMEOUT`, `SHORT_TIMEOUT`, `UI_TIMEOUT`, `LONG_TIMEOUT`, `NAV_TIMEOUT`)
- **Fix anti-patterns:** Remove `.catch(() => false)` on `isVisible()`, deprecated `isVisible({ timeout })`, and `.click().catch(() => {})` suppressions

## Changes

| Category | Count | Files |
|----------|-------|-------|
| `waitForResponse` removal | 1 | `accept-results.ts` |
| Anti-pattern fixes | 8 | 3 test files |
| Timeout centralization | 108 | 15 files |

## Test plan

- [x] `npm run pw:guard` passes (timeout guard + demo UI-only guard)
- [ ] CI: Analyzer Harness Demo 2/2 shard passes (the flaky test)
- [ ] CI: All Playwright/Cypress shards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)