### PR TITLE
fix(ci): produce test-jar in fork E2E shared build

### DIFF
--- a/.github/workflows/e2e-fork-pr.yml
+++ b/.github/workflows/e2e-fork-pr.yml
@@ -143,7 +143,10 @@ jobs:
           cd ..
           mvn clean install -DskipTests -Dmaven.test.skip=true
           cd ..
-          mvn clean install -DskipTests -Dmaven.test.skip=true -Dspotless.check.skip=true -Dfix.version=3
+          # NOTE: Do NOT add -Dmaven.test.skip=true here — the root build must
+          # compile test classes so maven-jar-plugin produces the test-jar
+          # (openelisglobal:jar:tests) required by GenericASTM/File/HL7 plugins.
+          mvn clean install -DskipTests -Dspotless.check.skip=true -Dfix.version=3
 
       - name: Build plugins
         run: mvn clean install -DskipTests -Dmaven.test.skip=true

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -65,6 +65,9 @@ jobs:
           cd ..
           mvn clean install -DskipTests -Dmaven.test.skip=true
           cd ..
+          # NOTE: Do NOT add -Dmaven.test.skip=true here — the root build must
+          # compile test classes so maven-jar-plugin produces the test-jar
+          # (openelisglobal:jar:tests) required by GenericASTM/File/HL7 plugins.
           mvn clean install -DskipTests -Dspotless.check.skip=true -Dfix.version=3
 
       - name: Build plugins

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,13 @@ mvn clean install -DskipTests
 - `-Dmaven.test.skip=true`: Skips test compilation AND execution (including
   Failsafe)
 
+**Exception — CI shared-build root project:** The E2E `shared-build` step in
+both `e2e-playwright.yml` and `e2e-fork-pr.yml` intentionally omits
+`-Dmaven.test.skip=true` on the root project build because the `test-jar`
+artifact must be produced for plugin compilation (GenericASTM, GenericFile,
+GenericHL7 depend on it). The `dataexport` and `plugins` sub-builds still use
+both flags.
+
 ### Pre-Commit Formatting (MANDATORY)
 
 **MUST run BEFORE EVERY commit:**


### PR DESCRIPTION
## Summary

- Remove `-Dmaven.test.skip=true` from the root project Maven command in `e2e-fork-pr.yml`'s Shared Build job — this flag prevented test class compilation, so the `maven-jar-plugin:test-jar` goal produced no artifact
- Three plugins (`GenericASTM`, `GenericFile`, `GenericHL7`) depend on `openelisglobal:jar:tests:3.2.1.3` and failed to resolve it, breaking all fork PR E2E tests
- Add clarifying comments to both `e2e-fork-pr.yml` and `e2e-playwright.yml` explaining why the root build intentionally omits this flag
- Update `CLAUDE.md` test-skip guidance with an exception note for CI shared-build

## Context

PR #3125 introduced the fork E2E workflow. PR #2464 (the first fork-based PR to use it) failed at `Shared Build (Fork)` → `Build plugins` with:
```
[ERROR] Could not find artifact org.openelisglobal:openelisglobal:jar:tests:3.2.1.3
```

The `dataexport` sub-builds and `plugins` build correctly use both `-DskipTests -Dmaven.test.skip=true`. Only the root project build must omit `-Dmaven.test.skip=true` so test classes are compiled and the test-jar is packaged.

## Test plan

- [ ] Merge this PR to develop
- [ ] Re-run `03 - E2E` on PR #2464 (or push a commit) — the `workflow_run` trigger reads `e2e-fork-pr.yml` from develop, so the fix takes effect automatically
- [ ] Verify `Shared Build (Fork)` passes and Maven logs show `Building jar: .../openelisglobal-3.2.1.3-tests.jar`
- [ ] Verify `GenericASTM` and downstream plugins build successfully
- [ ] Verify E2E test jobs (Playwright, Analyzer Harness, Cypress) run to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)