### PR TITLE
fix(ci): skip main E2E jobs for fork PRs to prevent red checks

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -202,6 +202,7 @@ jobs:
   playwright-core:
     name: Playwright Core ${{ matrix.shard_index }}/${{ matrix.shard_total }}
     needs: shared-build
+    if: needs.shared-build.outputs.image_transfer != 'fork-fallback'
     runs-on: ubuntu-latest
     environment: e2e
     strategy:
@@ -347,7 +348,7 @@ jobs:
   # ─── Analyzer Harness ──────────────────────────────────────────────────────
   analyzer-harness:
     name: Analyzer Harness
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-analyzer-e2e') }}
+    if: ${{ needs.shared-build.outputs.image_transfer != 'fork-fallback' && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-analyzer-e2e')) }}
     needs: shared-build
     uses: ./.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
     secrets: inherit
@@ -356,6 +357,7 @@ jobs:
   cypress:
     name: Cypress
     needs: shared-build
+    if: needs.shared-build.outputs.image_transfer != 'fork-fallback'
     uses: ./.github/workflows/e2e-cypress-deprecated.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary

- Add `if: needs.shared-build.outputs.image_transfer != 'fork-fallback'` to `playwright-core`, `analyzer-harness`, and `cypress` jobs in `e2e-playwright.yml`
- These jobs can't run for fork PRs (no real Docker images available) — they were pulling `fork-pending` placeholders and failing red
- The actual tests run in the `E2E (Fork PR)` workflow instead
- The `e2e-gate` already handles `fork-fallback` correctly — no gate changes needed

## Context

Follow-up to #3142. PR #2464 shows 9 red check failures because the downstream E2E jobs try to pull `fork-pending` placeholder images. With this fix they'll show as **skipped** (gray) instead.

## Test plan

- [ ] Merge to develop
- [ ] Re-run `03 - E2E` on PR #2464
- [ ] Confirm Playwright/Cypress/Analyzer Harness jobs show **skipped** (gray)
- [ ] Confirm `03 Checkpoint - E2E` still passes
- [ ] Confirm `E2E (Fork PR)` workflow still triggers and runs tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)