### PR TITLE
fix(e2e): use page.reload() for retries to fix dispatcher GC flake

### DIFF
--- a/frontend/playwright/helpers/results-ui.ts
+++ b/frontend/playwright/helpers/results-ui.ts
@@ -88,17 +88,23 @@ async function navigateUntilVisible(
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= attempts; attempt++) {
-    // First attempt navigates; retries reload the same page context.
-    // page.reload() reuses the existing frame, avoiding the dispatcher
-    // object churn from repeated goto() that causes
-    // "Object with guid response@… was not bound in the connection".
-    if (attempt === 1) {
-      await page.goto(url, { waitUntil: "load" });
-    } else {
-      await page.reload({ waitUntil: "load" });
-    }
-
     try {
+      // First attempt navigates; retries reload the same page context.
+      // page.reload() reuses the existing frame, avoiding the dispatcher
+      // object churn from repeated goto() that causes
+      // "Object with guid response@… was not bound in the connection".
+      if (attempt === 1) {
+        await page.goto(url, {
+          waitUntil: "load",
+          timeout: perAttemptTimeoutMs,
+        });
+      } else {
+        await page.reload({
+          waitUntil: "load",
+          timeout: perAttemptTimeoutMs,
+        });
+      }
+
       await expect(visibleLocator()).toBeVisible({
         timeout: perAttemptTimeoutMs,
       });

--- a/frontend/playwright/helpers/results-ui.ts
+++ b/frontend/playwright/helpers/results-ui.ts
@@ -88,7 +88,15 @@ async function navigateUntilVisible(
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= attempts; attempt++) {
-    await page.goto(url, { waitUntil: "load" });
+    // First attempt navigates; retries reload the same page context.
+    // page.reload() reuses the existing frame, avoiding the dispatcher
+    // object churn from repeated goto() that causes
+    // "Object with guid response@… was not bound in the connection".
+    if (attempt === 1) {
+      await page.goto(url, { waitUntil: "load" });
+    } else {
+      await page.reload({ waitUntil: "load" });
+    }
 
     try {
       await expect(visibleLocator()).toBeVisible({


### PR DESCRIPTION
## Summary

- Replaces repeated `page.goto()` calls with `goto`-once + `reload`-for-retries in `navigateUntilVisible()` ([results-ui.ts](frontend/playwright/helpers/results-ui.ts))
- Fixes the intermittent `Object with guid response@… was not bound in the connection` error on develop CI (file-import-results.spec.ts QS7 import test)
- `page.reload()` reuses the existing page/frame context instead of creating a fresh navigation context, eliminating the dispatcher object churn that triggers the Playwright GC race

## Root Cause

`navigateUntilVisible()` calls `page.goto(url)` in a retry loop. Each `goto()` creates a fresh page context with new dispatcher objects (request, response, frame). When the visibility check fails and the loop immediately fires another `goto()`, the previous context's dispatcher objects can be garbage-collected before Playwright's internal connection tracking releases them — causing the "not bound in the connection" error.

The file-import test is the worst case: `timeoutMs: 165,000` / `perAttemptTimeoutMs: 5,000` = **33 potential `goto()` calls**. This overwhelms the dispatcher cleanup even with Playwright's GC fix (shipped in v1.41, we're on 1.58.2).

**Why PR CI passes but develop fails:** Different runner pools with different I/O latencies — the race window is narrow enough that timing differences determine the outcome.

## Test plan

- [x] `npm run pw:guard` passes (no-timeout guard + demo-ui-only guard)
- [ ] PR CI: all Playwright shards green
- [ ] Develop CI after merge: harness-demo shard 2/2 passes without flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)