### PR TITLE
fix(ci): post E2E commit status to PR head SHA, not merge SHA

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -155,10 +155,11 @@ jobs:
           fi
 
       - name: Prepare build context data
-        if: always() && steps.push-images.outputs.mode != ''
+        if: always()
         run: |
           mkdir -p /tmp/e2e-build-context
-          echo "${{ steps.push-images.outputs.mode }}" > /tmp/e2e-build-context/image_transfer
+          MODE="${{ steps.push-images.outputs.mode }}"
+          echo "${MODE:-none}" > /tmp/e2e-build-context/image_transfer
           echo "${{ github.event_name }}" > /tmp/e2e-build-context/event_name
 
           IS_FORK="false"
@@ -183,7 +184,7 @@ jobs:
           echo "Build context: mode=${{ steps.push-images.outputs.mode }} event=${{ github.event_name }} fork=$IS_FORK pr=#$PR_NUMBER"
 
       - name: Upload build context for test workflow
-        if: always() && steps.push-images.outputs.mode != ''
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-build-context

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -553,15 +553,17 @@ jobs:
             const gateResult = '${{ needs.e2e-gate.result }}';
             const imageTransfer = '${{ needs.setup.outputs.image_transfer }}';
 
-            // If build produced no usable images, report as skipped
+            let state, description;
             if (imageTransfer === 'none') {
-              return;
+              state = 'failure';
+              description = 'E2E build failed — no images produced';
+            } else if (gateResult === 'success') {
+              state = 'success';
+              description = 'E2E tests passed';
+            } else {
+              state = 'failure';
+              description = 'E2E tests failed';
             }
-
-            const state = gateResult === 'success' ? 'success' : 'failure';
-            const description = state === 'success'
-              ? 'E2E tests passed'
-              : 'E2E tests failed';
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -79,7 +79,7 @@ jobs:
   set-pending-status:
     name: Set Pending Status
     needs: setup
-    if: needs.setup.outputs.image_transfer != 'none' && needs.setup.outputs.pr_sha != ''
+    if: needs.setup.outputs.image_transfer != 'none' && needs.setup.outputs.head_sha != ''
     runs-on: ubuntu-latest
     steps:
       - name: Post pending commit status
@@ -89,7 +89,7 @@ jobs:
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ needs.setup.outputs.pr_sha }}',
+              sha: '${{ needs.setup.outputs.head_sha }}',
               state: 'pending',
               context: '03 Checkpoint - E2E',
               description: 'E2E tests running...',
@@ -542,7 +542,7 @@ jobs:
   # workflow_run checks don't automatically appear on PRs.
   report-status:
     name: Report Status
-    if: always() && needs.setup.outputs.pr_sha != ''
+    if: always() && needs.setup.outputs.head_sha != ''
     needs: [setup, e2e-gate]
     runs-on: ubuntu-latest
     steps:
@@ -565,7 +565,7 @@ jobs:
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ needs.setup.outputs.pr_sha }}',
+              sha: '${{ needs.setup.outputs.head_sha }}',
               state,
               context: '03 Checkpoint - E2E',
               description,


### PR DESCRIPTION
## Summary

- Fixes commit status posting in the `E2E / Tests` workflow to use the PR's HEAD SHA instead of the merge commit SHA
- Without this fix, the `03 Checkpoint - E2E` status is posted to a SHA invisible on the PR's checks page

Follow-up to #3148.

## Test plan

- [ ] Merge to develop
- [ ] Re-run `03 - E2E` on PR #2464
- [ ] Verify `03 Checkpoint - E2E` status appears on the PR checks tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)