### PR TITLE
fix(ci): pass build_run_id to reusable workflows for cross-run artifact downloads

### DIFF
--- a/.github/workflows/e2e-cypress-deprecated.yml
+++ b/.github/workflows/e2e-cypress-deprecated.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   packages: read
+  actions: read
 
 jobs:
   e2e-cypress:

--- a/.github/workflows/e2e-cypress-deprecated.yml
+++ b/.github/workflows/e2e-cypress-deprecated.yml
@@ -6,6 +6,17 @@ name: E2E / Cypress (Deprecated)
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      build_run_id:
+        description: "Run ID of the build workflow (for cross-run artifact download). Empty = same run."
+        required: false
+        type: string
+        default: ""
+      is_fork:
+        description: "Whether this is a fork PR (artifacts in same run from fork-rebuild)"
+        required: false
+        type: string
+        default: "false"
 
 permissions:
   contents: read
@@ -94,7 +105,17 @@ jobs:
       - name: Prepare .env from template
         run: cp .env.example .env
 
-      - name: Download Docker image map artifact
+      - name: Download image map from build workflow (non-fork)
+        if: inputs.is_fork != 'true' && inputs.build_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-image-map-base
+          path: /tmp/e2e-image-map
+          run-id: ${{ inputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download image map from fork-rebuild (fork)
+        if: inputs.is_fork == 'true' || inputs.build_run_id == ''
         uses: actions/download-artifact@v4
         with:
           name: e2e-image-map-base

--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: read
   packages: read
+  actions: read
 
 jobs:
   demo-shards:

--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -5,6 +5,17 @@ name: E2E / Playwright / Analyzer Harness (Reusable)
 
 on:
   workflow_call:
+    inputs:
+      build_run_id:
+        description: "Run ID of the build workflow (for cross-run artifact download). Empty = same run."
+        required: false
+        type: string
+        default: ""
+      is_fork:
+        description: "Whether this is a fork PR (artifacts in same run from fork-rebuild)"
+        required: false
+        type: string
+        default: "false"
 
 permissions:
   contents: read
@@ -61,13 +72,33 @@ jobs:
       - name: Prepare .env
         run: cp .env.example .env
 
-      - name: Download plugin jars artifact
+      - name: Download plugin jars from build workflow (non-fork)
+        if: inputs.is_fork != 'true' && inputs.build_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-plugin-jars
+          path: /tmp/e2e-plugin-jars
+          run-id: ${{ inputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download plugin jars from fork-rebuild (fork)
+        if: inputs.is_fork == 'true' || inputs.build_run_id == ''
         uses: actions/download-artifact@v4
         with:
           name: e2e-plugin-jars
           path: /tmp/e2e-plugin-jars
 
-      - name: Download Docker image map artifact
+      - name: Download image map from build workflow (non-fork)
+        if: inputs.is_fork != 'true' && inputs.build_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-image-map
+          path: /tmp/e2e-image-map
+          run-id: ${{ inputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download image map from fork-rebuild (fork)
+        if: inputs.is_fork == 'true' || inputs.build_run_id == ''
         uses: actions/download-artifact@v4
         with:
           name: e2e-image-map

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -418,6 +418,9 @@ jobs:
         (needs.setup.outputs.event_name != 'pull_request' || true)
       }}
     uses: ./.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+    with:
+      build_run_id: ${{ needs.setup.outputs.build_run_id }}
+      is_fork: ${{ needs.setup.outputs.is_fork }}
     secrets: inherit
 
   # ─── Cypress (Deprecated) ───────────────────────────────────────────────────
@@ -431,6 +434,9 @@ jobs:
         (needs.fork-rebuild.result == 'success' || needs.fork-rebuild.result == 'skipped')
       }}
     uses: ./.github/workflows/e2e-cypress-deprecated.yml
+    with:
+      build_run_id: ${{ needs.setup.outputs.build_run_id }}
+      is_fork: ${{ needs.setup.outputs.is_fork }}
     secrets: inherit
 
   # ─── Gate ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes analyzer harness and Cypress failing with 'Artifact not found for e2e-plugin-jars' because they download from the current run instead of the build run.

Adds build_run_id and is_fork inputs to both reusable workflows with conditional download steps matching the Playwright job pattern.