### PR TITLE
Ahri/inventory biorepository fixes

### DIFF
--- a/frontend/src/components/inventory/InventoryReports.jsx
+++ b/frontend/src/components/inventory/InventoryReports.jsx
@@ -96,6 +96,16 @@ const InventoryReports = () => {
     setSuccess(null);
   };
 
+  const handleDateRangeChange = (dates) => {
+    setFormData((prev) => ({
+      ...prev,
+      startDate: dates && dates.length > 0 ? dates[0] || null : null,
+      endDate: dates && dates.length > 1 ? dates[1] || null : null,
+    }));
+    setError(null);
+    setSuccess(null);
+  };
+
   // Validate form
   const validate = () => {
     // Date range reports require dates
@@ -230,10 +240,7 @@ const InventoryReports = () => {
                   <DatePicker
                     datePickerType="range"
                     value={[formData.startDate, formData.endDate]}
-                    onChange={(dates) => {
-                      handleChange("startDate", dates[0] || null);
-                      handleChange("endDate", dates[1] || null);
-                    }}
+                    onChange={handleDateRangeChange}
                   >
                     <DatePickerInput
                       id="startDate"
@@ -319,6 +326,7 @@ const InventoryReports = () => {
                     lowContrast
                   />
                 )}
+
 
                 {/* Success notification */}
                 {success && (

--- a/frontend/src/components/inventory/InventoryReportsModal.jsx
+++ b/frontend/src/components/inventory/InventoryReportsModal.jsx
@@ -88,6 +88,15 @@ const InventoryReportsModal = ({ open, onClose }) => {
     setError(null);
   };
 
+  const handleDateRangeChange = (dates) => {
+    setFormData((prev) => ({
+      ...prev,
+      startDate: dates && dates.length > 0 ? dates[0] || null : null,
+      endDate: dates && dates.length > 1 ? dates[1] || null : null,
+    }));
+    setError(null);
+  };
+
   const validate = () => {
     if (
       ["USAGE_TRENDS", "TRANSACTION_HISTORY"].includes(
@@ -238,10 +247,7 @@ const InventoryReportsModal = ({ open, onClose }) => {
           <DatePicker
             datePickerType="range"
             value={[formData.startDate, formData.endDate]}
-            onChange={(dates) => {
-              handleChange("startDate", dates[0] || null);
-              handleChange("endDate", dates[1] || null);
-            }}
+            onChange={handleDateRangeChange}
           >
             <DatePickerInput
               id="startDate"

--- a/frontend/src/components/inventory/InventoryService.js
+++ b/frontend/src/components/inventory/InventoryService.js
@@ -337,12 +337,54 @@ export const UsageAPI = {
 
 export const ReportsAPI = {
   generate: async (params) => {
+    const formatLocalDate = (date) => {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      return `${year}-${month}-${day}`;
+    };
+
+    const normalizeDateValue = (value) => {
+      if (!value) return null;
+      if (value instanceof Date && !Number.isNaN(value.getTime())) {
+        return formatLocalDate(value);
+      }
+      return value;
+    };
+
+    const parseFilename = (contentDisposition) => {
+      if (!contentDisposition) {
+        return "inventory-report";
+      }
+
+      const utf8Match = contentDisposition.match(
+        /filename\*\s*=\s*UTF-8''([^;]+)/i,
+      );
+      if (utf8Match?.[1]) {
+        return decodeURIComponent(utf8Match[1]).trim();
+      }
+
+      const quotedMatch = contentDisposition.match(/filename\s*=\s*"([^"]+)"/i);
+      if (quotedMatch?.[1]) {
+        return quotedMatch[1].trim();
+      }
+
+      const plainMatch = contentDisposition.match(/filename\s*=\s*([^;]+)/i);
+      if (plainMatch?.[1]) {
+        return plainMatch[1].trim().replace(/^["']|["']$/g, "");
+      }
+
+      return "inventory-report";
+    };
+
     const queryParams = new URLSearchParams();
     if (params.reportType) queryParams.append("reportType", params.reportType);
     if (params.exportFormat)
       queryParams.append("exportFormat", params.exportFormat);
-    if (params.startDate) queryParams.append("startDate", params.startDate);
-    if (params.endDate) queryParams.append("endDate", params.endDate);
+    if (params.startDate)
+      queryParams.append("startDate", normalizeDateValue(params.startDate));
+    if (params.endDate)
+      queryParams.append("endDate", normalizeDateValue(params.endDate));
     if (params.includeInactive !== undefined)
       queryParams.append("includeInactive", params.includeInactive);
     if (params.includeExpired !== undefined)
@@ -364,20 +406,11 @@ export const ReportsAPI = {
           const contentDisposition = response.headers.get(
             "Content-Disposition",
           );
-          let filename = "inventory-report";
-
-          if (contentDisposition) {
-            const filenameMatch =
-              contentDisposition.match(/filename="?(.+)"?/i);
-            if (filenameMatch) {
-              filename = filenameMatch[1];
-            }
-          }
 
           resolve({
             data: blob,
             contentType,
-            filename,
+            filename: parseFilename(contentDisposition),
           });
         },
         (error) => {

--- a/frontend/src/components/notebook/pages/biorepository/ManifestUploadModal.js
+++ b/frontend/src/components/notebook/pages/biorepository/ManifestUploadModal.js
@@ -13,14 +13,8 @@ import {
   InlineNotification,
   Loading,
   Tag,
-  Link,
 } from "@carbon/react";
-import {
-  DocumentImport,
-  Checkmark,
-  Warning,
-  Download,
-} from "@carbon/icons-react";
+import { Checkmark, Warning, Download } from "@carbon/icons-react";
 import { FormattedMessage, useIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { postToOpenElisServerJsonResponse } from "../../../utils/Utils";
@@ -41,9 +35,9 @@ import { postToOpenElisServerJsonResponse } from "../../../utils/Utils";
 function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
   const intl = useIntl();
 
-  const [file, setFile] = useState(null);
   const [parsedData, setParsedData] = useState([]);
   const [validationErrors, setValidationErrors] = useState([]);
+  const [validationWarnings, setValidationWarnings] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [importStatus, setImportStatus] = useState(null); // null, 'parsed', 'validating', 'preview', 'importing', 'complete'
@@ -79,33 +73,6 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     "notes",
   ];
 
-  // All fields supported by the backend DTO (used for validation)
-  // This MUST match SampleRegistrationDTO.java fields exactly
-  const supportedBackendFields = new Set([
-    // Required
-    "externalId",
-    "sampleTypeId", // Maps from CSV "sampleType"
-    "biosafetyLevel",
-    "collectionDate",
-    "originLab",
-    // Conditional
-    "consentId",
-    "ethicsApprovalRef",
-    "mtaReference",
-    // Optional
-    "projectId",
-    "principalInvestigator",
-    "preservationMedium",
-    "arrivalCondition",
-    "specialHandling", // Maps from CSV "notes"
-    // System fields (set by backend, not from CSV)
-    "barcode",
-    "receiptDate",
-    "requiredTempMin",
-    "requiredTempMax",
-    "shipmentId",
-  ]);
-
   // CSV column to backend field mapping
   const csvToBackendFieldMap = {
     externalId: "externalId",
@@ -122,33 +89,6 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     arrivalCondition: "arrivalCondition",
     notes: "specialHandling",
   };
-
-  // Supported sample types per spec (Sample Type Classifications)
-  const supportedSampleTypes = [
-    {
-      category: "Blood-derived",
-      types: ["Serum", "Plasma", "Whole Blood", "Buffy Coat"],
-    },
-    { category: "Nucleic Acids", types: ["DNA", "RNA", "cDNA"] },
-    { category: "Tissue", types: ["Biopsy", "FFPE Block", "Fresh Frozen"] },
-    { category: "Cellular", types: ["Cell Line", "PBMCs", "Primary Cells"] },
-    {
-      category: "Microbiological",
-      types: ["Bacterial Isolate", "Viral Culture", "Fungal Isolate"],
-    },
-    {
-      category: "Other",
-      types: [
-        "Urine",
-        "CSF",
-        "Saliva",
-        "Stool",
-        "Respiratory Swab",
-        "Fluid",
-        "Environmental",
-      ],
-    },
-  ];
 
   // All expected CSV headers (for template generation)
   const expectedHeaders = Object.keys(csvToBackendFieldMap);
@@ -313,7 +253,6 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
         return;
       }
 
-      setFile(uploadedFile);
       setError(null);
 
       const reader = new FileReader();
@@ -322,6 +261,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
           const { data, errors } = parseCSV(e.target.result);
           setParsedData(data);
           setValidationErrors(errors);
+          setValidationWarnings([]);
           setBackendValidationDone(false);
           // Set to 'parsed' - user must click Preview & Validate to proceed
           setImportStatus("parsed");
@@ -411,7 +351,13 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     validateWithBackend(samples, (validationResult) => {
       setLoading(false);
 
-      if (!validationResult) {
+      if (validationResult?.error) {
+        setError(validationResult.message || validationResult.error);
+        setImportStatus("parsed");
+        return;
+      }
+
+      if (!validationResult || !Array.isArray(validationResult.rows)) {
         setError(
           intl.formatMessage({
             id: "biorepository.manifest.error.validationFailed",
@@ -425,6 +371,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
 
       // Process backend validation results
       const backendErrors = [];
+      const backendWarnings = [];
       const updatedData = parsedData.map((row, index) => {
         const backendRow = validationResult.rows?.[index];
         if (backendRow && !backendRow.valid && backendRow.errors) {
@@ -436,15 +383,26 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
             });
           });
         }
+        if (backendRow?.warnings) {
+          backendRow.warnings.forEach((warningMsg) => {
+            backendWarnings.push({
+              row: row._rowNumber,
+              field: "sampleType",
+              message: warningMsg,
+            });
+          });
+        }
         return {
           ...row,
           _valid: backendRow?.valid ?? row._valid,
           _backendErrors: backendRow?.errors || [],
+          _backendWarnings: backendRow?.warnings || [],
         };
       });
 
       setParsedData(updatedData);
       setValidationErrors((prev) => [...prev, ...backendErrors]);
+      setValidationWarnings(backendWarnings);
       setBackendValidationDone(true);
       setImportStatus("preview");
 
@@ -513,8 +471,17 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
       }),
       (response) => {
         setLoading(false);
-        if (response?.error) {
-          setError(response.error);
+        if (!response) {
+          setError(
+            intl.formatMessage({
+              id: "biorepository.manifest.error.importFailed",
+              defaultMessage:
+                "Failed to import samples with server. Please try again.",
+            }),
+          );
+          setImportStatus("preview");
+        } else if (response?.error) {
+          setError(response.message || response.error);
           setImportStatus("preview");
         } else {
           setImportStatus("complete");
@@ -538,9 +505,9 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
   ]);
 
   const handleClear = useCallback(() => {
-    setFile(null);
     setParsedData([]);
     setValidationErrors([]);
+    setValidationWarnings([]);
     setImportStatus(null);
     setError(null);
     setBackendValidationDone(false);
@@ -597,12 +564,20 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     sampleType: row.sampleType || "-",
     originLab: row.originLab || "-",
     biosafetyLevel: row.biosafetyLevel || "BSL_1",
-    status: row._valid ? "valid" : "error",
+    status: row._valid
+      ? row._backendWarnings?.length > 0
+        ? "warning"
+        : "valid"
+      : "error",
   }));
 
   // Show errors for specific rows
   const getRowErrors = (rowNumber) => {
     return validationErrors.filter((e) => e.row === rowNumber);
+  };
+
+  const getRowWarnings = (rowNumber) => {
+    return validationWarnings.filter((e) => e.row === rowNumber);
   };
 
   return (
@@ -772,7 +747,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
           <div
             style={{
               padding: "1rem",
-              backgroundColor: "#e0f0e0",
+              backgroundColor: "#e8f3ff",
               borderRadius: "4px",
               marginBottom: "1rem",
             }}
@@ -780,28 +755,15 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
             <h6 style={{ marginBottom: "0.5rem" }}>
               <FormattedMessage
                 id="biorepository.manifest.sampleTypes.title"
-                defaultMessage="Supported Sample Types:"
+                defaultMessage="Sample Type Handling:"
               />
             </h6>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-                gap: "0.5rem",
-              }}
-            >
-              {supportedSampleTypes.map((category) => (
-                <div key={category.category}>
-                  <strong style={{ fontSize: "0.75rem", color: "#161616" }}>
-                    {category.category}:
-                  </strong>
-                  <br />
-                  <span style={{ fontSize: "0.75rem", color: "#525252" }}>
-                    {category.types.join(", ")}
-                  </span>
-                </div>
-              ))}
-            </div>
+            <p style={{ margin: 0, fontSize: "0.875rem", color: "#393939" }}>
+              <FormattedMessage
+                id="biorepository.manifest.sampleTypes.help"
+                defaultMessage="The manifest accepts the sample type labels used by AHRI. Existing sample types are matched by ID, name, localized name, or abbreviation. If a biorepository sample type is not already configured, validation will mark it for creation and the import will register it automatically."
+              />
+            </p>
           </div>
           <FileUploader
             labelTitle={intl.formatMessage({
@@ -927,6 +889,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                       {rows.map((row) => {
                         const rowNumber = parseInt(row.id);
                         const rowErrors = getRowErrors(rowNumber);
+                        const rowWarnings = getRowWarnings(rowNumber);
                         return (
                           <React.Fragment key={row.id}>
                             <TableRow {...getRowProps({ row })}>
@@ -938,6 +901,13 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                                         <FormattedMessage
                                           id="biorepository.manifest.status.pending"
                                           defaultMessage="Pending"
+                                        />
+                                      </Tag>
+                                    ) : cell.value === "warning" ? (
+                                      <Tag type="warm-gray" size="sm">
+                                        <FormattedMessage
+                                          id="biorepository.manifest.status.warning"
+                                          defaultMessage="Will Create Type"
                                         />
                                       </Tag>
                                     ) : (
@@ -968,6 +938,23 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                                       <div key={idx}>
                                         • {err.field}: {err.message}
                                       </div>
+                                    ))}
+                                  </div>
+                                </TableCell>
+                              </TableRow>
+                            )}
+                            {rowWarnings.length > 0 && (
+                              <TableRow>
+                                <TableCell colSpan={headers.length}>
+                                  <div
+                                    style={{
+                                      backgroundColor: "#fff8e1",
+                                      padding: "0.5rem",
+                                      fontSize: "0.875rem",
+                                    }}
+                                  >
+                                    {rowWarnings.map((warning, idx) => (
+                                      <div key={idx}>• {warning.message}</div>
                                     ))}
                                   </div>
                                 </TableCell>
@@ -1050,6 +1037,12 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                 />
               </Tag>
             )}
+            {validationWarnings.length > 0 && (
+              <Tag type="warm-gray" style={{ marginLeft: "0.5rem" }}>
+                <Warning size={16} style={{ marginRight: "0.25rem" }} />
+                {validationWarnings.length} warning(s)
+              </Tag>
+            )}
           </div>
 
           {validationErrors.length > 0 && (
@@ -1063,6 +1056,45 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                 id: "biorepository.manifest.validation.subtitle",
                 defaultMessage:
                   "Please fix the errors below before importing. Rows with errors are highlighted.",
+              })}
+              lowContrast
+              hideCloseButton
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+
+          {validationErrors.length > 0 && validSampleCount > 0 && (
+            <InlineNotification
+              kind="info"
+              title={intl.formatMessage({
+                id: "biorepository.manifest.partialImport.title",
+                defaultMessage: "Partial Import Available",
+              })}
+              subtitle={intl.formatMessage(
+                {
+                  id: "biorepository.manifest.partialImport.subtitle",
+                  defaultMessage:
+                    "{count} valid sample(s) can still be imported. Rows marked Error will be skipped.",
+                },
+                { count: validSampleCount },
+              )}
+              lowContrast
+              hideCloseButton
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+
+          {validationWarnings.length > 0 && (
+            <InlineNotification
+              kind="info"
+              title={intl.formatMessage({
+                id: "biorepository.manifest.warnings.title",
+                defaultMessage: "Validation Warnings",
+              })}
+              subtitle={intl.formatMessage({
+                id: "biorepository.manifest.warnings.subtitle",
+                defaultMessage:
+                  "Some rows introduce new sample types. Those sample types will be created automatically during import and added to the biorepository-approved list.",
               })}
               lowContrast
               hideCloseButton
@@ -1096,6 +1128,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                     {rows.map((row) => {
                       const rowNumber = parseInt(row.id);
                       const rowErrors = getRowErrors(rowNumber);
+                      const rowWarnings = getRowWarnings(rowNumber);
                       return (
                         <React.Fragment key={row.id}>
                           <TableRow {...getRowProps({ row })}>
@@ -1107,6 +1140,13 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                                       <FormattedMessage
                                         id="biorepository.manifest.status.valid"
                                         defaultMessage="Valid"
+                                      />
+                                    </Tag>
+                                  ) : cell.value === "warning" ? (
+                                    <Tag type="warm-gray" size="sm">
+                                      <FormattedMessage
+                                        id="biorepository.manifest.status.warning"
+                                        defaultMessage="Will Create Type"
                                       />
                                     </Tag>
                                   ) : (
@@ -1137,6 +1177,23 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                                     <div key={idx}>
                                       • {err.field}: {err.message}
                                     </div>
+                                  ))}
+                                </div>
+                              </TableCell>
+                            </TableRow>
+                          )}
+                          {rowWarnings.length > 0 && (
+                            <TableRow>
+                              <TableCell colSpan={headers.length}>
+                                <div
+                                  style={{
+                                    backgroundColor: "#fff8e1",
+                                    padding: "0.5rem",
+                                    fontSize: "0.875rem",
+                                  }}
+                                >
+                                  {rowWarnings.map((warning, idx) => (
+                                    <div key={idx}>• {warning.message}</div>
                                   ))}
                                 </div>
                               </TableCell>

--- a/frontend/src/components/storage/LocationManagement/EditBoxModal.jsx
+++ b/frontend/src/components/storage/LocationManagement/EditBoxModal.jsx
@@ -103,7 +103,7 @@ const EditBoxModal = ({ open, mode, box, parentRack, onClose, onSave }) => {
         id: "number-number",
         label: intl.formatMessage({
           id: "storage.box.schema.numberNumber",
-          defaultMessage: "Number-Number (1-1)",
+          defaultMessage: "Continuous Number (1, 2, 3)",
         }),
       },
     ],

--- a/frontend/src/components/storage/LocationManagement/EditBoxModal.jsx
+++ b/frontend/src/components/storage/LocationManagement/EditBoxModal.jsx
@@ -103,6 +103,13 @@ const EditBoxModal = ({ open, mode, box, parentRack, onClose, onSave }) => {
         id: "number-number",
         label: intl.formatMessage({
           id: "storage.box.schema.numberNumber",
+          defaultMessage: "Number-Number (1-1)",
+        }),
+      },
+      {
+        id: "continuous",
+        label: intl.formatMessage({
+          id: "storage.box.schema.continuous",
           defaultMessage: "Continuous Number (1, 2, 3)",
         }),
       },

--- a/frontend/src/components/storage/StorageDashboard.jsx
+++ b/frontend/src/components/storage/StorageDashboard.jsx
@@ -2906,6 +2906,11 @@ const StorageDashboard = () => {
       Object.keys(occupiedCoordinates).some((coordinate) =>
         /^\d+-\d+$/.test(coordinate),
       );
+    const hasLegacyContinuousCoordinates =
+      hint === "number-number" &&
+      Object.keys(occupiedCoordinates).some((coordinate) =>
+        /^\d+$/.test(coordinate),
+      );
 
     // Generate coordinate labels based on position schema hint
     const getCoordinateLabel = (rowIdx, colIdx) => {
@@ -2915,13 +2920,21 @@ const StorageDashboard = () => {
         return `${letter}${colIdx + 1}`;
       }
 
-      if (hasLegacyNumberCoordinates) {
-        // Backward compatibility for boxes that already stored positions as 1-1, 1-2, ...
+      if (hint === "number-number" && !hasLegacyContinuousCoordinates) {
+        // Existing number-number schema uses row-column coordinates like 1-1, 1-2, ...
         return `${rowIdx + 1}-${colIdx + 1}`;
       }
 
-      // Continuous numbering for AHRI biorepository boxes: 1, 2, 3, ... in row-major order.
-      return String(rowIdx * (selectedBox.columns || 0) + colIdx + 1);
+      if (hint === "continuous" || hasLegacyContinuousCoordinates) {
+        // Backward compatibility for boxes created before the explicit continuous schema type existed.
+        return String(rowIdx * (selectedBox.columns || 0) + colIdx + 1);
+      }
+
+      if (hasLegacyNumberCoordinates) {
+        return `${rowIdx + 1}-${colIdx + 1}`;
+      }
+
+      return `${rowIdx + 1}-${colIdx + 1}`;
     };
 
     return (

--- a/frontend/src/components/storage/StorageDashboard.jsx
+++ b/frontend/src/components/storage/StorageDashboard.jsx
@@ -2900,17 +2900,28 @@ const StorageDashboard = () => {
     // occupiedCoordinates is now an object: { "A1": { externalId: "...", sampleItemId: "..." }, ... }
     const occupiedCoordinates = selectedBox.occupiedCoordinates || {};
 
+    const hint = selectedBox.positionSchemaHint || "letter-number";
+    const hasLegacyNumberCoordinates =
+      hint === "number-number" &&
+      Object.keys(occupiedCoordinates).some((coordinate) =>
+        /^\d+-\d+$/.test(coordinate),
+      );
+
     // Generate coordinate labels based on position schema hint
     const getCoordinateLabel = (rowIdx, colIdx) => {
-      const hint = selectedBox.positionSchemaHint || "letter-number";
       if (hint === "letter-number") {
         // A1, A2, ..., B1, B2, etc.
         const letter = String.fromCharCode(65 + rowIdx); // A=65
         return `${letter}${colIdx + 1}`;
-      } else {
-        // 1-1, 1-2, etc.
+      }
+
+      if (hasLegacyNumberCoordinates) {
+        // Backward compatibility for boxes that already stored positions as 1-1, 1-2, ...
         return `${rowIdx + 1}-${colIdx + 1}`;
       }
+
+      // Continuous numbering for AHRI biorepository boxes: 1, 2, 3, ... in row-major order.
+      return String(rowIdx * (selectedBox.columns || 0) + colIdx + 1);
     };
 
     return (

--- a/frontend/src/components/storage/StorageDashboard.jsx
+++ b/frontend/src/components/storage/StorageDashboard.jsx
@@ -2901,11 +2901,6 @@ const StorageDashboard = () => {
     const occupiedCoordinates = selectedBox.occupiedCoordinates || {};
 
     const hint = selectedBox.positionSchemaHint || "letter-number";
-    const hasLegacyNumberCoordinates =
-      hint === "number-number" &&
-      Object.keys(occupiedCoordinates).some((coordinate) =>
-        /^\d+-\d+$/.test(coordinate),
-      );
     // Generate coordinate labels based on position schema hint
     const getCoordinateLabel = (rowIdx, colIdx) => {
       if (hint === "letter-number") {
@@ -2921,10 +2916,6 @@ const StorageDashboard = () => {
 
       if (hint === "continuous") {
         return String(rowIdx * (selectedBox.columns || 0) + colIdx + 1);
-      }
-
-      if (hasLegacyNumberCoordinates) {
-        return `${rowIdx + 1}-${colIdx + 1}`;
       }
 
       return `${rowIdx + 1}-${colIdx + 1}`;

--- a/frontend/src/components/storage/StorageDashboard.jsx
+++ b/frontend/src/components/storage/StorageDashboard.jsx
@@ -2906,12 +2906,6 @@ const StorageDashboard = () => {
       Object.keys(occupiedCoordinates).some((coordinate) =>
         /^\d+-\d+$/.test(coordinate),
       );
-    const hasLegacyContinuousCoordinates =
-      hint === "number-number" &&
-      Object.keys(occupiedCoordinates).some((coordinate) =>
-        /^\d+$/.test(coordinate),
-      );
-
     // Generate coordinate labels based on position schema hint
     const getCoordinateLabel = (rowIdx, colIdx) => {
       if (hint === "letter-number") {
@@ -2920,13 +2914,12 @@ const StorageDashboard = () => {
         return `${letter}${colIdx + 1}`;
       }
 
-      if (hint === "number-number" && !hasLegacyContinuousCoordinates) {
+      if (hint === "number-number") {
         // Existing number-number schema uses row-column coordinates like 1-1, 1-2, ...
         return `${rowIdx + 1}-${colIdx + 1}`;
       }
 
-      if (hint === "continuous" || hasLegacyContinuousCoordinates) {
-        // Backward compatibility for boxes created before the explicit continuous schema type existed.
+      if (hint === "continuous") {
         return String(rowIdx * (selectedBox.columns || 0) + colIdx + 1);
       }
 

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/BioSampleRestController.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/BioSampleRestController.java
@@ -6,6 +6,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -19,11 +20,16 @@ import org.openelisglobal.biorepository.service.BioSampleService;
 import org.openelisglobal.biorepository.service.BiorepositoryApprovedSampleTypeService;
 import org.openelisglobal.biorepository.service.RetentionPolicyService;
 import org.openelisglobal.biorepository.service.ShipmentService;
+import org.openelisglobal.biorepository.valueholder.BiorepositoryApprovedSampleType;
+import org.openelisglobal.biorepository.valueholder.BiorepositoryApprovedSampleType.SampleCategory;
 import org.openelisglobal.biorepository.valueholder.BioSample;
 import org.openelisglobal.biorepository.valueholder.BioSample.BiosafetyLevel;
 import org.openelisglobal.biorepository.valueholder.RetentionPolicy;
 import org.openelisglobal.biorepository.valueholder.Shipment;
 import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.common.services.DisplayListService;
+import org.openelisglobal.localization.service.LocalizationService;
+import org.openelisglobal.localization.valueholder.Localization;
 import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.sampleitem.service.SampleItemService;
@@ -78,6 +84,9 @@ public class BioSampleRestController extends BaseRestController {
 
     @Autowired
     private RetentionPolicyService retentionPolicyService;
+
+    @Autowired
+    private LocalizationService localizationService;
 
     /**
      * Get a BioSample extension by ID.
@@ -1146,7 +1155,12 @@ public class BioSampleRestController extends BaseRestController {
             } else {
                 TypeOfSample sampleType = findSampleTypeByNameOrId(sampleTypeId.trim());
                 if (sampleType == null) {
-                    rowResult.addError("Invalid sample type: " + sampleTypeId);
+                    if (isManifestSampleTypeAutoCreatable(sampleTypeId)) {
+                        rowResult.addWarning("New biorepository sample type will be created: "
+                                + normalizeSampleTypeLabel(sampleTypeId));
+                    } else {
+                        rowResult.addError("Invalid sample type: " + sampleTypeId);
+                    }
                 }
             }
 
@@ -1234,8 +1248,8 @@ public class BioSampleRestController extends BaseRestController {
         String barcode = dto.getExternalId() != null ? dto.getExternalId().trim()
                 : generateBarcode().getBody().get("barcode");
 
-        // Find sample type by name or ID
-        TypeOfSample sampleType = findSampleTypeByNameOrId(dto.getSampleTypeId());
+        // Find or create sample type by name or ID for biorepository intake.
+        TypeOfSample sampleType = resolveManifestSampleType(dto.getSampleTypeId(), sysUserId, true);
         if (sampleType == null) {
             throw new IllegalArgumentException("Invalid sample type: " + dto.getSampleTypeId());
         }
@@ -1307,6 +1321,7 @@ public class BioSampleRestController extends BaseRestController {
             return null;
         }
         nameOrId = nameOrId.trim();
+        String normalizedInput = normalizeSampleTypeLabel(nameOrId);
 
         // Try to find by ID first
         try {
@@ -1321,13 +1336,162 @@ public class BioSampleRestController extends BaseRestController {
         // Try to find by description (name)
         List<TypeOfSample> allTypes = typeOfSampleService.getAllTypeOfSamples();
         for (TypeOfSample type : allTypes) {
-            if (nameOrId.equalsIgnoreCase(type.getDescription())
-                    || nameOrId.equalsIgnoreCase(type.getLocalizedName())) {
+            if (matchesSampleTypeIdentifier(nameOrId, normalizedInput, type)) {
                 return type;
             }
         }
 
         return null;
+    }
+
+    private TypeOfSample resolveManifestSampleType(String nameOrId, String sysUserId, boolean createIfMissing) {
+        TypeOfSample existingType = findSampleTypeByNameOrId(nameOrId);
+        if (existingType != null) {
+            ensureBiorepositoryApprovedSampleType(existingType, sysUserId);
+            return existingType;
+        }
+
+        if (!createIfMissing || !isManifestSampleTypeAutoCreatable(nameOrId)) {
+            return null;
+        }
+
+        return createManifestSampleType(nameOrId, sysUserId);
+    }
+
+    private TypeOfSample createManifestSampleType(String requestedType, String sysUserId) {
+        String normalizedType = normalizeSampleTypeLabel(requestedType);
+        if (normalizedType == null || normalizedType.isBlank()) {
+            return null;
+        }
+
+        TypeOfSample existing = findSampleTypeByNameOrId(normalizedType);
+        if (existing != null) {
+            ensureBiorepositoryApprovedSampleType(existing, sysUserId);
+            return existing;
+        }
+
+        TypeOfSample typeOfSample = new TypeOfSample();
+        typeOfSample.setDescription(normalizedType);
+        typeOfSample.setDomain("H");
+        typeOfSample.setLocalAbbreviation(generateUniqueSampleTypeAbbreviation(normalizedType));
+        typeOfSample.setIsActive(true);
+        typeOfSample.setSortOrder(Integer.MAX_VALUE);
+        typeOfSample.setSysUserId(sysUserId);
+        typeOfSample.setNameKey("Sample.type." + normalizedType.replaceAll("[^A-Za-z0-9]+", "_"));
+        typeOfSample.setLocalization(createSampleTypeLocalization(normalizedType, sysUserId));
+
+        TypeOfSample saved = typeOfSampleService.save(typeOfSample);
+        typeOfSampleService.clearCache();
+        refreshSampleTypeLists();
+        ensureBiorepositoryApprovedSampleType(saved, sysUserId);
+        return saved;
+    }
+
+    private void ensureBiorepositoryApprovedSampleType(TypeOfSample sampleType, String sysUserId) {
+        if (sampleType == null || sampleType.getId() == null || sysUserId == null) {
+            return;
+        }
+
+        if (approvedSampleTypeService.getByTypeOfSampleId(sampleType.getId()) != null) {
+            return;
+        }
+
+        BiorepositoryApprovedSampleType approvedType = new BiorepositoryApprovedSampleType();
+        approvedType.setTypeOfSample(sampleType);
+        approvedType.setCategory(determineBiorepositorySampleCategory(sampleType.getDescription()));
+        approvedType.setIsActive(true);
+        approvedType.setDisplayOrder((int) approvedSampleTypeService.countActive() + 1);
+        approvedType.setSysUserId(sysUserId);
+        approvedSampleTypeService.save(approvedType);
+    }
+
+    private SampleCategory determineBiorepositorySampleCategory(String sampleTypeName) {
+        String normalized = normalizeSampleTypeLabel(sampleTypeName).toLowerCase(Locale.ROOT);
+
+        if (normalized.contains("serum") || normalized.contains("plasma") || normalized.contains("blood")
+                || normalized.contains("buffy")) {
+            return SampleCategory.BLOOD_DERIVED;
+        }
+        if (normalized.contains("dna") || normalized.contains("rna") || normalized.contains("cdna")
+                || normalized.contains("nucleic")) {
+            return SampleCategory.NUCLEIC_ACIDS;
+        }
+        if (normalized.contains("tissue") || normalized.contains("biopsy") || normalized.contains("ffpe")
+                || normalized.contains("block")) {
+            return SampleCategory.TISSUE;
+        }
+        if (normalized.contains("cell") || normalized.contains("pbmc")) {
+            return SampleCategory.CELLULAR;
+        }
+        if (normalized.contains("isolate") || normalized.contains("culture") || normalized.contains("bacteria")
+                || normalized.contains("bacterial") || normalized.contains("viral")
+                || normalized.contains("fungal")) {
+            return SampleCategory.MICROBIOLOGICAL;
+        }
+
+        return SampleCategory.OTHER;
+    }
+
+    private boolean matchesSampleTypeIdentifier(String rawInput, String normalizedInput, TypeOfSample type) {
+        return normalizedInput.equalsIgnoreCase(normalizeSampleTypeLabel(type.getDescription()))
+                || normalizedInput.equalsIgnoreCase(normalizeSampleTypeLabel(type.getLocalizedName()))
+                || rawInput.equalsIgnoreCase(type.getLocalAbbreviation());
+    }
+
+    private boolean isManifestSampleTypeAutoCreatable(String sampleType) {
+        if (sampleType == null) {
+            return false;
+        }
+
+        String normalized = normalizeSampleTypeLabel(sampleType);
+        if (normalized == null || normalized.isBlank()) {
+            return false;
+        }
+
+        return !normalized.matches("^\\d+$");
+    }
+
+    private String normalizeSampleTypeLabel(String sampleType) {
+        if (sampleType == null) {
+            return "";
+        }
+
+        return sampleType.trim().replaceAll("\\s+", " ");
+    }
+
+    private String generateUniqueSampleTypeAbbreviation(String sampleTypeName) {
+        String cleaned = sampleTypeName.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]+", "");
+        if (cleaned.isBlank()) {
+            cleaned = "BIOSAMPLE";
+        }
+
+        String base = cleaned.substring(0, Math.min(10, cleaned.length()));
+        String candidate = base;
+        int suffix = 1;
+
+        while (typeOfSampleService.getTypeOfSampleByLocalAbbrevAndDomain(candidate, "H") != null) {
+            String suffixText = Integer.toString(suffix++);
+            int maxBaseLength = Math.max(1, 10 - suffixText.length());
+            String baseCandidate = cleaned.substring(0, Math.min(maxBaseLength, cleaned.length()));
+            candidate = baseCandidate + suffixText;
+        }
+
+        return candidate;
+    }
+
+    private Localization createSampleTypeLocalization(String sampleTypeName, String sysUserId) {
+        Localization localization = new Localization();
+        localization.setEnglish(sampleTypeName);
+        localization.setFrench(sampleTypeName);
+        localization.setDescription("type of sample name");
+        localization.setSysUserId(sysUserId);
+        return localizationService.save(localization);
+    }
+
+    private void refreshSampleTypeLists() {
+        DisplayListService.getInstance().refreshList(DisplayListService.ListType.SAMPLE_TYPE);
+        DisplayListService.getInstance().refreshList(DisplayListService.ListType.SAMPLE_TYPE_ACTIVE);
+        DisplayListService.getInstance().refreshList(DisplayListService.ListType.SAMPLE_TYPE_INACTIVE);
     }
 
     // ========== RETENTION & DISPOSAL ENDPOINTS ==========

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/dto/ManifestValidationResponse.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/dto/ManifestValidationResponse.java
@@ -51,6 +51,7 @@ public class ManifestValidationResponse {
         private int rowIndex;
         private boolean valid = true;
         private List<String> errors = new ArrayList<>();
+        private List<String> warnings = new ArrayList<>();
 
         public RowValidationResult(int rowIndex) {
             this.rowIndex = rowIndex;
@@ -83,6 +84,18 @@ public class ManifestValidationResponse {
         public void addError(String error) {
             this.errors.add(error);
             this.valid = false;
+        }
+
+        public List<String> getWarnings() {
+            return warnings;
+        }
+
+        public void setWarnings(List<String> warnings) {
+            this.warnings = warnings;
+        }
+
+        public void addWarning(String warning) {
+            this.warnings.add(warning);
         }
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryApprovedSampleType.java
+++ b/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryApprovedSampleType.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.biorepository.valueholder;
 
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -27,6 +28,7 @@ import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
  */
 @Entity
 @Table(name = "biorepository_approved_sample_type", schema = "clinlims")
+@AttributeOverride(name = "lastupdated", column = @Column(name = "lastupdated"))
 public class BiorepositoryApprovedSampleType extends BaseObject<Integer> {
 
     /**

--- a/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryApprovedSampleType.java
+++ b/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryApprovedSampleType.java
@@ -1,6 +1,5 @@
 package org.openelisglobal.biorepository.valueholder;
 
-import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -28,7 +27,6 @@ import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
  */
 @Entity
 @Table(name = "biorepository_approved_sample_type", schema = "clinlims")
-@AttributeOverride(name = "lastupdated", column = @Column(name = "lastupdated"))
 public class BiorepositoryApprovedSampleType extends BaseObject<Integer> {
 
     /**

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryReportRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryReportRestController.java
@@ -1,0 +1,48 @@
+package org.openelisglobal.inventory.controller.rest;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.inventory.service.InventoryReportService;
+import org.openelisglobal.inventory.service.InventoryReportService.GeneratedReport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rest/inventory/reports")
+public class InventoryReportRestController {
+
+    @Autowired
+    private InventoryReportService inventoryReportService;
+
+    @PostMapping("/generate")
+    public void generateReport(@RequestParam String reportType,
+            @RequestParam(defaultValue = "PDF") String exportFormat, @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate, @RequestParam(defaultValue = "false") boolean includeInactive,
+            @RequestParam(defaultValue = "true") boolean includeExpired,
+            @RequestParam(defaultValue = "false") boolean groupByType,
+            @RequestParam(defaultValue = "false") boolean groupByLocation, HttpServletResponse response)
+            throws IOException {
+        try {
+            GeneratedReport report = inventoryReportService.generateReport(reportType, exportFormat, startDate, endDate,
+                    includeInactive, includeExpired, groupByType, groupByLocation);
+
+            response.setStatus(HttpStatus.OK.value());
+            response.setContentType(report.getContentType());
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + report.getFileName() + "\"");
+            response.setContentLength(report.getContent().length);
+            response.getOutputStream().write(report.getContent());
+            response.getOutputStream().flush();
+        } catch (IllegalArgumentException e) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "generateReport", e.getMessage());
+            response.sendError(HttpStatus.BAD_REQUEST.value(), e.getMessage());
+        } catch (Exception e) {
+            LogEvent.logError(e);
+            response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Failed to generate inventory report");
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/inventory/service/InventoryReportService.java
+++ b/src/main/java/org/openelisglobal/inventory/service/InventoryReportService.java
@@ -1,0 +1,31 @@
+package org.openelisglobal.inventory.service;
+
+public interface InventoryReportService {
+
+    GeneratedReport generateReport(String reportType, String exportFormat, String startDate, String endDate,
+            boolean includeInactive, boolean includeExpired, boolean groupByType, boolean groupByLocation);
+
+    class GeneratedReport {
+        private final byte[] content;
+        private final String contentType;
+        private final String fileName;
+
+        public GeneratedReport(byte[] content, String contentType, String fileName) {
+            this.content = content;
+            this.contentType = contentType;
+            this.fileName = fileName;
+        }
+
+        public byte[] getContent() {
+            return content;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/inventory/service/InventoryReportServiceImpl.java
+++ b/src/main/java/org/openelisglobal/inventory/service/InventoryReportServiceImpl.java
@@ -1,0 +1,566 @@
+package org.openelisglobal.inventory.service;
+
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Element;
+import com.itextpdf.text.Font;
+import com.itextpdf.text.FontFactory;
+import com.itextpdf.text.PageSize;
+import com.itextpdf.text.Paragraph;
+import com.itextpdf.text.Phrase;
+import com.itextpdf.text.pdf.PdfPCell;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.text.DecimalFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.inventory.valueholder.InventoryItem;
+import org.openelisglobal.inventory.valueholder.InventoryLot;
+import org.openelisglobal.inventory.valueholder.InventoryTransaction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class InventoryReportServiceImpl implements InventoryReportService {
+
+    private static final DateTimeFormatter FILE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final List<DateTimeFormatter> INPUT_DATE_FORMATS = Arrays.asList(
+            DateTimeFormatter.ISO_LOCAL_DATE,
+            DateTimeFormatter.ofPattern("MM/dd/yyyy"),
+            DateTimeFormatter.ofPattern("dd/MM/yyyy"),
+            DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+    private static final DateTimeFormatter DISPLAY_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DecimalFormat QUANTITY_FORMAT = new DecimalFormat("#,##0.##");
+
+    @Autowired
+    private InventoryItemService inventoryItemService;
+
+    @Autowired
+    private InventoryLotService inventoryLotService;
+
+    @Autowired
+    private InventoryTransactionService inventoryTransactionService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public GeneratedReport generateReport(String reportType, String exportFormat, String startDate, String endDate,
+            boolean includeInactive, boolean includeExpired, boolean groupByType, boolean groupByLocation) {
+        String normalizedReportType = normalizeRequired(reportType, "reportType");
+        String normalizedExportFormat = normalizeRequired(exportFormat, "exportFormat");
+
+        ReportTable table = buildTable(normalizedReportType, startDate, endDate, includeInactive, includeExpired,
+                groupByType, groupByLocation);
+
+        byte[] content;
+        String contentType;
+        String extension;
+
+        switch (normalizedExportFormat) {
+        case "PDF":
+            content = buildPdf(table);
+            contentType = "application/pdf";
+            extension = "pdf";
+            break;
+        case "EXCEL":
+            content = buildWorkbook(table);
+            contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+            extension = "xlsx";
+            break;
+        case "CSV":
+            content = buildCsv(table).getBytes(StandardCharsets.UTF_8);
+            contentType = "text/csv";
+            extension = "csv";
+            break;
+        default:
+            throw new IllegalArgumentException("Unsupported export format: " + exportFormat);
+        }
+
+        String fileName = String.format("inventory_%s_%s.%s", normalizedReportType.toLowerCase(Locale.ROOT),
+                LocalDate.now().format(FILE_DATE_FORMAT), extension);
+        return new GeneratedReport(content, contentType, fileName);
+    }
+
+    private ReportTable buildTable(String reportType, String startDate, String endDate, boolean includeInactive,
+            boolean includeExpired, boolean groupByType, boolean groupByLocation) {
+        switch (reportType) {
+        case "STOCK_LEVELS":
+            return buildStockLevelsTable(includeInactive, includeExpired, groupByType, groupByLocation, false);
+        case "LOW_STOCK":
+            return buildStockLevelsTable(includeInactive, includeExpired, groupByType, groupByLocation, true);
+        case "EXPIRATION_FORECAST":
+            return buildExpirationForecastTable(includeInactive, includeExpired, groupByType, groupByLocation);
+        case "TRANSACTION_HISTORY":
+            return buildTransactionHistoryTable(includeInactive, startDate, endDate);
+        case "USAGE_TRENDS":
+            return buildUsageTrendsTable(includeInactive, startDate, endDate, groupByType, groupByLocation);
+        case "LOT_TRACEABILITY":
+            return buildLotTraceabilityTable(includeInactive, includeExpired, groupByType, groupByLocation);
+        default:
+            throw new IllegalArgumentException("Unsupported report type: " + reportType);
+        }
+    }
+
+    private ReportTable buildStockLevelsTable(boolean includeInactive, boolean includeExpired, boolean groupByType,
+            boolean groupByLocation, boolean lowStockOnly) {
+        List<InventoryItem> items = includeInactive ? inventoryItemService.getAll() : inventoryItemService.getAllActive();
+        List<InventoryLot> lots = filterLots(loadLots(), includeInactive, includeExpired);
+        Map<Long, List<InventoryLot>> lotsByItem = lots.stream()
+                .filter(lot -> lot.getInventoryItem() != null && lot.getInventoryItem().getId() != null)
+                .collect(Collectors.groupingBy(lot -> lot.getInventoryItem().getId(), LinkedHashMap::new,
+                        Collectors.toList()));
+
+        List<List<String>> rows = new ArrayList<>();
+        for (InventoryItem item : items) {
+            List<InventoryLot> itemLots = lotsByItem.getOrDefault(item.getId(), List.of());
+            double totalQuantity = itemLots.stream().map(InventoryLot::getCurrentQuantity).filter(Objects::nonNull)
+                    .mapToDouble(Double::doubleValue).sum();
+            int activeLots = (int) itemLots.stream().filter(lot -> lot.getCurrentQuantity() != null
+                    && lot.getCurrentQuantity() > 0 && !"DISPOSED".equals(String.valueOf(lot.getStatus()))).count();
+            int threshold = item.getLowStockThreshold() != null ? item.getLowStockThreshold() : 0;
+            String stockStatus = stockStatus(totalQuantity, threshold);
+
+            if (lowStockOnly && "In Stock".equals(stockStatus)) {
+                continue;
+            }
+
+            LinkedHashSet<String> locations = itemLots.stream().map(this::displayLocation).collect(Collectors.toCollection(LinkedHashSet::new));
+            rows.add(List.of(
+                    safe(item.getName()),
+                    safe(String.valueOf(item.getItemType())),
+                    formatQuantity(totalQuantity),
+                    safe(item.getUnits()),
+                    String.valueOf(threshold),
+                    stockStatus,
+                    String.valueOf(activeLots),
+                    String.join("; ", locations)));
+        }
+
+        sortRows(rows, groupByType ? 1 : null, groupByLocation ? 7 : null, 0);
+        return new ReportTable(lowStockOnly ? "Low Stock Report" : "Stock Levels Report",
+                List.of("Item Name", "Item Type", "Total Quantity", "Units", "Low Stock Threshold", "Status",
+                        "Active Lots", "Storage Locations"),
+                rows);
+    }
+
+    private ReportTable buildExpirationForecastTable(boolean includeInactive, boolean includeExpired, boolean groupByType,
+            boolean groupByLocation) {
+        List<List<String>> rows = filterLots(loadLots(), includeInactive, includeExpired).stream()
+                .filter(lot -> lot.getEffectiveExpirationDate() != null)
+                .sorted(Comparator.comparing(InventoryLot::getEffectiveExpirationDate))
+                .map(lot -> {
+                    LocalDate expirationDate = toLocalDate(lot.getEffectiveExpirationDate());
+                    long daysRemaining = ChronoUnit.DAYS.between(LocalDate.now(), expirationDate);
+                    return List.of(
+                            safe(itemName(lot)),
+                            safe(String.valueOf(lot.getInventoryItem().getItemType())),
+                            safe(lot.getLotNumber()),
+                            formatQuantity(lot.getCurrentQuantity()),
+                            safe(lot.getInventoryItem().getUnits()),
+                            safe(expirationDate.format(DISPLAY_DATE_FORMAT)),
+                            String.valueOf(daysRemaining),
+                            safe(String.valueOf(lot.getQcStatus())),
+                            safe(String.valueOf(lot.getStatus())),
+                            displayLocation(lot));
+                })
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        sortRows(rows, groupByType ? 1 : null, groupByLocation ? 9 : null, 5);
+        return new ReportTable("Expiration Forecast Report",
+                List.of("Item Name", "Item Type", "Lot Number", "Current Quantity", "Units", "Effective Expiry",
+                        "Days Remaining", "QC Status", "Lot Status", "Storage Location"),
+                rows);
+    }
+
+    private ReportTable buildTransactionHistoryTable(boolean includeInactive, String startDate, String endDate) {
+        DateRange range = requireDateRange(startDate, endDate, "Transaction history report");
+        List<List<String>> rows = inventoryTransactionService.getByDateRange(range.start(), range.end()).stream()
+                .filter(tx -> includeInactive || isActiveItem(tx.getLot()))
+                .sorted(Comparator.comparing(InventoryTransaction::getTransactionDate).reversed())
+                .map(tx -> List.of(
+                        safe(itemName(tx.getLot())),
+                        safe(lotNumber(tx)),
+                        safe(String.valueOf(tx.getTransactionType())),
+                        formatQuantity(tx.getQuantityChange()),
+                        formatQuantity(tx.getQuantityAfter()),
+                        safe(toLocalDateTime(tx.getTransactionDate()).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))),
+                        safe(String.valueOf(tx.getReferenceType())),
+                        safe(tx.getNotes()),
+                        displayLocation(tx.getLot())))
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        return new ReportTable("Transaction History Report",
+                List.of("Item Name", "Lot Number", "Transaction Type", "Quantity Change", "Quantity After",
+                        "Transaction Date", "Reference Type", "Notes", "Storage Location"),
+                rows);
+    }
+
+    private ReportTable buildUsageTrendsTable(boolean includeInactive, String startDate, String endDate,
+            boolean groupByType, boolean groupByLocation) {
+        DateRange range = requireDateRange(startDate, endDate, "Usage trends report");
+        Map<String, UsageAggregate> aggregates = new LinkedHashMap<>();
+
+        for (InventoryTransaction tx : inventoryTransactionService.getByDateRange(range.start(), range.end())) {
+            if (!"CONSUMPTION".equals(String.valueOf(tx.getTransactionType())) || tx.getLot() == null) {
+                continue;
+            }
+            if (!includeInactive && !isActiveItem(tx.getLot())) {
+                continue;
+            }
+
+            String itemType = safe(String.valueOf(tx.getLot().getInventoryItem().getItemType()));
+            String location = displayLocation(tx.getLot());
+            String key = itemName(tx.getLot()) + "|" + (groupByType ? itemType : "") + "|" + (groupByLocation ? location : "");
+            UsageAggregate aggregate = aggregates.computeIfAbsent(key,
+                    ignored -> new UsageAggregate(itemName(tx.getLot()), itemType, safe(tx.getLot().getInventoryItem().getUnits()), location));
+            aggregate.events++;
+            aggregate.totalConsumed += Math.abs(tx.getQuantityChange() != null ? tx.getQuantityChange() : 0.0);
+            LocalDateTime txDate = toLocalDateTime(tx.getTransactionDate());
+            if (aggregate.firstUsage == null || txDate.isBefore(aggregate.firstUsage)) {
+                aggregate.firstUsage = txDate;
+            }
+            if (aggregate.lastUsage == null || txDate.isAfter(aggregate.lastUsage)) {
+                aggregate.lastUsage = txDate;
+            }
+        }
+
+        List<List<String>> rows = aggregates.values().stream()
+                .map(aggregate -> List.of(
+                        safe(aggregate.itemName),
+                        safe(aggregate.itemType),
+                        safe(aggregate.units),
+                        String.valueOf(aggregate.events),
+                        formatQuantity(aggregate.totalConsumed),
+                        aggregate.firstUsage != null ? aggregate.firstUsage.toLocalDate().format(DISPLAY_DATE_FORMAT) : "",
+                        aggregate.lastUsage != null ? aggregate.lastUsage.toLocalDate().format(DISPLAY_DATE_FORMAT) : "",
+                        safe(aggregate.location)))
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        sortRows(rows, groupByType ? 1 : null, groupByLocation ? 7 : null, 0);
+        return new ReportTable("Usage Trends Report",
+                List.of("Item Name", "Item Type", "Units", "Consumption Events", "Total Consumed", "First Usage",
+                        "Last Usage", "Storage Location"),
+                rows);
+    }
+
+    private ReportTable buildLotTraceabilityTable(boolean includeInactive, boolean includeExpired, boolean groupByType,
+            boolean groupByLocation) {
+        List<List<String>> rows = new ArrayList<>();
+        for (InventoryLot lot : filterLots(loadLots(), includeInactive, includeExpired)) {
+            List<InventoryTransaction> transactions = inventoryTransactionService.getByLotId(lot.getId());
+            InventoryTransaction latest = transactions.stream()
+                    .max(Comparator.comparing(InventoryTransaction::getTransactionDate))
+                    .orElse(null);
+            rows.add(List.of(
+                    safe(itemName(lot)),
+                    safe(String.valueOf(lot.getInventoryItem().getItemType())),
+                    safe(lot.getLotNumber()),
+                    safe(lot.getBarcode()),
+                    lot.getReceiptDate() != null ? toLocalDate(lot.getReceiptDate()).format(DISPLAY_DATE_FORMAT) : "",
+                    formatQuantity(lot.getCurrentQuantity()),
+                    safe(String.valueOf(lot.getQcStatus())),
+                    safe(String.valueOf(lot.getStatus())),
+                    displayLocation(lot),
+                    latest != null ? safe(String.valueOf(latest.getTransactionType())) : "",
+                    latest != null ? safe(toLocalDateTime(latest.getTransactionDate()).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))) : "",
+                    latest != null ? safe(latest.getNotes()) : ""));
+        }
+
+        sortRows(rows, groupByType ? 1 : null, groupByLocation ? 8 : null, 0);
+        return new ReportTable("Lot Traceability Report",
+                List.of("Item Name", "Item Type", "Lot Number", "Barcode", "Receipt Date", "Current Quantity",
+                        "QC Status", "Lot Status", "Storage Location", "Latest Transaction", "Latest Transaction Date",
+                        "Latest Notes"),
+                rows);
+    }
+
+    private List<InventoryLot> loadLots() {
+        List<InventoryLot> lots = inventoryLotService.getAll();
+        lots.forEach(lot -> {
+            if (lot.getInventoryItem() != null) {
+                lot.getInventoryItem().getName();
+            }
+        });
+        return lots;
+    }
+
+    private List<InventoryLot> filterLots(List<InventoryLot> lots, boolean includeInactive, boolean includeExpired) {
+        return lots.stream()
+                .filter(lot -> lot.getInventoryItem() != null)
+                .filter(lot -> includeInactive || lot.getInventoryItem().isActive())
+                .filter(lot -> includeExpired || !lot.isExpired())
+                .collect(Collectors.toList());
+    }
+
+    private String buildCsv(ReportTable table) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('\uFEFF');
+        sb.append(csvLine(table.headers));
+        for (List<String> row : table.rows) {
+            sb.append(csvLine(row));
+        }
+        return sb.toString();
+    }
+
+    private byte[] buildWorkbook(ReportTable table) {
+        try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("Report");
+
+            org.apache.poi.ss.usermodel.Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerFont.setUnderline(org.apache.poi.ss.usermodel.Font.U_SINGLE);
+            CellStyle headerStyle = workbook.createCellStyle();
+            headerStyle.setFont(headerFont);
+
+            Row titleRow = sheet.createRow(0);
+            Cell titleCell = titleRow.createCell(0);
+            titleCell.setCellValue(table.title);
+
+            Row headerRow = sheet.createRow(2);
+            for (int i = 0; i < table.headers.size(); i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(table.headers.get(i));
+                cell.setCellStyle(headerStyle);
+            }
+
+            int rowIndex = 3;
+            for (List<String> row : table.rows) {
+                Row excelRow = sheet.createRow(rowIndex++);
+                for (int i = 0; i < row.size(); i++) {
+                    excelRow.createCell(i).setCellValue(row.get(i));
+                }
+            }
+
+            for (int i = 0; i < table.headers.size(); i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(output);
+            return output.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate Excel report", e);
+        }
+    }
+
+    private byte[] buildPdf(ReportTable table) {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            Document document = new Document(table.headers.size() > 7 ? PageSize.A4.rotate() : PageSize.A4, 24, 24, 24, 24);
+            PdfWriter.getInstance(document, output);
+            document.open();
+
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14);
+            Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 9);
+            Font cellFont = FontFactory.getFont(FontFactory.HELVETICA, 8);
+
+            Paragraph title = new Paragraph(table.title, titleFont);
+            title.setAlignment(Element.ALIGN_CENTER);
+            title.setSpacingAfter(12f);
+            document.add(title);
+
+            PdfPTable pdfTable = new PdfPTable(table.headers.size());
+            pdfTable.setWidthPercentage(100f);
+            pdfTable.setSpacingBefore(8f);
+
+            for (String header : table.headers) {
+                PdfPCell cell = new PdfPCell(new Phrase(header, headerFont));
+                cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+                cell.setPadding(4f);
+                pdfTable.addCell(cell);
+            }
+
+            for (List<String> row : table.rows) {
+                for (String value : row) {
+                    PdfPCell cell = new PdfPCell(new Phrase(value, cellFont));
+                    cell.setPadding(3f);
+                    pdfTable.addCell(cell);
+                }
+            }
+
+            document.add(pdfTable);
+            document.close();
+            return output.toByteArray();
+        } catch (DocumentException | java.io.IOException e) {
+            throw new IllegalStateException("Failed to generate PDF report", e);
+        }
+    }
+
+    private String csvLine(List<String> values) {
+        return values.stream().map(this::escapeCsv).collect(Collectors.joining(",")) + "\n";
+    }
+
+    private String escapeCsv(String value) {
+        String safeValue = safe(value);
+        return "\"" + safeValue.replace("\"", "\"\"") + "\"";
+    }
+
+    private void sortRows(List<List<String>> rows, Integer primaryIndex, Integer secondaryIndex, Integer fallbackIndex) {
+        List<Integer> order = new ArrayList<>();
+        if (primaryIndex != null) {
+            order.add(primaryIndex);
+        }
+        if (secondaryIndex != null && !order.contains(secondaryIndex)) {
+            order.add(secondaryIndex);
+        }
+        if (fallbackIndex != null && !order.contains(fallbackIndex)) {
+            order.add(fallbackIndex);
+        }
+        if (order.isEmpty()) {
+            return;
+        }
+
+        rows.sort((left, right) -> {
+            for (Integer index : order) {
+                int result = safe(left.get(index)).compareToIgnoreCase(safe(right.get(index)));
+                if (result != 0) {
+                    return result;
+                }
+            }
+            return 0;
+        });
+    }
+
+    private DateRange requireDateRange(String startDate, String endDate, String reportName) {
+        if (isBlank(startDate) || isBlank(endDate)) {
+            throw new IllegalArgumentException(reportName + " requires startDate and endDate");
+        }
+
+        LocalDate start = parseDate(startDate, "startDate");
+        LocalDate end = parseDate(endDate, "endDate");
+        if (end.isBefore(start)) {
+            throw new IllegalArgumentException("endDate cannot be earlier than startDate");
+        }
+
+        return new DateRange(Timestamp.valueOf(start.atStartOfDay()),
+                Timestamp.valueOf(end.plusDays(1).atStartOfDay().minusNanos(1)));
+    }
+
+    private LocalDate parseDate(String rawValue, String fieldName) {
+        for (DateTimeFormatter formatter : INPUT_DATE_FORMATS) {
+            try {
+                return LocalDate.parse(rawValue, formatter);
+            } catch (DateTimeParseException ignored) {
+                // try next format
+            }
+        }
+        throw new IllegalArgumentException("Invalid " + fieldName + " format: " + rawValue);
+    }
+
+    private String normalizeRequired(String value, String fieldName) {
+        if (isBlank(value)) {
+            throw new IllegalArgumentException(fieldName + " is required");
+        }
+        return value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private boolean isActiveItem(InventoryLot lot) {
+        return lot != null && lot.getInventoryItem() != null && lot.getInventoryItem().isActive();
+    }
+
+    private String itemName(InventoryLot lot) {
+        return lot != null && lot.getInventoryItem() != null ? safe(lot.getInventoryItem().getName()) : "";
+    }
+
+    private String lotNumber(InventoryTransaction tx) {
+        return tx.getLot() != null ? safe(tx.getLot().getLotNumber()) : "";
+    }
+
+    private String displayLocation(InventoryLot lot) {
+        if (!isBlank(lot.getStoragePath())) {
+            return lot.getStoragePath();
+        }
+        if (!isBlank(lot.getSpecificStorageLocation())) {
+            return lot.getSpecificStorageLocation();
+        }
+        if (!isBlank(lot.getLocationType())) {
+            return lot.getLocationType() + (lot.getLocationId() != null ? (" #" + lot.getLocationId()) : "");
+        }
+        return "Unassigned";
+    }
+
+    private LocalDate toLocalDate(Timestamp timestamp) {
+        return timestamp.toLocalDateTime().toLocalDate();
+    }
+
+    private LocalDateTime toLocalDateTime(Timestamp timestamp) {
+        return timestamp.toLocalDateTime();
+    }
+
+    private String stockStatus(double totalQuantity, int threshold) {
+        if (totalQuantity <= 0) {
+            return "Out of Stock";
+        }
+        if (threshold > 0 && totalQuantity <= threshold) {
+            return "Low Stock";
+        }
+        return "In Stock";
+    }
+
+    private String formatQuantity(Double value) {
+        return value == null ? "" : QUANTITY_FORMAT.format(value);
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static class ReportTable {
+        private final String title;
+        private final List<String> headers;
+        private final List<List<String>> rows;
+
+        private ReportTable(String title, List<String> headers, List<List<String>> rows) {
+            this.title = title;
+            this.headers = headers;
+            this.rows = rows;
+        }
+    }
+
+    private static class UsageAggregate {
+        private final String itemName;
+        private final String itemType;
+        private final String units;
+        private final String location;
+        private int events;
+        private double totalConsumed;
+        private LocalDateTime firstUsage;
+        private LocalDateTime lastUsage;
+
+        private UsageAggregate(String itemName, String itemType, String units, String location) {
+            this.itemName = itemName;
+            this.itemType = itemType;
+            this.units = units;
+            this.location = location;
+        }
+    }
+
+    private record DateRange(Timestamp start, Timestamp end) {
+    }
+}

--- a/src/main/java/org/openelisglobal/storage/service/StorageBoxConfigurationHandler.java
+++ b/src/main/java/org/openelisglobal/storage/service/StorageBoxConfigurationHandler.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
  * label,type,rows,columns,positionSchemaHint,code,active,parentRackCode Plate
  * ULF1-S1-R1-001,96-well,8,12,letter-number,P001,true,R1 Box
  * ULF1-S2-R1-001,9x9,9,9,number-number,B001,true,R1 Archive
- * 2024-001,10x10,10,10,number-number,A2024-001,true,AR1
+ * 2024-001,10x10,10,10,continuous,A2024-001,true,AR1
  */
 @Component
 @Transactional

--- a/src/main/resources/liquibase/3.5.x.x/030-fix-biorepository-approved-sample-type-lastupdated.xml
+++ b/src/main/resources/liquibase/3.5.x.x/030-fix-biorepository-approved-sample-type-lastupdated.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="fix-biorepository-approved-sample-type-lastupdated-column" author="openelis-biorepository">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="biorepository_approved_sample_type" schemaName="clinlims"/>
+            <columnExists tableName="biorepository_approved_sample_type" schemaName="clinlims" columnName="lastupdated"/>
+            <not>
+                <columnExists tableName="biorepository_approved_sample_type" schemaName="clinlims" columnName="last_updated"/>
+            </not>
+        </preConditions>
+        <comment>Rename biorepository_approved_sample_type.lastupdated to last_updated to match BaseObject</comment>
+
+        <renameColumn
+            schemaName="clinlims"
+            tableName="biorepository_approved_sample_type"
+            oldColumnName="lastupdated"
+            newColumnName="last_updated"
+            columnDataType="TIMESTAMP"/>
+
+        <rollback>
+            <renameColumn
+                schemaName="clinlims"
+                tableName="biorepository_approved_sample_type"
+                oldColumnName="last_updated"
+                newColumnName="lastupdated"
+                columnDataType="TIMESTAMP"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -86,5 +86,6 @@
     <!-- ======================================================== -->
 
     <include file="liquibase/3.5.x.x/029-electronic-signature.xml"/>
+    <include file="liquibase/3.5.x.x/030-fix-biorepository-approved-sample-type-lastupdated.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/inventory/service/InventoryReportServiceImplTest.java
+++ b/src/test/java/org/openelisglobal/inventory/service/InventoryReportServiceImplTest.java
@@ -1,0 +1,97 @@
+package org.openelisglobal.inventory.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.inventory.service.InventoryReportService.GeneratedReport;
+import org.openelisglobal.inventory.valueholder.InventoryEnums.ItemType;
+import org.openelisglobal.inventory.valueholder.InventoryEnums.LotStatus;
+import org.openelisglobal.inventory.valueholder.InventoryEnums.QCStatus;
+import org.openelisglobal.inventory.valueholder.InventoryItem;
+import org.openelisglobal.inventory.valueholder.InventoryLot;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InventoryReportServiceImplTest {
+
+    @Mock
+    private InventoryItemService inventoryItemService;
+
+    @Mock
+    private InventoryLotService inventoryLotService;
+
+    @Mock
+    private InventoryTransactionService inventoryTransactionService;
+
+    @InjectMocks
+    private InventoryReportServiceImpl inventoryReportService;
+
+    @Test
+    public void generateReport_shouldBuildCsvStockLevelsReport_whenRequestIsValid() {
+        InventoryItem item = new InventoryItem();
+        item.setId(1L);
+        item.setFhirUuid(UUID.randomUUID());
+        item.setName("Test Reagent");
+        item.setItemType(ItemType.REAGENT);
+        item.setUnits("mL");
+        item.setLowStockThreshold(5);
+        item.setIsActive("Y");
+
+        InventoryLot lot = new InventoryLot();
+        lot.setId(10L);
+        lot.setFhirUuid(UUID.randomUUID());
+        lot.setInventoryItem(item);
+        lot.setLotNumber("LOT-001");
+        lot.setInitialQuantity(10.0);
+        lot.setCurrentQuantity(10.0);
+        lot.setQcStatus(QCStatus.PASSED);
+        lot.setStatus(LotStatus.ACTIVE);
+        lot.setStoragePath("Freezer 1 / Shelf A");
+
+        when(inventoryItemService.getAllActive()).thenReturn(List.of(item));
+        when(inventoryLotService.getAll()).thenReturn(List.of(lot));
+
+        GeneratedReport report = inventoryReportService.generateReport("stock_levels", "csv", null, null, false,
+                false, false, false);
+
+        assertEquals("text/csv", report.getContentType());
+        assertTrue(report.getFileName().matches("inventory_stock_levels_\\d{8}\\.csv"));
+
+        String csv = new String(report.getContent(), StandardCharsets.UTF_8);
+        assertTrue(csv.startsWith("\uFEFF"));
+        assertTrue(csv.contains("\"Item Name\""));
+        assertTrue(csv.contains("\"Test Reagent\""));
+        assertTrue(csv.contains("\"In Stock\""));
+        assertTrue(csv.contains("\"Freezer 1 / Shelf A\""));
+    }
+
+    @Test
+    public void generateReport_shouldRejectUnsupportedExportFormat() {
+        try {
+            inventoryReportService.generateReport("stock_levels", "json", null, null, false, false, false, false);
+            fail("Expected IllegalArgumentException for unsupported export format");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Unsupported export format: json", e.getMessage());
+        }
+    }
+
+    @Test
+    public void generateReport_shouldRequireDatesForTransactionHistory() {
+        try {
+            inventoryReportService.generateReport("transaction_history", "csv", null, null, false, false, false,
+                    false);
+            fail("Expected IllegalArgumentException when transaction history dates are missing");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Transaction history report requires startDate and endDate", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR includes 3 AHRI fixes:

1. Inventory report generation/export fix
2. Biorepository manifest sample type fix
   - accepts broader AHRI specimen types
   - creates new valid sample types with warnings
   - keeps duplicate barcode protection
3. Continuous box numbering for biorepository storage
   - numeric boxes now show 1, 2, 3... instead of 1-1, 1-2...

## Validation
- Tested locally on the Docker dev stack
- Verified inventory report generation works
- Verified biorepository manifest validation/import accepts DNA, RNA, and other new sample types
- Verified duplicate barcodes are still blocked
- Verified numeric storage boxes render continuous numbering
