### PR TITLE
test(AnalyzerQueryService): add @Before fixture and document intentional not-found IDs (fixes #3169)

### DIFF
--- a/src/test/java/org/openelisglobal/analyzer/service/AnalyzerQueryServiceIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/service/AnalyzerQueryServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openelisglobal.BaseWebContextSensitiveTest;
@@ -13,15 +14,30 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
- * Integration tests for AnalyzerQueryService query workflow
- * 
- * 
- * These tests verify: - Query analyzer workflow with full Spring context -
- * Timeout handling for long-running queries - ASTM response parsing and field
- * extraction
- * 
- * Uses BaseWebContextSensitiveTest for full Spring context and database
- * integration.
+ * Integration tests for {@link AnalyzerQueryService} query workflow.
+ *
+ * <p>
+ * These tests verify the complete query lifecycle including timeout handling,
+ * ASTM response parsing, and graceful error recovery.
+ *
+ * <p>
+ * <strong>Fixture strategy — intentionally absent analyzer rows:</strong>
+ * Analyzer IDs {@code 999901}, {@code 999902}, and {@code 999903} are
+ * deliberately not present in the test dataset. When {@code startQuery()} is
+ * called with an unknown ID, {@code AnalyzerQueryServiceImpl.executeQuery()}
+ * encounters an {@code ObjectNotFoundException} internally and converts it into
+ * a {@code "failed"} job state. These tests validate that the service handles
+ * the not-found path gracefully — returning a valid job ID, a queryable status
+ * map, and a terminal state — without propagating the exception to the caller.
+ *
+ * <p>
+ * If real analyzer connectivity needs to be tested, insert rows with valid
+ * {@code ip_address} and {@code port} values into the dataset and update the
+ * IDs accordingly.
+ *
+ * <p>
+ * Uses {@link BaseWebContextSensitiveTest} for full Spring context and database
+ * integration. Dataset: {@code testdata/analyzer-query-service.xml}.
  */
 @RunWith(SpringRunner.class)
 public class AnalyzerQueryServiceIntegrationTest extends BaseWebContextSensitiveTest {
@@ -29,54 +45,46 @@ public class AnalyzerQueryServiceIntegrationTest extends BaseWebContextSensitive
     @Autowired
     private AnalyzerQueryService analyzerQueryService;
 
+    @Before
+    public void setUp() throws Exception {
+        // Loads minimal system_user fixture required by the Spring context.
+        // No analyzer rows are inserted — see class-level Javadoc for rationale.
+        executeDataSetWithStateManagement("testdata/analyzer-query-service.xml");
+    }
+
     @Test
-    public void testQueryAnalyzer_WithTimeout_HandlesGracefully() {
-        // Arrange
-        // Use a numeric ID that won't exist in the test DB — startQuery() calls
-        // analyzerService.get() which expects a numeric primary key.
+    public void testQueryAnalyzer_WithNonExistentId_HandlesGracefully() {
+        // Analyzer ID 999901 is intentionally absent from the dataset.
+        // startQuery() should return a valid job ID and the status should
+        // reflect a graceful failure rather than propagating an exception.
         String analyzerId = "999901";
 
-        // Act - Start query (full implementation executes asynchronously)
         String jobId = analyzerQueryService.startQuery(analyzerId);
 
-        // Assert - Verify job was created
-        assertNotNull("Job ID should not be null", jobId);
+        assertNotNull("Job ID should not be null even for a non-existent analyzer", jobId);
 
-        // Get status to verify job exists
         Map<String, Object> status = analyzerQueryService.getStatus(analyzerId, jobId);
         assertNotNull("Status should not be null", status);
         assertEquals("Analyzer ID should match", analyzerId, status.get("analyzerId"));
         assertEquals("Job ID should match", jobId, status.get("jobId"));
 
-        // Verify initial state is "pending" (full implementation starts async)
         String initialState = (String) status.get("state");
         assertTrue("Initial state should be pending or in_progress",
                 "pending".equals(initialState) || "in_progress".equals(initialState));
-
-        // Note: Full implementation now executes asynchronously. This test verifies:
-        // - Query starts with "pending" or "in_progress" state
-        // - Status can be polled while running
-        // - For timeout testing, configure analyzer with unreachable IP/port
-        // - Timeout should occur after configured timeout period
-        // - Status should transition to "failed" state with error message
     }
 
     @Test
-    public void testParseASTMResponse_ExtractsFields() throws InterruptedException {
-        // Arrange
-        // Note: This test requires a configured analyzer with valid IP:Port pointing to
-        // mock server
-        // Use a numeric ID that won't exist in the test DB — startQuery() calls
-        // analyzerService.get() which expects a numeric primary key.
+    public void testParseASTMResponse_WithNonExistentId_CompletesWithoutException() throws InterruptedException {
+        // Analyzer ID 999902 is intentionally absent from the dataset.
+        // The query should proceed asynchronously and reach a terminal state
+        // (completed or failed) without throwing an unhandled exception.
         String analyzerId = "999902";
 
-        // Act - Start query (full implementation executes ASTM protocol)
         String jobId = analyzerQueryService.startQuery(analyzerId);
         assertNotNull("Job ID should not be null", jobId);
 
-        // Wait for query to complete (poll status)
         Map<String, Object> status = null;
-        int maxWait = 30; // seconds
+        int maxWait = 30;
         int waited = 0;
         while (waited < maxWait) {
             Thread.sleep(1000);
@@ -88,76 +96,59 @@ public class AnalyzerQueryServiceIntegrationTest extends BaseWebContextSensitive
             waited++;
         }
 
-        // Assert - Verify job completed
-        assertNotNull("Status should not be null", status);
+        assertNotNull("Status should not be null after polling", status);
         String finalState = (String) status.get("state");
 
         if ("completed".equals(finalState)) {
-            // Verify fields list exists and contains data
             Object fieldsObj = status.get("fields");
-            assertNotNull("Fields should be present in status", fieldsObj);
+            assertNotNull("Fields should be present when state is completed", fieldsObj);
             assertTrue("Fields should be a list", fieldsObj instanceof List);
 
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> fields = (List<Map<String, Object>>) fieldsObj;
-            // With mock server, we should get fields from fields.json
-            // Verify at least one field was extracted
-            assertTrue("Should extract at least one field from ASTM response", fields.size() > 0);
+            assertTrue("Should extract at least one field", fields.size() > 0);
 
-            // Verify field structure
             Map<String, Object> firstField = fields.get(0);
             assertNotNull("Field should have fieldName", firstField.get("fieldName"));
             assertNotNull("Field should have fieldType", firstField.get("fieldType"));
         } else {
-            // If failed, log the error for debugging
-            String error = (String) status.get("error");
-            System.out.println("Query failed with error: " + error);
-            // This is acceptable if analyzer is not configured or mock server is down
-            // Test still verifies the query workflow executes
+            // "failed" is the expected terminal state when the analyzer ID does
+            // not exist — the service converts the ObjectNotFoundException into
+            // this state rather than propagating it.
+            assertEquals("Non-existent analyzer should reach failed state", "failed", finalState);
         }
-
-        // Full implementation now verifies:
-        // - ASTM response is parsed correctly
-        // - Fields are extracted from R (Result) records
-        // - Field types are correctly identified (NUMERIC, QUALITATIVE, etc.)
-        // - Field names, units, and codes are extracted
-        // - Fields are stored in AnalyzerField entities (verified via database query)
     }
 
     @Test
-    public void testQueryWorkflow_CompleteLifecycle() throws Exception {
-        // Arrange
-        // Use a numeric ID that won't exist in the test DB — startQuery() calls
-        // analyzerService.get() which expects a numeric primary key.
+    public void testQueryWorkflow_WithNonExistentId_ReachesTerminalState() throws Exception {
+        // Analyzer ID 999903 is intentionally absent from the dataset.
+        // Verifies the full job lifecycle: start → poll → terminal state → cancel.
         String analyzerId = "999903";
 
-        // Act - Start query
         String jobId = analyzerQueryService.startQuery(analyzerId);
         assertNotNull("Job ID should not be null", jobId);
 
-        // Poll status until completed (with timeout)
         Map<String, Object> status = null;
-        int maxAttempts = 30; // 30 seconds max
+        int maxAttempts = 30;
         for (int i = 0; i < maxAttempts; i++) {
             status = analyzerQueryService.getStatus(analyzerId, jobId);
-            assertNotNull("Status should not be null", status);
+            assertNotNull("Status should not be null on each poll", status);
             String state = (String) status.get("state");
             if ("completed".equals(state) || "failed".equals(state) || "cancelled".equals(state)) {
                 break;
             }
-            Thread.sleep(1000); // Wait 1 second between polls
+            Thread.sleep(1000);
         }
 
-        // Verify final state is completed or failed (either is acceptable)
         String finalState = (String) status.get("state");
-        assertTrue("State should be completed, failed, or cancelled",
+        assertTrue("State should reach a terminal value (completed, failed, or cancelled)",
                 "completed".equals(finalState) || "failed".equals(finalState) || "cancelled".equals(finalState));
 
-        // Cancel query (should handle gracefully even if already completed)
+        // Cancel should be handled gracefully even if job already reached terminal
+        // state
         analyzerQueryService.cancel(analyzerId, jobId);
 
-        // Verify status is still retrievable after cancel
         Map<String, Object> finalStatus = analyzerQueryService.getStatus(analyzerId, jobId);
-        assertNotNull("Status should still be retrievable", finalStatus);
+        assertNotNull("Status should remain retrievable after cancel", finalStatus);
     }
 }

--- a/src/test/resources/testdata/analyzer-query-service.xml
+++ b/src/test/resources/testdata/analyzer-query-service.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Minimal fixture for AnalyzerQueryServiceIntegrationTest. No analyzer
+    rows are present — this is intentional. The tests validate that AnalyzerQueryServiceImpl
+    handles non-existent analyzer IDs gracefully by converting the internal ObjectNotFoundException
+    into a "failed" job state rather than propagating the exception to the caller.
+    See AnalyzerQueryServiceIntegrationTest class-level Javadoc for full details. -->
+<dataset>
+    <system_user id="1" login_name="testUser" last_name="Doe"
+        first_name="John" is_active="Y" is_employee="Y" />
+</dataset>


### PR DESCRIPTION
Fixes #3169

## What changed
- Added `@Before` with `executeDataSetWithStateManagement()` following 
  the project's established test pattern
- Created `testdata/analyzer-query-service.xml` — minimal dataset with 
  no analyzer rows (intentional — see below)
- Added class-level Javadoc documenting that IDs `999901`–`999903` are 
  deliberately absent: the tests validate graceful handling of the 
  not-found path inside `AnalyzerQueryServiceImpl.executeQuery()`, not 
  happy-path behavior
- Renamed test methods to reflect the not-found scenario being tested

## Why no analyzer rows?
The service converts `ObjectNotFoundException` into a `"failed"` job 
state internally. These tests verify that graceful degradation works 
end-to-end. The absent IDs are the test input, not missing setup.

## Files changed
- `AnalyzerQueryServiceIntegrationTest.java`
- `testdata/analyzer-query-service.xml`