### PR TITLE
Refactor LabelManagementRestController: replace DAO dependencies with StorageLocationService

### DIFF
--- a/src/main/java/org/openelisglobal/storage/controller/LabelManagementRestController.java
+++ b/src/main/java/org/openelisglobal/storage/controller/LabelManagementRestController.java
@@ -6,10 +6,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.common.rest.BaseRestController;
-import org.openelisglobal.storage.dao.StorageDeviceDAO;
-import org.openelisglobal.storage.dao.StorageRackDAO;
-import org.openelisglobal.storage.dao.StorageShelfDAO;
 import org.openelisglobal.storage.service.LabelManagementService;
+import org.openelisglobal.storage.service.StorageLocationService;
 import org.openelisglobal.storage.valueholder.StorageDevice;
 import org.openelisglobal.storage.valueholder.StorageRack;
 import org.openelisglobal.storage.valueholder.StorageShelf;
@@ -29,19 +27,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/rest/storage")
 public class LabelManagementRestController extends BaseRestController {
 
+    @Autowired
+    private StorageLocationService storageLocationService;
+
     private static final Logger logger = LoggerFactory.getLogger(LabelManagementRestController.class);
 
     @Autowired
     private LabelManagementService labelManagementService;
-
-    @Autowired
-    private StorageDeviceDAO storageDeviceDAO;
-
-    @Autowired
-    private StorageShelfDAO storageShelfDAO;
-
-    @Autowired
-    private StorageRackDAO storageRackDAO;
 
     /**
      * Generate and return PDF label POST /rest/storage/{type}/{id}/print-label
@@ -169,11 +161,11 @@ public class LabelManagementRestController extends BaseRestController {
             Integer locationId = Integer.parseInt(id);
             switch (type) {
             case "device":
-                return storageDeviceDAO.get(locationId).orElse(null);
+                return storageLocationService.get(locationId, StorageDevice.class);
             case "shelf":
-                return storageShelfDAO.get(locationId).orElse(null);
+                return storageLocationService.get(locationId, StorageShelf.class);
             case "rack":
-                return storageRackDAO.get(locationId).orElse(null);
+                return storageLocationService.get(locationId, StorageRack.class);
             default:
                 return null;
             }


### PR DESCRIPTION
# Pull Requests Requirements
- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Removed direct dependency injections on "StorageDeviceDAO", "StorageShelfDAO" and "StorageRackDAO" from "LabelManagementRestController". Replaced with "StorageLocationService", which already exposes a generic "get(Integer id, Class<?> entityClass)" method implemented in "StorageLocationServiceImpl".

## Related Issue
https://github.com/DIGI-UW/OpenELIS-Global-2/issues/3158

## Other
Controller now complies with the 5-layer architecture principle (Controller → Service → DAO). 
The location lookup logic is identical, only the layer boundary is corrected.
