### PR TITLE
perf(eqa): memoize computed table data and handlers in EQAOrdersPage

### DIFF
--- a/frontend/src/components/eqa/EQAOrdersPage.js
+++ b/frontend/src/components/eqa/EQAOrdersPage.js
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, {
+  useState,
+  useEffect,
+  useContext,
+  useMemo,
+  useCallback,
+} from "react";
 import {
   Grid,
   Column,
@@ -110,55 +116,74 @@ const EQAOrdersPage = () => {
     });
   };
 
-  const headers = [
-    {
-      key: "labNumber",
-      header: intl.formatMessage({ id: "eqa.tests.labNumber" }),
-    },
-    {
-      key: "programName",
-      header: intl.formatMessage({ id: "eqa.tests.program" }),
-    },
-    {
-      key: "providerName",
-      header: intl.formatMessage({ id: "eqa.tests.provider" }),
-    },
-    {
-      key: "status",
-      header: intl.formatMessage({ id: "eqa.tests.status" }),
-    },
-    {
-      key: "deadline",
-      header: intl.formatMessage({ id: "eqa.tests.deadline" }),
-    },
-    {
-      key: "priority",
-      header: intl.formatMessage({ id: "eqa.tests.priority" }),
-    },
-    {
-      key: "dateEntered",
-      header: intl.formatMessage({ id: "eqa.tests.dateEntered" }),
-    },
-  ];
+  const headers = useMemo(
+    () => [
+      {
+        key: "labNumber",
+        header: intl.formatMessage({ id: "eqa.tests.labNumber" }),
+      },
+      {
+        key: "programName",
+        header: intl.formatMessage({ id: "eqa.tests.program" }),
+      },
+      {
+        key: "providerName",
+        header: intl.formatMessage({ id: "eqa.tests.provider" }),
+      },
+      {
+        key: "status",
+        header: intl.formatMessage({ id: "eqa.tests.status" }),
+      },
+      {
+        key: "deadline",
+        header: intl.formatMessage({ id: "eqa.tests.deadline" }),
+      },
+      {
+        key: "priority",
+        header: intl.formatMessage({ id: "eqa.tests.priority" }),
+      },
+      {
+        key: "dateEntered",
+        header: intl.formatMessage({ id: "eqa.tests.dateEntered" }),
+      },
+    ],
+    [intl],
+  );
 
-  const rows = orders.map((order) => ({
-    id: String(order.id),
-    labNumber: order.labNumber || "",
-    programName: order.programName || "",
-    providerName: order.providerName || "",
-    status: order.status || "",
-    deadline: order.deadline
-      ? new Date(order.deadline).toLocaleDateString()
-      : "",
-    priority: order.priority || "",
-    dateEntered: order.dateEntered
-      ? new Date(order.dateEntered).toLocaleDateString()
-      : "",
-  }));
+  const rows = useMemo(
+    () =>
+      orders.map((order) => ({
+        id: String(order.id),
+        labNumber: order.labNumber || "",
+        programName: order.programName || "",
+        providerName: order.providerName || "",
+        status: order.status || "",
+        deadline: order.deadline
+          ? new Date(order.deadline).toLocaleDateString()
+          : "",
+        priority: order.priority || "",
+        dateEntered: order.dateEntered
+          ? new Date(order.dateEntered).toLocaleDateString()
+          : "",
+      })),
+    [orders],
+  );
 
-  const handleEnterNewTest = () => {
+  const handleEnterNewTest = useCallback(() => {
     history.push("/SamplePatientEntry?isEQA=true");
-  };
+  }, [history]);
+
+  const handleStatusFilterChange = useCallback((e) => {
+    setStatusFilter(e.target.value);
+  }, []);
+
+  const handleProgramFilterChange = useCallback((e) => {
+    setProgramFilter(e.target.value);
+  }, []);
+
+  const handlePriorityFilterChange = useCallback((e) => {
+    setPriorityFilter(e.target.value);
+  }, []);
 
   if (loading) {
     return <Loading />;
@@ -234,7 +259,7 @@ const EQAOrdersPage = () => {
                 id="eqa-status-filter"
                 labelText={intl.formatMessage({ id: "eqa.filter.status" })}
                 value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value)}
+                onChange={handleStatusFilterChange}
               >
                 <SelectItem
                   value=""
@@ -263,7 +288,7 @@ const EQAOrdersPage = () => {
                 id="eqa-program-filter"
                 labelText={intl.formatMessage({ id: "eqa.filter.program" })}
                 value={programFilter}
-                onChange={(e) => setProgramFilter(e.target.value)}
+                onChange={handleProgramFilterChange}
               >
                 <SelectItem
                   value=""
@@ -283,7 +308,7 @@ const EQAOrdersPage = () => {
                 id="eqa-priority-filter"
                 labelText={intl.formatMessage({ id: "eqa.filter.priority" })}
                 value={priorityFilter}
-                onChange={(e) => setPriorityFilter(e.target.value)}
+                onChange={handlePriorityFilterChange}
               >
                 <SelectItem
                   value=""


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

- Memoized headers in EQAOrdersPage using useMemo([intl]).
- Memoized rows mapping using useMemo([orders]).
- Memoized prop handlers with useCallback to stabilize function references without changing behavior.

## Validation

- Ran unit tests: npm run test -- --watchAll=false
- Ran formatting check: npm run check-format
- npm run lint is not available in this package.
- npm run build fails in this environment due to parent ESLint config (next/core-web-vitals); build passes with DISABLE_ESLINT_PLUGIN=true npm run build.

## Related Issue
Fixes #3176 

**Notes**
Only frontend/src/components/eqa/EQAOrdersPage.js is part of this change.

