### PR TITLE
fix(ci): wait for bridge to create incoming dirs before chmod

### DIFF
--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Create analyzer import bind mount directories
         run: |
           mkdir -p projects/analyzer-harness/volume/analyzer-imports
-          chmod -R a+rwx projects/analyzer-harness/volume/analyzer-imports
+          sudo chmod -R a+rwX projects/analyzer-harness/volume/analyzer-imports
 
       - name: Start analyzer harness stack (no rebuild)
         run: docker compose -f build.docker-compose.yml -f .github/ci/ci.analyzer-harness.yml up -d --no-build --wait --wait-timeout 900
@@ -166,7 +166,7 @@ jobs:
             timeout 30 bash -c "until [ -d projects/analyzer-harness/volume/analyzer-imports/$dir/incoming ]; do sleep 1; done"
             echo "Found: $dir/incoming"
           done
-          chmod -R a+rwx projects/analyzer-harness/volume/analyzer-imports
+          sudo chmod -R a+rwX projects/analyzer-harness/volume/analyzer-imports
 
       - name: Verify analyzer test mappings exist (prevent unmapped-result race)
         run: |

--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -158,6 +158,16 @@ jobs:
           TEST_USER: ${{ vars.TEST_USER || 'admin' }}
           TEST_PASS: ${{ secrets.TEST_PASS }}
 
+      - name: Fix analyzer-imports permissions (bridge creates dirs as root)
+        run: |
+          # Bridge creates incoming/ dirs asynchronously after seed registration.
+          # Wait for each expected directory to appear, then fix permissions.
+          for dir in quantstudio-5 quantstudio-7 fluorocycler-xt; do
+            timeout 30 bash -c "until [ -d projects/analyzer-harness/volume/analyzer-imports/$dir/incoming ]; do sleep 1; done"
+            echo "Found: $dir/incoming"
+          done
+          chmod -R a+rwx projects/analyzer-harness/volume/analyzer-imports
+
       - name: Verify analyzer test mappings exist (prevent unmapped-result race)
         run: |
           for analyzer in "Cepheid GeneXpert (ASTM Mode)" "QuantStudio 5" "QuantStudio 7" "FluoroCycler XT"; do


### PR DESCRIPTION
## Summary
- Bridge creates `analyzer-imports/*/incoming/` dirs asynchronously after seed registration
- Playwright file-import tests fail with `EACCES` writing to these root-owned dirs
- Fix: wait for each expected directory to appear, then `chmod -R a+rwx`

Unblocks PR #3103 (Analyzer Harness Demo 2/2 failure).

## Test plan
- [ ] Analyzer Harness Demo 2/2 passes (file-import-results tests)
- [ ] No regression on Demo 1/2 (ASTM tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)