### PR TITLE
feat: verify and fix FILE profiles for Madagascar LA2M testing

### DIFF
--- a/projects/analyzer-profiles/file/fluorocycler-xt.json
+++ b/projects/analyzer-profiles/file/fluorocycler-xt.json
@@ -1,7 +1,7 @@
 {
   "profileMeta": {
     "id": "fluorocycler-xt",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "displayName": "Bruker FluoroCycler XT",
     "manufacturer": "Bruker"
   },
@@ -11,9 +11,13 @@
   },
   "supported_extensions": [
     ".xlsx",
-    ".xls",
-    ".csv"
+    ".xls"
   ],
+  "site_workflow": {
+    "description": "FluoroCycler XT natively exports PDF only. Technicians at LA2M manually copy values from FluoroSoftware into an Excel file with labeled column headers. Loris uploaded the corrected Excel format with headers on 2026-03-25.",
+    "native_export": "PDF",
+    "import_format": "Manual Excel copy with headers"
+  },
   "column_mapping": {
     "SampleID": "sampleId",
     "WellPosition": "position",
@@ -31,23 +35,28 @@
   "required_columns": [
     "SampleID",
     "WellPosition",
-    "AssayName",
     "TargetName",
     "CP",
-    "Interpretation",
-    "RunDate"
+    "Interpretation"
   ],
   "optional_columns": [
+    "AssayName",
     "TargetNo",
     "CalcConc",
     "CalcConcUnit",
+    "RunDate",
     "RunID",
     "Notes"
   ],
   "fallback_mapping": {
-    "description": "Raw copy-paste: no SampleID column, use WellPosition as fallback",
+    "description": "If technician uses abbreviated headers or French labels, try these alternates",
     "CT": "result",
-    "Ct": "result"
+    "Ct": "result",
+    "Echantillon": "sampleId",
+    "Position": "position",
+    "Cible": "testCode",
+    "Resultat": "result",
+    "Interpretation": "interpretation"
   },
   "default_test_mappings": [
     { "analyzer_code": "VIH-1", "test_name_hint": "HIV-1 Viral Load", "loinc": "20447-9", "unit": "copies/mL" },
@@ -56,6 +65,6 @@
   "configDefaults": {
     "fileFormat": "EXCEL",
     "hasHeader": true,
-    "sheetName": "Results"
+    "sheetIndex": 0
   }
 }

--- a/projects/analyzer-profiles/file/genexpert-csv.json
+++ b/projects/analyzer-profiles/file/genexpert-csv.json
@@ -1,0 +1,87 @@
+{
+  "profileMeta": {
+    "id": "genexpert-csv",
+    "version": "1.0.0",
+    "displayName": "Cepheid GeneXpert (CSV Export)",
+    "manufacturer": "Cepheid",
+    "validation_status": "DRAFT - GeneXpert XVI at LA2M currently uses ASTM over TCP/IP, but network/IP config issues are blocking that path. CSV flat-file export from Dx software is the fastest fallback. Awaiting real CSV export sample from site."
+  },
+  "category": "MOLECULAR",
+  "protocol": {
+    "name": "FILE",
+    "format": "CSV"
+  },
+  "supported_extensions": [
+    ".csv",
+    ".txt"
+  ],
+  "site_workflow": {
+    "description": "GeneXpert Dx software can export test results to CSV via File > Export Results. This provides a flat-file alternative when the ASTM TCP/IP connection is unavailable due to network configuration issues.",
+    "primary_path": "ASTM over TCP/IP (genexpert-astm profile)",
+    "fallback_path": "CSV file export from Dx software (this profile)"
+  },
+  "column_mapping": {
+    "Sample ID": "sampleId",
+    "Patient ID": "patientId",
+    "Assay": "assayName",
+    "Test Result": "result",
+    "Test Type": "testCode",
+    "Ct": "ctValue",
+    "End Pt": "endPt",
+    "Probe Check Ct": "probeCheckCt",
+    "Error": "errorCode",
+    "Error Status": "errorStatus",
+    "Reagent Lot ID": "reagentLotId",
+    "Start Time": "testDate",
+    "End Time": "testEndTime",
+    "Module Serial Number": "moduleSerial",
+    "Cartridge Serial Number": "cartridgeSerial",
+    "Instrument Serial Number": "instrumentSerial",
+    "Notes": "notes"
+  },
+  "required_columns": [
+    "Sample ID",
+    "Assay",
+    "Test Result"
+  ],
+  "optional_columns": [
+    "Patient ID",
+    "Test Type",
+    "Ct",
+    "End Pt",
+    "Probe Check Ct",
+    "Error",
+    "Error Status",
+    "Reagent Lot ID",
+    "Start Time",
+    "End Time",
+    "Module Serial Number",
+    "Cartridge Serial Number",
+    "Instrument Serial Number",
+    "Notes"
+  ],
+  "result_interpretation": {
+    "qualitative_values": {
+      "MTB DETECTED": "Detected",
+      "MTB NOT DETECTED": "Not Detected",
+      "MTB TRACE DETECTED": "Trace",
+      "RIF Resistance DETECTED": "Detected",
+      "RIF Resistance NOT DETECTED": "Not Detected",
+      "RIF Resistance INDETERMINATE": "Indeterminate",
+      "INVALID": "Invalid",
+      "ERROR": "Error",
+      "NO RESULT": "No Result"
+    }
+  },
+  "default_test_mappings": [
+    { "analyzer_code": "MTB-RIF", "test_name_hint": "Mycobacterium tuberculosis DNA", "loinc": "23826-1", "unit": "" },
+    { "analyzer_code": "RIF", "test_name_hint": "Rifampin Resistance", "loinc": "46244-0", "unit": "" },
+    { "analyzer_code": "MTB-RIF-ULTRA", "test_name_hint": "MTB/RIF Ultra", "loinc": "23826-1", "unit": "" },
+    { "analyzer_code": "HIV-VL", "test_name_hint": "HIV-1 RNA", "loinc": "20447-9", "unit": "copies/mL" }
+  ],
+  "configDefaults": {
+    "fileFormat": "CSV",
+    "delimiter": ",",
+    "hasHeader": true
+  }
+}

--- a/projects/analyzer-profiles/file/multiskan-fc.json
+++ b/projects/analyzer-profiles/file/multiskan-fc.json
@@ -1,9 +1,10 @@
 {
   "profileMeta": {
     "id": "multiskan-fc",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "displayName": "Thermo Multiskan FC",
-    "manufacturer": "Thermo Fisher"
+    "manufacturer": "Thermo Fisher",
+    "validation_status": "PENDING - awaiting real export files from site. Herbert reported no OE plugin available 2026-03-20. Profile based on standard SkanIt export format; may need adjustment after real file validation."
   },
   "protocol": {
     "name": "FILE",
@@ -23,9 +24,16 @@
     "Content": "content",
     "Concentration": "concentration"
   },
+  "locale_support": {
+    "description": "Madagascar site uses French locale. CSV exports may use semicolons as delimiter and commas as decimal separator.",
+    "french_csv": {
+      "delimiter": ";",
+      "decimal_separator": ","
+    }
+  },
   "layouts": {
     "plate_grid": {
-      "description": "8x12 plate grid after metadata header",
+      "description": "8x12 plate grid after metadata header (standard SkanIt export)",
       "metadata_rows": ["Instrument", "Protocol", "Date", "Time", "Filter", "Plate Type"],
       "grid_rows": 8,
       "grid_cols": 12
@@ -37,7 +45,7 @@
   },
   "configDefaults": {
     "fileFormat": "CSV",
-    "delimiter": ",",
+    "delimiter": ";",
     "hasHeader": true
   }
 }

--- a/projects/analyzer-profiles/file/quantstudio.json
+++ b/projects/analyzer-profiles/file/quantstudio.json
@@ -1,7 +1,7 @@
 {
   "profileMeta": {
     "id": "quantstudio",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "displayName": "QuantStudio QS5/QS7",
     "manufacturer": "Thermo Fisher"
   },
@@ -58,13 +58,20 @@
       "CQCONF",
       "Amp Score",
       "Y-Intercept",
-      "R²",
+      "R\u00b2",
       "Slope",
       "Efficiency"
     ],
     "metadata_block": true,
     "header_marker": "Well",
     "sheet_name": "Results"
+  },
+  "sheet_detection": {
+    "strategy": "header_scan",
+    "description": "QS7 has results on sheet 'Results' (often index 0). QS5 has results on 3rd sheet (index 2). Both use the same column layout confirmed by Loris on 2026-03-25. The parser should scan sheets for the header_marker row rather than relying on a fixed sheet index.",
+    "preferred_sheet_names": ["Results"],
+    "header_marker": "Well",
+    "max_sheets_to_scan": 5
   },
   "line_field_order": [
     "sampleId",
@@ -81,6 +88,6 @@
   "configDefaults": {
     "fileFormat": "EXCEL",
     "hasHeader": true,
-    "sheetIndex": 0
+    "sheetIndex": null
   }
 }

--- a/projects/analyzer-profiles/file/tecan-f50.json
+++ b/projects/analyzer-profiles/file/tecan-f50.json
@@ -1,9 +1,10 @@
 {
   "profileMeta": {
     "id": "tecan-f50",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "displayName": "Tecan Infinite F50",
-    "manufacturer": "Tecan"
+    "manufacturer": "Tecan",
+    "validation_status": "PENDING - awaiting real export files from site. Herbert reported no OE plugin available 2026-03-20. Profile based on standard Magellan export format; may need adjustment after real file validation."
   },
   "protocol": {
     "name": "FILE",
@@ -23,16 +24,23 @@
     "CorrectedOD": "correctedOD",
     "Interpretation": "interpretation"
   },
+  "locale_support": {
+    "description": "Madagascar site may use French locale with semicolons as delimiter and comma as decimal separator",
+    "french_csv": {
+      "delimiter": ";",
+      "decimal_separator": ","
+    }
+  },
   "layouts": {
     "plate_grid": {
-      "description": "8x12 plate grid after metadata header",
+      "description": "8x12 plate grid after metadata header (standard Magellan export)",
       "metadata_rows": ["Application", "Instrument", "Method", "Date", "Time", "Wavelength", "Plate"],
       "grid_rows": 8,
       "grid_cols": 12,
       "row_labels": ["A", "B", "C", "D", "E", "F", "G", "H"]
     },
     "well_per_row": {
-      "description": "One row per well with SampleID, OD values",
+      "description": "One row per well with SampleID, OD values (custom site template)",
       "columns": ["WellPosition", "SampleID", "OD_450", "OD_620", "CorrectedOD", "Interpretation"]
     }
   },


### PR DESCRIPTION
## Summary
- Verify all FILE profiles against real site exports from Madagascar LA2M
- Fix column mappings, sheet handling, format support as needed
- Profile JSON only — no backend code changes

## Changes
- **quantstudio.json**: Added `sheet_detection` with `header_scan` for QS5 3rd-sheet exports
- **fluorocycler-xt.json**: Removed CSV (Excel-only), added French fallback columns, documented manual copy workflow
- **tecan-f50.json**: Added French locale support, marked PENDING real file validation
- **multiskan-fc.json**: Switched default delimiter to `;` for French locale, marked PENDING
- **genexpert-csv.json**: NEW — GeneXpert CSV flat-file profile as ASTM fallback path

## Checklist
- [x] quantstudio.json verified (QS5 3rd-sheet headers)
- [x] fluorocycler-xt.json verified (corrected Excel)
- [ ] tecan-f50.json verified against Herbert's CSV (PENDING real files)
- [ ] multiskan-fc.json verified against Herbert's exports (PENDING real files)
- [x] Attune CytPix assessed (PDF-only, deferred to manual entry)
- [x] GeneXpert CSV profile created

🤖 Generated with [Claude Code](https://claude.com/claude-code)