### PR TITLE
fix(ci): pre-create incoming dirs before bridge starts

### DIFF
--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -137,6 +137,10 @@ jobs:
       - name: Create analyzer import bind mount directories
         run: |
           mkdir -p projects/analyzer-harness/volume/analyzer-imports
+          # Pre-create incoming/ dirs so the bridge doesn't have to (avoids async timeout)
+          for slug in quantstudio-5 quantstudio-7 fluorocycler-xt; do
+            mkdir -p "projects/analyzer-harness/volume/analyzer-imports/$slug/incoming"
+          done
           chmod -R a+rwx projects/analyzer-harness/volume/analyzer-imports
 
       - name: Start analyzer harness stack (no rebuild)
@@ -163,7 +167,7 @@ jobs:
           # Bridge creates incoming/ dirs asynchronously after seed registration.
           # Wait for all expected directories to appear, then fix permissions.
           for dir in quantstudio-5 quantstudio-7 fluorocycler-xt; do
-            timeout 30 bash -c "until [ -d projects/analyzer-harness/volume/analyzer-imports/$dir/incoming ]; do sleep 1; done"
+            timeout 120 bash -c "until [ -d projects/analyzer-harness/volume/analyzer-imports/$dir/incoming ]; do sleep 1; done"
             echo "Found: $dir/incoming"
           done
           chmod -R a+rwx projects/analyzer-harness/volume/analyzer-imports


### PR DESCRIPTION
## Summary
Pre-create `analyzer-imports/{slug}/incoming` directories before `docker compose up`, eliminating the async race where the bridge creates them after seed registration.

The 30s timeout was failing ~75% of E2E runs. This fix pre-creates the dirs and increases the safety-net timeout to 120s.

## Test plan
- [ ] E2E harness Demo shards pass reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)