### PR TITLE
Fix #3168: Mock AnalyzerQueryService in SourceOfSampleServiceTest

### DIFF
--- a/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
+++ b/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
@@ -36,11 +36,12 @@ public class SourceOfSampleServiceTest extends BaseWebContextSensitiveTest {
 
     @Before
     public void setUp() throws Exception {
-        // Mock startQuery to prevent real network calls and resolve SocketTimeoutException (Issue #3168)
-        Mockito.when(analyzerQueryService.startQuery(Mockito.anyString()))
-                .thenReturn("mock-job-id");
+        // Mock startQuery to prevent real network calls and resolve
+        // SocketTimeoutException (Issue #3168)
+        Mockito.when(analyzerQueryService.startQuery(Mockito.anyString())).thenReturn("mock-job-id");
 
-        // Mock getStatus to provide a default response consistent with the service contract
+        // Mock getStatus to provide a default response consistent with the service
+        // contract
         Mockito.when(analyzerQueryService.getStatus(Mockito.anyString(), Mockito.anyString()))
                 .thenReturn(Map.of("state", "COMPLETED", "progress", 100));
 
@@ -58,7 +59,8 @@ public class SourceOfSampleServiceTest extends BaseWebContextSensitiveTest {
         Mockito.when(analyzerQueryService.getStatus(Mockito.anyString(), Mockito.anyString()))
                 .thenReturn(Map.of("state", "FAILED", "progress", 0));
 
-        // Verify that even when the analyzer fails, the service still returns data correctly
+        // Verify that even when the analyzer fails, the service still returns data
+        // correctly
         SourceOfSampleList = sourceOfSampleService.getAll();
         assertNotNull(SourceOfSampleList);
         assertFalse(SourceOfSampleList.isEmpty());

--- a/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
+++ b/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
@@ -53,6 +53,18 @@ public class SourceOfSampleServiceTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
+    public void testGetStatusWhenAnalyzerFails() {
+        // Mock the service to return a FAILED state
+        Mockito.when(analyzerQueryService.getStatus(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Map.of("state", "FAILED", "progress", 0));
+
+        // Verify that even when the analyzer fails, the service still returns data correctly
+        SourceOfSampleList = sourceOfSampleService.getAll();
+        assertNotNull(SourceOfSampleList);
+        assertFalse(SourceOfSampleList.isEmpty());
+    }
+
+    @Test
     public void getAll_ShouldReturnAllSourceOfSamples() {
         SourceOfSampleList = sourceOfSampleService.getAll();
         assertNotNull(SourceOfSampleList);

--- a/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
+++ b/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
@@ -14,11 +14,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analyzer.service.AnalyzerQueryServiceImpl;
 import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.sourceofsample.service.SourceOfSampleService;
 import org.openelisglobal.sourceofsample.valueholder.SourceOfSample;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.openelisglobal.analyzer.service.AnalyzerQueryServiceImpl;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class SourceOfSampleServiceTest extends BaseWebContextSensitiveTest {

--- a/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
+++ b/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
@@ -12,16 +12,22 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.sourceofsample.service.SourceOfSampleService;
 import org.openelisglobal.sourceofsample.valueholder.SourceOfSample;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.openelisglobal.analyzer.service.AnalyzerQueryServiceImpl;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class SourceOfSampleServiceTest extends BaseWebContextSensitiveTest {
 
     @Autowired
     private SourceOfSampleService sourceOfSampleService;
+
+    @MockitoBean
+    private AnalyzerQueryServiceImpl analyzerQueryService;
 
     private List<SourceOfSample> SourceOfSampleList;
     private Map<String, Object> propertyValues;
@@ -30,6 +36,14 @@ public class SourceOfSampleServiceTest extends BaseWebContextSensitiveTest {
 
     @Before
     public void setUp() throws Exception {
+        // Mock startQuery to prevent real network calls and resolve SocketTimeoutException (Issue #3168)
+        Mockito.when(analyzerQueryService.startQuery(Mockito.anyString()))
+                .thenReturn("mock-job-id");
+
+        // Mock getStatus to provide a default empty response for the test context
+        Mockito.when(analyzerQueryService.getStatus(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new java.util.HashMap<>());
+
         executeDataSetWithStateManagement("testdata/source-of-sample.xml");
 
         propertyValues = new HashMap<>();

--- a/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
+++ b/src/test/java/org/openelisglobal/sourceofsample/SourceOfSampleServiceTest.java
@@ -40,9 +40,9 @@ public class SourceOfSampleServiceTest extends BaseWebContextSensitiveTest {
         Mockito.when(analyzerQueryService.startQuery(Mockito.anyString()))
                 .thenReturn("mock-job-id");
 
-        // Mock getStatus to provide a default empty response for the test context
+        // Mock getStatus to provide a default response consistent with the service contract
         Mockito.when(analyzerQueryService.getStatus(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(new java.util.HashMap<>());
+                .thenReturn(Map.of("state", "COMPLETED", "progress", 100));
 
         executeDataSetWithStateManagement("testdata/source-of-sample.xml");
 


### PR DESCRIPTION
## Summary
Utilized `@MockitoBean` to replace the real `AnalyzerQueryServiceImpl` with a mock. This prevents the test from making real network calls (TCP/Socket connections), which was causing `SocketTimeoutException` failures.

## Impact
* **Stability:** Resolved the `SocketTimeoutException` errors occurring in `SourceOfSampleServiceTest` by mocking the external service.
* **Reliability:** The test no longer attempts to connect to a physical or networked analyzer, making it pass consistently in any environment (Local, Docker, or CI).
* **Isolation:** Properly isolated the service logic from external dependencies.

## Related Issue
Fixes #3168

## Pull Request Requirements
- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. (N/A - Backend logic fix)
- [x] The PR title follows conventional commit label standards.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.