### PR TITLE
fix(#3166): Improve audit trail query timing assertion in AnalyzerMap

### DIFF
--- a/src/test/java/org/openelisglobal/analyzer/service/AnalyzerMappingAuditTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/service/AnalyzerMappingAuditTest.java
@@ -260,8 +260,6 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
         int mappingCount = 100;
         String[] mappingIds = new String[mappingCount];
 
-        long startTime = System.currentTimeMillis();
-
         // Create 100 mappings
         for (int i = 0; i < mappingCount; i++) {
             AnalyzerFieldMapping mapping = new AnalyzerFieldMapping();
@@ -293,6 +291,7 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
 
         // Act: Query all mappings individually and verify audit trail entries
         // Use get() method to retrieve individual mappings with audit trail fields
+        long startTime = System.currentTimeMillis();
         int mappingsWithAuditTrail = 0;
         for (int i = 0; i < mappingCount; i++) {
             AnalyzerFieldMapping mapping = analyzerFieldMappingService.get(mappingIds[i]);
@@ -313,7 +312,7 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
         // Note: We're creating 100 mappings with 3 operations each (create, update,
         // disable) = 300 changes
         // The query should complete in <1 second
-        assertTrue("Audit trail query should complete in <1 second", queryTime < 1000);
+        assertTrue("Audit trail query should complete in <1 second (was " + queryTime + "ms)", queryTime < 1000);
     }
 
     /**


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Root cause: startTime was captured before all 600 DB operations (100 creates + 200 gets + 200 updates), but SC-003 only requires the final query phase (100 reads) to be under 1 second.
Fix: Moved startTime from before the setup phase to just before the query loop — a 2-line change (one deletion, one addition). No production code was touched.

## Screenshots
<img width="751" height="575" alt="image" src="https://github.com/user-attachments/assets/308998ce-9c4e-4bc7-8fcb-dfccb24fea20" />


## Related Issue
Issue: #3198 AnalyzerMappingAuditTest performance regression - audit trail query exceeds 1s threshold

## Performance 
Before fix: startTime was captured before all 600 DB operations (100 creates + 200 gets + 200 updates), measuring ~2,500ms and failing the <1s assertion.

After fix: startTime is captured just before the 100-read query loop (the actual audit trail query), measuring ~32ms — well within the <1s SC-003 requirement.

## Validation
`mvn clean install -DskipTests -Dmaven.test.skip=true` builds and compiles
<img width="854" height="265" alt="image" src="https://github.com/user-attachments/assets/2c451cb9-b859-4d93-9195-73ec408af4c2" />


