### PR TITLE
Feat(#3165): pre commit guardrails for agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
     "PreToolUse": [
       {
         "matcher": "Bash(git commit)",
-        "hooks": ["bash .githooks/pre-commit"]
+        "hooks": ["bash \"$(git rev-parse --show-toplevel)/.githooks/pre-commit\""]
       }
     ],
     "SessionStart": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit)",
+        "hooks": ["bash .githooks/pre-commit"]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          "git worktree list",
+          "git status --short"
+        ]
+      }
+    ]
+  }
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,7 @@
 # Auto-format hook: Runs formatters on staged files before commit
 # This prevents CI failures from formatting issues
 
-set -e
+set -euo pipefail
 
 echo "🎨 Running auto-formatters on staged files..."
 
@@ -29,7 +29,7 @@ POM_FILES=$(echo "$STAGED_FILES" | grep 'pom\.xml$' || true)
 if [ -n "$JAVA_FILES" ] || [ -n "$MD_FILES" ] || [ -n "$SH_FILES" ] || [ -n "$XML_FILES" ] || [ -n "$GITIGNORE_FILES" ] || [ -n "$POM_FILES" ]; then
     echo "  → Formatting Spotless-managed files (java/md/sh/xml/gitignore/pom)..."
     # Spotless applies to entire project, but we only re-stage modified files
-    mvn spotless:apply -q 2>/dev/null || true
+    mvn spotless:apply -q 2>/dev/null
     FORMATTED=true
 fi
 
@@ -40,7 +40,7 @@ if [ -n "$FRONTEND_FILES" ]; then
     # Format only staged frontend files
     echo "$FRONTEND_FILES" | while IFS= read -r file; do
         if [ -f "$file" ]; then
-            (cd frontend && npx prettier --write "../$file" --silent 2>/dev/null) || true
+            (cd frontend && npx prettier --write "../$file" --silent 2>/dev/null)
         fi
     done
     FORMATTED=true
@@ -55,11 +55,11 @@ if [ -n "$PYTHON_FILES" ]; then
         if [ -f "$file" ]; then
             # Determine which catalyst project this file belongs to
             if echo "$file" | grep -q 'catalyst-agents'; then
-                (cd projects/catalyst/catalyst-agents && uv run ruff format "../../$file" 2>/dev/null) || true
+                (cd projects/catalyst/catalyst-agents && uv run ruff format "../../$file" 2>/dev/null)
             elif echo "$file" | grep -q 'catalyst-gateway'; then
-                (cd projects/catalyst/catalyst-gateway && uv run ruff format "../../$file" 2>/dev/null) || true
+                (cd projects/catalyst/catalyst-gateway && uv run ruff format "../../$file" 2>/dev/null)
             elif echo "$file" | grep -q 'catalyst-mcp'; then
-                (cd projects/catalyst/catalyst-mcp && uv run ruff format "../../$file" 2>/dev/null) || true
+                (cd projects/catalyst/catalyst-mcp && uv run ruff format "../../$file" 2>/dev/null)
             fi
         fi
     done

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ volume/lucene/*
 !.cursor/rules/
 !.cursor/worktrees.json
 .claude/*
+!.claude/settings.json
 **/*checksum*.properties
 **/*checksums*.properties
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -790,8 +790,10 @@ bash .githooks/setup.sh   # run once per clone/worktree
 
 Sets `core.hooksPath` to `.githooks/`.
 
-**Both options** run the same `.githooks/pre-commit` script which formats staged
-files only (spotless + prettier + ruff) and re-stages them.
+**Both options** run the same `.githooks/pre-commit` script which invokes
+spotless + prettier + ruff for the configured scope (typically the entire
+repo), may reformat unstaged files in the working tree, and then re-stages
+any affected files that are part of the commit.
 
 **`setup-workspace.sh`** auto-selects: lefthook if available, native hooks
 otherwise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -768,6 +768,40 @@ npm run cy:run -- --spec "cypress/e2e/{feature}.cy.js"  # Individual E2E test
 # Check .specify/memory/constitution.md for relevant principles
 ```
 
+### Automated Pre-Commit Hooks
+
+Formatting is enforced automatically via pre-commit hooks. Choose **one** setup
+method (not both):
+
+**Option A — lefthook (recommended):**
+
+```bash
+npm i -g @evilmartians/lefthook   # or your OS package manager
+lefthook install                   # run once per clone/worktree
+```
+
+Reads `lefthook.yml` from repo root, delegates to `.githooks/pre-commit`.
+
+**Option B — native git hooks:**
+
+```bash
+bash .githooks/setup.sh   # run once per clone/worktree
+```
+
+Sets `core.hooksPath` to `.githooks/`.
+
+**Both options** run the same `.githooks/pre-commit` script which formats staged
+files only (spotless + prettier + ruff) and re-stages them.
+
+**`setup-workspace.sh`** auto-selects: lefthook if available, native hooks
+otherwise.
+
+**Claude Code:** `.claude/settings.json` provides additional guardrails:
+
+- `PreToolUse` hook runs formatters before any `git commit` command
+- `SessionStart` hook runs `git worktree list` + `git status` for context
+  recovery
+
 **Before Creating PR:**
 
 - [ ] All tests pass

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+# lefthook.yml — Universal pre-commit formatting guardrail
+#
+# Alternative to `.githooks/setup.sh` — use ONE, not both:
+#   Option A (lefthook): npm i -g @evilmartians/lefthook && lefthook install
+#   Option B (native):   bash .githooks/setup.sh
+#
+# Lefthook reads this file from the repo root, so the config is always
+# available in worktrees. `lefthook install` must still run once per
+# clone/worktree to install the git hook shim.
+
+pre-commit:
+  commands:
+    auto-format:
+      run: bash .githooks/pre-commit

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -9,8 +9,12 @@ git submodule update --init --recursive
 echo "  Submodules initialized."
 
 # 2. Set up git hooks (pre-commit formatting)
-if [ -f .githooks/setup.sh ]; then
-  echo "Setting up git hooks..."
+# Prefer lefthook if available; fall back to native .githooks
+if command -v lefthook &>/dev/null; then
+  echo "Setting up pre-commit hooks via lefthook..."
+  lefthook install
+elif [ -f .githooks/setup.sh ]; then
+  echo "Setting up git hooks (native)..."
   bash .githooks/setup.sh
 fi
 

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -13,6 +13,16 @@ echo "  Submodules initialized."
 if command -v lefthook &>/dev/null; then
   echo "Setting up pre-commit hooks via lefthook..."
   lefthook install
+
+  # Ensure Git actually uses the lefthook shim in .git/hooks
+  current_hooks_path=""
+  if git config --get core.hooksPath >/dev/null 2>&1; then
+    current_hooks_path="$(git config --get core.hooksPath)"
+  fi
+  if [ -n "${current_hooks_path}" ] && [ "${current_hooks_path}" != ".git/hooks" ]; then
+    echo "  Detected existing core.hooksPath='${current_hooks_path}'. Unsetting so lefthook hooks run from .git/hooks."
+    git config --unset core.hooksPath
+  fi
 elif [ -f .githooks/setup.sh ]; then
   echo "Setting up git hooks (native)..."
   bash .githooks/setup.sh

--- a/src/test/java/org/openelisglobal/analyzer/service/AnalyzerMappingAuditTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/service/AnalyzerMappingAuditTest.java
@@ -260,6 +260,8 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
         int mappingCount = 100;
         String[] mappingIds = new String[mappingCount];
 
+        long startTime = System.currentTimeMillis();
+
         // Create 100 mappings
         for (int i = 0; i < mappingCount; i++) {
             AnalyzerFieldMapping mapping = new AnalyzerFieldMapping();
@@ -291,7 +293,6 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
 
         // Act: Query all mappings individually and verify audit trail entries
         // Use get() method to retrieve individual mappings with audit trail fields
-        long startTime = System.currentTimeMillis();
         int mappingsWithAuditTrail = 0;
         for (int i = 0; i < mappingCount; i++) {
             AnalyzerFieldMapping mapping = analyzerFieldMappingService.get(mappingIds[i]);
@@ -312,7 +313,7 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
         // Note: We're creating 100 mappings with 3 operations each (create, update,
         // disable) = 300 changes
         // The query should complete in <1 second
-        assertTrue("Audit trail query should complete in <1 second (was " + queryTime + "ms)", queryTime < 1000);
+        assertTrue("Audit trail query should complete in <1 second", queryTime < 1000);
     }
 
     /**

--- a/src/test/java/org/openelisglobal/analyzer/service/AnalyzerMappingAuditTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/service/AnalyzerMappingAuditTest.java
@@ -260,8 +260,6 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
         int mappingCount = 100;
         String[] mappingIds = new String[mappingCount];
 
-        long startTime = System.currentTimeMillis();
-
         // Create 100 mappings
         for (int i = 0; i < mappingCount; i++) {
             AnalyzerFieldMapping mapping = new AnalyzerFieldMapping();
@@ -293,6 +291,7 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
 
         // Act: Query all mappings individually and verify audit trail entries
         // Use get() method to retrieve individual mappings with audit trail fields
+        long startTime = System.currentTimeMillis();
         int mappingsWithAuditTrail = 0;
         for (int i = 0; i < mappingCount; i++) {
             AnalyzerFieldMapping mapping = analyzerFieldMappingService.get(mappingIds[i]);
@@ -313,7 +312,7 @@ public class AnalyzerMappingAuditTest extends BaseWebContextSensitiveTest {
         // Note: We're creating 100 mappings with 3 operations each (create, update,
         // disable) = 300 changes
         // The query should complete in <1 second
-        assertTrue("Audit trail query should complete in <1 second", queryTime < 1000);
+        assertTrue("Audit trail query should complete in <1 second (was " + queryTime + "ms)", queryTime < 1000);
     }
 
     /**


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this project.

## Summary
- Added layered pre-commit formatting guardrails to prevent CI failures from spotless/prettier violations. A `lefthook.yml` at repo root delegates to the existing `pre-commit` script, providing a universal hook config that's available in all worktrees. 
- A `settings.json` adds Claude Code-specific PreToolUse (runs formatters before git commit) and SessionStart (runs git worktree list + git status for context recovery) hooks. 
- `setup-workspace.sh` now auto-selects lefthook if installed, falling back to native git hooks. All documented in a new "Automated Pre-Commit Hooks" section in AGENTS.md.



## Screenshots
<img width="672" height="309" alt="image" src="https://github.com/user-attachments/assets/c6a1a60b-a3ed-4ead-b129-7dc88d23411c" />


## Related Issue

#3165 

## Validation
<img width="660" height="99" alt="image" src="https://github.com/user-attachments/assets/d918f9a6-7de9-4789-b053-2e28065a646b" />
Build Succeeds


## Note
- lefthook install still needs to run once per worktree (same as native hooks). The advantage is that the config file is always available since it's tracked in the repo.
- No formatting logic was duplicated — everything delegates to the existing `pre-commit` script.
