### PR TITLE
fix: prevent negative values in quantity fields (#2961)

### DIFF
--- a/frontend/src/components/addOrder/SampleType.js
+++ b/frontend/src/components/addOrder/SampleType.js
@@ -149,9 +149,11 @@ const SampleType = (props) => {
   }
 
   function handleQuantity(value) {
+    const val = value.target.value;
+    if (val !== "" && Number(val) < 0) return;
     setSampleXml({
       ...sampleXml,
-      quantity: value.target.value,
+      quantity: val,
     });
   }
 

--- a/frontend/src/components/genericSample/GenericSampleOrder.js
+++ b/frontend/src/components/genericSample/GenericSampleOrder.js
@@ -635,14 +635,17 @@ export default function GenericSampleOrder({
                     labelText={
                       <FormattedMessage
                         id="sample.quantity.label"
-                        defaultMessage="Quantity"
+                        defaultMessage="Quantity (must be positive number)"
                       />
                     }
                     type="number"
+                    min="0"
                     value={defaultForm.quantity}
-                    onChange={(e) =>
-                      updateDefaultField("quantity", e.target.value)
-                    }
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      if (val !== "" && Number(val) < 0) return;
+                      updateDefaultField("quantity", val);
+                    }}
                   />
                 </Column>
               )}


### PR DESCRIPTION
 **Issue**
Fixes #2961 — Quantity field allows negative values in "Receive Sample" form

 **What was changed**
- `SampleType.js`: Added validation in `handleQuantity()` to reject negative input
- `GenericSampleOrder.js`: Added `min="0"` prop and onChange validation

**How to test**
1. Go to Generic Sample → Create Order
2. Try entering -1 in the Quantity field → should be blocked
3. Enter positive values → should work normally

**Screenshots**
<img width="1919" height="956" alt="image" src="https://github.com/user-attachments/assets/a2a0d991-2730-477b-8d1e-23173ffde5ad" />
