### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2277,3 +2277,90 @@ sdk env        # SDKMAN auto-switch
 **Last Updated:** 2026-01-27 **Constitution Version:** 1.9.0 **Maintained By:**
 OpenELIS Global Core Team **Questions?** Post in GitHub Discussions or weekly
 developer sync
+
+---
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+The Cloud VM has Java 21, Maven 3.8, Node.js 20 (via nvm), Docker CE 28,
+PostgreSQL client 16, and Playwright Chromium pre-installed. The Docker daemon
+runs with `fuse-overlayfs` storage driver and `iptables-legacy` (required for
+nested containers inside the Firecracker VM).
+
+### Analyzer harness (primary dev target)
+
+The analyzer harness is the scoped development environment. It runs via Docker
+Compose from `projects/analyzer-harness/` with 8 containers: PostgreSQL, OE
+backend (WAR-mounted), HAPI FHIR, React frontend, nginx proxy, ASTM simulator,
+analyzer bridge, and virtual serial ports.
+
+**Full restart workflow** follows
+`.specify/oe/commands/restart-analyzer-harness.md`. Quick summary:
+
+```bash
+cd $(git rev-parse --show-toplevel)
+set -a && . ./.env && set +a
+
+# 1. Build WAR (only if Java code changed)
+mvn clean install -DskipTests -Dspotless.check.skip=true
+
+# 2. Bootstrap harness volume (idempotent)
+bash projects/analyzer-harness/bootstrap.sh
+
+# 3. Stage generic plugin JARs (only GenericASTM, GenericHL7, GenericFile)
+mkdir -p projects/analyzer-harness/volume/plugins
+rm -f projects/analyzer-harness/volume/plugins/*.jar
+for p in GenericASTM GenericHL7 GenericFile; do
+  cp plugins/analyzers/$p/target/${p}*.jar projects/analyzer-harness/volume/plugins/
+done
+
+# 4. Ensure bind-mount directories exist
+mkdir -p volume/letsencrypt volume/nginx/certbot
+mkdir -p projects/analyzer-harness/volume/analyzer-imports
+
+# 5. Start stack (no Let's Encrypt for local dev)
+cd projects/analyzer-harness
+docker compose -f docker-compose.dev.yml -f docker-compose.analyzer-test.yml up -d
+
+# 6. Wait for webapp
+timeout 120 bash -c 'until curl -sk https://localhost/ | grep -q "OpenELIS\|Login"; do sleep 5; done'
+
+# 7. Load fixtures + seed analyzers
+cd $(git rev-parse --show-toplevel)
+PGPASSWORD=clinlims DB_PORT=15432 DB_HOST=localhost \
+  ./src/test/resources/load-test-fixtures.sh --analyzers=full --no-verify
+BASE_URL=https://localhost bash projects/analyzer-harness/seed-analyzers.sh
+```
+
+**Access:** `https://localhost/` — login: `admin` / `adminADMIN!`
+
+### Gotchas
+
+- **Docker socket permissions:** The ubuntu user may not have Docker socket
+  access after daemon start. Run `sudo chmod 666 /var/run/docker.sock` if
+  `docker ps` returns permission denied.
+- **Plugin build requires test-jar:** Plugins depend on
+  `openelisglobal:jar:tests`. Build the main project with
+  `mvn clean install -DskipTests -Dspotless.check.skip=true` (NOT with
+  `-Dmaven.test.skip=true`) so the test-jar artifact is produced before building
+  plugins.
+- **Only generic plugins needed:** For the analyzer harness, stage only
+  GenericASTM, GenericHL7, and GenericFile — legacy plugins are not used.
+- **Node.js 20 via nvm:** Always activate with
+  `export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use 20` before
+  running frontend commands.
+- **psql client needed for fixtures:** The fixture loader script
+  (`load-test-fixtures.sh`) uses either Docker exec or direct `psql`. Install
+  `postgresql-client` and set `PGPASSWORD=clinlims` for direct connection.
+
+### Lint and test commands
+
+| Check | Command | Working dir |
+|-------|---------|-------------|
+| Backend format | `mvn spotless:check` | repo root |
+| Backend build | `mvn clean install -DskipTests -Dmaven.test.skip=true` | repo root |
+| Frontend format | `npx prettier ./ --check` | `frontend/` |
+| Frontend tests | `CI=true npm test -- --watchAll=false --coverage=false` | `frontend/` |
+| Playwright E2E | `TEST_USER=admin TEST_PASS='adminADMIN!' npm run pw:test -- --project=harness-demo` | `frontend/` |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment setup guidance for Cloud Agent VMs, including:

- Environment overview (Java 21, Maven, Node.js 20, Docker CE with fuse-overlayfs)
- Analyzer harness startup workflow (the full `/restart-analyzer-harness` sequence)
- Gotchas: Docker socket permissions, plugin test-jar dependency, generic-only plugins, nvm activation, psql client for fixtures
- Lint and test command reference table

### Demo: Analyzer Harness Running

[analyzer_harness_demo_walkthrough.mp4](https://cursor.com/agents/bc-0a1390f0-9b15-4225-baa7-5798f8e545e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanalyzer_harness_demo_walkthrough.mp4)

[7 seeded analyzers all active in the harness](https://cursor.com/agents/bc-0a1390f0-9b15-4225-baa7-5798f8e545e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanalyzers_list_7_active.webp)

## Screenshots

[OpenELIS login page](https://cursor.com/agents/bc-0a1390f0-9b15-4225-baa7-5798f8e545e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_page.webp)
[Dashboard after login](https://cursor.com/agents/bc-0a1390f0-9b15-4225-baa7-5798f8e545e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_after_login.webp)
[Edit QuantStudio 5 analyzer](https://cursor.com/agents/bc-0a1390f0-9b15-4225-baa7-5798f8e545e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_analyzer_quantstudio5.webp)
[Add New Analyzer form](https://cursor.com/agents/bc-0a1390f0-9b15-4225-baa7-5798f8e545e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadd_new_analyzer_form.webp)

## Related Issue

Documentation-only change — no related issue.

## Other

This is generated by the Cursor Cloud Agent environment setup process. The `AGENTS.md` section is intended for future cloud agent sessions to remember non-obvious startup caveats.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a1390f0-9b15-4225-baa7-5798f8e545e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a1390f0-9b15-4225-baa7-5798f8e545e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

