### PR TITLE
fix(ci): harden e2e workflow trust boundaries

### DIFF
--- a/.github/e2e-ci-operator-model.md
+++ b/.github/e2e-ci-operator-model.md
@@ -38,8 +38,8 @@ Requires default-branch merge (controls `workflow_run` orchestration):
 - Non-fork PRs: shared build publishes GHCR cache directly.
 - Fork PRs: downstream `fork-rebuild` is the explicit short-term exception that
   rebuilds from PR merge ref and writes only `packages: write`.
-- Status reporting remains isolated in tiny reporter jobs with
-  `statuses: write` only.
+- Status reporting remains isolated in tiny reporter jobs with `statuses: write`
+  only.
 
 ## CI Auth Contract
 

--- a/.github/e2e-ci-operator-model.md
+++ b/.github/e2e-ci-operator-model.md
@@ -1,0 +1,117 @@
+# E2E CI Operator Model
+
+This guide explains trust boundaries and the repo/operator settings required for
+the split E2E workflow model.
+
+## Workflow Boundary Model
+
+- `03 - E2E` builds and publishes transient `e2e-cache` images to GHCR.
+- `E2E / Tests` executes Playwright/Cypress/harness and reports
+  `03 Checkpoint - E2E`.
+- `Publish Images` is post-merge only (`push`/`release`) and gated on the
+  successful `03 Checkpoint - E2E` status.
+
+## What Changes Apply Pre-Merge vs Post-Merge
+
+Pre-merge (picked up from checked-out PR payload):
+
+- Scripts and test code executed in job steps
+- Compose files and fixture SQL loaded by tests
+- Submodule pointers in checked-out PR refs
+
+Requires default-branch merge (controls `workflow_run` orchestration):
+
+- Workflow topology and job wiring
+- Job-level permission model
+- Cross-workflow artifact plumbing
+- Trigger conditions for `workflow_run` pipelines
+
+## Local Reusable Workflow Resolution
+
+- `uses: ./.github/workflows/<file>.yml` resolves from the checked-out commit in
+  that job.
+- In `workflow_run` contexts, orchestration behavior still depends on default
+  branch workflow definitions; this is why merge validation is required.
+
+## Fork vs Non-Fork Safety Model
+
+- Non-fork PRs: shared build publishes GHCR cache directly.
+- Fork PRs: downstream `fork-rebuild` is the explicit short-term exception that
+  rebuilds from PR merge ref and writes only `packages: write`.
+- Status reporting remains isolated in tiny reporter jobs with
+  `statuses: write` only.
+
+## CI Auth Contract
+
+Use this contract in all E2E test executors:
+
+- `TEST_USER: ${{ vars.TEST_USER || 'admin' }}`
+- `TEST_PASS: ${{ vars.TEST_PASS || 'adminADMIN!' }}`
+
+No E2E PR executor should require `secrets.TEST_PASS`.
+
+## Publish Environment Contract
+
+- DockerHub publish credentials are scoped to environment `publish`.
+- Environment branch policy must restrict deployments to `develop`.
+
+## GitHub Configuration — Automation First
+
+Run from repo root with sufficient admin permissions:
+
+```bash
+# Ensure GH CLI is authenticated for repo admin APIs
+gh auth status
+
+# Repository-level CI vars
+gh variable set TEST_USER --body "admin" --repo DIGI-UW/OpenELIS-Global-2
+gh variable set TEST_PASS --body "adminADMIN!" --repo DIGI-UW/OpenELIS-Global-2
+
+# Optional: DockerHub username as repo variable
+gh variable set DOCKERHUB_USERNAME --body "<dockerhub-username>" --repo DIGI-UW/OpenELIS-Global-2
+
+# Create or update environment "publish"
+gh api --method PUT repos/DIGI-UW/OpenELIS-Global-2/environments/publish
+
+# Enable custom deployment branch policies on publish environment
+printf '%s' '{"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}' \
+  | gh api --method PUT repos/DIGI-UW/OpenELIS-Global-2/environments/publish --input -
+
+# Restrict publish environment to develop branch
+gh api --method POST repos/DIGI-UW/OpenELIS-Global-2/environments/publish/deployment-branch-policies \
+  -f name=develop \
+  -f type=branch
+```
+
+Environment secrets are repo-admin controlled and may require dedicated
+commands/permissions:
+
+```bash
+# Example for environment-scoped secret (requires admin + proper GH CLI setup)
+gh secret set DOCKERHUB_TOKEN --env publish --repo DIGI-UW/OpenELIS-Global-2
+```
+
+## Manual Fallback (If API/Permissions Block Automation)
+
+1. Open repo settings: `Settings` -> `Environments` -> `publish`.
+2. Create environment `publish` if missing.
+3. Under deployment branches, allow only selected branches and set `develop`.
+4. Add environment secret `DOCKERHUB_TOKEN`.
+5. Confirm repo variables:
+   - `TEST_USER=admin`
+   - `TEST_PASS=adminADMIN!`
+   - `DOCKERHUB_USERNAME=<dockerhub-username>`
+
+## Verification Checklist
+
+```bash
+# Confirm repo variables exist
+gh variable list --repo DIGI-UW/OpenELIS-Global-2
+
+# Confirm publish environment exists and branch policy is applied
+gh api repos/DIGI-UW/OpenELIS-Global-2/environments/publish
+gh api repos/DIGI-UW/OpenELIS-Global-2/environments/publish/deployment-branch-policies
+
+# Confirm relevant workflows are present in current branch
+ls .github/workflows/e2e-*.yml .github/workflows/publish-images.yml
+```

--- a/.github/workflows/e2e-cache-cleanup.yml
+++ b/.github/workflows/e2e-cache-cleanup.yml
@@ -1,0 +1,103 @@
+name: E2E Cache Cleanup
+
+on:
+  schedule:
+    - cron: "15 3 * * 1"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Delete e2e-cache package versions older than 7 days
+    if: github.repository == 'DIGI-UW/OpenELIS-Global-2'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Delete old GHCR e2e-cache package versions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const cutoffMs = 7 * 24 * 60 * 60 * 1000;
+            const cutoff = Date.now() - cutoffMs;
+            const targetPrefix = 'openelis-global-2/e2e-cache/';
+
+            const listAllOrgPackages = async () => {
+              const all = [];
+              let page = 1;
+              while (true) {
+                const resp = await github.request('GET /orgs/{org}/packages', {
+                  org: owner,
+                  package_type: 'container',
+                  per_page: 100,
+                  page,
+                });
+                if (!resp.data.length) {
+                  break;
+                }
+                all.push(...resp.data);
+                if (resp.data.length < 100) {
+                  break;
+                }
+                page += 1;
+              }
+              return all;
+            };
+
+            const listAllVersions = async (packageName) => {
+              const all = [];
+              let page = 1;
+              while (true) {
+                const resp = await github.request('GET /orgs/{org}/packages/{package_type}/{package_name}/versions', {
+                  org: owner,
+                  package_type: 'container',
+                  package_name: packageName,
+                  per_page: 100,
+                  page,
+                });
+                if (!resp.data.length) {
+                  break;
+                }
+                all.push(...resp.data);
+                if (resp.data.length < 100) {
+                  break;
+                }
+                page += 1;
+              }
+              return all;
+            };
+
+            const packages = await listAllOrgPackages();
+            const targets = packages.filter((pkg) => pkg.name.startsWith(targetPrefix));
+            core.info(`Found ${targets.length} e2e-cache packages in org '${owner}'.`);
+
+            let deleted = 0;
+            let scanned = 0;
+
+            for (const pkg of targets) {
+              const versions = await listAllVersions(pkg.name);
+              core.info(`Package ${pkg.name}: ${versions.length} versions total.`);
+              for (const version of versions) {
+                scanned += 1;
+                const createdAt = new Date(version.created_at).getTime();
+                if (Number.isNaN(createdAt) || createdAt >= cutoff) {
+                  continue;
+                }
+
+                try {
+                  await github.request('DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}', {
+                    org: owner,
+                    package_type: 'container',
+                    package_name: pkg.name,
+                    package_version_id: version.id,
+                  });
+                  deleted += 1;
+                  core.info(`Deleted ${pkg.name} version ${version.id} created ${version.created_at}.`);
+                } catch (error) {
+                  core.warning(`Failed deleting ${pkg.name} version ${version.id}: ${error.message}`);
+                }
+              }
+            }
+
+            core.info(`Scanned ${scanned} versions. Deleted ${deleted} versions older than 7 days.`);

--- a/.github/workflows/e2e-cypress-deprecated.yml
+++ b/.github/workflows/e2e-cypress-deprecated.yml
@@ -22,6 +22,16 @@ on:
         required: false
         type: string
         default: ""
+      test_user:
+        description: "CI login user for Cypress execution"
+        required: false
+        type: string
+        default: "admin"
+      test_pass:
+        description: "CI login password for Cypress execution"
+        required: false
+        type: string
+        default: "adminADMIN!"
 
 permissions:
   contents: read
@@ -92,6 +102,7 @@ jobs:
           ref: ${{ inputs.head_sha || github.sha }}
           repository: ${{github.repository}}
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -186,8 +197,8 @@ jobs:
           CYPRESS_BASE_URL: https://localhost
           LC_ALL: en_US.UTF-8
           LANG: en_US.UTF-8
-          TEST_USER: ${{ vars.TEST_USER || 'admin' }}
-          TEST_PASS: ${{ secrets.TEST_PASS || 'adminADMIN!' }}
+          TEST_USER: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
 
       - name: Upload Cypress screenshots (${{ matrix.shard }})
         if: always()

--- a/.github/workflows/e2e-cypress-deprecated.yml
+++ b/.github/workflows/e2e-cypress-deprecated.yml
@@ -26,12 +26,12 @@ on:
         description: "CI login user for Cypress execution"
         required: false
         type: string
-        default: "admin"
+        default: ""
       test_pass:
         description: "CI login password for Cypress execution"
         required: false
         type: string
-        default: "adminADMIN!"
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-playwright-analyzer-harness-manual.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-manual.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   run:
     uses: ./.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     with:
       test_user: ${{ vars.TEST_USER || 'admin' }}
       test_pass: ${{ vars.TEST_PASS || 'adminADMIN!' }}

--- a/.github/workflows/e2e-playwright-analyzer-harness-manual.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-manual.yml
@@ -8,4 +8,6 @@ on:
 jobs:
   run:
     uses: ./.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
-    secrets: inherit
+    with:
+      test_user: ${{ vars.TEST_USER || 'admin' }}
+      test_pass: ${{ vars.TEST_PASS || 'adminADMIN!' }}

--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -21,6 +21,16 @@ on:
         required: false
         type: string
         default: ""
+      test_user:
+        description: "CI login user for E2E harness execution"
+        required: false
+        type: string
+        default: "admin"
+      test_pass:
+        description: "CI login password for E2E harness execution"
+        required: false
+        type: string
+        default: "adminADMIN!"
 
 permissions:
   contents: read
@@ -31,7 +41,6 @@ jobs:
   demo-shards:
     name: Demo ${{ matrix.shard_index }}/${{ matrix.shard_total }}
     runs-on: ubuntu-latest
-    environment: e2e
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +56,7 @@ jobs:
         with:
           ref: ${{ inputs.head_sha || github.sha }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -171,8 +181,8 @@ jobs:
         run: bash projects/analyzer-harness/seed-analyzers.sh
         env:
           BASE_URL: https://localhost
-          TEST_USER: ${{ vars.TEST_USER || 'admin' }}
-          TEST_PASS: ${{ secrets.TEST_PASS }}
+          TEST_USER: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
           DB_CONTAINER: openelisglobal-database
 
       - name: Fix analyzer-imports permissions (bridge creates dirs as root)
@@ -204,8 +214,8 @@ jobs:
           done
         env:
           BASE_URL: https://localhost
-          TEST_USER: ${{ vars.TEST_USER || 'admin' }}
-          TEST_PASS: ${{ secrets.TEST_PASS }}
+          TEST_USER: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
 
       - name: Run analyzer Playwright harness-demo shard
         run: npm run pw:test -- --project=harness-demo --workers=1 --shard=${{ matrix.shard_index }}/${{ matrix.shard_total }}
@@ -214,8 +224,8 @@ jobs:
           CI: true
           ANALYZER_HARNESS: "true"
           BASE_URL: https://localhost
-          TEST_USER: ${{ vars.TEST_USER || 'admin' }}
-          TEST_PASS: ${{ secrets.TEST_PASS }}
+          TEST_USER: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
           # Must match bridge.file.pollIntervalMs (bridge default: 5000ms)
           FILE_IMPORT_POLL_MS: "5000"
           FILE_IMPORT_DROP_BUFFER_MS: "45000"
@@ -274,6 +284,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -25,12 +25,12 @@ on:
         description: "CI login user for E2E harness execution"
         required: false
         type: string
-        default: "admin"
+        default: ""
       test_pass:
         description: "CI login password for E2E harness execution"
         required: false
         type: string
-        default: "adminADMIN!"
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -12,10 +12,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -28,7 +24,9 @@ jobs:
   shared-build:
     name: Shared Build
     runs-on: ubuntu-latest
-    environment: e2e
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_transfer: ${{ steps.push-images.outputs.mode }}
     steps:
@@ -36,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Java 21
         uses: actions/setup-java@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,18 +3,12 @@
 # - Non-fork: images already on GHCR from build workflow, pull and test
 # - Fork: rebuild from GHA cache (fast), push to GHCR, then pull and test
 # Result: identical CI checks for all PR types.
-name: E2E / Tests and Publish
+name: E2E / Tests
 
 on:
   workflow_run:
     workflows: ["03 - E2E"]
     types: [completed]
-
-permissions:
-  contents: read
-  packages: write
-  statuses: write
-  actions: read
 
 concurrency:
   group: e2e-tests-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.head_sha }}
@@ -28,6 +22,9 @@ jobs:
     name: Setup
     if: github.repository == 'DIGI-UW/OpenELIS-Global-2' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     outputs:
       is_fork: ${{ steps.context.outputs.is_fork }}
       pr_number: ${{ steps.context.outputs.pr_number }}
@@ -89,6 +86,8 @@ jobs:
     needs: setup
     if: needs.setup.outputs.image_transfer != 'none' && needs.setup.outputs.head_sha != ''
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Post pending commit status
         uses: actions/github-script@v7
@@ -112,13 +111,16 @@ jobs:
     needs: setup
     if: needs.setup.outputs.is_fork == 'true'
     runs-on: ubuntu-latest
-    environment: e2e
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout PR merge ref
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ needs.setup.outputs.pr_number }}/merge
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Java 21
         uses: actions/setup-java@v4
@@ -255,7 +257,10 @@ jobs:
     needs: [setup, fork-rebuild]
     if: always() && needs.setup.outputs.image_transfer != 'none' && (needs.fork-rebuild.result == 'success' || needs.fork-rebuild.result == 'skipped')
     runs-on: ubuntu-latest
-    environment: e2e
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -270,6 +275,7 @@ jobs:
         with:
           ref: ${{ needs.setup.outputs.is_fork == 'true' && format('refs/pull/{0}/merge', needs.setup.outputs.pr_number) || github.event.workflow_run.head_sha }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -371,7 +377,7 @@ jobs:
           CI: true
           BASE_URL: https://localhost
           TEST_USER: ${{ vars.TEST_USER || 'admin' }}
-          TEST_PASS: ${{ secrets.TEST_PASS }}
+          TEST_PASS: ${{ vars.TEST_PASS || 'adminADMIN!' }}
 
       - name: Upload blob report
         if: ${{ !cancelled() }}
@@ -414,15 +420,19 @@ jobs:
       ${{
         always() &&
         needs.setup.outputs.image_transfer != 'none' &&
-        (needs.fork-rebuild.result == 'success' || needs.fork-rebuild.result == 'skipped') &&
-        (needs.setup.outputs.event_name != 'pull_request' || true)
+        (needs.fork-rebuild.result == 'success' || needs.fork-rebuild.result == 'skipped')
       }}
     uses: ./.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     with:
       build_run_id: ${{ needs.setup.outputs.build_run_id }}
       is_fork: ${{ needs.setup.outputs.is_fork }}
       head_sha: ${{ needs.setup.outputs.head_sha }}
-    secrets: inherit
+      test_user: ${{ vars.TEST_USER || 'admin' }}
+      test_pass: ${{ vars.TEST_PASS || 'adminADMIN!' }}
 
   # ─── Cypress (Deprecated) ───────────────────────────────────────────────────
   cypress:
@@ -435,11 +445,16 @@ jobs:
         (needs.fork-rebuild.result == 'success' || needs.fork-rebuild.result == 'skipped')
       }}
     uses: ./.github/workflows/e2e-cypress-deprecated.yml
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     with:
       build_run_id: ${{ needs.setup.outputs.build_run_id }}
       is_fork: ${{ needs.setup.outputs.is_fork }}
       head_sha: ${{ needs.setup.outputs.head_sha }}
-    secrets: inherit
+      test_user: ${{ vars.TEST_USER || 'admin' }}
+      test_pass: ${{ vars.TEST_PASS || 'adminADMIN!' }}
 
   # ─── Gate ───────────────────────────────────────────────────────────────────
   e2e-gate:
@@ -447,10 +462,19 @@ jobs:
     if: always()
     needs: [setup, playwright-core, analyzer-harness, cypress]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Enforce all E2E results
-        if: needs.setup.outputs.image_transfer != 'none'
         run: |
+          if [[ "${{ needs.setup.outputs.image_transfer }}" == "none" ]]; then
+            echo "No image transfer mode available (build failure propagated)."
+            exit 1
+          fi
+          if [[ "${{ needs.playwright-core.result }}" == "skipped" && "${{ needs.analyzer-harness.result }}" == "skipped" && "${{ needs.cypress.result }}" == "skipped" ]]; then
+            echo "All E2E executors were skipped; failing gate."
+            exit 1
+          fi
           if [[ "${{ needs.playwright-core.result }}" != "success" ]]; then
             echo "Playwright Core failed: ${{ needs.playwright-core.result }}"
             exit 1
@@ -465,94 +489,6 @@ jobs:
           fi
           echo "E2E gate passed."
 
-  # ─── Publish Images ─────────────────────────────────────────────────────────
-  publish-images:
-    name: Publish ${{ matrix.dockerhub_suffix || 'backend' }}
-    if: >-
-      ${{
-        always() &&
-        needs.e2e-gate.result == 'success' &&
-        github.repository == 'DIGI-UW/OpenELIS-Global-2' &&
-        (needs.setup.outputs.event_name == 'push' || needs.setup.outputs.event_name == 'release')
-      }}
-    needs: [setup, e2e-gate]
-    runs-on: ubuntu-latest
-    environment: e2e
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - compose_image: openelisglobal-webapp.build
-            dockerhub_suffix: backend
-          - compose_image: frontend
-            dockerhub_suffix: frontend
-          - compose_image: openelisglobal-proxy.build
-            dockerhub_suffix: proxy
-          - compose_image: external-fhir-api.build
-            dockerhub_suffix: fhir
-          - compose_image: openelisglobal-databse.build
-            dockerhub_suffix: database
-    steps:
-      - name: Download image map from build workflow (non-fork)
-        if: needs.setup.outputs.is_fork != 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: e2e-image-map
-          path: /tmp/e2e-image-map
-          run-id: ${{ needs.setup.outputs.build_run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download image map from fork-rebuild (fork)
-        if: needs.setup.outputs.is_fork == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: e2e-image-map
-          path: /tmp/e2e-image-map
-
-      - name: Resolve GHCR source image for matrix target
-        id: source
-        run: |
-          SOURCE_GHCR_IMAGE="$(awk -F'|' -v src='${{ matrix.compose_image }}' '$1 == src {print $2; exit}' /tmp/e2e-image-map/e2e-image-map.txt)"
-          if [ -z "$SOURCE_GHCR_IMAGE" ]; then
-            echo "No GHCR mapping found for compose image: ${{ matrix.compose_image }}"
-            echo "Available mappings:"
-            cat /tmp/e2e-image-map/e2e-image-map.txt
-            exit 1
-          fi
-          echo "ghcr_source=$SOURCE_GHCR_IMAGE" >> "$GITHUB_OUTPUT"
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          registry: docker.io
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ vars.DOCKERHUB_USERNAME }}/openelis-global-2${{ matrix.dockerhub_suffix != 'backend' && format('-{0}', matrix.dockerhub_suffix) || '' }}
-
-      - name: Pull tested image from GHCR
-        run: docker pull "${{ steps.source.outputs.ghcr_source }}"
-
-      - name: Retag and publish tested image to DockerHub
-        run: |
-          while IFS= read -r target_tag; do
-            [ -z "$target_tag" ] && continue
-            echo "Publishing $target_tag from ${{ steps.source.outputs.ghcr_source }}"
-            docker tag "${{ steps.source.outputs.ghcr_source }}" "$target_tag"
-            docker push "$target_tag"
-          done <<< "${{ steps.meta.outputs.tags }}"
-
   # ─── Report Status ──────────────────────────────────────────────────────────
   # Posts commit status back to PR so results are visible in the PR checks tab.
   # workflow_run checks don't automatically appear on PRs.
@@ -561,6 +497,8 @@ jobs:
     if: always() && needs.setup.outputs.head_sha != ''
     needs: [setup, e2e-gate]
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Post commit status to PR
         uses: actions/github-script@v7

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -39,6 +39,10 @@ jobs:
         id: context
         run: |
           if [ "${{ steps.download.outcome }}" != "success" ] || [ ! -d /tmp/e2e-build-context ]; then
+            if [ "${{ github.event.workflow_run.conclusion }}" = "success" ]; then
+              echo "::error::Expected build context artifact from successful 03 - E2E run, but it was not available."
+              exit 1
+            fi
             echo "event_name=unknown" >> "$GITHUB_OUTPUT"
             echo "image_transfer=none" >> "$GITHUB_OUTPUT"
             echo "head_sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
@@ -64,6 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      statuses: read
     steps:
       - name: Wait for E2E checkpoint success
         uses: actions/github-script@v7

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,181 @@
+# Publishes tested images after merge/release only.
+# Triggered by 03 - E2E completion and gated on downstream E2E checkpoint status.
+name: Publish Images
+
+on:
+  workflow_run:
+    workflows: ["03 - E2E"]
+    types: [completed]
+
+concurrency:
+  group: publish-images-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    name: Setup Publish Context
+    if: github.repository == 'DIGI-UW/OpenELIS-Global-2' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      event_name: ${{ steps.context.outputs.event_name }}
+      head_sha: ${{ steps.context.outputs.head_sha }}
+      image_transfer: ${{ steps.context.outputs.image_transfer }}
+      build_run_id: ${{ github.event.workflow_run.id }}
+    steps:
+      - name: Download build context artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-build-context
+          path: /tmp/e2e-build-context
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Parse build context
+        id: context
+        run: |
+          if [ "${{ steps.download.outcome }}" != "success" ] || [ ! -d /tmp/e2e-build-context ]; then
+            echo "event_name=unknown" >> "$GITHUB_OUTPUT"
+            echo "image_transfer=none" >> "$GITHUB_OUTPUT"
+            echo "head_sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          EVENT_NAME="$(cat /tmp/e2e-build-context/event_name 2>/dev/null || echo 'unknown')"
+          IMAGE_TRANSFER="$(cat /tmp/e2e-build-context/image_transfer 2>/dev/null || echo 'none')"
+          HEAD_SHA="$(cat /tmp/e2e-build-context/head_sha 2>/dev/null || echo '')"
+          if [ -z "$HEAD_SHA" ]; then
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          fi
+
+          echo "event_name=$EVENT_NAME" >> "$GITHUB_OUTPUT"
+          echo "image_transfer=$IMAGE_TRANSFER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "Publish context: event=$EVENT_NAME image_transfer=$IMAGE_TRANSFER head_sha=$HEAD_SHA"
+
+  wait-for-e2e-checkpoint:
+    name: Wait For 03 Checkpoint - E2E
+    needs: setup
+    if: needs.setup.outputs.head_sha != '' && (needs.setup.outputs.event_name == 'push' || needs.setup.outputs.event_name == 'release') && needs.setup.outputs.image_transfer != 'none'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Wait for E2E checkpoint success
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = '${{ needs.setup.outputs.head_sha }}';
+            const contextName = '03 Checkpoint - E2E';
+            const timeoutMs = 45 * 60 * 1000;
+            const pollMs = 30 * 1000;
+            const started = Date.now();
+
+            while (Date.now() - started < timeoutMs) {
+              const res = await github.rest.repos.listCommitStatusesForRef({
+                owner,
+                repo,
+                ref: sha,
+                per_page: 100,
+              });
+
+              const status = res.data.find((s) => s.context === contextName);
+              if (!status) {
+                core.info(`No '${contextName}' status yet for ${sha}; waiting...`);
+              } else if (status.state === 'success') {
+                core.info(`Found successful '${contextName}' status.`);
+                return;
+              } else if (status.state === 'failure' || status.state === 'error') {
+                core.setFailed(`Checkpoint status is ${status.state}: ${status.description || 'no description'}`);
+                return;
+              } else {
+                core.info(`Checkpoint currently '${status.state}'; waiting...`);
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, pollMs));
+            }
+
+            core.setFailed(`Timed out waiting for '${contextName}' on ${sha}`);
+
+  publish-images:
+    name: Publish ${{ matrix.dockerhub_suffix || 'backend' }}
+    needs: [setup, wait-for-e2e-checkpoint]
+    if: needs.wait-for-e2e-checkpoint.result == 'success'
+    runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compose_image: openelisglobal-webapp.build
+            dockerhub_suffix: backend
+          - compose_image: frontend
+            dockerhub_suffix: frontend
+          - compose_image: openelisglobal-proxy.build
+            dockerhub_suffix: proxy
+          - compose_image: external-fhir-api.build
+            dockerhub_suffix: fhir
+          - compose_image: openelisglobal-databse.build
+            dockerhub_suffix: database
+    steps:
+      - name: Download image map from triggering build workflow
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-image-map
+          path: /tmp/e2e-image-map
+          run-id: ${{ needs.setup.outputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve GHCR source image for matrix target
+        id: source
+        run: |
+          SOURCE_GHCR_IMAGE="$(awk -F'|' -v src='${{ matrix.compose_image }}' '$1 == src {print $2; exit}' /tmp/e2e-image-map/e2e-image-map.txt)"
+          if [ -z "$SOURCE_GHCR_IMAGE" ]; then
+            echo "No GHCR mapping found for compose image: ${{ matrix.compose_image }}"
+            echo "Available mappings:"
+            cat /tmp/e2e-image-map/e2e-image-map.txt
+            exit 1
+          fi
+          echo "ghcr_source=$SOURCE_GHCR_IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.DOCKERHUB_USERNAME }}/openelis-global-2${{ matrix.dockerhub_suffix != 'backend' && format('-{0}', matrix.dockerhub_suffix) || '' }}
+
+      - name: Pull tested image from GHCR
+        run: docker pull "${{ steps.source.outputs.ghcr_source }}"
+
+      - name: Retag and publish tested image to DockerHub
+        run: |
+          while IFS= read -r target_tag; do
+            [ -z "$target_tag" ] && continue
+            echo "Publishing $target_tag from ${{ steps.source.outputs.ghcr_source }}"
+            docker tag "${{ steps.source.outputs.ghcr_source }}" "$target_tag"
+            docker push "$target_tag"
+          done <<< "${{ steps.meta.outputs.tags }}"

--- a/.specify/plans/e2e-ci-privilege-matrix.md
+++ b/.specify/plans/e2e-ci-privilege-matrix.md
@@ -1,0 +1,145 @@
+# E2E CI Privilege Matrix (Phase 1)
+
+This matrix inventories the current trust boundaries for E2E CI before
+hardening changes.
+
+Scope:
+
+- `.github/workflows/e2e-playwright.yml`
+- `.github/workflows/e2e-tests.yml`
+- `.github/workflows/e2e-playwright-analyzer-harness-reusable.yml`
+- `.github/workflows/e2e-playwright-analyzer-harness-manual.yml`
+- `.github/workflows/e2e-cypress-deprecated.yml`
+
+## 1) Workflow-Level Privilege Baseline
+
+| Workflow | Trigger | Workflow-level permissions | Notable trust implications |
+| --- | --- | --- | --- |
+| `03 - E2E` (`e2e-playwright.yml`) | `pull_request`, `push`, `release`, `workflow_dispatch` | `contents: read`, `packages: write` | PR lane can attempt GHCR push (forks fail naturally due to token scope). |
+| `E2E / Tests and Publish` (`e2e-tests.yml`) | `workflow_run` on `03 - E2E` | `contents: read`, `packages: write`, `statuses: write`, `actions: read` | Broad write scope shared by setup, tests, publish, and reporter jobs. |
+| `E2E / Playwright / Analyzer Harness (Reusable)` | `workflow_call` | `contents: read`, `packages: read`, `actions: read` | Good read-only baseline, but still consumes secret-backed `TEST_PASS`. |
+| `E2E / Playwright / Analyzer Harness (Manual)` | `workflow_dispatch` | inherited from called workflow | Uses `secrets: inherit` at wrapper entrypoint. |
+| `E2E / Cypress (Deprecated)` | `workflow_call`, `workflow_dispatch` | `contents: read`, `packages: read`, `actions: read` | Read-only package usage, but still references secret-backed fallback for `TEST_PASS`. |
+
+## 2) Job-Level Privilege Matrix
+
+Legend:
+
+- PR code checkout: checks out branch/merge ref controlled by PR author.
+- PR code execution: runs build/test tooling against that checked-out PR code.
+- GHCR write: pushes package versions to `ghcr.io/.../e2e-cache/...`.
+- Status write: posts `03 Checkpoint - E2E` commit status.
+
+| Workflow | Job | Effective permission need (current behavior) | PR code checkout | PR code execution | GHCR write | Status write | Secrets / vars flow | `secrets: inherit` | `environment: e2e` | `persist-credentials: false` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `e2e-playwright.yml` | `shared-build` | `contents: read`, `packages: write` | Yes (`actions/checkout`) | Yes (Maven, npm, Docker build/push) | Yes | No | `secrets.GITHUB_TOKEN` for GHCR login | No | Yes | No |
+| `e2e-tests.yml` | `setup` | `actions: read`, `contents: read` | No | No | No | No | `secrets.GITHUB_TOKEN` for cross-run artifact read | No | No | N/A |
+| `e2e-tests.yml` | `set-pending-status` | `statuses: write` | No | No | No | Yes | GITHUB token via `github-script` | No | No | N/A |
+| `e2e-tests.yml` | `fork-rebuild` | `packages: write`, `contents: read` | Yes (`refs/pull/<n>/merge`) | Yes (Maven, npm, Docker build/push) | Yes | No | `secrets.GITHUB_TOKEN` for GHCR login | No | Yes | No |
+| `e2e-tests.yml` | `playwright-core` | `packages: read`, `actions: read`, `contents: read` | Yes (merge ref for forks, workflow_run SHA otherwise) | Yes (Playwright + compose runtime) | No | No | `TEST_USER` from vars fallback; `TEST_PASS` from `secrets.TEST_PASS`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login | No | Yes | No |
+| `e2e-tests.yml` | `analyzer-harness` (reusable call) | Should be read-only test execution | Indirect (inside called workflow) | Indirect | No (in called workflow) | No | Inputs passed + full secret inheritance | Yes | Indirect | Indirect/no |
+| `e2e-tests.yml` | `cypress` (reusable call) | Should be read-only test execution | Indirect (inside called workflow) | Indirect | No (in called workflow) | No | Inputs passed + full secret inheritance | Yes | Indirect | Indirect/no |
+| `e2e-tests.yml` | `e2e-gate` | none beyond default token | No | No (only evaluates upstream results) | No | No | none | No | No | N/A |
+| `e2e-tests.yml` | `publish-images` | `packages: read`, DockerHub creds, `actions: read` | No | No (retag/push only) | No write (reads GHCR) | No | `vars.DOCKERHUB_USERNAME`, `secrets.DOCKERHUB_TOKEN`, `secrets.GITHUB_TOKEN` | No | Yes | N/A |
+| `e2e-tests.yml` | `report-status` | `statuses: write` | No | No | No | Yes | GITHUB token via `github-script` | No | No | N/A |
+| `e2e-playwright-analyzer-harness-reusable.yml` | `demo-shards` | `packages: read`, `actions: read`, `contents: read` | Yes (`inputs.head_sha` / `github.sha`) | Yes (Playwright harness stack + seeding) | No | No | `TEST_USER` vars fallback; `TEST_PASS` from `secrets.TEST_PASS`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login | No | Yes | No |
+| `e2e-playwright-analyzer-harness-reusable.yml` | `merge-reports` | `actions: read`, `contents: read` | Yes (`actions/checkout`) | Yes (report merge tooling) | No | No | none explicit | No | No | No |
+| `e2e-playwright-analyzer-harness-reusable.yml` | `analyzer-e2e-gate` | none beyond default token | No | No (result checks only) | No | No | none | No | No | N/A |
+| `e2e-playwright-analyzer-harness-manual.yml` | `run` | delegated to called workflow | Delegated | Delegated | Delegated | No | full inherited secret scope to called workflow | Yes | Delegated | Delegated/no |
+| `e2e-cypress-deprecated.yml` | `e2e-cypress` | `packages: read`, `actions: read`, `contents: read` | Yes (`inputs.head_sha` / `github.sha`) | Yes (Cypress + compose runtime) | No | No | `TEST_USER` vars fallback; `TEST_PASS` from `secrets.TEST_PASS || 'adminADMIN!'`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login | No | No | No |
+
+## 3) Explicit PR-Controlled Code Execution Points
+
+The following jobs currently execute PR-controlled code with nontrivial token
+capability:
+
+1. `e2e-playwright.yml` / `shared-build`
+   - Runs in `pull_request` context with `packages: write`.
+   - For fork PRs, GHCR push fails by token scope, but build/test commands still run.
+2. `e2e-tests.yml` / `fork-rebuild`
+   - Runs in privileged `workflow_run` context, checks out `refs/pull/<n>/merge`.
+   - Rebuilds and pushes GHCR cache images using write-capable token.
+3. Test executor lanes (Playwright core, analyzer harness reusable, Cypress)
+   - Check out PR-controlled refs and run test commands.
+   - Should be read-only consumers but currently mixed with secret usage and
+     broad inheritance at callers.
+
+## 4) Status Publication Boundary
+
+Current status writers in `e2e-tests.yml`:
+
+- `set-pending-status` posts pending `03 Checkpoint - E2E`.
+- `report-status` posts final `03 Checkpoint - E2E`.
+
+Both are appropriately tiny in behavior (no checkout/build/tests), but workflow
+top-level permissions currently grant `statuses: write` to all jobs in the file.
+
+## 5) GHCR Package Transfer Boundary
+
+Current GHCR namespace usage:
+
+- Shared build and fork-rebuild publish images under:
+  `ghcr.io/<owner>/openelis-global-2/e2e-cache/<normalized-image>:sha-<...>`
+- Test executors pull and retag from `e2e-image-map` artifacts.
+- `publish-images` consumes tested images and republishes to DockerHub in the
+  same workflow file that also handles PR test orchestration.
+
+Risk currently is not namespace naming, but mixed responsibilities and shared
+workflow-level write permissions in `e2e-tests.yml`.
+
+## 6) Secret and Variable Flow Inventory
+
+Current references:
+
+- `secrets.TEST_PASS` used by:
+  - `e2e-tests.yml` `playwright-core`
+  - `e2e-playwright-analyzer-harness-reusable.yml` (`demo-shards` envs)
+  - `e2e-cypress-deprecated.yml` (`TEST_PASS: ${{ secrets.TEST_PASS || 'adminADMIN!' }}`)
+- `vars.TEST_USER || 'admin'` used across Playwright/Cypress lanes.
+- `secrets: inherit` used by:
+  - `e2e-tests.yml` reusable calls to analyzer harness and Cypress
+  - `e2e-playwright-analyzer-harness-manual.yml` wrapper
+- DockerHub publish currently uses:
+  - `vars.DOCKERHUB_USERNAME`
+  - `secrets.DOCKERHUB_TOKEN`
+  - job is bound to `environment: e2e` (to be replaced by `publish` env).
+
+## 7) Fork vs Non-Fork Execution Graphs (Current)
+
+### Same-repo PR
+
+1. `03 - E2E` / `shared-build` checks out PR code, builds, pushes GHCR cache.
+2. `E2E / Tests and Publish` triggered by `workflow_run`.
+3. `setup` parses build context.
+4. `set-pending-status` posts pending checkpoint.
+5. `fork-rebuild` skipped.
+6. `playwright-core`, `analyzer-harness`, `cypress` run from GHCR cache.
+7. `e2e-gate` evaluates results.
+8. `report-status` posts final checkpoint.
+9. `publish-images` skipped (event is PR, not push/release).
+
+### Fork PR
+
+1. `03 - E2E` / `shared-build` checks out PR code, GHCR push denied, emits
+   `image_transfer=fork-fallback`.
+2. `E2E / Tests and Publish` triggered by `workflow_run`.
+3. `setup` parses build context.
+4. `set-pending-status` posts pending checkpoint.
+5. `fork-rebuild` checks out `refs/pull/<n>/merge`, rebuilds, pushes GHCR cache.
+6. `playwright-core`, `analyzer-harness`, `cypress` consume fork-rebuild artifacts.
+7. `e2e-gate` evaluates results.
+8. `report-status` posts final checkpoint.
+9. `publish-images` skipped (event is PR, not push/release).
+
+## 8) Findings Summary Before Hardening
+
+1. `e2e-tests.yml` is overprivileged at workflow scope (`packages: write` +
+   `statuses: write`) relative to per-job intent.
+2. `secrets: inherit` remains at reusable workflow call boundaries.
+3. `secrets.TEST_PASS` remains in multiple executor workflows.
+4. `environment: e2e` is still present in build, test, fork-rebuild, and publish.
+5. `persist-credentials: false` is not set on current checkout steps.
+6. The primary trust-boundary exception is `fork-rebuild` executing PR-controlled
+   code in privileged `workflow_run` context.
+
+This file serves as the baseline evidence for Phases 2-6 hardening work.

--- a/.specify/plans/e2e-ci-privilege-matrix.md
+++ b/.specify/plans/e2e-ci-privilege-matrix.md
@@ -1,7 +1,7 @@
 # E2E CI Privilege Matrix (Phase 1)
 
-This matrix inventories the current trust boundaries for E2E CI before
-hardening changes.
+This matrix inventories the current trust boundaries for E2E CI before hardening
+changes.
 
 Scope:
 
@@ -13,13 +13,13 @@ Scope:
 
 ## 1) Workflow-Level Privilege Baseline
 
-| Workflow | Trigger | Workflow-level permissions | Notable trust implications |
-| --- | --- | --- | --- |
-| `03 - E2E` (`e2e-playwright.yml`) | `pull_request`, `push`, `release`, `workflow_dispatch` | `contents: read`, `packages: write` | PR lane can attempt GHCR push (forks fail naturally due to token scope). |
-| `E2E / Tests and Publish` (`e2e-tests.yml`) | `workflow_run` on `03 - E2E` | `contents: read`, `packages: write`, `statuses: write`, `actions: read` | Broad write scope shared by setup, tests, publish, and reporter jobs. |
-| `E2E / Playwright / Analyzer Harness (Reusable)` | `workflow_call` | `contents: read`, `packages: read`, `actions: read` | Good read-only baseline, but still consumes secret-backed `TEST_PASS`. |
-| `E2E / Playwright / Analyzer Harness (Manual)` | `workflow_dispatch` | inherited from called workflow | Uses `secrets: inherit` at wrapper entrypoint. |
-| `E2E / Cypress (Deprecated)` | `workflow_call`, `workflow_dispatch` | `contents: read`, `packages: read`, `actions: read` | Read-only package usage, but still references secret-backed fallback for `TEST_PASS`. |
+| Workflow                                         | Trigger                                                | Workflow-level permissions                                              | Notable trust implications                                                            |
+| ------------------------------------------------ | ------------------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `03 - E2E` (`e2e-playwright.yml`)                | `pull_request`, `push`, `release`, `workflow_dispatch` | `contents: read`, `packages: write`                                     | PR lane can attempt GHCR push (forks fail naturally due to token scope).              |
+| `E2E / Tests and Publish` (`e2e-tests.yml`)      | `workflow_run` on `03 - E2E`                           | `contents: read`, `packages: write`, `statuses: write`, `actions: read` | Broad write scope shared by setup, tests, publish, and reporter jobs.                 |
+| `E2E / Playwright / Analyzer Harness (Reusable)` | `workflow_call`                                        | `contents: read`, `packages: read`, `actions: read`                     | Good read-only baseline, but still consumes secret-backed `TEST_PASS`.                |
+| `E2E / Playwright / Analyzer Harness (Manual)`   | `workflow_dispatch`                                    | inherited from called workflow                                          | Uses `secrets: inherit` at wrapper entrypoint.                                        |
+| `E2E / Cypress (Deprecated)`                     | `workflow_call`, `workflow_dispatch`                   | `contents: read`, `packages: read`, `actions: read`                     | Read-only package usage, but still references secret-backed fallback for `TEST_PASS`. |
 
 ## 2) Job-Level Privilege Matrix
 
@@ -30,23 +30,23 @@ Legend:
 - GHCR write: pushes package versions to `ghcr.io/.../e2e-cache/...`.
 - Status write: posts `03 Checkpoint - E2E` commit status.
 
-| Workflow | Job | Effective permission need (current behavior) | PR code checkout | PR code execution | GHCR write | Status write | Secrets / vars flow | `secrets: inherit` | `environment: e2e` | `persist-credentials: false` |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `e2e-playwright.yml` | `shared-build` | `contents: read`, `packages: write` | Yes (`actions/checkout`) | Yes (Maven, npm, Docker build/push) | Yes | No | `secrets.GITHUB_TOKEN` for GHCR login | No | Yes | No |
-| `e2e-tests.yml` | `setup` | `actions: read`, `contents: read` | No | No | No | No | `secrets.GITHUB_TOKEN` for cross-run artifact read | No | No | N/A |
-| `e2e-tests.yml` | `set-pending-status` | `statuses: write` | No | No | No | Yes | GITHUB token via `github-script` | No | No | N/A |
-| `e2e-tests.yml` | `fork-rebuild` | `packages: write`, `contents: read` | Yes (`refs/pull/<n>/merge`) | Yes (Maven, npm, Docker build/push) | Yes | No | `secrets.GITHUB_TOKEN` for GHCR login | No | Yes | No |
-| `e2e-tests.yml` | `playwright-core` | `packages: read`, `actions: read`, `contents: read` | Yes (merge ref for forks, workflow_run SHA otherwise) | Yes (Playwright + compose runtime) | No | No | `TEST_USER` from vars fallback; `TEST_PASS` from `secrets.TEST_PASS`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login | No | Yes | No |
-| `e2e-tests.yml` | `analyzer-harness` (reusable call) | Should be read-only test execution | Indirect (inside called workflow) | Indirect | No (in called workflow) | No | Inputs passed + full secret inheritance | Yes | Indirect | Indirect/no |
-| `e2e-tests.yml` | `cypress` (reusable call) | Should be read-only test execution | Indirect (inside called workflow) | Indirect | No (in called workflow) | No | Inputs passed + full secret inheritance | Yes | Indirect | Indirect/no |
-| `e2e-tests.yml` | `e2e-gate` | none beyond default token | No | No (only evaluates upstream results) | No | No | none | No | No | N/A |
-| `e2e-tests.yml` | `publish-images` | `packages: read`, DockerHub creds, `actions: read` | No | No (retag/push only) | No write (reads GHCR) | No | `vars.DOCKERHUB_USERNAME`, `secrets.DOCKERHUB_TOKEN`, `secrets.GITHUB_TOKEN` | No | Yes | N/A |
-| `e2e-tests.yml` | `report-status` | `statuses: write` | No | No | No | Yes | GITHUB token via `github-script` | No | No | N/A |
-| `e2e-playwright-analyzer-harness-reusable.yml` | `demo-shards` | `packages: read`, `actions: read`, `contents: read` | Yes (`inputs.head_sha` / `github.sha`) | Yes (Playwright harness stack + seeding) | No | No | `TEST_USER` vars fallback; `TEST_PASS` from `secrets.TEST_PASS`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login | No | Yes | No |
-| `e2e-playwright-analyzer-harness-reusable.yml` | `merge-reports` | `actions: read`, `contents: read` | Yes (`actions/checkout`) | Yes (report merge tooling) | No | No | none explicit | No | No | No |
-| `e2e-playwright-analyzer-harness-reusable.yml` | `analyzer-e2e-gate` | none beyond default token | No | No (result checks only) | No | No | none | No | No | N/A |
-| `e2e-playwright-analyzer-harness-manual.yml` | `run` | delegated to called workflow | Delegated | Delegated | Delegated | No | full inherited secret scope to called workflow | Yes | Delegated | Delegated/no |
-| `e2e-cypress-deprecated.yml` | `e2e-cypress` | `packages: read`, `actions: read`, `contents: read` | Yes (`inputs.head_sha` / `github.sha`) | Yes (Cypress + compose runtime) | No | No | `TEST_USER` vars fallback; `TEST_PASS` from `secrets.TEST_PASS || 'adminADMIN!'`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login | No | No | No |
+| Workflow                                       | Job                                | Effective permission need (current behavior)        | PR code checkout                                      | PR code execution                        | GHCR write              | Status write | Secrets / vars flow                                                                                                         | `secrets: inherit` | `environment: e2e`                                                    | `persist-credentials: false` |
+| ---------------------------------------------- | ---------------------------------- | --------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------- | ----------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------ | --------------------------------------------------------------------- | ---------------------------- | --- | --- |
+| `e2e-playwright.yml`                           | `shared-build`                     | `contents: read`, `packages: write`                 | Yes (`actions/checkout`)                              | Yes (Maven, npm, Docker build/push)      | Yes                     | No           | `secrets.GITHUB_TOKEN` for GHCR login                                                                                       | No                 | Yes                                                                   | No                           |
+| `e2e-tests.yml`                                | `setup`                            | `actions: read`, `contents: read`                   | No                                                    | No                                       | No                      | No           | `secrets.GITHUB_TOKEN` for cross-run artifact read                                                                          | No                 | No                                                                    | N/A                          |
+| `e2e-tests.yml`                                | `set-pending-status`               | `statuses: write`                                   | No                                                    | No                                       | No                      | Yes          | GITHUB token via `github-script`                                                                                            | No                 | No                                                                    | N/A                          |
+| `e2e-tests.yml`                                | `fork-rebuild`                     | `packages: write`, `contents: read`                 | Yes (`refs/pull/<n>/merge`)                           | Yes (Maven, npm, Docker build/push)      | Yes                     | No           | `secrets.GITHUB_TOKEN` for GHCR login                                                                                       | No                 | Yes                                                                   | No                           |
+| `e2e-tests.yml`                                | `playwright-core`                  | `packages: read`, `actions: read`, `contents: read` | Yes (merge ref for forks, workflow_run SHA otherwise) | Yes (Playwright + compose runtime)       | No                      | No           | `TEST_USER` from vars fallback; `TEST_PASS` from `secrets.TEST_PASS`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login | No                 | Yes                                                                   | No                           |
+| `e2e-tests.yml`                                | `analyzer-harness` (reusable call) | Should be read-only test execution                  | Indirect (inside called workflow)                     | Indirect                                 | No (in called workflow) | No           | Inputs passed + full secret inheritance                                                                                     | Yes                | Indirect                                                              | Indirect/no                  |
+| `e2e-tests.yml`                                | `cypress` (reusable call)          | Should be read-only test execution                  | Indirect (inside called workflow)                     | Indirect                                 | No (in called workflow) | No           | Inputs passed + full secret inheritance                                                                                     | Yes                | Indirect                                                              | Indirect/no                  |
+| `e2e-tests.yml`                                | `e2e-gate`                         | none beyond default token                           | No                                                    | No (only evaluates upstream results)     | No                      | No           | none                                                                                                                        | No                 | No                                                                    | N/A                          |
+| `e2e-tests.yml`                                | `publish-images`                   | `packages: read`, DockerHub creds, `actions: read`  | No                                                    | No (retag/push only)                     | No write (reads GHCR)   | No           | `vars.DOCKERHUB_USERNAME`, `secrets.DOCKERHUB_TOKEN`, `secrets.GITHUB_TOKEN`                                                | No                 | Yes                                                                   | N/A                          |
+| `e2e-tests.yml`                                | `report-status`                    | `statuses: write`                                   | No                                                    | No                                       | No                      | Yes          | GITHUB token via `github-script`                                                                                            | No                 | No                                                                    | N/A                          |
+| `e2e-playwright-analyzer-harness-reusable.yml` | `demo-shards`                      | `packages: read`, `actions: read`, `contents: read` | Yes (`inputs.head_sha` / `github.sha`)                | Yes (Playwright harness stack + seeding) | No                      | No           | `TEST_USER` vars fallback; `TEST_PASS` from `secrets.TEST_PASS`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login      | No                 | Yes                                                                   | No                           |
+| `e2e-playwright-analyzer-harness-reusable.yml` | `merge-reports`                    | `actions: read`, `contents: read`                   | Yes (`actions/checkout`)                              | Yes (report merge tooling)               | No                      | No           | none explicit                                                                                                               | No                 | No                                                                    | No                           |
+| `e2e-playwright-analyzer-harness-reusable.yml` | `analyzer-e2e-gate`                | none beyond default token                           | No                                                    | No (result checks only)                  | No                      | No           | none                                                                                                                        | No                 | No                                                                    | N/A                          |
+| `e2e-playwright-analyzer-harness-manual.yml`   | `run`                              | delegated to called workflow                        | Delegated                                             | Delegated                                | Delegated               | No           | full inherited secret scope to called workflow                                                                              | Yes                | Delegated                                                             | Delegated/no                 |
+| `e2e-cypress-deprecated.yml`                   | `e2e-cypress`                      | `packages: read`, `actions: read`, `contents: read` | Yes (`inputs.head_sha` / `github.sha`)                | Yes (Cypress + compose runtime)          | No                      | No           | `TEST_USER` vars fallback; `TEST_PASS` from `secrets.TEST_PASS                                                              |                    | 'adminADMIN!'`; `secrets.GITHUB_TOKEN` for artifact read + GHCR login | No                           | No  | No  |
 
 ## 3) Explicit PR-Controlled Code Execution Points
 
@@ -55,9 +55,11 @@ capability:
 
 1. `e2e-playwright.yml` / `shared-build`
    - Runs in `pull_request` context with `packages: write`.
-   - For fork PRs, GHCR push fails by token scope, but build/test commands still run.
+   - For fork PRs, GHCR push fails by token scope, but build/test commands still
+     run.
 2. `e2e-tests.yml` / `fork-rebuild`
-   - Runs in privileged `workflow_run` context, checks out `refs/pull/<n>/merge`.
+   - Runs in privileged `workflow_run` context, checks out
+     `refs/pull/<n>/merge`.
    - Rebuilds and pushes GHCR cache images using write-capable token.
 3. Test executor lanes (Playwright core, analyzer harness reusable, Cypress)
    - Check out PR-controlled refs and run test commands.
@@ -94,7 +96,8 @@ Current references:
 - `secrets.TEST_PASS` used by:
   - `e2e-tests.yml` `playwright-core`
   - `e2e-playwright-analyzer-harness-reusable.yml` (`demo-shards` envs)
-  - `e2e-cypress-deprecated.yml` (`TEST_PASS: ${{ secrets.TEST_PASS || 'adminADMIN!' }}`)
+  - `e2e-cypress-deprecated.yml`
+    (`TEST_PASS: ${{ secrets.TEST_PASS || 'adminADMIN!' }}`)
 - `vars.TEST_USER || 'admin'` used across Playwright/Cypress lanes.
 - `secrets: inherit` used by:
   - `e2e-tests.yml` reusable calls to analyzer harness and Cypress
@@ -126,7 +129,8 @@ Current references:
 3. `setup` parses build context.
 4. `set-pending-status` posts pending checkpoint.
 5. `fork-rebuild` checks out `refs/pull/<n>/merge`, rebuilds, pushes GHCR cache.
-6. `playwright-core`, `analyzer-harness`, `cypress` consume fork-rebuild artifacts.
+6. `playwright-core`, `analyzer-harness`, `cypress` consume fork-rebuild
+   artifacts.
 7. `e2e-gate` evaluates results.
 8. `report-status` posts final checkpoint.
 9. `publish-images` skipped (event is PR, not push/release).
@@ -137,9 +141,10 @@ Current references:
    `statuses: write`) relative to per-job intent.
 2. `secrets: inherit` remains at reusable workflow call boundaries.
 3. `secrets.TEST_PASS` remains in multiple executor workflows.
-4. `environment: e2e` is still present in build, test, fork-rebuild, and publish.
+4. `environment: e2e` is still present in build, test, fork-rebuild, and
+   publish.
 5. `persist-credentials: false` is not set on current checkout steps.
-6. The primary trust-boundary exception is `fork-rebuild` executing PR-controlled
-   code in privileged `workflow_run` context.
+6. The primary trust-boundary exception is `fork-rebuild` executing
+   PR-controlled code in privileged `workflow_run` context.
 
 This file serves as the baseline evidence for Phases 2-6 hardening work.

--- a/.specify/plans/e2e-ci-required-vs-convenience.md
+++ b/.specify/plans/e2e-ci-required-vs-convenience.md
@@ -7,27 +7,27 @@ This note classifies current E2E pipeline capabilities into:
 
 ## Required For Validation
 
-| Capability | Why required |
-| --- | --- |
-| Build once and share image outputs across E2E lanes | Avoids inconsistent test surfaces between Playwright/Cypress/analyzer harness. |
-| Fork + non-fork PR E2E support | Project requirement for trustworthy contribution gate coverage. |
-| Final PR-facing `03 Checkpoint - E2E` status | Required for branch-protection-friendly, single checkpoint UX. |
-| Read-only package consumption in test executors | Needed to pull prebuilt GHCR cache images. |
-| Cross-run artifact reads (`actions: read`) in downstream workflow | Required for image maps/plugin jars from triggering run. |
-| Deterministic CI login contract (`TEST_USER` / `TEST_PASS` fallback) | Required for noninteractive E2E auth in all test lanes. |
-| E2E gate aggregation job | Required to fail PR when any required test lane fails. |
+| Capability                                                           | Why required                                                                   |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Build once and share image outputs across E2E lanes                  | Avoids inconsistent test surfaces between Playwright/Cypress/analyzer harness. |
+| Fork + non-fork PR E2E support                                       | Project requirement for trustworthy contribution gate coverage.                |
+| Final PR-facing `03 Checkpoint - E2E` status                         | Required for branch-protection-friendly, single checkpoint UX.                 |
+| Read-only package consumption in test executors                      | Needed to pull prebuilt GHCR cache images.                                     |
+| Cross-run artifact reads (`actions: read`) in downstream workflow    | Required for image maps/plugin jars from triggering run.                       |
+| Deterministic CI login contract (`TEST_USER` / `TEST_PASS` fallback) | Required for noninteractive E2E auth in all test lanes.                        |
+| E2E gate aggregation job                                             | Required to fail PR when any required test lane fails.                         |
 
 ## Optimization / Convenience / Mixed Concern
 
-| Capability | Classification | Why not fundamentally required in current location |
-| --- | --- | --- |
-| Workflow-wide `packages: write` in `e2e-tests.yml` | Over-scoped convenience | Only cache-publishing lanes need write; tests should be read-only. |
-| Workflow-wide `statuses: write` in `e2e-tests.yml` | Over-scoped convenience | Only status reporter jobs need it. |
-| `secrets: inherit` on reusable calls | Convenience anti-pattern | Named inputs/secrets are sufficient and safer. |
-| `secrets.TEST_PASS` usage in PR test execution | Legacy convenience | CI defaults are intentionally non-secret; vars fallback is adequate. |
-| `environment: e2e` on test/build jobs | Legacy coupling | Not required for E2E validation; introduces unnecessary secret surface. |
-| Publish-to-DockerHub logic inside `e2e-tests.yml` | Mixed concern | Publication is post-merge concern, should live in separate workflow lane. |
-| Fork rebuild running in privileged `workflow_run` | Temporary exception | Needed today for parity/performance, but architectural migration target remains artifact-based transfer. |
+| Capability                                         | Classification           | Why not fundamentally required in current location                                                       |
+| -------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Workflow-wide `packages: write` in `e2e-tests.yml` | Over-scoped convenience  | Only cache-publishing lanes need write; tests should be read-only.                                       |
+| Workflow-wide `statuses: write` in `e2e-tests.yml` | Over-scoped convenience  | Only status reporter jobs need it.                                                                       |
+| `secrets: inherit` on reusable calls               | Convenience anti-pattern | Named inputs/secrets are sufficient and safer.                                                           |
+| `secrets.TEST_PASS` usage in PR test execution     | Legacy convenience       | CI defaults are intentionally non-secret; vars fallback is adequate.                                     |
+| `environment: e2e` on test/build jobs              | Legacy coupling          | Not required for E2E validation; introduces unnecessary secret surface.                                  |
+| Publish-to-DockerHub logic inside `e2e-tests.yml`  | Mixed concern            | Publication is post-merge concern, should live in separate workflow lane.                                |
+| Fork rebuild running in privileged `workflow_run`  | Temporary exception      | Needed today for parity/performance, but architectural migration target remains artifact-based transfer. |
 
 ## Explicit Policy Decisions For Implementation
 

--- a/.specify/plans/e2e-ci-required-vs-convenience.md
+++ b/.specify/plans/e2e-ci-required-vs-convenience.md
@@ -1,0 +1,51 @@
+# E2E CI Required vs Convenience Classification (Phase 2)
+
+This note classifies current E2E pipeline capabilities into:
+
+- required for validation correctness
+- optimization or convenience (or mixed concern needing relocation)
+
+## Required For Validation
+
+| Capability | Why required |
+| --- | --- |
+| Build once and share image outputs across E2E lanes | Avoids inconsistent test surfaces between Playwright/Cypress/analyzer harness. |
+| Fork + non-fork PR E2E support | Project requirement for trustworthy contribution gate coverage. |
+| Final PR-facing `03 Checkpoint - E2E` status | Required for branch-protection-friendly, single checkpoint UX. |
+| Read-only package consumption in test executors | Needed to pull prebuilt GHCR cache images. |
+| Cross-run artifact reads (`actions: read`) in downstream workflow | Required for image maps/plugin jars from triggering run. |
+| Deterministic CI login contract (`TEST_USER` / `TEST_PASS` fallback) | Required for noninteractive E2E auth in all test lanes. |
+| E2E gate aggregation job | Required to fail PR when any required test lane fails. |
+
+## Optimization / Convenience / Mixed Concern
+
+| Capability | Classification | Why not fundamentally required in current location |
+| --- | --- | --- |
+| Workflow-wide `packages: write` in `e2e-tests.yml` | Over-scoped convenience | Only cache-publishing lanes need write; tests should be read-only. |
+| Workflow-wide `statuses: write` in `e2e-tests.yml` | Over-scoped convenience | Only status reporter jobs need it. |
+| `secrets: inherit` on reusable calls | Convenience anti-pattern | Named inputs/secrets are sufficient and safer. |
+| `secrets.TEST_PASS` usage in PR test execution | Legacy convenience | CI defaults are intentionally non-secret; vars fallback is adequate. |
+| `environment: e2e` on test/build jobs | Legacy coupling | Not required for E2E validation; introduces unnecessary secret surface. |
+| Publish-to-DockerHub logic inside `e2e-tests.yml` | Mixed concern | Publication is post-merge concern, should live in separate workflow lane. |
+| Fork rebuild running in privileged `workflow_run` | Temporary exception | Needed today for parity/performance, but architectural migration target remains artifact-based transfer. |
+
+## Explicit Policy Decisions For Implementation
+
+1. PR CI validates only; real publication is post-merge.
+2. GHCR `e2e-cache` stays, but as explicit transient cache lane.
+3. Executor jobs become read-only package consumers.
+4. Status reporting is isolated to tiny reporter jobs.
+5. CI auth contract is uniform everywhere:
+   - `TEST_USER: ${{ vars.TEST_USER || 'admin' }}`
+   - `TEST_PASS: ${{ vars.TEST_PASS || 'adminADMIN!' }}`
+6. `fork-rebuild` remains a documented short-term exception with minimal scope:
+   `packages: write` only.
+
+## What This Means For Next Edits
+
+1. Extract post-merge `publish-images` to dedicated `publish-images.yml`.
+2. Move from workflow-level to job-scoped permissions in `e2e-tests.yml`.
+3. Remove `secrets: inherit` and pass only named inputs/secrets.
+4. Remove `environment: e2e`; introduce `environment: publish` for publish lane.
+5. Add e2e-cache cleanup workflow (7-day retention).
+6. Add operator runbook for `gh`-automated and manual fallback repo settings.

--- a/.specify/plans/e2e-ci-trust-boundary-hardening.md
+++ b/.specify/plans/e2e-ci-trust-boundary-hardening.md
@@ -1,0 +1,503 @@
+---
+name: e2e ci trust boundary hardening
+overview:
+  Preserve the current two-layer E2E architecture where it materially helps
+  fork/non-fork parity and GHCR-backed cache transfer, but reduce the privileged
+  surface so that PR CI only validates, never publishes real deliverables, and
+  uses privilege solely where the workflow model truly requires it. The target
+  state is a clean separation between transient E2E cache publication, read-only
+  test execution, and the final 03 Checkpoint reporter.
+todos:
+  - id: save-plan-record
+    content:
+      Record the agreed workplan in .specify/plans/ on a dedicated
+      branch/worktree before implementation work begins.
+    status: completed
+  - id: map-current-trust-boundaries
+    content:
+      Inventory every current privilege boundary in 03 - E2E and E2E / Tests and
+      Publish, including reusable/manual wrapper entrypoints, packages write,
+      statuses write, actions read, inherited secrets, GHCR image transfer, and
+      PR-code checkout points.
+    status: pending
+  - id: classify-required-vs-accidental-privilege
+    content:
+      Separate truly required capabilities from convenience-driven ones so the
+      workflow design reflects the rule that PR CI validates only and merged
+      branches alone publish reusable outputs.
+    status: pending
+  - id: isolate-ghcr-e2e-cache-lane
+    content:
+      Redesign the GHCR usage model as an explicit transient e2e-cache lane with
+      distinct write and read permission scopes, separate from any future real
+      image publication concerns.
+    status: pending
+  - id: remove-nonessential-secret-dependence
+    content:
+      Define one explicit deterministic CI auth contract, then replace TEST_PASS
+      and any broad secret inheritance in PR validation paths with that contract
+      or other non-sensitive inputs.
+    status: pending
+  - id: shrink-job-permissions
+    content:
+      Move from workflow-wide permissions to job-scoped least privilege so cache
+      publishers, test executors, and the 03 Checkpoint reporter each get only
+      the minimum permissions they require.
+    status: pending
+  - id: resolve-fork-pr-trust-model
+    content:
+      Decide and document whether privileged fork rebuilds remain a short-term
+      exception or must be eliminated by moving fork execution fully into the
+      unprivileged pull_request lane.
+    status: pending
+  - id: verify-develop-merge-behavior
+    content:
+      Prove that the resulting design remains green after merge to develop and
+      preserves expected behavior for same-repo PRs, fork PRs, and push/release
+      publish flows.
+    status: pending
+  - id: document-operator-model
+    content:
+      Write clear repo guidance describing which workflow changes require
+      default branch merge, which code/config changes are picked up pre-merge,
+      and how to reason about the split safely.
+    status: pending
+isProject: false
+---
+
+# E2E CI Trust Boundary Hardening Plan
+
+## Why This Plan Exists
+
+The recent CI work surfaced a real architectural tension rather than a single
+bug:
+
+- The project needs a meaningful analyzer-harness and core E2E gate on PRs.
+- Fork and non-fork PRs should remain as aligned as practical.
+- `GHCR` is being used as a transient cache and transport layer between the
+  build and test phases because it is materially simpler than artifact tarballs
+  or double rebuilds.
+- The project does **not** want pre-merge CI to behave like publishing.
+- The only clearly unavoidable privileged PR-side action is reporting the final
+  `03 Checkpoint - E2E` result back to the PR.
+
+GitHub Actions supports this pattern, but its security model is explicit:
+
+- `pull_request` is the unprivileged lane for untrusted PR code.
+- `workflow_run` can access secrets and write-capable tokens.
+- Running PR-controlled code in a privileged `workflow_run` lane expands risk
+  and must be treated as an intentional exception, not a default.
+
+Relevant references:
+
+- GitHub docs on `workflow_run` privileges and warnings:
+  <https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows>
+- GitHub Security Lab on "pwn requests":
+  <https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/>
+- GitHub reusable workflow same-commit behavior for local references:
+  <https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/>
+
+This plan defines the work needed to get from the current workable-but-blurry
+setup to a setup whose trust boundaries are explicit, minimal, and durable.
+
+## Current State Summary
+
+The current E2E pipeline is split across:
+
+- `.github/workflows/e2e-playwright.yml`
+- `.github/workflows/e2e-tests.yml`
+- `.github/workflows/e2e-playwright-analyzer-harness-reusable.yml`
+- `.github/workflows/e2e-playwright-analyzer-harness-manual.yml`
+
+Current behavior:
+
+1. `03 - E2E` builds images and attempts to push them to `GHCR`.
+2. `E2E / Tests and Publish` is triggered via `workflow_run`.
+3. Non-fork PRs consume the cached images from `GHCR`.
+4. Fork PRs fall back to a privileged rebuild path in the downstream workflow.
+5. The downstream workflow also posts the custom `03 Checkpoint - E2E` status.
+6. Some test lanes still depend on `TEST_PASS` and broad secret inheritance.
+7. The manual analyzer-harness wrapper still broadens the surface via
+   `secrets: inherit`, even though it is not the main PR execution path.
+
+Current pain points:
+
+- Workflow-level permissions are broader than the actual responsibilities of
+  each job.
+- The GHCR cache lane is operationally useful, but its privilege model is not
+  isolated clearly enough from other concerns.
+- `TEST_PASS` is not a meaningful secret boundary, but it still forces secret
+  handling into PR validation paths.
+- The current plan needs one explicit replacement contract for CI auth, or the
+  secret-removal phase will drift during implementation.
+- The fork rebuild path is the main trust-boundary exception because it runs
+  PR-controlled code in a more privileged workflow context.
+- Publication logic still lives in the same `workflow_run` file as the
+  privileged PR-side test orchestration, which keeps the trust boundary harder
+  to reason about even when the jobs are conditionally isolated.
+- The repo lacks concise operator guidance on what changes are picked up pre-
+  merge versus what requires default-branch workflow updates.
+
+## Design Principles
+
+The target setup must follow these principles:
+
+- PR CI validates only.
+- Real publication happens only on `push`/`release` after merge.
+- `GHCR` cache writes for PRs are treated as transient E2E transport, not as
+  product publishing.
+- Cache publication and cache consumption are separate permission classes.
+- CI auth uses one documented deterministic contract rather than ad hoc
+  `TEST_PASS` consumption across reusable workflows.
+- The final `03 Checkpoint - E2E` reporter is a tiny trusted lane.
+- Secrets are removed from PR validation unless they are genuinely necessary.
+- Workflow privilege is scoped per job, not granted broadly at the workflow
+  level.
+- Any remaining privileged execution of PR-controlled code is documented as an
+  explicit exception with a migration path away from it.
+
+## Recommended Target Architecture
+
+The recommended target keeps the current two-layer topology for now, because it
+still provides practical benefits:
+
+- `GHCR` remains the simplest cache/transport between build and test layers.
+- The custom `03 Checkpoint - E2E` reporter remains available.
+- Fork and non-fork PRs keep a comparable external UX.
+
+However, the trust model is tightened into four distinct lanes:
+
+Implementation choice for this hardening effort:
+
+- Lane D should be extracted out of `e2e-tests.yml` into a separate post-merge
+  workflow triggered only on `push`/`release`.
+- If extraction proves too disruptive for the first pass, then keeping Lane D in
+  the same file is an explicitly temporary state that must still satisfy strict
+  job isolation and must not be treated as the target architecture.
+
+### Lane A: Shared Build / Cache Publisher
+
+Purpose:
+
+- Build Docker images once.
+- Publish transient E2E cache images under a dedicated `e2e-cache` namespace.
+
+Rules:
+
+- This lane may have `packages: write`.
+- It must not have `statuses: write`.
+- It must not publish DockerHub or any long-lived release artifact.
+- Cache images must remain namespaced and documented as ephemeral test assets.
+
+### Lane B: Test Executors
+
+Purpose:
+
+- Run Playwright core, analyzer harness, and any remaining PR validation tests.
+
+Rules:
+
+- These jobs should have only `packages: read`, `contents: read`, and whatever
+  minimal artifact-read capability is required.
+- These jobs should not have `statuses: write`.
+- These jobs should not inherit broad secrets.
+- These jobs should run with deterministic CI credentials that are not treated
+  as protected repository secrets.
+
+### Lane C: 03 Checkpoint Reporter
+
+Purpose:
+
+- Post `pending` and final `03 Checkpoint - E2E` results back to the PR.
+
+Rules:
+
+- This job gets `statuses: write`.
+- It should not check out PR code.
+- It should not build, publish, or execute test commands.
+- It may read workflow conclusions or artifacts, but should remain tiny and
+  trusted.
+
+### Lane D: Post-Merge Publication
+
+Purpose:
+
+- Publish tested images or other release artifacts after merge only.
+
+Rules:
+
+- Runs on `push` to `develop` and/or `release`.
+- Consumes tested outputs only after the E2E gate is green.
+- Remains isolated from PR validation concerns entirely.
+
+## Workplan
+
+## Phase 1: Inventory The Real Trust Boundaries
+
+Goal:
+
+- Replace intuition with an explicit privilege map of the current pipeline.
+
+Tasks:
+
+1. Enumerate the permissions and secret inputs currently used by each job in:
+   - `e2e-playwright.yml`
+   - `e2e-tests.yml`
+   - `e2e-playwright-analyzer-harness-reusable.yml`
+   - `e2e-playwright-analyzer-harness-manual.yml`
+   - any called Cypress reusable workflows
+2. Mark which jobs:
+   - check out PR-controlled code
+   - run Maven, npm, Docker, or Playwright against PR-controlled inputs
+   - push to `GHCR`
+   - post statuses
+   - use `secrets: inherit`
+   - rely on `TEST_PASS`
+3. Record the current fork and non-fork execution graphs separately.
+
+Deliverable:
+
+- A one-page privilege matrix covering every job, token scope, secret input, and
+  PR-code execution point.
+
+Checkpoint:
+
+- No implementation begins until the privilege map is complete and reviewed.
+
+## Phase 2: Separate Required Privilege From Convenience
+
+Goal:
+
+- Distinguish what the pipeline genuinely requires from what was added for speed
+  or simplicity.
+
+Questions to answer explicitly:
+
+1. Is `packages: write` required for correctness, or only for the transient
+   `GHCR` cache handoff?
+2. Is `TEST_PASS` a true secret, or can it be replaced with deterministic test
+   credentials?
+3. Is the custom `03 Checkpoint - E2E` status required, or could branch
+   protection rely directly on gate jobs?
+4. Which parts of the current downstream workflow exist only because fork PRs
+   cannot push cache images from the `pull_request` lane?
+5. Does Lane D remain a job-isolated post-merge section temporarily, or is it
+   extracted immediately into its own post-merge workflow? The recommended
+   target is extraction.
+
+Deliverable:
+
+- A short architecture note with two columns:
+  - `required for validation`
+  - `optimization or convenience`
+
+Checkpoint:
+
+- The team signs off on the set of capabilities that are truly allowed in PR CI.
+
+## Phase 3: Isolate GHCR As A Dedicated E2E Cache Lane
+
+Goal:
+
+- Keep the performance and simplicity benefits of `GHCR` while making its role
+  narrow and explicit.
+
+Tasks:
+
+1. Formalize the `ghcr.io/<owner>/openelis-global-2/e2e-cache/...` namespace as
+   transient CI cache only.
+2. Ensure only the cache-publisher lane can write to that namespace.
+3. Ensure test lanes are read-only consumers of cache artifacts.
+4. Verify no other workflow path reuses this namespace for release publication.
+5. Add cleanup and retention guidance so the cache lane stays operationally
+   isolated from long-lived artifacts.
+
+Checkpoint:
+
+- The pipeline has exactly two package permission classes:
+  - `packages: write` for cache publishing
+  - `packages: read` for cache consumption
+
+## Phase 4: Remove Nonessential Secret Dependence
+
+Goal:
+
+- Make PR validation independent of protected secrets wherever possible.
+
+Tasks:
+
+1. Replace `TEST_PASS` with deterministic CI fixture credentials or other
+   non-sensitive values that can safely exist in unprivileged lanes.
+2. Write down the exact CI auth contract before implementation:
+   - where the credential comes from
+   - which jobs consume it
+   - whether it is a repo variable, checked-in fixture value, or another
+     deterministic non-secret input
+   - how manual and reusable workflows receive it without `secrets: inherit`
+3. Remove `secrets: inherit` from any called workflow that does not require a
+   specific explicit secret.
+4. Pass only named inputs or named secrets where a true secret remains
+   necessary.
+5. Verify that analyzer harness seeding, application login, and Playwright setup
+   still work in both same-repo and fork PR contexts.
+
+Checkpoint:
+
+- PR validation no longer depends on broad inherited secrets.
+
+## Phase 5: Move To Job-Scoped Least Privilege
+
+Goal:
+
+- Shrink permissions to the minimum needed for each lane.
+
+Tasks:
+
+1. Remove broad workflow-level permissions from `e2e-tests.yml` where possible.
+2. Assign job-scoped permissions:
+   - cache publisher: `packages: write`
+   - test executors: `packages: read`
+   - reporter: `statuses: write`
+3. Set `persist-credentials: false` on checkouts that run PR-controlled code and
+   do not need git writes.
+4. Confirm that reporter jobs do not check out PR code at all.
+5. Replace wrapper-level `secrets: inherit` with named inputs/secrets, including
+   the manual analyzer-harness entrypoint.
+
+Checkpoint:
+
+- No job has both broader write privilege and a larger-than-necessary execution
+  surface.
+
+## Phase 6: Resolve The Fork PR Trust Exception
+
+Goal:
+
+- Decide deliberately whether the privileged fork rebuild remains acceptable.
+
+This is the one design area where the conversation leaves a real trade-off:
+
+- Keeping fork rebuild in the downstream lane preserves current parity and keeps
+  `GHCR` as the simplest cache handoff.
+- Removing it yields a stricter security model, but likely requires either:
+  - a pull-request-only validation path
+  - slower rebuilds
+  - different branch protection mechanics
+  - or a less uniform fork/non-fork experience
+
+Required output:
+
+- A written decision with one of two states:
+
+State A: **Short-term accepted exception**
+
+- Fork rebuild remains, but it is documented as the only privileged execution of
+  PR-controlled code.
+- Its permissions and secret surface are minimized aggressively.
+- It gets a follow-up migration plan.
+
+State B: **Strict no-privileged-fork-execution**
+
+- Fork PR validation moves fully into the unprivileged `pull_request` lane.
+- `workflow_run` becomes reporter-only or is removed from PR validation
+  altogether.
+
+Checkpoint:
+
+- This decision is made explicitly before implementation is considered complete.
+
+## Phase 7: Validate Merge-to-Develop Behavior
+
+Goal:
+
+- Ensure the refined design works not only on PRs, but also after merge.
+
+Tasks:
+
+1. Confirm that merged `develop` uses one coherent workflow + payload lineage.
+2. Validate non-fork PR flow end-to-end.
+3. Validate fork PR flow end-to-end, including approval requirements if
+   applicable.
+4. Validate `push` to `develop` and `release` publish paths remain unaffected
+   except where intentionally changed.
+5. Validate the manual analyzer-harness entrypoint after the auth/secret
+   contract changes so it does not silently diverge from the main reusable
+   workflow.
+6. Confirm `03 Checkpoint - E2E` stays green in the intended branch protection
+   model.
+
+Checkpoint:
+
+- The new setup is proven green for:
+  - same-repo PRs
+  - fork PRs
+  - merged develop
+  - post-merge publish flows
+
+## Phase 8: Document The Operator Model
+
+Goal:
+
+- Stop future confusion about what GitHub picks up from PR code versus default-
+  branch workflows.
+
+Required documentation:
+
+1. Which changes are picked up pre-merge because they live in checked-out repo
+   payload:
+   - scripts
+   - configs
+   - tests
+   - compose files
+   - submodule pointers
+2. Which changes require default-branch merge to affect `workflow_run`
+   orchestration:
+   - workflow topology
+   - job wiring
+   - top-level permissions
+   - artifact plumbing
+3. How local reusable workflow references resolve.
+4. How to reason about fork versus non-fork PR behavior safely.
+
+Checkpoint:
+
+- The repo has a concise operator note that future contributors can follow
+  without rediscovering these boundaries by trial and error.
+
+## Success Criteria
+
+This plan is complete only when all of the following are true:
+
+- The project retains a useful and comprehensible E2E gate for same-repo and
+  fork PRs.
+- `GHCR` is isolated as a transient `e2e-cache` lane, not treated as general
+  publishing.
+- Test execution jobs are read-only consumers, not broad privileged workflows.
+- The deterministic CI auth contract is documented and replaces ad hoc
+  `TEST_PASS` reliance in routine PR validation.
+- The only clearly privileged PR-facing action left is the `03 Checkpoint - E2E`
+  reporter, unless the team deliberately accepts a documented fork exception.
+- `TEST_PASS` and broad secret inheritance are removed from routine PR
+  validation.
+- Lane D publication is either extracted into its own post-merge workflow or is
+  explicitly documented as a temporary exception with strict job isolation.
+- Merge to `develop` remains green and does not regress the fork/non-fork model.
+- The repo has documentation explaining the GitHub Actions trust boundary and
+  default-branch-versus-checked-out-payload behavior clearly.
+
+## Recommended Order Of Execution
+
+When work resumes, execute in this order:
+
+1. Phase 1 privilege inventory
+2. Phase 2 required-vs-convenience classification
+3. Phase 3 GHCR cache-lane isolation
+4. Phase 4 secret removal
+5. Phase 5 job-scoped permissions
+6. Phase 6 fork trust decision
+7. Phase 7 validation across PR and merged flows
+8. Phase 8 operator documentation
+
+This order keeps the design evidence-driven: we first map the current risk, then
+shrink it, then decide whether the final remaining fork exception is acceptable
+or must be eliminated.

--- a/.specify/plans/e2e-ci-trust-boundary-hardening.md
+++ b/.specify/plans/e2e-ci-trust-boundary-hardening.md
@@ -18,7 +18,8 @@ todos:
       Inventory every current privilege boundary in 03 - E2E and E2E / Tests and
       Publish, including reusable/manual wrapper entrypoints, packages write,
       statuses write, actions read, inherited secrets, GHCR image transfer, and
-      PR-code checkout points.
+      PR-code checkout points. Output a privilege matrix in
+      .specify/plans/e2e-ci-privilege-matrix.md.
     status: pending
   - id: classify-required-vs-accidental-privilege
     content:
@@ -30,25 +31,37 @@ todos:
     content:
       Redesign the GHCR usage model as an explicit transient e2e-cache lane with
       distinct write and read permission scopes, separate from any future real
-      image publication concerns.
+      image publication concerns. Implement a scheduled cleanup workflow with
+      7-day retention for e2e-cache images.
+    status: pending
+  - id: extract-lane-d-publication
+    content:
+      Extract publish-images into a separate publish-images.yml workflow
+      triggered by workflow_run on 03 - E2E filtered to push/release events.
+      Create a publish environment with deployment branch restriction on develop
+      for DockerHub credentials.
     status: pending
   - id: remove-nonessential-secret-dependence
     content:
-      Define one explicit deterministic CI auth contract, then replace TEST_PASS
-      and any broad secret inheritance in PR validation paths with that contract
-      or other non-sensitive inputs.
+      Replace secrets.TEST_PASS with vars.TEST_PASS defaulting to adminADMIN!
+      across all workflows. Replace secrets inherit with named inputs/secrets on
+      all reusable workflow calls including Cypress and analyzer harness. Remove
+      environment e2e from all jobs; move TEST_USER and TEST_PASS to repo-level
+      variables.
     status: pending
   - id: shrink-job-permissions
     content:
       Move from workflow-wide permissions to job-scoped least privilege so cache
       publishers, test executors, and the 03 Checkpoint reporter each get only
-      the minimum permissions they require.
+      the minimum permissions they require. Set persist-credentials false on all
+      checkout steps. Verify e2e-gate treats all-skipped as failure.
     status: pending
   - id: resolve-fork-pr-trust-model
     content:
-      Decide and document whether privileged fork rebuilds remain a short-term
-      exception or must be eliminated by moving fork execution fully into the
-      unprivileged pull_request lane.
+      Fork-rebuild stays as a short-term accepted exception (State A). Scope
+      fork-rebuild job to packages write only — no statuses write, no broad
+      secrets. Status reporting remains in Lane C reporter which already covers
+      fork PRs. Document as explicit exception with migration path.
     status: pending
   - id: verify-develop-merge-behavior
     content:
@@ -58,9 +71,9 @@ todos:
     status: pending
   - id: document-operator-model
     content:
-      Write clear repo guidance describing which workflow changes require
-      default branch merge, which code/config changes are picked up pre-merge,
-      and how to reason about the split safely.
+      Write clear repo guidance in .github/ describing which workflow changes
+      require default branch merge, which code/config changes are picked up
+      pre-merge, and how to reason about the split safely.
     status: pending
 isProject: false
 ---
@@ -143,18 +156,28 @@ Current pain points:
 The target setup must follow these principles:
 
 - PR CI validates only.
-- Real publication happens only on `push`/`release` after merge.
+- Real publication happens only on `push`/`release` after merge, in a separate
+  extracted workflow with a branch-restricted `publish` environment.
 - `GHCR` cache writes for PRs are treated as transient E2E transport, not as
-  product publishing.
+  product publishing. A scheduled cleanup workflow enforces 7-day retention.
 - Cache publication and cache consumption are separate permission classes.
-- CI auth uses one documented deterministic contract rather than ad hoc
-  `TEST_PASS` consumption across reusable workflows.
+- CI auth uses one documented deterministic contract: `vars.TEST_PASS`
+  (repo-level variable, default `'adminADMIN!'`) replaces `secrets.TEST_PASS`.
+  No secrets are needed for PR test execution.
 - The final `03 Checkpoint - E2E` reporter is a tiny trusted lane.
 - Secrets are removed from PR validation unless they are genuinely necessary.
 - Workflow privilege is scoped per job, not granted broadly at the workflow
-  level.
+  level. All checkouts set `persist-credentials: false`.
+- The `e2e` environment is removed; test jobs use repo-level variables. A
+  `publish` environment with deployment branch restriction on `develop` gates
+  DockerHub credentials.
+- Fork PR E2E is a first-class requirement. The fork-rebuild job is a
+  documented short-term exception scoped to `packages: write` only, with
+  status reporting handled by Lane C.
 - Any remaining privileged execution of PR-controlled code is documented as an
   explicit exception with a migration path away from it.
+- Cypress E2E remains in the PR gate (migration is a separate long-term
+  effort); it is hardened like all other test executors.
 
 ## Recommended Target Architecture
 
@@ -167,13 +190,13 @@ still provides practical benefits:
 
 However, the trust model is tightened into four distinct lanes:
 
-Implementation choice for this hardening effort:
+Implementation decision (confirmed via QA):
 
-- Lane D should be extracted out of `e2e-tests.yml` into a separate post-merge
-  workflow triggered only on `push`/`release`.
-- If extraction proves too disruptive for the first pass, then keeping Lane D in
-  the same file is an explicitly temporary state that must still satisfy strict
-  job isolation and must not be treated as the target architecture.
+- Lane D will be extracted out of `e2e-tests.yml` into a separate
+  `publish-images.yml` workflow triggered by `workflow_run` on `03 - E2E`
+  filtered to `push`/`release` events.
+- The extracted workflow uses `environment: publish` with a deployment branch
+  restriction on `develop` to gate DockerHub credentials.
 
 ### Lane A: Shared Build / Cache Publisher
 
@@ -193,16 +216,21 @@ Rules:
 
 Purpose:
 
-- Run Playwright core, analyzer harness, and any remaining PR validation tests.
+- Run Playwright core, analyzer harness, Cypress (deprecated but still active),
+  and any remaining PR validation tests.
 
 Rules:
 
 - These jobs should have only `packages: read`, `contents: read`, and whatever
   minimal artifact-read capability is required.
 - These jobs should not have `statuses: write`.
-- These jobs should not inherit broad secrets.
-- These jobs should run with deterministic CI credentials that are not treated
-  as protected repository secrets.
+- These jobs should not inherit broad secrets. All reusable workflow calls
+  (including Cypress and analyzer harness) use named inputs/secrets, not
+  `secrets: inherit`.
+- These jobs should run with deterministic CI credentials via `vars.TEST_PASS`
+  (repo-level variable, default `'adminADMIN!'`) and `vars.TEST_USER` (default
+  `'admin'`). No environment is needed.
+- All checkouts set `persist-credentials: false`.
 
 ### Lane C: 03 Checkpoint Reporter
 
@@ -218,7 +246,7 @@ Rules:
 - It may read workflow conclusions or artifacts, but should remain tiny and
   trusted.
 
-### Lane D: Post-Merge Publication
+### Lane D: Post-Merge Publication (Extracted Workflow)
 
 Purpose:
 
@@ -226,7 +254,11 @@ Purpose:
 
 Rules:
 
-- Runs on `push` to `develop` and/or `release`.
+- Lives in a separate `publish-images.yml` workflow, triggered by
+  `workflow_run` on `03 - E2E` filtered to `push`/`release` events.
+- Uses `environment: publish` with deployment branch restriction on `develop`.
+- DockerHub credentials (`DOCKERHUB_TOKEN`) are scoped to the `publish`
+  environment.
 - Consumes tested outputs only after the E2E gate is green.
 - Remains isolated from PR validation concerns entirely.
 
@@ -257,8 +289,8 @@ Tasks:
 
 Deliverable:
 
-- A one-page privilege matrix covering every job, token scope, secret input, and
-  PR-code execution point.
+- A privilege matrix in `.specify/plans/e2e-ci-privilege-matrix.md` covering
+  every job, token scope, secret input, and PR-code execution point.
 
 Checkpoint:
 
@@ -275,15 +307,14 @@ Questions to answer explicitly:
 
 1. Is `packages: write` required for correctness, or only for the transient
    `GHCR` cache handoff?
-2. Is `TEST_PASS` a true secret, or can it be replaced with deterministic test
-   credentials?
+2. ~~Is `TEST_PASS` a true secret?~~ **Resolved:** No. Replace with
+   `vars.TEST_PASS` defaulting to `'adminADMIN!'`.
 3. Is the custom `03 Checkpoint - E2E` status required, or could branch
    protection rely directly on gate jobs?
 4. Which parts of the current downstream workflow exist only because fork PRs
    cannot push cache images from the `pull_request` lane?
-5. Does Lane D remain a job-isolated post-merge section temporarily, or is it
-   extracted immediately into its own post-merge workflow? The recommended
-   target is extraction.
+5. ~~Lane D extraction timing?~~ **Resolved:** Extract now into
+   `publish-images.yml`.
 
 Deliverable:
 
@@ -306,17 +337,19 @@ Tasks:
 
 1. Formalize the `ghcr.io/<owner>/openelis-global-2/e2e-cache/...` namespace as
    transient CI cache only.
-2. Ensure only the cache-publisher lane can write to that namespace.
+2. Ensure only the cache-publisher lane (and fork-rebuild) can write to that
+   namespace.
 3. Ensure test lanes are read-only consumers of cache artifacts.
 4. Verify no other workflow path reuses this namespace for release publication.
-5. Add cleanup and retention guidance so the cache lane stays operationally
-   isolated from long-lived artifacts.
+5. Implement a scheduled cleanup workflow (e.g., weekly cron) that deletes
+   e2e-cache package versions older than 7 days using the GitHub API. This can
+   be delivered as a follow-up PR but is scoped into this effort.
 
 Checkpoint:
 
 - The pipeline has exactly two package permission classes:
-  - `packages: write` for cache publishing
-  - `packages: read` for cache consumption
+  - `packages: write` for cache publishing (shared-build + fork-rebuild)
+  - `packages: read` for cache consumption (all test executors)
 
 ## Phase 4: Remove Nonessential Secret Dependence
 
@@ -324,26 +357,38 @@ Goal:
 
 - Make PR validation independent of protected secrets wherever possible.
 
+Decisions (confirmed via QA):
+
+- `TEST_PASS` is not a real secret — the value `'adminADMIN!'` is already
+  hardcoded as a fallback in the Cypress workflow.
+- CI auth contract: `vars.TEST_PASS` (repo-level variable, default
+  `'adminADMIN!'`) and `vars.TEST_USER` (repo-level variable, default
+  `'admin'`). No secret is needed for E2E login.
+- The `e2e` environment is removed. `TEST_USER` and `TEST_PASS` move to
+  repo-level variables. A `publish` environment (branch-restricted to
+  `develop`) is created for DockerHub credentials only.
+
 Tasks:
 
-1. Replace `TEST_PASS` with deterministic CI fixture credentials or other
-   non-sensitive values that can safely exist in unprivileged lanes.
-2. Write down the exact CI auth contract before implementation:
-   - where the credential comes from
-   - which jobs consume it
-   - whether it is a repo variable, checked-in fixture value, or another
-     deterministic non-secret input
-   - how manual and reusable workflows receive it without `secrets: inherit`
-3. Remove `secrets: inherit` from any called workflow that does not require a
-   specific explicit secret.
-4. Pass only named inputs or named secrets where a true secret remains
-   necessary.
-5. Verify that analyzer harness seeding, application login, and Playwright setup
+1. Replace all `secrets.TEST_PASS` with `vars.TEST_PASS || 'adminADMIN!'`
+   across `e2e-tests.yml`, `e2e-playwright-analyzer-harness-reusable.yml`, and
+   `e2e-cypress-deprecated.yml`.
+2. Replace `secrets: inherit` on the analyzer-harness and Cypress reusable
+   workflow calls with named inputs for `TEST_PASS` and `TEST_USER`.
+3. Remove `environment: e2e` from all jobs (shared-build, fork-rebuild,
+   playwright-core, demo-shards).
+4. Create `publish` environment with deployment branch restriction on `develop`;
+   move `DOCKERHUB_TOKEN` into it.
+5. Pass only named inputs or named secrets where a true secret remains
+   necessary (e.g., `DOCKERHUB_TOKEN` in the extracted publish workflow).
+6. Verify that analyzer harness seeding, application login, and Playwright setup
    still work in both same-repo and fork PR contexts.
 
 Checkpoint:
 
 - PR validation no longer depends on broad inherited secrets.
+- No job references `environment: e2e`.
+- The only environment in use is `publish` on the extracted Lane D workflow.
 
 ## Phase 5: Move To Job-Scoped Least Privilege
 
@@ -351,60 +396,61 @@ Goal:
 
 - Shrink permissions to the minimum needed for each lane.
 
+Decisions (confirmed via QA):
+
+- No private submodules exist — `persist-credentials: false` is a clean sweep
+  across all checkouts with no complications.
+- The `e2e-gate` job must be verified to treat "all test jobs skipped" as
+  failure, not success. Fix if needed (one-line check).
+
 Tasks:
 
 1. Remove broad workflow-level permissions from `e2e-tests.yml` where possible.
 2. Assign job-scoped permissions:
-   - cache publisher: `packages: write`
-   - test executors: `packages: read`
-   - reporter: `statuses: write`
-3. Set `persist-credentials: false` on checkouts that run PR-controlled code and
-   do not need git writes.
+   - cache publisher (shared-build, fork-rebuild): `packages: write`
+   - test executors (playwright-core, analyzer-harness, cypress): `packages: read`
+   - reporter (set-pending-status, report-status): `statuses: write`
+   - fork-rebuild: `packages: write` only — no `statuses: write`
+3. Set `persist-credentials: false` on ALL checkout steps across all workflows.
 4. Confirm that reporter jobs do not check out PR code at all.
 5. Replace wrapper-level `secrets: inherit` with named inputs/secrets, including
    the manual analyzer-harness entrypoint.
+6. Verify `e2e-gate` treats "all test jobs skipped" as failure; add explicit
+   check if needed.
 
 Checkpoint:
 
 - No job has both broader write privilege and a larger-than-necessary execution
   surface.
+- Every checkout sets `persist-credentials: false`.
 
 ## Phase 6: Resolve The Fork PR Trust Exception
 
-Goal:
+Decision (confirmed via QA): **State A — Short-term accepted exception**
 
-- Decide deliberately whether the privileged fork rebuild remains acceptable.
+Rationale:
 
-This is the one design area where the conversation leaves a real trade-off:
+- Fork PR E2E support is a firm requirement for the project.
+- Eliminating fork rebuild would require artifact-based image transfer or
+  local-only Docker builds — a larger architectural change out of scope here.
+- The risk is mitigated by scoping fork-rebuild to the minimum:
 
-- Keeping fork rebuild in the downstream lane preserves current parity and keeps
-  `GHCR` as the simplest cache handoff.
-- Removing it yields a stricter security model, but likely requires either:
-  - a pull-request-only validation path
-  - slower rebuilds
-  - different branch protection mechanics
-  - or a less uniform fork/non-fork experience
+Mitigations:
 
-Required output:
-
-- A written decision with one of two states:
-
-State A: **Short-term accepted exception**
-
-- Fork rebuild remains, but it is documented as the only privileged execution of
+- Fork-rebuild job gets `packages: write` only — no `statuses: write`, no
+  broad secrets, no other write permissions.
+- `persist-credentials: false` on the checkout.
+- Status reporting for fork PRs is handled by Lane C (the reporter), which
+  already works for both fork and non-fork paths.
+- Fork-rebuild is documented as the sole remaining privileged execution of
   PR-controlled code.
-- Its permissions and secret surface are minimized aggressively.
-- It gets a follow-up migration plan.
-
-State B: **Strict no-privileged-fork-execution**
-
-- Fork PR validation moves fully into the unprivileged `pull_request` lane.
-- `workflow_run` becomes reporter-only or is removed from PR validation
-  altogether.
+- Migration path: move to artifact-based image transfer so fork execution
+  can move fully into the unprivileged `pull_request` lane.
 
 Checkpoint:
 
-- This decision is made explicitly before implementation is considered complete.
+- Fork-rebuild is the only job that both checks out PR-controlled code and has
+  write permissions, and this is explicitly documented.
 
 ## Phase 7: Validate Merge-to-Develop Behavior
 
@@ -441,6 +487,8 @@ Goal:
 - Stop future confusion about what GitHub picks up from PR code versus default-
   branch workflows.
 
+Location: `.github/` (near the workflows, as a living document).
+
 Required documentation:
 
 1. Which changes are picked up pre-merge because they live in checked-out repo
@@ -458,6 +506,8 @@ Required documentation:
    - artifact plumbing
 3. How local reusable workflow references resolve.
 4. How to reason about fork versus non-fork PR behavior safely.
+5. The CI auth contract: where test credentials come from, how they flow.
+6. The `publish` environment and its branch restriction.
 
 Checkpoint:
 
@@ -473,14 +523,17 @@ This plan is complete only when all of the following are true:
 - `GHCR` is isolated as a transient `e2e-cache` lane, not treated as general
   publishing.
 - Test execution jobs are read-only consumers, not broad privileged workflows.
-- The deterministic CI auth contract is documented and replaces ad hoc
-  `TEST_PASS` reliance in routine PR validation.
-- The only clearly privileged PR-facing action left is the `03 Checkpoint - E2E`
-  reporter, unless the team deliberately accepts a documented fork exception.
-- `TEST_PASS` and broad secret inheritance are removed from routine PR
+- The deterministic CI auth contract (`vars.TEST_PASS` / `vars.TEST_USER` with
+  hardcoded defaults) is documented and replaces `secrets.TEST_PASS`.
+- The only privileged PR-facing actions are the `03 Checkpoint - E2E` reporter
+  (Lane C) and the fork-rebuild job (documented exception, `packages: write`
+  only).
+- `secrets.TEST_PASS` and broad `secrets: inherit` are removed from PR
   validation.
-- Lane D publication is either extracted into its own post-merge workflow or is
-  explicitly documented as a temporary exception with strict job isolation.
+- Lane D publication is extracted into `publish-images.yml` with
+  `environment: publish` (branch-restricted to `develop`).
+- The `e2e` environment is removed; all test jobs use repo-level variables.
+- A scheduled e2e-cache cleanup workflow enforces 7-day retention.
 - Merge to `develop` remains green and does not regress the fork/non-fork model.
 - The repo has documentation explaining the GitHub Actions trust boundary and
   default-branch-versus-checked-out-payload behavior clearly.

--- a/.specify/plans/e2e-ci-trust-boundary-hardening.md
+++ b/.specify/plans/e2e-ci-trust-boundary-hardening.md
@@ -20,27 +20,27 @@ todos:
       statuses write, actions read, inherited secrets, GHCR image transfer, and
       PR-code checkout points. Output a privilege matrix in
       .specify/plans/e2e-ci-privilege-matrix.md.
-    status: pending
+    status: completed
   - id: classify-required-vs-accidental-privilege
     content:
       Separate truly required capabilities from convenience-driven ones so the
       workflow design reflects the rule that PR CI validates only and merged
       branches alone publish reusable outputs.
-    status: pending
+    status: completed
   - id: isolate-ghcr-e2e-cache-lane
     content:
       Redesign the GHCR usage model as an explicit transient e2e-cache lane with
       distinct write and read permission scopes, separate from any future real
       image publication concerns. Implement a scheduled cleanup workflow with
       7-day retention for e2e-cache images.
-    status: pending
+    status: completed
   - id: extract-lane-d-publication
     content:
       Extract publish-images into a separate publish-images.yml workflow
       triggered by workflow_run on 03 - E2E filtered to push/release events.
       Create a publish environment with deployment branch restriction on develop
       for DockerHub credentials.
-    status: pending
+    status: completed
   - id: remove-nonessential-secret-dependence
     content:
       Replace secrets.TEST_PASS with vars.TEST_PASS defaulting to adminADMIN!
@@ -48,21 +48,21 @@ todos:
       all reusable workflow calls including Cypress and analyzer harness. Remove
       environment e2e from all jobs; move TEST_USER and TEST_PASS to repo-level
       variables.
-    status: pending
+    status: completed
   - id: shrink-job-permissions
     content:
       Move from workflow-wide permissions to job-scoped least privilege so cache
       publishers, test executors, and the 03 Checkpoint reporter each get only
       the minimum permissions they require. Set persist-credentials false on all
       checkout steps. Verify e2e-gate treats all-skipped as failure.
-    status: pending
+    status: completed
   - id: resolve-fork-pr-trust-model
     content:
       Fork-rebuild stays as a short-term accepted exception (State A). Scope
       fork-rebuild job to packages write only — no statuses write, no broad
       secrets. Status reporting remains in Lane C reporter which already covers
       fork PRs. Document as explicit exception with migration path.
-    status: pending
+    status: completed
   - id: verify-develop-merge-behavior
     content:
       Prove that the resulting design remains green after merge to develop and
@@ -74,7 +74,7 @@ todos:
       Write clear repo guidance in .github/ describing which workflow changes
       require default branch merge, which code/config changes are picked up
       pre-merge, and how to reason about the split safely.
-    status: pending
+    status: completed
 isProject: false
 ---
 
@@ -168,6 +168,9 @@ The target setup must follow these principles:
 - Secrets are removed from PR validation unless they are genuinely necessary.
 - Workflow privilege is scoped per job, not granted broadly at the workflow
   level. All checkouts set `persist-credentials: false`.
+- CI auth fallback is explicit and uniform everywhere in E2E test execution:
+  - `TEST_USER: ${{ vars.TEST_USER || 'admin' }}`
+  - `TEST_PASS: ${{ vars.TEST_PASS || 'adminADMIN!' }}`
 - The `e2e` environment is removed; test jobs use repo-level variables. A
   `publish` environment with deployment branch restriction on `develop` gates
   DockerHub credentials.
@@ -178,6 +181,24 @@ The target setup must follow these principles:
   explicit exception with a migration path away from it.
 - Cypress E2E remains in the PR gate (migration is a separate long-term
   effort); it is hardened like all other test executors.
+
+## Delivery Strategy And Constraints
+
+Primary delivery mode:
+
+- Implement in one PR on the hardening branch when possible.
+
+Allowed split condition:
+
+- If GitHub Actions workflow update constraints materially block safe rollout
+  validation in one PR (especially around `workflow_run` default-branch
+  orchestration behavior), split into the minimum number of PRs required to
+  preserve correctness and reviewer clarity.
+
+Execution preference:
+
+- Keep one PR unless a split is technically necessary; document the exact
+  reason and boundary if split is required.
 
 ## Recommended Target Architecture
 
@@ -264,6 +285,25 @@ Rules:
 
 ## Workplan
 
+## Cross-Phase Drift Guardrails
+
+To prevent drift during implementation, enforce these checkpoints after each
+phase:
+
+1. Re-run privilege inventory snippets against edited workflow files and compare
+   with the expected lane model.
+2. Confirm no reintroduction of:
+   - workflow-level broad write permissions
+   - `secrets: inherit` in reusable workflow calls
+   - `environment: e2e`
+   - missing `persist-credentials: false` on checkout steps
+3. Confirm the CI auth contract remains uniform:
+   - `TEST_USER: ${{ vars.TEST_USER || 'admin' }}`
+   - `TEST_PASS: ${{ vars.TEST_PASS || 'adminADMIN!' }}`
+4. Validate that reporter jobs remain tiny and trusted (no checkout/build/test).
+5. Record any divergence from plan intent immediately in this document before
+   proceeding.
+
 ## Phase 1: Inventory The Real Trust Boundaries
 
 Goal:
@@ -343,7 +383,7 @@ Tasks:
 4. Verify no other workflow path reuses this namespace for release publication.
 5. Implement a scheduled cleanup workflow (e.g., weekly cron) that deletes
    e2e-cache package versions older than 7 days using the GitHub API. This can
-   be delivered as a follow-up PR but is scoped into this effort.
+   be delivered in this PR and is required for this effort.
 
 Checkpoint:
 
@@ -361,9 +401,15 @@ Decisions (confirmed via QA):
 
 - `TEST_PASS` is not a real secret — the value `'adminADMIN!'` is already
   hardcoded as a fallback in the Cypress workflow.
+- Risk posture is explicit: these CI credentials are intentionally non-secret
+  defaults already broadly exposed in existing OpenELIS CI/dev usage; removing
+  secret plumbing does not create a new trust boundary regression.
 - CI auth contract: `vars.TEST_PASS` (repo-level variable, default
   `'adminADMIN!'`) and `vars.TEST_USER` (repo-level variable, default
   `'admin'`). No secret is needed for E2E login.
+- Strict fallback expressions are required in all relevant workflow jobs:
+  - `TEST_USER: ${{ vars.TEST_USER || 'admin' }}`
+  - `TEST_PASS: ${{ vars.TEST_PASS || 'adminADMIN!' }}`
 - The `e2e` environment is removed. `TEST_USER` and `TEST_PASS` move to
   repo-level variables. A `publish` environment (branch-restricted to
   `develop`) is created for DockerHub credentials only.
@@ -480,6 +526,13 @@ Checkpoint:
   - merged develop
   - post-merge publish flows
 
+Operational note:
+
+- Pre-merge workflow behavior and post-merge behavior can differ for
+  `workflow_run` orchestration. If a discrepancy appears, stop and record
+  whether it is due to default-branch workflow pickup rules versus checked-out
+  payload behavior.
+
 ## Phase 8: Document The Operator Model
 
 Goal:
@@ -513,6 +566,37 @@ Checkpoint:
 
 - The repo has a concise operator note that future contributors can follow
   without rediscovering these boundaries by trial and error.
+
+## GitHub Configuration Execution Model
+
+Goal:
+
+- Minimize manual operator work by automating repository configuration via `gh`
+  where possible, and provide deterministic manual steps only where API/CLI
+  controls are insufficient.
+
+Automation-first:
+
+- Use `gh`/GitHub API to:
+  - create or update the `publish` environment
+  - set deployment branch policy restriction to `develop`
+  - configure required environment secrets/variables where API permissions
+    allow (for example `DOCKERHUB_TOKEN`, `DOCKERHUB_USERNAME`)
+  - set/update repository-level variables:
+    - `TEST_USER` (default: `admin`)
+    - `TEST_PASS` (default: `adminADMIN!`)
+
+Manual fallback:
+
+- If any repo setting is not fully manageable via `gh` due to permission model,
+  provide exact click-path and values in a checklist with no ambiguity.
+
+Required output:
+
+- Add an operator runbook under `.github/` with:
+  - exact `gh` commands used
+  - exact manual fallback steps for any unsupported setting
+  - verification commands/checks to confirm effective configuration
 
 ## Success Criteria
 

--- a/.specify/plans/e2e-ci-trust-boundary-hardening.md
+++ b/.specify/plans/e2e-ci-trust-boundary-hardening.md
@@ -174,13 +174,13 @@ The target setup must follow these principles:
 - The `e2e` environment is removed; test jobs use repo-level variables. A
   `publish` environment with deployment branch restriction on `develop` gates
   DockerHub credentials.
-- Fork PR E2E is a first-class requirement. The fork-rebuild job is a
-  documented short-term exception scoped to `packages: write` only, with
-  status reporting handled by Lane C.
+- Fork PR E2E is a first-class requirement. The fork-rebuild job is a documented
+  short-term exception scoped to `packages: write` only, with status reporting
+  handled by Lane C.
 - Any remaining privileged execution of PR-controlled code is documented as an
   explicit exception with a migration path away from it.
-- Cypress E2E remains in the PR gate (migration is a separate long-term
-  effort); it is hardened like all other test executors.
+- Cypress E2E remains in the PR gate (migration is a separate long-term effort);
+  it is hardened like all other test executors.
 
 ## Delivery Strategy And Constraints
 
@@ -197,8 +197,8 @@ Allowed split condition:
 
 Execution preference:
 
-- Keep one PR unless a split is technically necessary; document the exact
-  reason and boundary if split is required.
+- Keep one PR unless a split is technically necessary; document the exact reason
+  and boundary if split is required.
 
 ## Recommended Target Architecture
 
@@ -275,8 +275,8 @@ Purpose:
 
 Rules:
 
-- Lives in a separate `publish-images.yml` workflow, triggered by
-  `workflow_run` on `03 - E2E` filtered to `push`/`release` events.
+- Lives in a separate `publish-images.yml` workflow, triggered by `workflow_run`
+  on `03 - E2E` filtered to `push`/`release` events.
 - Uses `environment: publish` with deployment branch restriction on `develop`.
 - DockerHub credentials (`DOCKERHUB_TOKEN`) are scoped to the `publish`
   environment.
@@ -411,13 +411,13 @@ Decisions (confirmed via QA):
   - `TEST_USER: ${{ vars.TEST_USER || 'admin' }}`
   - `TEST_PASS: ${{ vars.TEST_PASS || 'adminADMIN!' }}`
 - The `e2e` environment is removed. `TEST_USER` and `TEST_PASS` move to
-  repo-level variables. A `publish` environment (branch-restricted to
-  `develop`) is created for DockerHub credentials only.
+  repo-level variables. A `publish` environment (branch-restricted to `develop`)
+  is created for DockerHub credentials only.
 
 Tasks:
 
-1. Replace all `secrets.TEST_PASS` with `vars.TEST_PASS || 'adminADMIN!'`
-   across `e2e-tests.yml`, `e2e-playwright-analyzer-harness-reusable.yml`, and
+1. Replace all `secrets.TEST_PASS` with `vars.TEST_PASS || 'adminADMIN!'` across
+   `e2e-tests.yml`, `e2e-playwright-analyzer-harness-reusable.yml`, and
    `e2e-cypress-deprecated.yml`.
 2. Replace `secrets: inherit` on the analyzer-harness and Cypress reusable
    workflow calls with named inputs for `TEST_PASS` and `TEST_USER`.
@@ -425,8 +425,8 @@ Tasks:
    playwright-core, demo-shards).
 4. Create `publish` environment with deployment branch restriction on `develop`;
    move `DOCKERHUB_TOKEN` into it.
-5. Pass only named inputs or named secrets where a true secret remains
-   necessary (e.g., `DOCKERHUB_TOKEN` in the extracted publish workflow).
+5. Pass only named inputs or named secrets where a true secret remains necessary
+   (e.g., `DOCKERHUB_TOKEN` in the extracted publish workflow).
 6. Verify that analyzer harness seeding, application login, and Playwright setup
    still work in both same-repo and fork PR contexts.
 
@@ -454,7 +454,8 @@ Tasks:
 1. Remove broad workflow-level permissions from `e2e-tests.yml` where possible.
 2. Assign job-scoped permissions:
    - cache publisher (shared-build, fork-rebuild): `packages: write`
-   - test executors (playwright-core, analyzer-harness, cypress): `packages: read`
+   - test executors (playwright-core, analyzer-harness, cypress):
+     `packages: read`
    - reporter (set-pending-status, report-status): `statuses: write`
    - fork-rebuild: `packages: write` only — no `statuses: write`
 3. Set `persist-credentials: false` on ALL checkout steps across all workflows.
@@ -483,15 +484,15 @@ Rationale:
 
 Mitigations:
 
-- Fork-rebuild job gets `packages: write` only — no `statuses: write`, no
-  broad secrets, no other write permissions.
+- Fork-rebuild job gets `packages: write` only — no `statuses: write`, no broad
+  secrets, no other write permissions.
 - `persist-credentials: false` on the checkout.
 - Status reporting for fork PRs is handled by Lane C (the reporter), which
   already works for both fork and non-fork paths.
 - Fork-rebuild is documented as the sole remaining privileged execution of
   PR-controlled code.
-- Migration path: move to artifact-based image transfer so fork execution
-  can move fully into the unprivileged `pull_request` lane.
+- Migration path: move to artifact-based image transfer so fork execution can
+  move fully into the unprivileged `pull_request` lane.
 
 Checkpoint:
 
@@ -580,8 +581,8 @@ Automation-first:
 - Use `gh`/GitHub API to:
   - create or update the `publish` environment
   - set deployment branch policy restriction to `develop`
-  - configure required environment secrets/variables where API permissions
-    allow (for example `DOCKERHUB_TOKEN`, `DOCKERHUB_USERNAME`)
+  - configure required environment secrets/variables where API permissions allow
+    (for example `DOCKERHUB_TOKEN`, `DOCKERHUB_USERNAME`)
   - set/update repository-level variables:
     - `TEST_USER` (default: `admin`)
     - `TEST_PASS` (default: `adminADMIN!`)


### PR DESCRIPTION
## Summary
- harden the E2E CI trust boundary by moving from workflow-wide privilege to job-scoped permissions, removing `secrets: inherit`, and standardizing non-secret CI auth via `vars.TEST_USER` / `vars.TEST_PASS`
- extract post-merge DockerHub publication into a dedicated `publish-images.yml` workflow, keep PR validation in `E2E / Tests`, and add a scheduled `e2e-cache` cleanup workflow for 7-day GHCR retention
- add planning and operator artifacts documenting the privilege matrix, required-vs-convenience classification, rollout checkpoints, and GitHub configuration model

## Test plan
- [x] Parse all changed workflow YAML files locally
- [x] Verify no linter errors on changed workflow and doc files
- [x] Re-run drift checks to confirm `secrets: inherit`, `environment: e2e`, and `secrets.TEST_PASS` are removed from E2E paths
- [x] Verify `persist-credentials: false` is set on all E2E checkout steps
- [x] Apply and verify GitHub-side setup with `gh` for `TEST_USER`, `TEST_PASS`, and the `publish` environment branch restriction on `develop`
- [ ] Observe CI on this PR, including the split `E2E / Tests` and `Publish Images` behavior
- [ ] Confirm `DOCKERHUB_TOKEN` remains available to the `publish` workflow through the intended org/environment secret path

## Follow-up notes
- `TEST_USER` and `TEST_PASS` are now repo variables with explicit workflow fallbacks.
- The `publish` environment exists and is branch-restricted to `develop`.
- The PR title/body were updated from the original plan-only scope to reflect the implemented changes.

Made with [Cursor](https://cursor.com)