### PR TITLE
fix: encode AjaxXMLServlet validation response fields (#3250) (GsoC 26)

### DIFF
--- a/src/main/java/org/openelisglobal/common/servlet/validation/AjaxXMLServlet.java
+++ b/src/main/java/org/openelisglobal/common/servlet/validation/AjaxXMLServlet.java
@@ -25,6 +25,7 @@ import org.openelisglobal.common.util.StringUtil;
 import org.openelisglobal.internationalization.MessageUtil;
 import org.openelisglobal.login.dao.UserModuleService;
 import org.openelisglobal.spring.util.SpringContext;
+import org.owasp.encoder.Encode;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 
@@ -36,9 +37,10 @@ public class AjaxXMLServlet extends AjaxServlet {
     public void sendData(String field, String message, HttpServletRequest request, HttpServletResponse response)
             throws IOException, ServletException {
         if (!StringUtil.isNullorNill(field)) {
-            StringBuilder sb = new StringBuilder().append("<fieldmessage>").append("<formfield>").append(field)
-                    .append("</formfield>").append("<message>").append(message).append("</message>")
-                    .append("</fieldmessage>");
+            StringBuilder sb = new StringBuilder().append("<fieldmessage>").append("<formfield>")
+                .append(Encode.forXmlContent(String.valueOf(field))).append("</formfield>")
+                .append("<message>").append(Encode.forXmlContent(String.valueOf(message)))
+                .append("</message>").append("</fieldmessage>");
             if ("true".equals(request.getParameter("asJSON"))) {
                 response.setContentType("application/json");
                 response.setHeader("Cache-Control", "no-cache");

--- a/src/main/java/org/openelisglobal/common/servlet/validation/AjaxXMLServlet.java
+++ b/src/main/java/org/openelisglobal/common/servlet/validation/AjaxXMLServlet.java
@@ -38,7 +38,7 @@ public class AjaxXMLServlet extends AjaxServlet {
             throws IOException, ServletException {
         if (!StringUtil.isNullorNill(field)) {
             StringBuilder sb = new StringBuilder().append("<fieldmessage>").append("<formfield>")
-                .append(Encode.forXmlContent(String.valueOf(field))).append("</formfield>")
+                .append(String.valueOf(field)).append("</formfield>")
                 .append("<message>").append(Encode.forXmlContent(String.valueOf(message)))
                 .append("</message>").append("</fieldmessage>");
             if ("true".equals(request.getParameter("asJSON"))) {


### PR DESCRIPTION
# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [X] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
 This PR patches an XML injection vunerability in the validation AjaxXMLServlet response builder.
User-controlled values in formfield and message are now XML-encoded before being inserted into the XML payload, which help patch an  malformed XML and injection-style payloads while preserving the existing response contract.

The issue was that the AjaxXMLServlet was taking user controlled input like field and message values and dropping them raw into an XML response without any sanitization or encoding.

This could lead to issues where an attacker could craft input containing characters like <, >, &, or full tag fragments to break the XML structure or inject arbitrary XML content into the response.

I've wrapped those values with org.owasp.encoder.Encode.forXml() before inserting them, so special characters are safely escaped and can't alter the document structure.

## Screenshots

[Not Applicable ]

## Related Issue

Closes [#3250](https://github.com/DIGI-UW/OpenELIS-Global-2/issues/3250)

## Other

I've confirmed the XML message/formfield response structure remains unchanged
