### PR TITLE
fix: encode message in AjaxQueryXMLServlet response (#3252)

### DIFF
--- a/src/main/java/org/openelisglobal/common/servlet/query/AjaxQueryXMLServlet.java
+++ b/src/main/java/org/openelisglobal/common/servlet/query/AjaxQueryXMLServlet.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.json.XML;
+import org.owasp.encoder.Encode;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.common.provider.query.BaseQueryProvider;
 import org.openelisglobal.common.provider.query.QueryProviderFactory;
@@ -29,7 +30,7 @@ public class AjaxQueryXMLServlet extends AjaxServlet {
 
         if (!StringUtil.isNullorNill(field)) {
             StringBuilder sb = new StringBuilder().append("<fieldmessage>").append("<formfield>").append(field)
-                    .append("</formfield>").append("<message>").append(message).append("</message>")
+                    .append("</formfield>").append("<message>").append(Encode.forXmlContent(String.valueOf(message))).append("</message>")
                     .append("</fieldmessage>");
             if ("true".equals(request.getParameter("asJSON"))) {
                 response.setContentType("application/json");


### PR DESCRIPTION
# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [X] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

Summary
This PR fixes an XML injection vulnerability in AjaxQueryXMLServlet sendData where message content was inserted into XML without output encoding and so it includes a security fix for the vulnerability in AjaxQueryXMLServlet.sendData(). 

The message parameter is now XML encoded using org.owasp.encoder.Encode.forXmlContent() to prevent XML injection attacks.

The patch does the following-

Encodes the message field (free form user/system text, higher injection risk).

Does not encode the field parameter (since it's already pre encoded by some QueryProvider callers - which should avoid any instances of double escaping

Without encoding the XML output could lead to this: 

An attacker crafting a malicious message value like:
</message><injected>attack</injected><message>
 without encoding would break out of the <message> tag and inject arbitrary XML into the response structure, 

allowing XML structure corruption and response tampering this would mean that consumers parsing the responseXML would receive unexpected nodes and could lead to information disclosure depending on what gets injected and how the client handles it


With encoding it becomes safe:

xml<fieldmessage>
  <formfield>someField</formfield>
  <message>&lt;/message&gt;&lt;injected&gt;attack&lt;/injected&gt;&lt;message&gt;</message>
</fieldmessage>

any special characters in input will be escaped so the injection fails.

This prevents: 

Screenshots
Not applicable : backend security fix

Related Issue
Refs [#3252](https://github.com/DIGI-UW/OpenELIS-Global-2/issues/3252)

## Other
I noticed formfield encoding is currently mixed across callers. Some providers already pass pre encoded values while others pass raw values. If we Centralize the 'formfield' encoding in sendData right now this could cause double encoding issues, for example entity text becoming double escaped. For this reason, I've ensured this PR encodes only message as an fix as of now. 

A future cleanup should be able to standardize the encoding across providers and servlet responses globally

