### PR TITLE
test(patient-merge): add integration tests for PatientMergeRestController

### DIFF
--- a/src/test/java/org/openelisglobal/patient/merge/controller/rest/PatientMergeRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/patient/merge/controller/rest/PatientMergeRestControllerTest.java
@@ -271,4 +271,52 @@ public class PatientMergeRestControllerTest extends BaseWebContextSensitiveTest 
         String responseBody = result.getResponse().getContentAsString();
         assertTrue("Should indicate already merged", responseBody.contains("already merged"));
     }
+
+    @Test
+    public void getMergeDetails_WithoutSession_Returns403() throws Exception {
+        mockMvc.perform(get("/rest/patient/merge/details/" + patient1.getId()).accept(MediaType.APPLICATION_JSON))
+                // No session attached — hasGlobalAdminRole() returns false
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void validateMerge_WithoutSession_Returns403() throws Exception {
+        PatientMergeRequestDTO request = new PatientMergeRequestDTO();
+        request.setPatient1Id(patient1.getId());
+        request.setPatient2Id(patient2.getId());
+        request.setPrimaryPatientId(patient1.getId());
+        request.setReason("Unauthenticated validate attempt");
+        request.setConfirmed(false);
+
+        mockMvc.perform(post("/rest/patient/merge/validate").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                // No session — hasGlobalAdminRole() returns false → 403
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void executeMerge_WithoutSession_Returns403() throws Exception {
+        PatientMergeRequestDTO request = new PatientMergeRequestDTO();
+        request.setPatient1Id(patient1.getId());
+        request.setPatient2Id(patient2.getId());
+        request.setPrimaryPatientId(patient1.getId());
+        request.setReason("Unauthenticated execute attempt");
+        request.setConfirmed(true);
+
+        mockMvc.perform(post("/rest/patient/merge/execute").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                // No session — hasGlobalAdminRole() returns false → 403
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void executeMerge_MissingRequiredFields_Returns400() throws Exception {
+        PatientMergeRequestDTO request = new PatientMergeRequestDTO();
+        // All IDs are null — no patient1Id, patient2Id or primaryPatientId set
+        request.setReason("Missing fields test");
+        request.setConfirmed(true);
+
+        mockMvc.perform(post("/rest/patient/merge/execute").session(mockSession).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))).andExpect(status().isBadRequest());
+    }
 }


### PR DESCRIPTION
## Summary
Adds 4 new integration tests to `PatientMergeRestControllerTest.java`
covering security, input validation, and edge case behaviour for the
Patient Merge REST API. All existing 9 tests are untouched and continue
to pass.

### Endpoints Tested
- `GET  /rest/patient/merge/details/{patientId}`
- `POST /rest/patient/merge/validate`
- `POST /rest/patient/merge/execute`

### New Tests Added

| Test | Endpoint | What It Covers |
|------|----------|---------------|
| `getMergeDetails_WithoutSession_Returns403` | `GET /details/{id}` | Unauthenticated request returns 403 — `hasGlobalAdminRole()` security guard was never tested for the failure path |
| `validateMerge_WithoutSession_Returns403` | `POST /validate` | Unauthenticated caller must never be able to inspect patient data |
| `executeMerge_WithoutSession_Returns403` | `POST /execute` | Most destructive operation — merge execution without auth must be completely blocked |
| `executeMerge_MissingRequiredFields_Returns400` | `POST /execute` | Controller checks all 3 required IDs before calling service — this 400 path was tested for `/validate` but missing for `/execute` |

### Why the Security Tests Matter
`hasGlobalAdminRole()` is called on every single endpoint in this
controller and is the only security mechanism protecting patient merge
— one of the most sensitive and destructive operations in the system.
Despite this, zero tests existed for the case where this check fails.
Tests 1–3 directly close this gap.

## Screenshots
No UI changes — this PR adds backend integration test coverage only.

## Related Issue

## Checklist
- [x] PR title follows conventional commit label standards
  (`test(patient-merge):`)
- [x] All existing 9 tests are untouched and passing
- [x] New tests follow the same patterns as existing OpenELIS tests
  (`BaseWebContextSensitiveTest`, MockMvc, `@Rollback`, JUnit 4)
- [x] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
- [x] Security coverage added — all 3 endpoints tested for 403 response
- [x] No UI changes, no schema changes, no breaking changes
- [x] `./mvnw spotless:apply` run before committing
- [x] I have read and agree to the Contributing Guidelines of this
  project

## Other
- Session handling uses `MockHttpSession` with `UserSessionData` —
  same pattern as existing test setup
- No new dependencies added
