### PR TITLE
chore(deps): combined dependency updates + Transifex translations

### DIFF
--- a/.github/ci/ci.analyzer-harness.yml
+++ b/.github/ci/ci.analyzer-harness.yml
@@ -56,6 +56,10 @@ services:
       - SERVER_SSL_ENABLED=false
       - LOGGING_LEVEL_ORG_ITECH=INFO
       - BRIDGE_FILE_ENABLED=true
+      # Fast polling for CI — files are written atomically by Playwright tests.
+      # Production keeps FileConfig.java defaults (5000ms poll, 3000ms stability).
+      - BRIDGE_FILE_POLL_INTERVAL_MS=1000
+      - BRIDGE_FILE_FILE_STABILITY_TIMEOUT_MS=500
       # Bridge connects directly to app (not through proxy), so no /api/ prefix
       # HttpForwardingRouter appends /astm, /hl7, /csv per message protocol
       - ORG_ITECH_AHB_FORWARD_HTTP_SERVER_URI=https://oe.openelis.org:8443/OpenELIS-Global/analyzer

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -215,9 +215,11 @@ GOOD:
 ### VII. Internationalization first (frontend)
 
 - No hardcoded user-facing strings. Use React Intl and add message IDs to
-  `frontend/src/languages/{locale}.json`.
-- Minimum expectation for new UI text: provide at least **en + fr** (per project
-  guidance).
+  `frontend/src/languages/en.json` ONLY.
+- Do NOT edit non-English locale files (`fr.json`, `es.json`, etc.) —
+  translations are managed on
+  [Transifex](https://explore.transifex.com/openmrs/openelis-1/) and pulled
+  automatically. A CI check blocks PRs that modify non-English locale files.
 
 **Examples**
 
@@ -297,7 +299,8 @@ Flag changes that:
 ### Frontend (React 17 + Carbon + React Intl)
 
 - For new components/logic, ensure tests exist where appropriate (Jest/RTL).
-- Verify no hardcoded UI strings; message IDs added to language JSON files.
+- Verify no hardcoded UI strings; message IDs added to `en.json` only (Transifex
+  handles other locales).
 
 ### Cypress E2E (full chain, real backend + DB)
 

--- a/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
+++ b/.github/workflows/e2e-playwright-analyzer-harness-reusable.yml
@@ -226,9 +226,9 @@ jobs:
           BASE_URL: https://localhost
           TEST_USER: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
           TEST_PASS: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
-          # Must match bridge.file.pollIntervalMs (bridge default: 5000ms)
-          FILE_IMPORT_POLL_MS: "5000"
-          FILE_IMPORT_DROP_BUFFER_MS: "45000"
+          # Must match bridge.file.poll-interval-ms (CI override: 1000ms)
+          FILE_IMPORT_POLL_MS: "1000"
+          FILE_IMPORT_DROP_BUFFER_MS: "15000"
 
       - name: Upload blob report
         if: ${{ !cancelled() }}

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-duplicate-keys:
-    name: Run
+    name: Duplicate key check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,4 +27,46 @@ jobs:
               for e in errors: print(f'::error::{e}')
               sys.exit(1)
           print('All i18n files OK — no duplicate keys')
+          "
+
+  check-translation-source:
+    name: Translation source-of-truth check
+    if: github.head_ref != 'chore/update-transifex'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure only en.json is modified (translations belong on Transifex)
+        run: |
+          python3 -c "
+          import subprocess, sys
+
+          base = 'origin/' + '${{ github.base_ref }}'
+          result = subprocess.run(
+              ['git', 'diff', '--name-only', base + '...HEAD', '--',
+               'frontend/src/languages/'],
+              capture_output=True, text=True, check=True)
+          changed = [f for f in result.stdout.strip().split('\n') if f.strip()]
+
+          non_english = [f for f in changed
+                         if not f.endswith('/en.json')]
+
+          if non_english:
+              print('::error::Non-English translation files were modified in this PR.')
+              print('::error::Translations should be done on Transifex, not in code.')
+              print('::error::Only frontend/src/languages/en.json should be edited by developers.')
+              print()
+              print('Files that should not be modified:')
+              for f in non_english:
+                  print(f'  - {f}')
+              print()
+              print('If you added new i18n keys, add them ONLY to en.json.')
+              print('Translators will provide translations via Transifex.')
+              print()
+              print('If this is a Transifex sync PR, ensure it uses the')
+              print('chore/update-transifex branch (auto-bypasses this check).')
+              sys.exit(1)
+          print('i18n source-of-truth OK — only en.json modified')
           "

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -51,7 +51,7 @@ jobs:
           changed = [f for f in result.stdout.strip().split('\n') if f.strip()]
 
           non_english = [f for f in changed
-                         if not f.endswith('/en.json')]
+                         if f.endswith('.json') and not f.endswith('/en.json')]
 
           if non_english:
               print('::error::Non-English translation files were modified in this PR.')

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1022,12 +1022,31 @@ hardcoded English text in components.
 - Use `intl.formatMessage({ id: 'storage.location.label' })` for all text
 - Supported locales: en (English), fr (French), ar (Arabic), es (Spanish), hi
   (Hindi), pt (Portuguese), sw (Swahili)
-- New features MUST provide translations for at least en + fr
+- New features MUST add keys to `en.json` ONLY (see Translation Workflow below)
 - Date/time formatting via `intl.formatDate()`, `intl.formatTime()`
 - Number formatting via `intl.formatNumber()`
 
+**Translation Workflow (Transifex)**:
+
+Transifex is the **source of truth** for all non-English translations. The
+project lives under the OpenMRS organization: `o:openmrs:p:openelis-1:r:enjson`.
+
+- **Developers**: Add new i18n keys to `frontend/src/languages/en.json` ONLY. Do
+  NOT edit `fr.json`, `es.json`, or any other locale file. A CI check
+  ("Translation source-of-truth check") will block PRs that modify non-English
+  locale files.
+- **Source push** (`tx-push.yml`): On every push to `develop`, `en.json` is
+  automatically uploaded to Transifex.
+- **Translators**: Add translations on the
+  [Transifex project](https://explore.transifex.com/openmrs/openelis-1/).
+- **Translation pull** (`tx-pull.yml`): Daily at 20:30 UTC, translations are
+  pulled from Transifex and auto-merged to `develop` via the
+  `chore/update-transifex` branch.
+
 **Rationale**: OpenELIS operates in multilingual countries (e.g., Rwanda: en/fr,
 Kenya: en/sw). Hardcoded strings force costly retrofitting and delay deployment.
+Transifex provides a single source of truth for translations, enabling community
+translators to contribute without touching code.
 
 **Example**:
 
@@ -1039,7 +1058,7 @@ Kenya: en/sw). Hardcoded strings force costly retrofitting and delay deployment.
 <Button>{intl.formatMessage({ id: 'button.save.location' })}</Button>
 ```
 
-**Translation Files** (`en.json`):
+**Translation Files** — developers edit `en.json` only:
 
 ```json
 {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,9 @@ Then customize `.env` for your environment (database passwords, domain, etc.).
 - **React Intl 5.20.12** - ALL user-facing strings MUST use this
 - Message files: `frontend/src/languages/{locale}.json`
 - Usage: `intl.formatMessage({ id: 'key' })`
+- **Add new keys to `en.json` ONLY** — non-English translations are managed on
+  [Transifex](https://explore.transifex.com/openmrs/openelis-1/) (see Section
+  VII)
 
 **Styling:**
 
@@ -440,9 +443,22 @@ hardcoded English text.
 - Message files: `frontend/src/languages/{locale}.json`
 - Use `intl.formatMessage({ id: 'storage.location.label' })`
 - Supported locales: en, fr, ar, es, hi, pt, sw
-- New features MUST provide translations for at least en + fr
+- New keys go in `en.json` ONLY — do NOT edit other locale files
 - Date/time formatting via `intl.formatDate()`, `intl.formatTime()`
 - Number formatting via `intl.formatNumber()`
+
+**Translation Workflow (Transifex):**
+
+[Transifex](https://explore.transifex.com/openmrs/openelis-1/) is the source of
+truth for non-English translations. Developers only edit `en.json`:
+
+1. Developer adds i18n key to `en.json` in their PR
+2. `tx-push.yml` uploads `en.json` to Transifex on merge to `develop`
+3. Translators work on Transifex
+4. `tx-pull.yml` pulls translations daily and auto-merges to `develop`
+
+A CI check ("Translation source-of-truth check") blocks PRs that modify
+non-English locale files. The `chore/update-transifex` bot branch is exempt.
 
 **Example:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,8 @@ Key principles to verify:
       Valueholder→DAO→Service→Controller→Form)
 - [ ] Carbon Design System (NO Bootstrap/Tailwind)
 - [ ] FHIR R4 compliance (for external-facing entities)
-- [ ] React Intl (NO hardcoded strings)
+- [ ] React Intl (NO hardcoded strings, new keys in `en.json` ONLY — Transifex
+      is source of truth for non-English translations)
 - [ ] Test-Driven Development (TDD workflow)
 - [ ] Liquibase for schema changes
 - [ ] @Transactional in services ONLY (NOT controllers)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6778,9 +6778,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10078,9 +10078,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -10290,9 +10290,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -14400,9 +14400,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -14824,7 +14824,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -20228,7 +20230,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>org.hl7.fhir.r4</artifactId>
-            <version>6.9.0</version>
+            <version>6.9.4</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>org.hl7.fhir.utilities</artifactId>
-            <version>6.9.0</version>
+            <version>6.9.4</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/projects/catalyst/catalyst-agents/uv.lock
+++ b/projects/catalyst/catalyst-agents/uv.lock
@@ -721,11 +721,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
 ]
 
 [[package]]
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -983,9 +983,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]

--- a/projects/catalyst/catalyst-gateway/uv.lock
+++ b/projects/catalyst/catalyst-gateway/uv.lock
@@ -549,11 +549,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **frontend**: `npm update` for transitive dependency security fixes (yaml, picomatch, path-to-regexp, brace-expansion, node-forge)
- **pom.xml**: `org.hl7.fhir.r4` + `org.hl7.fhir.utilities` 6.9.0 → 6.9.4 (aligned versions)
- **catalyst-agents**: pyasn1 0.6.2→0.6.3, requests 2.32.5→2.33.1
- **catalyst-gateway**: pyasn1 0.6.2→0.6.3
- **ci: i18n source-of-truth check**: New CI job blocks PRs that modify non-English translation files. Translations belong on Transifex, not in code. Bypassed for the Transifex bot branch.

## Context: i18n policy enforcement

694 French + 31 barcode translations were added directly in code (PR #2800, OGC-284) before the Transifex-only policy was enforced. These need to be pushed to Transifex locally (`tx push --translations`) before merging the Transifex bot PR #3081, to avoid regression.

**Post-merge steps:**
1. Run `tx push --translations` locally to seed Transifex with code-added translations
2. Close #3081 (stale bot PR) and let the bot regenerate cleanly

## Auto-closes

closes #3183, closes #3186, closes #3219, closes #3228, closes #3229, closes #3244, closes #3086, closes #3087, closes #3180