### PR TITLE
fix(ci): use pull_request_target for merge-conflict label action (fork parity)

### DIFF
--- a/.github/workflows/label-merge-conflict.yml
+++ b/.github/workflows/label-merge-conflict.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches: [develop]
-  pull_request:
+  pull_request_target:
     branches: [develop]
 
 jobs:


### PR DESCRIPTION
## Summary
- Switch merge-conflict label workflow trigger from `pull_request` to `pull_request_target`
- Fork PRs now get identical merge-conflict detection behavior (labels applied/removed correctly)
- Safe because the action never checks out or executes PR code — API-only label operations

## Context
The `prince-chrismc/label-merge-conflicts-action` fails on all fork PRs with `GraphqlError: Resource not accessible by integration` because `GITHUB_TOKEN` is read-only for fork `pull_request` events. `pull_request_target` runs in the base repo context where the token has write access.

This is the textbook safe use case for `pull_request_target` — no code checkout, only GitHub API metadata operations.

## Test plan
- [ ] Verify the workflow triggers on a fork PR and successfully manages labels
- [ ] Verify the workflow still triggers on `push` to develop
- [ ] Verify no code checkout occurs in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)