### PR TITLE
fix(ci): use Checks API for E2E status + restore required checks

### DIFF
--- a/.github/workflows/e2e-pending-status.yml
+++ b/.github/workflows/e2e-pending-status.yml
@@ -1,0 +1,35 @@
+# Creates a "03 Checkpoint - E2E" check run immediately when a PR is
+# opened/updated. Uses pull_request_target so it works for fork PRs too
+# (fork pull_request events have read-only tokens).
+#
+# No code checkout — only creates a check run. Safe to run on pull_request_target.
+# The check run is later updated by the "E2E / Tests" workflow with results.
+name: E2E / Pending Status
+
+on:
+  pull_request_target:
+    branches: [develop]
+
+jobs:
+  set-pending:
+    name: Set E2E Pending
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Create pending check run
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: context.payload.pull_request.head.sha,
+              name: '03 Checkpoint - E2E',
+              status: 'queued',
+              output: {
+                title: 'E2E build in progress',
+                summary: 'Waiting for shared build to complete before running E2E tests...'
+              }
+            });

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -80,28 +80,58 @@ jobs:
 
           echo "Build context: is_fork=$IS_FORK image_transfer=$IMAGE_TRANSFER event=$EVENT_NAME pr=#$PR_NUMBER head_sha=$HEAD_SHA"
 
-  # ─── Set pending status on PR ───────────────────────────────────────────────
+  # ─── Set pending check run on PR ────────────────────────────────────────────
   set-pending-status:
     name: Set Pending Status
     needs: setup
     if: needs.setup.outputs.image_transfer != 'none' && needs.setup.outputs.head_sha != ''
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
     steps:
-      - name: Post pending commit status
+      - name: Create or update check run to in_progress
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.repos.createCommitStatus({
+            const sha = '${{ needs.setup.outputs.head_sha }}';
+            const name = '03 Checkpoint - E2E';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Find existing check run (created by e2e-pending-status.yml)
+            const { data: { check_runs } } = await github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ needs.setup.outputs.head_sha }}',
-              state: 'pending',
-              context: '03 Checkpoint - E2E',
-              description: 'E2E tests running...',
-              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              ref: sha,
+              check_name: name,
+              filter: 'latest'
             });
+
+            if (check_runs.length > 0) {
+              await github.rest.checks.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_run_id: check_runs[0].id,
+                status: 'in_progress',
+                details_url: runUrl,
+                output: {
+                  title: 'E2E tests running',
+                  summary: 'Playwright, Cypress, and Analyzer Harness tests are in progress...'
+                }
+              });
+            } else {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head_sha: sha,
+                name,
+                status: 'in_progress',
+                details_url: runUrl,
+                output: {
+                  title: 'E2E tests running',
+                  summary: 'Playwright, Cypress, and Analyzer Harness tests are in progress...'
+                }
+              });
+            }
 
   # ─── Fork Rebuild ───────────────────────────────────────────────────────────
   # Only runs for fork PRs. Rebuilds from GHA cache (fast) and pushes to GHCR
@@ -490,40 +520,69 @@ jobs:
           echo "E2E gate passed."
 
   # ─── Report Status ──────────────────────────────────────────────────────────
-  # Posts commit status back to PR so results are visible in the PR checks tab.
-  # workflow_run checks don't automatically appear on PRs.
+  # Updates the check run on the PR with final E2E results.
+  # workflow_run checks don't automatically appear on PRs, so we manage our own.
   report-status:
     name: Report Status
     if: always() && needs.setup.outputs.head_sha != ''
     needs: [setup, e2e-gate]
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
     steps:
-      - name: Post commit status to PR
+      - name: Update check run with results
         uses: actions/github-script@v7
         with:
           script: |
+            const sha = '${{ needs.setup.outputs.head_sha }}';
+            const name = '03 Checkpoint - E2E';
             const gateResult = '${{ needs.e2e-gate.result }}';
             const imageTransfer = '${{ needs.setup.outputs.image_transfer }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            let state, description;
+            let conclusion, title, summary;
             if (imageTransfer === 'none') {
-              state = 'failure';
-              description = 'E2E build failed — no images produced';
+              conclusion = 'failure';
+              title = 'E2E build failed';
+              summary = 'No Docker images were produced — E2E tests could not run.';
             } else if (gateResult === 'success') {
-              state = 'success';
-              description = 'E2E tests passed';
+              conclusion = 'success';
+              title = 'E2E tests passed';
+              summary = 'All Playwright, Cypress, and Analyzer Harness tests passed.';
             } else {
-              state = 'failure';
-              description = 'E2E tests failed';
+              conclusion = 'failure';
+              title = 'E2E tests failed';
+              summary = 'One or more E2E test suites failed. Click **Details** to view the full run.';
             }
-            await github.rest.repos.createCommitStatus({
+
+            // Find existing check run (created by e2e-pending-status.yml or set-pending-status job)
+            const { data: { check_runs } } = await github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ needs.setup.outputs.head_sha }}',
-              state,
-              context: '03 Checkpoint - E2E',
-              description,
-              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              ref: sha,
+              check_name: name,
+              filter: 'latest'
             });
+
+            if (check_runs.length > 0) {
+              await github.rest.checks.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_run_id: check_runs[0].id,
+                status: 'completed',
+                conclusion,
+                details_url: runUrl,
+                output: { title, summary }
+              });
+            } else {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head_sha: sha,
+                name,
+                status: 'completed',
+                conclusion,
+                details_url: runUrl,
+                output: { title, summary }
+              });
+            }


### PR DESCRIPTION
## Summary
- Switch `03 Checkpoint - E2E` from commit statuses (`createCommitStatus`) to check runs (`createCheckRun` / `checks.update`)
- Add `e2e-pending-status.yml` using `pull_request_target` to create the check run immediately on PR open (fork + non-fork parity)
- Update `e2e-tests.yml` Set Pending Status and Report Status jobs to use Checks API
- `details_url` links to the `E2E / Tests` workflow run — clicking the check shows the full shard graph
- Restore required status checks on `develop` branch protection

## Problem
PR #3148 split E2E into build + test workflows. The test results were posted via `createCommitStatus` because `workflow_run` checks don't appear on PRs. This caused:
1. Required checks list emptied (commit status != check run)
2. No job graph visible from PR checks tab
3. PRs appeared green before E2E ran (pending status only posted when runner available)

## Test plan
- [ ] New PR shows `03 Checkpoint - E2E` as queued immediately
- [ ] Check is clickable → links to `E2E / Tests` workflow run with full job graph
- [ ] Fork PR gets the same pending check (via `pull_request_target`)
- [ ] No duplicate required checks in PR UI
- [ ] PR cannot merge until all three checkpoints pass