### PR TITLE
fix(ci): poll check runs instead of commit statuses in publish-images

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      statuses: read
+      checks: read
     steps:
       - name: Wait for E2E checkpoint success
         uses: actions/github-script@v7
@@ -81,36 +81,37 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const sha = '${{ needs.setup.outputs.head_sha }}';
-            const contextName = '03 Checkpoint - E2E';
+            const checkName = '03 Checkpoint - E2E';
             const timeoutMs = 45 * 60 * 1000;
             const pollMs = 30 * 1000;
             const started = Date.now();
 
             while (Date.now() - started < timeoutMs) {
-              const res = await github.rest.repos.listCommitStatusesForRef({
+              const { data: { check_runs } } = await github.rest.checks.listForRef({
                 owner,
                 repo,
                 ref: sha,
-                per_page: 100,
+                check_name: checkName,
+                filter: 'latest'
               });
 
-              const status = res.data.find((s) => s.context === contextName);
-              if (!status) {
-                core.info(`No '${contextName}' status yet for ${sha}; waiting...`);
-              } else if (status.state === 'success') {
-                core.info(`Found successful '${contextName}' status.`);
+              const check = check_runs[0];
+              if (!check) {
+                core.info(`No '${checkName}' check run yet for ${sha}; waiting...`);
+              } else if (check.status === 'completed' && check.conclusion === 'success') {
+                core.info(`Found successful '${checkName}' check run.`);
                 return;
-              } else if (status.state === 'failure' || status.state === 'error') {
-                core.setFailed(`Checkpoint status is ${status.state}: ${status.description || 'no description'}`);
+              } else if (check.status === 'completed') {
+                core.setFailed(`Checkpoint concluded '${check.conclusion}': ${check.output?.title || 'no details'}`);
                 return;
               } else {
-                core.info(`Checkpoint currently '${status.state}'; waiting...`);
+                core.info(`Checkpoint status '${check.status}'; waiting...`);
               }
 
               await new Promise((resolve) => setTimeout(resolve, pollMs));
             }
 
-            core.setFailed(`Timed out waiting for '${contextName}' on ${sha}`);
+            core.setFailed(`Timed out waiting for '${checkName}' on ${sha}`);
 
   publish-images:
     name: Publish ${{ matrix.dockerhub_suffix || 'backend' }}


### PR DESCRIPTION
## Summary
Switch `publish-images.yml` from `listCommitStatusesForRef` to `checks.listForRef` for polling the `03 Checkpoint - E2E` status.

## Problem
PR #3272 switched the E2E checkpoint from commit statuses (`createCommitStatus`) to check runs (`createCheckRun`). The publish-images workflow still polled for commit statuses, which would never find the check run — causing a 45-minute timeout that blocks the release pipeline.

## Test plan
- [ ] Next release/push to develop triggers publish-images and successfully finds the E2E check run