### PR TITLE
traditionalmedicine: add other option to preparation and extraction

### DIFF
--- a/frontend/src/components/notebook/pages/traditionalmedicine/TraditionalMedicineExtractionPage.js
+++ b/frontend/src/components/notebook/pages/traditionalmedicine/TraditionalMedicineExtractionPage.js
@@ -127,6 +127,7 @@ function TraditionalMedicineExtractionPage({
     { id: "filter_paper", label: "Filter Paper" },
     { id: "vacuum", label: "Vacuum Filtration" },
     { id: "centrifugation", label: "Centrifugation" },
+    { id: "other", label: "Other" },
   ];
 
   const concentrationOptions = [

--- a/frontend/src/components/notebook/pages/traditionalmedicine/TraditionalMedicinePreparationPage.js
+++ b/frontend/src/components/notebook/pages/traditionalmedicine/TraditionalMedicinePreparationPage.js
@@ -104,6 +104,10 @@ function TraditionalMedicinePreparationPage({
       id: "freshly_processed",
       label: "Freshly processed samples: Used immediately",
     },
+    {
+      id: "other",
+      label: "Other",
+    },
   ];
 
   // Drying method options (per SRS)


### PR DESCRIPTION
## Summary
- add `Other` as a selectable option in Traditional Medicine Preparation processing methods
- add `Other` as a selectable option in Traditional Medicine Extraction filtration methods

## Validation
- tested locally in the Traditional Medicine workflow
- confirmed `Other` appears in Preparation and saves correctly
- confirmed `Other` appears in Extraction filtration and saves correctly
- confirmed values persist on reopen
