### PR TITLE
pathology: move mounting QC to staining step

### DIFF
--- a/frontend/src/components/notebook/pages/pathology/PathologySlidesPage.js
+++ b/frontend/src/components/notebook/pages/pathology/PathologySlidesPage.js
@@ -104,7 +104,6 @@ function PathologySlidesPage({
     // Quality Control
     qcStatus: "PASS",
     qcSectionQuality: true,
-    qcMountingQuality: true,
     qcLabelingCorrect: true,
     qcSlideIntegrity: true,
     qcIssues: "",
@@ -344,7 +343,6 @@ function PathologySlidesPage({
       // QC fields
       qcStatus: "PASS",
       qcSectionQuality: true,
-      qcMountingQuality: true,
       qcLabelingCorrect: true,
       qcSlideIntegrity: true,
       qcIssues: "",
@@ -385,7 +383,6 @@ function PathologySlidesPage({
               // QC fields
               qcStatus: response.qcStatus || "PASS",
               qcSectionQuality: response.qcSectionQuality !== false,
-              qcMountingQuality: response.qcMountingQuality !== false,
               qcLabelingCorrect: response.qcLabelingCorrect !== false,
               qcSlideIntegrity: response.qcSlideIntegrity !== false,
               qcIssues: response.qcIssues || "",
@@ -1636,24 +1633,6 @@ function PathologySlidesPage({
                     setSlideData((prev) => ({
                       ...prev,
                       qcSectionQuality: e.target.checked,
-                    }))
-                  }
-                  disabled={slideViewMode}
-                />
-              </Column>
-              <Column lg={4} md={4} sm={4}>
-                <Checkbox
-                  id="qcMountingQuality"
-                  name="qcMountingQuality"
-                  labelText={intl.formatMessage({
-                    id: "pathology.qc.slides.mountingQuality",
-                    defaultMessage: "Mounting quality verified",
-                  })}
-                  checked={slideData.qcMountingQuality}
-                  onChange={(e) =>
-                    setSlideData((prev) => ({
-                      ...prev,
-                      qcMountingQuality: e.target.checked,
                     }))
                   }
                   disabled={slideViewMode}

--- a/frontend/src/components/notebook/pages/pathology/PathologyStainingPage.js
+++ b/frontend/src/components/notebook/pages/pathology/PathologyStainingPage.js
@@ -110,6 +110,7 @@ function PathologyStainingPage({
     // Quality Control
     qcStatus: "PASS",
     qcStainIntensity: true,
+    qcMountingQuality: true,
     qcBackgroundClean: true,
     qcControlsValid: true,
     qcLabelingCorrect: true,
@@ -316,6 +317,7 @@ function PathologyStainingPage({
       // QC fields
       qcStatus: "PASS",
       qcStainIntensity: true,
+      qcMountingQuality: true,
       qcBackgroundClean: true,
       qcControlsValid: true,
       qcLabelingCorrect: true,
@@ -363,6 +365,7 @@ function PathologyStainingPage({
               // QC fields
               qcStatus: response.qcStatus || "PASS",
               qcStainIntensity: response.qcStainIntensity !== false,
+              qcMountingQuality: response.qcMountingQuality !== false,
               qcBackgroundClean: response.qcBackgroundClean !== false,
               qcControlsValid: response.qcControlsValid !== false,
               qcLabelingCorrect: response.qcLabelingCorrect !== false,
@@ -1456,6 +1459,24 @@ function PathologyStainingPage({
                     setStainingData((prev) => ({
                       ...prev,
                       qcStainIntensity: e.target.checked,
+                    }))
+                  }
+                  disabled={stainingViewMode}
+                />
+              </Column>
+              <Column lg={4} md={4} sm={4}>
+                <Checkbox
+                  id="qcMountingQuality"
+                  name="qcMountingQuality"
+                  labelText={intl.formatMessage({
+                    id: "pathology.qc.staining.qcMountingQuality",
+                    defaultMessage: "Mounting quality verified",
+                  })}
+                  checked={stainingData.qcMountingQuality}
+                  onChange={(e) =>
+                    setStainingData((prev) => ({
+                      ...prev,
+                      qcMountingQuality: e.target.checked,
                     }))
                   }
                   disabled={stainingViewMode}


### PR DESCRIPTION
## Summary
- move `Mounting quality verified` from Slide Preparation to Slide Staining
- keep the change limited to the two pathology workflow pages

## Validation
- tested locally in the pathology workflow
- confirmed the checkbox is removed from Slide Preparation
- confirmed the checkbox appears in Slide Staining
- confirmed the behavior persists on reopen
