### PR TITLE
fix(e2e): use keyboard navigation for Carbon Dropdown selection

### DIFF
--- a/frontend/playwright/fixtures/analyzer-form.ts
+++ b/frontend/playwright/fixtures/analyzer-form.ts
@@ -94,11 +94,8 @@ export class AnalyzerFormPage {
     await expect(trigger).toBeEnabled({ timeout: UI_TIMEOUT });
     await trigger.click();
 
-    // Scope listbox via aria-controls so we target the correct one
-    const listboxId = await trigger.first().getAttribute("aria-controls");
-    const listbox = listboxId
-      ? this.page.locator(`#${CSS.escape(listboxId)}`)
-      : this.page.getByRole("listbox");
+    // Scope listbox to this dropdown's container (Carbon renders it as a child)
+    const listbox = dropdown.getByRole("listbox");
     await expect(listbox).toBeVisible({ timeout: UI_TIMEOUT });
 
     try {

--- a/frontend/playwright/fixtures/analyzer-form.ts
+++ b/frontend/playwright/fixtures/analyzer-form.ts
@@ -94,21 +94,41 @@ export class AnalyzerFormPage {
     await expect(trigger).toBeEnabled({ timeout: UI_TIMEOUT });
     await trigger.click();
 
-    const listbox = this.page.getByRole("listbox");
+    // Scope listbox via aria-controls so we target the correct one
+    const listboxId = await trigger.first().getAttribute("aria-controls");
+    const listbox = listboxId
+      ? this.page.locator(`#${CSS.escape(listboxId)}`)
+      : this.page.getByRole("listbox");
     await expect(listbox).toBeVisible({ timeout: UI_TIMEOUT });
 
-    // Navigate with ArrowDown until the target option is highlighted
-    const option = listbox.getByRole("option", { name: text }).first();
-    await expect(option).toBeVisible({ timeout: UI_TIMEOUT });
+    try {
+      // Reset to top, then navigate down to the target option
+      const option = listbox.getByRole("option", { name: text }).first();
+      await expect(option).toBeVisible({ timeout: UI_TIMEOUT });
 
-    const maxPresses = 20;
-    for (let i = 0; i < maxPresses; i++) {
-      const selected = await option.getAttribute("aria-selected");
-      if (selected === "true") break;
-      await this.page.keyboard.press("ArrowDown");
+      await this.page.keyboard.press("Home");
+      const maxPresses = 20;
+      for (let i = 0; i < maxPresses; i++) {
+        const selected = await option.getAttribute("aria-selected");
+        if (selected === "true") break;
+        await this.page.keyboard.press("ArrowDown");
+      }
+
+      // Fail explicitly if we didn't reach the target
+      const finalSelected = await option.getAttribute("aria-selected");
+      if (finalSelected !== "true") {
+        throw new Error(
+          `Could not navigate to option "${text}" after ${maxPresses} ArrowDown presses`,
+        );
+      }
+
+      await this.page.keyboard.press("Enter");
+    } catch (e) {
+      // Close the listbox so it doesn't interfere with subsequent interactions
+      await this.page.keyboard.press("Escape");
+      await expect(listbox).not.toBeVisible({ timeout: UI_TIMEOUT });
+      throw e;
     }
-
-    await this.page.keyboard.press("Enter");
 
     // Ensure the listbox is fully closed before returning
     await expect(listbox).not.toBeVisible({ timeout: UI_TIMEOUT });

--- a/frontend/playwright/fixtures/analyzer-form.ts
+++ b/frontend/playwright/fixtures/analyzer-form.ts
@@ -79,17 +79,39 @@ export class AnalyzerFormPage {
     await this.nameInput.fill(name);
   }
 
-  /** Select an item from a Carbon Dropdown by visible text */
+  /**
+   * Select an item from a Carbon Dropdown using keyboard navigation.
+   *
+   * Carbon Dropdown (non-filterable) supports: open → ArrowDown/Up → Enter.
+   * We press ArrowDown until the target option gets aria-selected, then Enter.
+   * This avoids clicking inside the listbox overlay, which causes flaky
+   * pointer-interception on adjacent dropdowns during close animation.
+   */
   private async selectDropdownItem(dropdown: Locator, text: string) {
-    // Carbon places data-testid on the wrapper div, not the trigger button.
-    // Click the inner trigger button to reliably open the listbox.
     const trigger = dropdown.locator(
       'button[role="combobox"], .cds--list-box__field',
     );
     await expect(trigger).toBeEnabled({ timeout: UI_TIMEOUT });
     await trigger.click();
-    const item = this.page.getByRole("option", { name: text });
-    await item.first().click();
+
+    const listbox = this.page.getByRole("listbox");
+    await expect(listbox).toBeVisible({ timeout: UI_TIMEOUT });
+
+    // Navigate with ArrowDown until the target option is highlighted
+    const option = listbox.getByRole("option", { name: text }).first();
+    await expect(option).toBeVisible({ timeout: UI_TIMEOUT });
+
+    const maxPresses = 20;
+    for (let i = 0; i < maxPresses; i++) {
+      const selected = await option.getAttribute("aria-selected");
+      if (selected === "true") break;
+      await this.page.keyboard.press("ArrowDown");
+    }
+
+    await this.page.keyboard.press("Enter");
+
+    // Ensure the listbox is fully closed before returning
+    await expect(listbox).not.toBeVisible({ timeout: UI_TIMEOUT });
   }
 
   /** Select an analyzer type (category) from the dropdown */

--- a/frontend/playwright/helpers/create-analyzer-from-profile.ts
+++ b/frontend/playwright/helpers/create-analyzer-from-profile.ts
@@ -114,7 +114,7 @@ export async function createAnalyzerFromProfile(
   // Select profile (auto-fills fields)
   if (config.profileName) {
     await form.selectDefaultConfig(config.profileName);
-    await presentation.pause(1_000);
+    await presentation.pause(500);
   }
 
   // Select analyzer type (may already be set by profile)

--- a/frontend/playwright/tests/foundational/harness/analyzer-plugin-config.spec.ts
+++ b/frontend/playwright/tests/foundational/harness/analyzer-plugin-config.spec.ts
@@ -8,7 +8,6 @@ import {
 import {
   QUICK_TIMEOUT,
   SHORT_TIMEOUT,
-  UI_TIMEOUT,
   LONG_TIMEOUT,
 } from "../../../helpers/timeouts";
 
@@ -46,33 +45,11 @@ test.describe("Analyzer Plugin Config", () => {
         continue;
       }
 
-      for (let sel = 1; sel <= 4; sel++) {
-        // Carbon places data-testid on wrapper div; click inner trigger button
-        const trigger = form.pluginTypeDropdown.locator(
-          'button[role="combobox"], .cds--list-box__field',
-        );
-        await trigger.click();
-        const genericAstmOption = page
-          .getByRole("option", { name: /Generic ASTM/i })
-          .first();
-        let optionVisible = false;
-        try {
-          await expect(genericAstmOption).toBeVisible({
-            timeout: QUICK_TIMEOUT,
-          });
-          optionVisible = true;
-        } catch {
-          // Option not rendered in this attempt — retry
-        }
-        if (optionVisible) {
-          await genericAstmOption.click();
-          selectedPlugin = true;
-          break;
-        }
-        await page.keyboard.press("Escape");
-        await expect(genericAstmOption).not.toBeVisible({
-          timeout: QUICK_TIMEOUT,
-        });
+      try {
+        await form.selectPluginType("Generic ASTM");
+        selectedPlugin = true;
+      } catch {
+        // Selection failed (e.g. options not rendered) — retry
       }
       if (selectedPlugin) break;
 
@@ -89,16 +66,7 @@ test.describe("Analyzer Plugin Config", () => {
     ).toBeTruthy();
 
     await expect(form.defaultConfigDropdown).toBeVisible();
-    // Carbon: click inner trigger, not wrapper div
-    const configTrigger = form.defaultConfigDropdown.locator(
-      'button[role="combobox"], .cds--list-box__field',
-    );
-    await configTrigger.click();
-    const geneXpertProfile = page
-      .getByRole("option", { name: /GeneXpert.*ASTM/i })
-      .first();
-    await expect(geneXpertProfile).toBeVisible({ timeout: UI_TIMEOUT });
-    await geneXpertProfile.click();
+    await form.selectDefaultConfig("GeneXpert");
 
     // Selecting the profile should prefill key analyzer fields.
     await expect(form.identifierPatternInput).toHaveValue(/GENEXPERT/i);

--- a/frontend/playwright/tests/manual-only/harness/analyzer-test-connection-manual-only.spec.ts
+++ b/frontend/playwright/tests/manual-only/harness/analyzer-test-connection-manual-only.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { AnalyzerListPage } from "../../../fixtures/analyzer-list";
 import { AnalyzerFormPage } from "../../../fixtures/analyzer-form";
-import { LONG_TIMEOUT, UI_TIMEOUT } from "../../../helpers/timeouts";
+import { LONG_TIMEOUT } from "../../../helpers/timeouts";
 
 const GENEXPERT_HOST = process.env.GENEXPERT_HOST;
 const GENEXPERT_PORT = process.env.GENEXPERT_PORT || "1200";
@@ -47,10 +47,7 @@ test.describe("Real GeneXpert Test Connection (Manual Only)", () => {
 
     await form.fillName(analyzerName);
 
-    await form.pluginTypeDropdown.click();
-    const pluginOption = page.getByRole("option", { name: /Generic ASTM/ });
-    await expect(pluginOption.first()).toBeVisible({ timeout: UI_TIMEOUT });
-    await pluginOption.first().click();
+    await form.selectPluginType("Generic ASTM");
 
     await form.selectType("Molecular");
     await form.fillIpAddress(GENEXPERT_HOST!);


### PR DESCRIPTION
## Summary
- Replace click-based option selection with ArrowDown+Enter keyboard navigation in `selectDropdownItem` fixture helper
- Carbon Dropdown listbox overlay animation can intercept pointer events on adjacent dropdowns during close transition, causing intermittent FluoroCycler XT Demo 1/2 failures
- Consolidate 3 inline click-based dropdown patterns in `analyzer-plugin-config.spec.ts` and `analyzer-test-connection-manual-only.spec.ts` to use the shared `AnalyzerFormPage` fixture methods
- Reduce post-dropdown pause from 1s to 500ms since `selectDropdownItem` now waits for listbox close

## Test plan
- [ ] E2E harness shard (FluoroCycler XT Demo 1/2) passes consistently
- [ ] Foundational analyzer-plugin-config test passes
- [ ] No regressions in other analyzer demo flows