### PR TITLE
fix(tb): route QC and inoculation handoffs correctly

### DIFF
--- a/frontend/src/components/notebook/pages/tb/TBInitialProcessingPage.js
+++ b/frontend/src/components/notebook/pages/tb/TBInitialProcessingPage.js
@@ -563,11 +563,8 @@ function TBInitialProcessingPage({
                     status: "COMPLETED",
                   }),
                   () => {
-                    console.log("Samples marked as COMPLETED");
                     // Route samples to Page 4 (Incubation Monitoring)
-                    console.log("Routing samples to Page 4...");
                     routeSamplesToPage(sampleIds, 4);
-                    console.log("=== INOCULATION COMPLETE ===");
                     loadPageSamples();
                     loadStatistics();
                     if (onProgressUpdate) onProgressUpdate();

--- a/frontend/src/components/notebook/pages/tb/TBInitialProcessingPage.js
+++ b/frontend/src/components/notebook/pages/tb/TBInitialProcessingPage.js
@@ -564,9 +564,9 @@ function TBInitialProcessingPage({
                   }),
                   () => {
                     console.log("Samples marked as COMPLETED");
-                    // Route samples to Page 5 (Incubation Monitoring)
-                    console.log("Routing samples to Page 5...");
-                    routeSamplesToPage(sampleIds, 5);
+                    // Route samples to Page 4 (Incubation Monitoring)
+                    console.log("Routing samples to Page 4...");
+                    routeSamplesToPage(sampleIds, 4);
                     console.log("=== INOCULATION COMPLETE ===");
                     loadPageSamples();
                     loadStatistics();

--- a/frontend/src/components/notebook/pages/tb/TBQualityCheckPage.js
+++ b/frontend/src/components/notebook/pages/tb/TBQualityCheckPage.js
@@ -360,12 +360,13 @@ function TBQualityCheckPage({
       return;
     }
 
+    const shouldRouteToProcessing =
+      bulkApplyValues.qcResult === "PASS" ||
+      bulkApplyValues.qcResult === "FAIL_PROCEED";
+
     const resolvedDestination =
       bulkApplyValues.destination ||
-      (bulkApplyValues.qcResult === "PASS" ||
-      bulkApplyValues.qcResult === "FAIL_PROCEED"
-        ? "PROCESSING"
-        : "");
+      (shouldRouteToProcessing ? "PROCESSING" : "");
 
     if (
       bulkApplyValues.qcResult === "PASS_TO_STORAGE" &&
@@ -603,18 +604,6 @@ function TBQualityCheckPage({
           setSuccessMessage(message);
           setSelectedSampleIds([]);
 
-          // DEBUG: Log passing samples with their destinations
-          console.log("=== ROUTING DEBUG ===");
-          console.log(
-            "Passing samples:",
-            passingSamples.map((s) => ({
-              id: s.id,
-              accessionNumber: s.accessionNumber,
-              destination: s.destination,
-              qcResult: s.qcResult,
-            })),
-          );
-
           // Route samples to next page based on destination
           const processingIds = passingSamples
             .filter(
@@ -632,16 +621,6 @@ function TBQualityCheckPage({
                 s.destination === "LONG_TERM_STORAGE",
             )
             .map((s) => parseInt(s.id, 10));
-
-          console.log(
-            "Processing IDs (destination=PROCESSING):",
-            processingIds,
-          );
-          console.log(
-            "Storage IDs (destination=TEMPORARY_STORAGE or LONG_TERM_STORAGE):",
-            storageIds,
-          );
-          console.log("==================");
 
           if (processingIds.length > 0) {
             routeSamplesToPage(processingIds, 3); // Route to Page 3 (Initial Sample Processing)

--- a/frontend/src/components/notebook/pages/tb/TBQualityCheckPage.js
+++ b/frontend/src/components/notebook/pages/tb/TBQualityCheckPage.js
@@ -360,6 +360,28 @@ function TBQualityCheckPage({
       return;
     }
 
+    const resolvedDestination =
+      bulkApplyValues.destination ||
+      (bulkApplyValues.qcResult === "PASS" ||
+      bulkApplyValues.qcResult === "FAIL_PROCEED"
+        ? "PROCESSING"
+        : "");
+
+    if (
+      bulkApplyValues.qcResult === "PASS_TO_STORAGE" &&
+      resolvedDestination !== "TEMPORARY_STORAGE" &&
+      resolvedDestination !== "LONG_TERM_STORAGE"
+    ) {
+      setError(
+        intl.formatMessage({
+          id: "notebook.page.tb.qc.error.storageDestinationRequired",
+          defaultMessage:
+            "Please choose Temporary Storage or Long-term Storage for samples routed to storage.",
+        }),
+      );
+      return;
+    }
+
     // Build data object
     const data = {};
 
@@ -379,8 +401,7 @@ function TBQualityCheckPage({
 
     // Add QC result and routing
     if (bulkApplyValues.qcResult) data.qcResult = bulkApplyValues.qcResult;
-    if (bulkApplyValues.destination)
-      data.destination = bulkApplyValues.destination;
+    if (resolvedDestination) data.destination = resolvedDestination;
     if (bulkApplyValues.rejectionReason)
       data.rejectionReason = bulkApplyValues.rejectionReason;
     if (bulkApplyValues.rejectionRemarks)
@@ -596,7 +617,12 @@ function TBQualityCheckPage({
 
           // Route samples to next page based on destination
           const processingIds = passingSamples
-            .filter((s) => s.destination === "PROCESSING")
+            .filter(
+              (s) =>
+                s.destination === "PROCESSING" ||
+                ((!s.destination || s.destination === "") &&
+                  (s.qcResult === "PASS" || s.qcResult === "FAIL_PROCEED")),
+            )
             .map((s) => parseInt(s.id, 10));
 
           const storageIds = passingSamples

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -2978,6 +2978,7 @@
   "notebook.page.sampleReception.title": "Sample Reception",
   "notebook.page.sampleReception.totalSamples": "Total Samples",
   "notebook.page.sampleReception.verified": "Verified",
+  "notebook.page.tb.qc.error.storageDestinationRequired": "Please choose Temporary Storage or Long-term Storage for samples routed to storage.",
   "notebook.page.title": "Notebook",
   "notebook.pages.none.subtitle": "Click to add Pages",
   "notebook.pages.none.title": "No Pages Added",


### PR DESCRIPTION
## Summary
- default TB QC pass-through samples to processing when no destination was selected
- require an explicit storage destination when routing TB samples to storage
- send inoculated TB samples to Incubation & Monitoring instead of Assay/Test Execution

## Testing
Tested locally on localhost.

QC now routes correctly to processing or storage, inoculation routes to incubation, and finalized incubation results appear in Assay/Test Execution.