### PR TITLE
fix(ci): deduplicate workflow_run cascade on E2E and Publish pipelines

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,10 @@ on:
     types: [completed]
 
 concurrency:
-  group: e2e-tests-${{ github.event.workflow_run.head_sha }}
+  # Push (develop merge): key on github.sha so all triggers for the same
+  # develop HEAD collapse into one run. PR: key on the PR's unique head_sha
+  # so each PR keeps its own independent E2E run.
+  group: e2e-tests-${{ github.event.workflow_run.event == 'push' && github.sha || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: e2e-tests-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.head_sha }}
+  group: e2e-tests-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -9,7 +9,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: publish-images-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.head_sha }}
+  group: publish-images-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -9,7 +9,10 @@ on:
     types: [completed]
 
 concurrency:
-  group: publish-images-${{ github.event.workflow_run.head_sha }}
+  # Push (develop merge): key on github.sha so all triggers for the same
+  # develop HEAD collapse into one run. PR: key on the PR's unique head_sha
+  # so each PR keeps its own independent publish run.
+  group: publish-images-${{ github.event.workflow_run.event == 'push' && github.sha || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- **Problem:** Each PR's `03 - E2E` build completion triggers separate `E2E / Tests` and `Publish Images` runs via `workflow_run`. The concurrency group used `github.event.workflow_run.head_branch` + `github.event.workflow_run.head_sha` — both resolve to the **triggering PR's** branch/SHA (not develop's), making each group unique. 15 simultaneous PR builds → 15 independent downstream runs for the same develop code.
- **Root cause detail:** `github.event.workflow_run.head_sha` ≠ `github.sha`. The former is the triggering PR's head commit (unique per PR). The latter is the develop HEAD (same for all downstream runs). The old concurrency key used the former, so no deduplication occurred.
- **Fix:** Branch on event type. For push-to-develop triggers, key on `github.sha` (develop HEAD — identical across all triggers → collapses to 1 run). For PR triggers, keep `workflow_run.head_sha` (unique per PR → each PR retains its own E2E run).
- **Observed:** Commit `2e92da20e` on develop (2026-04-03) had 15 queued `E2E / Tests` runs and 15 `Publish Images` runs. Runner pool exhausted, and one partial success masked a Playwright failure as green.

## The two SHAs

| Expression | Value for downstream run | Unique per trigger? |
|---|---|---|
| `github.sha` | Develop HEAD (`2e92da20e`) | **No** — same for all |
| `github.event.workflow_run.head_sha` | Triggering PR's head commit | **Yes** — different per PR |

## Concurrency key logic

```yaml
group: e2e-tests-${{ github.event.workflow_run.event == 'push' && github.sha || github.event.workflow_run.head_sha }}
```

| Scenario | Key resolves to | Behavior |
|---|---|---|
| 15 PR builds trigger E2E for develop | `e2e-tests-2e92da20e` (all same) | **1 run**, 14 cancelled |
| PR `feature/a` build completes | `e2e-tests-abc123` (PR head) | Own group, runs independently |
| PR `feature/b` build completes | `e2e-tests-def456` (PR head) | Own group, parallel with A |

## Test plan

- [ ] After merge, trigger 2+ PR merges to develop — confirm only 1 `E2E / Tests` run executes
- [ ] Open 2 separate PRs — confirm each gets its own independent E2E run
- [ ] Verify `Publish Images` also deduplicates (1 run per develop SHA)
- [ ] Verify check-run UI shows single authoritative result (no green-masking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)