### PR TITLE
fix(ci): add always() to E2E executor — skipped fork-rebuild blocked non-fork path

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -281,9 +281,15 @@ jobs:
   authoritative-executor:
     name: Authoritative E2E Executor
     needs: [setup, fork-rebuild]
+    # always() overrides GitHub's default behavior of skipping jobs when a
+    # dependency (fork-rebuild) is skipped. Without it, non-fork PRs never
+    # reach the executor because fork-rebuild is correctly skipped for them.
     if: >-
-      (needs.setup.outputs.is_fork != 'true' && needs.setup.outputs.artifact_source_mode == 'cross_run')
-      || (needs.setup.outputs.is_fork == 'true' && needs.fork-rebuild.result == 'success')
+      always()
+      && (
+        (needs.setup.outputs.is_fork != 'true' && needs.setup.outputs.artifact_source_mode == 'cross_run')
+        || (needs.setup.outputs.is_fork == 'true' && needs.fork-rebuild.result == 'success')
+      )
     uses: ./.github/workflows/e2e-authoritative-reusable.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

PR #3298 introduced a dependency from `authoritative-executor` on `fork-rebuild` to support the unified fork/non-fork path. But GitHub Actions skips downstream jobs by default when a dependency is skipped. For non-fork PRs, `fork-rebuild` is correctly skipped (no fork to rebuild), which cascades into skipping the executor — even though the `if` condition would have evaluated to true.

**Fix:** Add `always()` to the `if` condition so GitHub evaluates it regardless of dependency skip status.

**Observed:** Develop commit `d1e968b09` (the #3298 merge itself) had `E2E Gate: failure` because `Authoritative E2E Executor: skipped`.

## Test plan

- [ ] Non-fork PR: executor runs (fork-rebuild skipped, executor NOT skipped)
- [ ] Fork PR: fork-rebuild runs, then executor runs
- [ ] Failed fork-rebuild: executor skipped (condition requires success)