### PR TITLE
fix(test): update file-import E2E for deriveFilePattern brace-globs

### DIFF
--- a/frontend/playwright/tests/foundational/harness/file-import.spec.ts
+++ b/frontend/playwright/tests/foundational/harness/file-import.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+
 /**
  * FILE protocol E2E tests.
  *
@@ -11,20 +12,40 @@ import { test, expect } from "@playwright/test";
  * (`projects/analyzer-harness/seed-analyzers.sh`) after SQL cleanup fixtures
  * are loaded. This spec validates the resulting FILE analyzers in the
  * `harness` Playwright project.
+ *
+ * Auth note: PUT/POST requests to OE REST API require either a valid CSRF
+ * token (session auth) or Basic Auth (which bypasses CSRF). We use Basic Auth
+ * headers for API mutation calls to avoid CSRF complexity.
  */
 
-/** All FILE analyzers seeded by projects/analyzer-harness/seed-analyzers.sh */
+/** Build Basic Auth header from env credentials. */
+function basicAuthHeaders(): Record<string, string> {
+  const user = process.env.TEST_USER || "admin";
+  const pass = process.env.TEST_PASS || "adminADMIN!";
+  return {
+    Authorization: `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`,
+  };
+}
+
+/**
+ * All FILE analyzers seeded by projects/analyzer-harness/seed-analyzers.sh.
+ *
+ * filePattern reflects deriveFilePattern() output:
+ *   - QuantStudio profile has supported_extensions: [".xls", ".xlsx"] → "*{.xls,.xlsx}"
+ *   - FluoroCycler XT profile has supported_extensions: [".xlsx", ".xls"] → "*{.xlsx,.xls}"
+ *   Order matches the JSON array order in each profile.
+ */
 const FILE_ANALYZERS = [
-  { name: "QuantStudio 5", fileFormat: "EXCEL", filePattern: "*.xls" },
+  { name: "QuantStudio 5", fileFormat: "EXCEL", filePattern: "*{.xls,.xlsx}" },
   {
     name: "QuantStudio 7",
     fileFormat: "EXCEL",
-    filePattern: "*.xlsx",
+    filePattern: "*{.xls,.xlsx}",
   },
   {
     name: "FluoroCycler XT",
     fileFormat: "EXCEL",
-    filePattern: "*.xlsx",
+    filePattern: "*{.xlsx,.xls}",
   },
 ];
 
@@ -95,10 +116,11 @@ test.describe("FILE config persistence", () => {
     const cfg = await cfgRes.json();
     expect(cfg.fileFormat).toBe("EXCEL");
 
-    // Update to TSV
+    // Update to TSV — use Basic Auth to bypass CSRF on PUT
     const putRes = await page.request.put(
       `${api}/file-import/configurations/${cfg.id}`,
       {
+        headers: basicAuthHeaders(),
         data: {
           importDirectory: cfg.importDirectory,
           archiveDirectory: cfg.archiveDirectory,
@@ -138,6 +160,7 @@ test.describe("FILE config persistence", () => {
     const revertRes = await page.request.put(
       `${api}/file-import/configurations/${cfg.id}`,
       {
+        headers: basicAuthHeaders(),
         data: {
           ...cfg,
           fileFormat: cfg.fileFormat,
@@ -173,7 +196,7 @@ test.describe("QuantStudio EXCEL config", () => {
     const cfg = await cfgRes.json();
 
     expect(cfg.fileFormat).toBe("EXCEL");
-    expect(cfg.filePattern).toBe("*.xls");
+    expect(cfg.filePattern).toBe("*{.xls,.xlsx}");
     expect(cfg.hasHeader).toBe(true);
 
     // Verify QuantStudio column mappings from profile


### PR DESCRIPTION
## Summary

- Update `file-import.spec.ts` filePattern expectations to match `deriveFilePattern()` brace-glob output (`*{.xls,.xlsx}` / `*{.xlsx,.xls}`)
- Add Basic Auth headers to PUT requests to bypass Spring Security CSRF protection (session-based `page.request` lacks CSRF tokens)
- Fix QuantStudio EXCEL config assertion (`*{.xls,.xlsx}` not `*.xls`)

## Context

PR #3301 correctly expanded harness CI coverage from `--project=harness-demo` to `--project=harness-foundational --project=harness-demo`, exposing 5 deterministic failures in `file-import.spec.ts` that were never previously executed:

1. **3 filePattern mismatches** — test expected single-extension globs (`*.xls`, `*.xlsx`) but `deriveFilePattern()` (OGC-526) now returns multi-extension brace-globs from profile `supported_extensions` arrays
2. **1 CSRF 403** — persistence test PUT via `page.request.put()` sends session cookie but no CSRF token; Spring rejects with 403. Fixed by sending Basic Auth header which uses the CSRF-exempt security filter chain
3. **1 stale assertion** — QuantStudio EXCEL config test had same single-extension expectation

## Test plan

- [x] All 7 harness-foundational tests pass locally (8.4s)
- [ ] CI harness-foundational shard passes
- [ ] No regressions in other shards