### PR TITLE
ci: validate non-fork fork-handoff path (20260403-160550)

### DIFF
--- a/.github/workflows/e2e-playwright-reusable.yml
+++ b/.github/workflows/e2e-playwright-reusable.yml
@@ -90,10 +90,6 @@ jobs:
         run: npm ci
         working-directory: frontend
 
-      - name: Enforce Playwright guards
-        run: npm run pw:guard
-        working-directory: frontend
-
       - name: Restore Playwright browser cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -63,6 +63,10 @@ jobs:
         run: npx prettier ./ --check
         working-directory: frontend
 
+      - name: Enforce Playwright guards
+        run: npm run pw:guard
+        working-directory: frontend
+
       - name: Run Frontend Unit Tests (Jest)
         run: npm test -- --watchAll=false --coverage=false
         working-directory: frontend

--- a/frontend/playwright/helpers/create-analyzer-from-profile.ts
+++ b/frontend/playwright/helpers/create-analyzer-from-profile.ts
@@ -97,26 +97,25 @@ async function removeMockNetwork(page: Page, mockName: string): Promise<void> {
 }
 
 async function waitForAnalyzerApiReady(page: Page): Promise<void> {
-  const deadline = Date.now() + API_READY_TIMEOUT_MS;
-  let lastStatus: number | null = null;
   const analyzerApiUrl = getAnalyzerApiUrl();
 
-  while (Date.now() < deadline) {
-    try {
-      const response = await page.request.get(analyzerApiUrl);
-      lastStatus = response.status();
-      if (response.ok()) {
-        return;
-      }
-    } catch {
-      // Keep polling until timeout. Network can flap while docker networks settle.
-    }
-    await page.waitForTimeout(API_RETRY_DELAY_MS);
-  }
-
-  throw new Error(
-    `Analyzer API did not become ready within ${API_READY_TIMEOUT_MS}ms (last status: ${lastStatus ?? "request failed"})`,
-  );
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await page.request.get(analyzerApiUrl);
+          return response.status();
+        } catch {
+          return 0; // Network can flap while docker networks settle
+        }
+      },
+      {
+        message: `Analyzer API at ${analyzerApiUrl} did not become ready`,
+        timeout: API_READY_TIMEOUT_MS,
+        intervals: [API_RETRY_DELAY_MS],
+      },
+    )
+    .toBe(200);
 }
 
 export async function createAnalyzerFromProfile(


### PR DESCRIPTION
## Summary
- Validate non-fork PR path for fork-handoff remediation.
- Confirms shared-build non-fork transfer mode and downstream E2E orchestration.

## Test plan
- [ ] Confirm `03 - E2E` uses non-fork path
- [ ] Confirm `E2E / Tests` consumes expected artifacts
- [ ] Confirm checkpoint status behavior is correct

Made with [Cursor](https://cursor.com)