### PR TITLE
fix(e2e): harden analyzer route stability and reduce CI OOM flakiness

### DIFF
--- a/.github/workflows/e2e-playwright-reusable.yml
+++ b/.github/workflows/e2e-playwright-reusable.yml
@@ -81,10 +81,12 @@ jobs:
 
       - name: Configure swap for OOM resilience
         run: |
-          sudo fallocate -l 4G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+          if [ ! -f /swapfile ]; then
+            sudo fallocate -l 4G /swapfile
+            sudo chmod 600 /swapfile
+            sudo mkswap /swapfile
+          fi
+          sudo swapon /swapfile 2>/dev/null || true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Add RouteErrorBoundary to 9 `/analyzers*` routes + `/AnalyzerResults` — catches render errors that previously white-screened the app
- Lazy-load analyzer routes + 3 heaviest routes (ShipmentReport, FreezerMonitoring, RoutedResultsViewer) — removes ~1.2 MB gzipped from initial bundle
- Fix `accept-results.ts` post-save race using `locator.or()` — handles both Save-visible and empty-state outcomes
- Add AbortController to AnalyzersList + fix Utils.js AbortError handling
- Harden CI: swap, Docker memory limits, Chromium OOM flags, pageerror telemetry
- Remove 6 dead dependencies (~160 MB npm install savings)

## Test plan
- [x] `npm run pw:guard` — all guards pass
- [x] `npx prettier ./ --check` — formatting clean
- [ ] CI green on non-fork path (PR #3306)
- [ ] CI green on fork path (PR #3304)
- [ ] Merge to develop — confirm no browser crashes or save-button flakes