### PR TITLE
fix(ci): remove virtual-serial from harness memory limits

### DIFF
--- a/.github/ci/ci.memory-limits-harness.yml
+++ b/.github/ci/ci.memory-limits-harness.yml
@@ -13,9 +13,3 @@ services:
       resources:
         limits:
           memory: 256M
-
-  virtual-serial:
-    deploy:
-      resources:
-        limits:
-          memory: 64M


### PR DESCRIPTION
## Summary
- Remove `virtual-serial` from `ci.memory-limits-harness.yml` — this service isn't in the CI harness compose (`ci.analyzer-harness.yml`), only in the local dev compose
- Docker Compose v2 rejects services without an image/build context, crashing both harness shards before any tests run

## Context
Follow-up to #3304/#3306. The harness memory limits file was created with all local harness services, but CI uses a subset.