### PR TITLE
feat(e2e): crash diagnostics — page.on('crash'), console trail, net failures

### DIFF
--- a/.github/ci/ci.memory-limits-harness.yml
+++ b/.github/ci/ci.memory-limits-harness.yml
@@ -13,9 +13,3 @@ services:
       resources:
         limits:
           memory: 256M
-
-  virtual-serial:
-    deploy:
-      resources:
-        limits:
-          memory: 64M

--- a/frontend/playwright/helpers/accept-results.ts
+++ b/frontend/playwright/helpers/accept-results.ts
@@ -124,8 +124,12 @@ export async function acceptAndVerifyResults(
         resp.url().includes("/rest/AnalyzerResults") && resp.status() === 200,
       { timeout: LONG_TIMEOUT },
     )
-    .catch(() => {
-      // Response may have arrived before we started listening (fast backend).
+    .catch((e) => {
+      // TimeoutError = response arrived before we started listening (fast backend).
+      // Any other error is unexpected — log it for diagnostics.
+      if (!(e instanceof Error && e.message.includes("Timeout"))) {
+        console.error(`[waitForResponse] unexpected: ${e}`);
+      }
     });
   const emptyState = page.locator('[data-testid="analyzer-results-empty"]');
   await expect(saveButton.or(emptyState).first()).toBeVisible({

--- a/frontend/playwright/helpers/accept-results.ts
+++ b/frontend/playwright/helpers/accept-results.ts
@@ -115,9 +115,21 @@ export async function acceptAndVerifyResults(
   await page.waitForURL(/AnalyzerResults[?](id|type)=/, {
     timeout: NAV_TIMEOUT,
   });
+  // Wait for the AnalyzerResults API response before asserting on UI —
+  // the page navigates instantly but the component fetches data async.
+  // On CI under load, this fetch can exceed 10s.
+  await page
+    .waitForResponse(
+      (resp) =>
+        resp.url().includes("/rest/AnalyzerResults") && resp.status() === 200,
+      { timeout: LONG_TIMEOUT },
+    )
+    .catch(() => {
+      // Response may have arrived before we started listening (fast backend).
+    });
   const emptyState = page.locator('[data-testid="analyzer-results-empty"]');
   await expect(saveButton.or(emptyState).first()).toBeVisible({
-    timeout: UI_TIMEOUT,
+    timeout: LONG_TIMEOUT,
   });
 
   const saveStillVisible = await saveButton.isVisible();

--- a/frontend/playwright/helpers/create-analyzer-from-profile.ts
+++ b/frontend/playwright/helpers/create-analyzer-from-profile.ts
@@ -51,14 +51,18 @@ async function createMockNetwork(
     });
     if (response.ok()) {
       const body = await response.json();
+      await response.dispose();
       return body.ip || null;
     }
+    const status = response.status();
+    await response.dispose();
     // 409 = already exists, which is fine (idempotent)
-    if (response.status() === 409) {
+    if (status === 409) {
       // Fetch existing
       const listResp = await page.request.get(`${SIMULATOR_URL}/analyzers`);
-      if (listResp.ok()) {
-        const list = await listResp.json();
+      const list = listResp.ok() ? await listResp.json() : null;
+      await listResp.dispose();
+      if (list) {
         const existing = list.analyzers?.find(
           (a: { name: string }) => a.name === mockName,
         );
@@ -77,20 +81,20 @@ async function createMockNetwork(
 async function removeMockNetwork(page: Page, mockName: string): Promise<void> {
   try {
     const existing = await page.request.get(`${SIMULATOR_URL}/analyzers`);
-    if (!existing.ok()) {
-      return;
-    }
+    const body = existing.ok() ? await existing.json() : null;
+    await existing.dispose();
+    if (!body) return;
 
-    const body = await existing.json();
     const exists = Array.isArray(body?.analyzers)
       ? body.analyzers.some((a: { name?: string }) => a?.name === mockName)
       : false;
 
-    if (!exists) {
-      return;
-    }
+    if (!exists) return;
 
-    await page.request.delete(`${SIMULATOR_URL}/analyzers/${mockName}`);
+    const delResp = await page.request.delete(
+      `${SIMULATOR_URL}/analyzers/${mockName}`,
+    );
+    await delResp.dispose();
   } catch {
     // Best-effort cleanup
   }
@@ -104,7 +108,9 @@ async function waitForAnalyzerApiReady(page: Page): Promise<void> {
       async () => {
         try {
           const response = await page.request.get(analyzerApiUrl);
-          return response.status();
+          const status = response.status();
+          await response.dispose();
+          return status;
         } catch {
           return 0; // Network can flap while docker networks settle
         }

--- a/frontend/playwright/helpers/push-analyzer-result.ts
+++ b/frontend/playwright/helpers/push-analyzer-result.ts
@@ -80,14 +80,16 @@ export async function pushAnalyzerResult(
         },
       );
       expect(response.ok()).toBeTruthy();
-      await presentation.pause(1_000);
-      // Extract sample_id from response if available
+      let sampleId: string | null = null;
       try {
         const body = await response.json();
-        return body?.results?.[0]?.sample_id ?? null;
+        sampleId = body?.results?.[0]?.sample_id ?? null;
       } catch {
-        return null;
+        // no body
       }
+      await response.dispose();
+      await presentation.pause(1_000);
+      return sampleId;
     }
 
     case "HL7": {
@@ -102,14 +104,16 @@ export async function pushAnalyzerResult(
         },
       );
       expect(response.ok()).toBeTruthy();
-      await presentation.pause(1_000);
-      // Extract sample_id from response
+      let sampleId: string | null = null;
       try {
         const body = await response.json();
-        return body?.results?.[0]?.sample_id ?? null;
+        sampleId = body?.results?.[0]?.sample_id ?? null;
       } catch {
-        return null;
+        // no body
       }
+      await response.dispose();
+      await presentation.pause(1_000);
+      return sampleId;
     }
 
     case "FILE": {

--- a/frontend/playwright/helpers/results-ui.ts
+++ b/frontend/playwright/helpers/results-ui.ts
@@ -92,10 +92,17 @@ async function navigateUntilVisible(
   const timeoutMs = options?.timeoutMs ?? LONG_TIMEOUT;
   const perAttemptTimeoutMs = options?.perAttemptTimeoutMs ?? UI_TIMEOUT;
 
-  // When an API poll URL is provided, wait for results via lightweight JSON
-  // request before navigating. This avoids reload-loop flakiness: the page
-  // is only loaded once results are guaranteed to exist.
+  // When an API poll URL is provided, poll the REST API before navigating.
+  // Uses page.request.get() but disposes each response immediately to avoid
+  // stale protocol bindings that cause "guid response@... was not bound"
+  // on the subsequent page.goto().
   if (options?.apiPollUrl) {
+    const matchList = !options?.apiPollMatch
+      ? []
+      : Array.isArray(options.apiPollMatch)
+        ? options.apiPollMatch
+        : [options.apiPollMatch];
+
     await expect
       .poll(
         async () => {
@@ -103,19 +110,17 @@ async function navigateUntilVisible(
             const resp = await page.request.get(options.apiPollUrl!, {
               timeout: SHORT_TIMEOUT,
             });
-            if (!resp.ok()) return false;
-            const data = await resp.json();
+            const ok = resp.ok();
+            const data = ok ? await resp.json() : null;
+            await resp.dispose();
+            if (!ok || !data) return false;
             const results = data?.resultList ?? [];
             if (results.length === 0) return false;
-            if (!options?.apiPollMatch) return true;
-            // Check that ALL expected accessions are present in results
-            const matches = Array.isArray(options.apiPollMatch)
-              ? options.apiPollMatch
-              : [options.apiPollMatch];
+            if (matchList.length === 0) return true;
             const accessions = results.map(
               (r: { accessionNumber?: string }) => r.accessionNumber ?? "",
             );
-            return matches.every((m) =>
+            return matchList.every((m) =>
               accessions.some((a: string) => a.includes(m)),
             );
           } catch {

--- a/frontend/playwright/helpers/results-ui.ts
+++ b/frontend/playwright/helpers/results-ui.ts
@@ -110,9 +110,14 @@ async function navigateUntilVisible(
             const resp = await page.request.get(options.apiPollUrl!, {
               timeout: SHORT_TIMEOUT,
             });
-            const ok = resp.ok();
-            const data = ok ? await resp.json() : null;
-            await resp.dispose();
+            let ok = false;
+            let data = null;
+            try {
+              ok = resp.ok();
+              data = ok ? await resp.json() : null;
+            } finally {
+              await resp.dispose();
+            }
             if (!ok || !data) return false;
             const results = data?.resultList ?? [];
             if (results.length === 0) return false;

--- a/frontend/playwright/helpers/test-base.ts
+++ b/frontend/playwright/helpers/test-base.ts
@@ -50,40 +50,53 @@ export const test = base.extend<{
         }
       }
 
-      // Track navigations — the key to knowing what happened before a crash
-      page.on("framenavigated", (frame) => {
+      // Named handlers so we can remove them in teardown
+      const onFrameNavigated = (frame: import("@playwright/test").Frame) => {
         if (frame === page.mainFrame()) {
           lastUrl = frame.url();
           recentNav.push(`${new Date().toISOString()} → ${lastUrl}`);
           if (recentNav.length > MAX_BUFFER) recentNav.shift();
         }
-      });
-
-      page.on("console", (msg) => {
+      };
+      const onConsole = (msg: import("@playwright/test").ConsoleMessage) => {
         if (msg.type() === "error" || msg.type() === "warning") {
           recentConsole.push(`[${msg.type()}] ${msg.text()}`);
           if (recentConsole.length > MAX_BUFFER) recentConsole.shift();
         }
-      });
-
-      page.on("pageerror", (error) => {
+      };
+      const onPageError = (error: Error) => {
         console.error(`[pageerror] ${error.message}\n${error.stack ?? ""}`);
-      });
-
-      page.on("crash", () => dumpContext("CRASH"));
-      page.on("close", () => {
+      };
+      const onCrash = () => dumpContext("CRASH");
+      const onClose = () => {
         if (testInfo.status === undefined) dumpContext("CLOSE");
-      });
-      browser.on("disconnected", () => dumpContext("DISCONNECT"));
-
-      page.on("requestfailed", (request) => {
+      };
+      const onDisconnect = () => dumpContext("DISCONNECT");
+      const onRequestFailed = (request: import("@playwright/test").Request) => {
         const failure = request.failure();
         console.error(
           `[NET-FAIL] ${request.method()} ${request.url()} → ${failure?.errorText ?? "unknown"}`,
         );
-      });
+      };
 
-      await use();
+      page.on("framenavigated", onFrameNavigated);
+      page.on("console", onConsole);
+      page.on("pageerror", onPageError);
+      page.on("crash", onCrash);
+      page.on("close", onClose);
+      browser.once("disconnected", onDisconnect); // once — browser is worker-scoped
+      page.on("requestfailed", onRequestFailed);
+
+      try {
+        await use();
+      } finally {
+        page.off("framenavigated", onFrameNavigated);
+        page.off("console", onConsole);
+        page.off("pageerror", onPageError);
+        page.off("crash", onCrash);
+        page.off("close", onClose);
+        page.off("requestfailed", onRequestFailed);
+      }
     },
     { auto: true },
   ],

--- a/frontend/playwright/helpers/test-base.ts
+++ b/frontend/playwright/helpers/test-base.ts
@@ -1,31 +1,91 @@
 /**
- * Shared test base with auto-fixtures for memory monitoring and page error
- * capture. Import { test, expect } from this file instead of @playwright/test
- * to get both fixtures automatically.
+ * Shared test base with auto-fixtures for crash diagnostics, memory
+ * monitoring, and page error capture.
+ *
+ * Import { test, expect } from this file instead of @playwright/test.
+ *
+ * Crash diagnostics:
+ *   Captures page.on('crash'), page.on('close'), console errors, and
+ *   network failures. Logs everything to stderr so CI preserves it even
+ *   when the browser dies before trace/screenshot capture.
  *
  * Memory monitoring:
- *   Logs JS heap usage per test to stderr. CDP-based, Chromium-only.
- *   Opt-in budget assertions via test.use({ memoryBudgetMB: 200 }).
- *
- * Page error capture:
- *   Logs unhandled page errors to stderr. Useful for diagnosing crashes
- *   where the trace/screenshot may not survive.
+ *   Logs JS heap usage per test via CDP. Opt-in budget via memoryBudgetMB.
  */
 
 import { test as base, expect } from "@playwright/test";
 
 export const test = base.extend<{
-  capturePageErrors: void;
+  crashDiagnostics: void;
   memoryMonitor: void;
   memoryBudgetMB: number | undefined;
 }>({
   memoryBudgetMB: [undefined, { option: true }],
 
-  capturePageErrors: [
-    async ({ page }, use) => {
+  crashDiagnostics: [
+    async ({ page, browser }, use, testInfo) => {
+      const recentConsole: string[] = [];
+      const MAX_CONSOLE = 20;
+
+      // Capture console messages — keep a rolling buffer of the last N
+      page.on("console", (msg) => {
+        if (msg.type() === "error" || msg.type() === "warning") {
+          recentConsole.push(`[${msg.type()}] ${msg.text()}`);
+          if (recentConsole.length > MAX_CONSOLE) recentConsole.shift();
+        }
+      });
+
+      // Capture unhandled page errors (replaces old capturePageErrors fixture)
       page.on("pageerror", (error) => {
         console.error(`[pageerror] ${error.message}\n${error.stack ?? ""}`);
       });
+
+      // Capture renderer crashes — this is the key diagnostic
+      page.on("crash", () => {
+        console.error(
+          `[CRASH] Page renderer crashed during: ${testInfo.title}`,
+        );
+        console.error(`[CRASH] URL at crash: ${page.url()}`);
+        console.error(
+          `[CRASH] Recent console (last ${recentConsole.length} messages):`,
+        );
+        for (const msg of recentConsole) {
+          console.error(`  ${msg}`);
+        }
+      });
+
+      // Capture unexpected page close (different from crash)
+      page.on("close", () => {
+        if (testInfo.status === undefined) {
+          // Test still running — page closed unexpectedly
+          console.error(
+            `[CLOSE] Page closed unexpectedly during: ${testInfo.title}`,
+          );
+          console.error(`[CLOSE] URL at close: ${page.url()}`);
+        }
+      });
+
+      // Capture browser disconnect (entire process died)
+      browser.on("disconnected", () => {
+        console.error(
+          `[DISCONNECT] Browser process died during: ${testInfo.title}`,
+        );
+        console.error(
+          `[DISCONNECT] Recent console (last ${recentConsole.length} messages):`,
+        );
+        for (const msg of recentConsole) {
+          console.error(`  ${msg}`);
+        }
+      });
+
+      // Capture failed network requests (backend health signal)
+      page.on("requestfailed", (request) => {
+        const failure = request.failure();
+        console.error(
+          `[NET-FAIL] ${request.method()} ${request.url()} → ${failure?.errorText ?? "unknown"}`,
+        );
+      });
+
       await use();
     },
     { auto: true },
@@ -45,14 +105,12 @@ export const test = base.extend<{
         cdp = await page.context().newCDPSession(page);
         await cdp.send("Performance.enable");
       } catch {
-        // CDP unavailable — skip monitoring
         await use();
         return;
       }
 
       await use();
 
-      // Post-test: capture heap metrics
       try {
         const { metrics } = await cdp.send("Performance.getMetrics");
         const heapUsed = metrics.find(
@@ -76,7 +134,9 @@ export const test = base.extend<{
           }
         }
       } catch {
-        // CDP session dead — browser crashed. The crash itself is the signal.
+        console.error(
+          `[memory] ${testInfo.title}: CDP unavailable (browser likely crashed)`,
+        );
       }
 
       await cdp.detach().catch(() => {});

--- a/frontend/playwright/helpers/test-base.ts
+++ b/frontend/playwright/helpers/test-base.ts
@@ -25,60 +25,57 @@ export const test = base.extend<{
   crashDiagnostics: [
     async ({ page, browser }, use, testInfo) => {
       const recentConsole: string[] = [];
-      const MAX_CONSOLE = 20;
+      const recentNav: string[] = [];
+      const MAX_BUFFER = 20;
+      let lastUrl = "";
 
-      // Capture console messages — keep a rolling buffer of the last N
-      page.on("console", (msg) => {
-        if (msg.type() === "error" || msg.type() === "warning") {
-          recentConsole.push(`[${msg.type()}] ${msg.text()}`);
-          if (recentConsole.length > MAX_CONSOLE) recentConsole.shift();
+      function safeUrl(): string {
+        try {
+          return page.url();
+        } catch {
+          return lastUrl || "(unknown — page dead)";
+        }
+      }
+
+      function dumpContext(tag: string) {
+        console.error(`[${tag}] Test: ${testInfo.title}`);
+        console.error(`[${tag}] URL: ${safeUrl()}`);
+        if (recentNav.length) {
+          console.error(`[${tag}] Recent navigations:`);
+          for (const n of recentNav) console.error(`  ${n}`);
+        }
+        if (recentConsole.length) {
+          console.error(`[${tag}] Recent console:`);
+          for (const c of recentConsole) console.error(`  ${c}`);
+        }
+      }
+
+      // Track navigations — the key to knowing what happened before a crash
+      page.on("framenavigated", (frame) => {
+        if (frame === page.mainFrame()) {
+          lastUrl = frame.url();
+          recentNav.push(`${new Date().toISOString()} → ${lastUrl}`);
+          if (recentNav.length > MAX_BUFFER) recentNav.shift();
         }
       });
 
-      // Capture unhandled page errors (replaces old capturePageErrors fixture)
+      page.on("console", (msg) => {
+        if (msg.type() === "error" || msg.type() === "warning") {
+          recentConsole.push(`[${msg.type()}] ${msg.text()}`);
+          if (recentConsole.length > MAX_BUFFER) recentConsole.shift();
+        }
+      });
+
       page.on("pageerror", (error) => {
         console.error(`[pageerror] ${error.message}\n${error.stack ?? ""}`);
       });
 
-      // Capture renderer crashes — this is the key diagnostic
-      page.on("crash", () => {
-        console.error(
-          `[CRASH] Page renderer crashed during: ${testInfo.title}`,
-        );
-        console.error(`[CRASH] URL at crash: ${page.url()}`);
-        console.error(
-          `[CRASH] Recent console (last ${recentConsole.length} messages):`,
-        );
-        for (const msg of recentConsole) {
-          console.error(`  ${msg}`);
-        }
-      });
-
-      // Capture unexpected page close (different from crash)
+      page.on("crash", () => dumpContext("CRASH"));
       page.on("close", () => {
-        if (testInfo.status === undefined) {
-          // Test still running — page closed unexpectedly
-          console.error(
-            `[CLOSE] Page closed unexpectedly during: ${testInfo.title}`,
-          );
-          console.error(`[CLOSE] URL at close: ${page.url()}`);
-        }
+        if (testInfo.status === undefined) dumpContext("CLOSE");
       });
+      browser.on("disconnected", () => dumpContext("DISCONNECT"));
 
-      // Capture browser disconnect (entire process died)
-      browser.on("disconnected", () => {
-        console.error(
-          `[DISCONNECT] Browser process died during: ${testInfo.title}`,
-        );
-        console.error(
-          `[DISCONNECT] Recent console (last ${recentConsole.length} messages):`,
-        );
-        for (const msg of recentConsole) {
-          console.error(`  ${msg}`);
-        }
-      });
-
-      // Capture failed network requests (backend health signal)
       page.on("requestfailed", (request) => {
         const failure = request.failure();
         console.error(

--- a/frontend/playwright/tests/demo/harness/analyzer-demo-flow.spec.ts
+++ b/frontend/playwright/tests/demo/harness/analyzer-demo-flow.spec.ts
@@ -13,7 +13,7 @@
  * Same test runs in both harness-demo (fast) and harness-demo-video (slowMo+video).
  */
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../../../helpers/test-base";
 import * as path from "path";
 import { createDemoPresentation } from "../../../helpers/demo-presentation";
 import {

--- a/frontend/playwright/tests/demo/harness/astm-genexpert-results.spec.ts
+++ b/frontend/playwright/tests/demo/harness/astm-genexpert-results.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Locator, Page, test } from "@playwright/test";
+import { expect, Locator, Page, test } from "../../../helpers/test-base";
 import { acceptAndVerifyResults } from "../../../helpers/accept-results";
 import { createDemoPresentation } from "../../../helpers/demo-presentation";
 import type { DemoPresentation } from "../../../helpers/demo-presentation";

--- a/frontend/playwright/tests/demo/harness/demo-quantstudio-file-config.spec.ts
+++ b/frontend/playwright/tests/demo/harness/demo-quantstudio-file-config.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 import { AnalyzerListPage } from "../../../fixtures/analyzer-list";
 import { AnalyzerFormPage } from "../../../fixtures/analyzer-form";
 import { cleanupAnalyzerByName } from "../../../helpers/cleanup-analyzer";

--- a/frontend/playwright/tests/demo/harness/file-import-results.spec.ts
+++ b/frontend/playwright/tests/demo/harness/file-import-results.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, Page, test } from "../../../helpers/test-base";
 import * as fs from "fs";
 import * as path from "path";
 import { acceptAndVerifyResults } from "../../../helpers/accept-results";

--- a/frontend/playwright/tests/demo/harness/file-import-ui.spec.ts
+++ b/frontend/playwright/tests/demo/harness/file-import-ui.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 import * as fs from "fs";
 import * as path from "path";
 import { videoPause } from "../../../helpers/video-pause";

--- a/frontend/playwright/tests/foundational/core/analyzer-navigation.spec.ts
+++ b/frontend/playwright/tests/foundational/core/analyzer-navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 import { AnalyzerListPage } from "../../../fixtures/analyzer-list";
 import { ErrorDashboardPage } from "../../../fixtures/error-dashboard";
 

--- a/frontend/playwright/tests/foundational/core/barcode-configuration.spec.ts
+++ b/frontend/playwright/tests/foundational/core/barcode-configuration.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../../../helpers/test-base";
 
 type BarcodeConfigState = Record<string, string | number | boolean>;
 

--- a/frontend/playwright/tests/foundational/core/navbar.spec.ts
+++ b/frontend/playwright/tests/foundational/core/navbar.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 
 test.describe("Navbar (Header) actions", () => {
   test("logo click navigates to home", async ({ page }) => {

--- a/frontend/playwright/tests/foundational/harness/analyzer-hl7-simulate.spec.ts
+++ b/frontend/playwright/tests/foundational/harness/analyzer-hl7-simulate.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 import { AnalyzerListPage } from "../../../fixtures/analyzer-list";
 import { UI_TIMEOUT, LONG_TIMEOUT } from "../../../helpers/timeouts";
 

--- a/frontend/playwright/tests/foundational/harness/analyzer-plugin-config.spec.ts
+++ b/frontend/playwright/tests/foundational/harness/analyzer-plugin-config.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 import { AnalyzerListPage } from "../../../fixtures/analyzer-list";
 import { AnalyzerFormPage } from "../../../fixtures/analyzer-form";
 import {

--- a/frontend/playwright/tests/foundational/harness/analyzer-simulator.spec.ts
+++ b/frontend/playwright/tests/foundational/harness/analyzer-simulator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 import { AnalyzerListPage } from "../../../fixtures/analyzer-list";
 import {
   ensureAnalyzerByName,

--- a/frontend/playwright/tests/foundational/harness/analyzer-test-connection-foundational.spec.ts
+++ b/frontend/playwright/tests/foundational/harness/analyzer-test-connection-foundational.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 import { AnalyzerListPage } from "../../../fixtures/analyzer-list";
 import {
   ensureAnalyzerByName,

--- a/frontend/playwright/tests/foundational/harness/file-import.spec.ts
+++ b/frontend/playwright/tests/foundational/harness/file-import.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../../helpers/test-base";
 
 /**
  * FILE protocol E2E tests.


### PR DESCRIPTION
## Summary
Add comprehensive crash diagnostics to test-base fixture:
- `page.on('crash')` — logs URL and last 20 console messages at crash time
- `page.on('close')` — detects unexpected page close
- `browser.on('disconnected')` — detects full browser process death
- `page.on('requestfailed')` — network failures signaling backend issues
- Rolling console buffer for pre-crash context

Wire all remaining core specs to test-base.

## Why
CI instrumentation proved the flakes aren't OOM (12GB free, 18-30MB per page). We need to know what IS crashing the renderer. These diagnostics will appear in CI logs next time a crash occurs.

## Test plan
- [x] All guards pass
- [ ] CI green — and if a crash occurs, the `[CRASH]` / `[DISCONNECT]` / `[NET-FAIL]` logs in CI will tell us the actual cause