### PR TITLE
fix(ci): raise FHIR container limit from 1GB to 2GB

### DIFF
--- a/.github/ci/ci.memory-limits.yml
+++ b/.github/ci/ci.memory-limits.yml
@@ -2,9 +2,9 @@
 # Prevents uncapped containers from starving the Chromium browser during E2E tests.
 # ubuntu-latest public runners have 16 GB RAM.
 #
-# Budget (core):  2560 + 1024 + 1536 + 256 + 128 + 128 = 5632M
-# Budget (harness): +512 + 256 + 64 = 832M (ci.memory-limits-harness.yml)
-# Total max: 6464M → leaves ~9.5 GB for Chromium + OS + swap
+# Budget (core):  2560 + 2048 + 1536 + 256 + 128 + 128 = 6656M
+# Budget (harness): +512 + 256 = 768M (ci.memory-limits-harness.yml)
+# Total max: 7424M → leaves ~8.5 GB for Chromium + OS + swap
 #
 # NOTE: We only set container memory limits here — NOT JVM heap flags.
 # The base compose sets CATALINA_OPTS and JAVA_OPTS with SSL/datasource props;
@@ -21,7 +21,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1024M
+          memory: 2048M
 
   db.openelis.org:
     deploy:


### PR DESCRIPTION
## Summary
Raise FHIR API container memory limit from 1GB to 2GB in `ci.memory-limits.yml`.

## Evidence
CI memory instrumentation showed pre-test state:
```
external-fhir-api   1024MiB / 1GiB   99.95%
```
The FHIR container was at 99.95% of its limit before any tests ran. JVM auto-sizes heap from cgroup (Java 11+ `UseContainerSupport`), so 1GB cgroup → ~500MB heap — not enough for HAPI FHIR.

## Impact
- FHIR: 1GB → 2GB
- Total core budget: 5632M → 6656M
- Remaining for Chromium + OS: ~8.5GB (was ~9.5GB)

## Test plan
- [ ] CI E2E green — FHIR container no longer at 100%
- [ ] Memory snapshot step shows FHIR at ~50% of 2GB instead of 100% of 1GB