### PR TITLE
test: add WorkPlanByTestController integration tests with dataset

### DIFF
--- a/src/test/java/org/openelisglobal/AppTestConfig.java
+++ b/src/test/java/org/openelisglobal/AppTestConfig.java
@@ -101,7 +101,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         "org.openelisglobal.reportdefinition", "org.openelisglobal.scheduler", "org.openelisglobal.sitebranding",
         "org.openelisglobal.resultvalidation", "org.openelisglobal.plugin", "org.openelisglobal.fhir.providers",
         "org.openelisglobal.common.dao", "org.openelisglobal.report", "org.openelisglobal.eqa", "org.openelisglobal.qc",
-        "org.openelisglobal.calendar", "org.openelisglobal.esig" }, excludeFilters = {
+        "org.openelisglobal.calendar", "org.openelisglobal.esig",
+        "org.openelisglobal.workplan" }, excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.patient.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.organization.controller.*"),
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.sample.controller.*"),

--- a/src/test/java/org/openelisglobal/AppTestConfig.java
+++ b/src/test/java/org/openelisglobal/AppTestConfig.java
@@ -352,4 +352,17 @@ public class AppTestConfig implements WebMvcConfigurer {
     public DataExportTaskDAO dataExportTaskDAO() {
         return mock(DataExportTaskDAO.class);
     }
+
+    @Bean
+    @Profile("test")
+    public org.openelisglobal.calendar.service.WeekendConfigService weekendConfigService() {
+        return mock(org.openelisglobal.calendar.service.WeekendConfigService.class);
+    }
+
+    @Bean
+    @Profile("test")
+    public org.openelisglobal.calendar.service.PublicHolidayService publicHolidayService() {
+        return mock(org.openelisglobal.calendar.service.PublicHolidayService.class);
+    }
+
 }

--- a/src/test/java/org/openelisglobal/workplan/controller/WorkPlanByTestControllerTest.java
+++ b/src/test/java/org/openelisglobal/workplan/controller/WorkPlanByTestControllerTest.java
@@ -35,11 +35,16 @@ import org.springframework.test.web.servlet.MvcResult;
  * ModelAndView. Tests use MockMvc to call /WorkPlanByTest and verify the model
  * attributes.
  */
+import org.springframework.test.annotation.DirtiesContext;
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class WorkPlanByTestControllerTest extends BaseWebContextSensitiveTest {
 
     private static final String TEST_DATA_FILE = "testdata/workplan-by-test-controller.xml";
     private static final String VALID_TEST_ID = "70001";
     private static final String INVALID_TEST_ID = "-1";
+
+
 
     @Autowired
     private UserService realUserService;
@@ -81,6 +86,10 @@ public class WorkPlanByTestControllerTest extends BaseWebContextSensitiveTest {
         Field statusListField = BaseWorkplanController.class.getDeclaredField("statusList");
         statusListField.setAccessible(true);
         statusListField.set(null, null);
+
+        Field nfsTestIdListField = BaseWorkplanController.class.getDeclaredField("nfsTestIdList");
+        nfsTestIdListField.setAccessible(true);
+        nfsTestIdListField.set(null, null);
     }
 
     private void injectField(Object target, Class<?> declaringClass, String fieldName, Object value) throws Exception {

--- a/src/test/java/org/openelisglobal/workplan/controller/WorkPlanByTestControllerTest.java
+++ b/src/test/java/org/openelisglobal/workplan/controller/WorkPlanByTestControllerTest.java
@@ -1,10 +1,16 @@
 package org.openelisglobal.workplan.controller;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.lang.reflect.Field;
 import java.util.Collections;

--- a/src/test/java/org/openelisglobal/workplan/controller/WorkPlanByTestControllerTest.java
+++ b/src/test/java/org/openelisglobal/workplan/controller/WorkPlanByTestControllerTest.java
@@ -23,19 +23,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-import org.springframework.test.web.servlet.MvcResult;
-
-/**
- * Integration tests for WorkPlanByTestController.
- *
- * TEST DATA: testdata/workplan-by-test-controller.xml ID ranges: 60001-60999
- * (domain), 70001-70999 (tests), 80001-80999 (samples)
- *
- * NOTE: WorkPlanByTestController is a regular @Controller (not REST), returning
- * ModelAndView. Tests use MockMvc to call /WorkPlanByTest and verify the model
- * attributes.
- */
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MvcResult;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class WorkPlanByTestControllerTest extends BaseWebContextSensitiveTest {
@@ -43,8 +32,6 @@ public class WorkPlanByTestControllerTest extends BaseWebContextSensitiveTest {
     private static final String TEST_DATA_FILE = "testdata/workplan-by-test-controller.xml";
     private static final String VALID_TEST_ID = "70001";
     private static final String INVALID_TEST_ID = "-1";
-
-
 
     @Autowired
     private UserService realUserService;

--- a/src/test/java/org/openelisglobal/workplan/controller/WorkPlanByTestControllerTest.java
+++ b/src/test/java/org/openelisglobal/workplan/controller/WorkPlanByTestControllerTest.java
@@ -1,0 +1,234 @@
+package org.openelisglobal.workplan.controller;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.openelisglobal.systemuser.service.UserService;
+import org.openelisglobal.test.beanItems.TestResultItem;
+import org.openelisglobal.workplan.form.WorkplanForm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Integration tests for WorkPlanByTestController.
+ *
+ * TEST DATA: testdata/workplan-by-test-controller.xml ID ranges: 60001-60999
+ * (domain), 70001-70999 (tests), 80001-80999 (samples)
+ *
+ * NOTE: WorkPlanByTestController is a regular @Controller (not REST), returning
+ * ModelAndView. Tests use MockMvc to call /WorkPlanByTest and verify the model
+ * attributes.
+ */
+public class WorkPlanByTestControllerTest extends BaseWebContextSensitiveTest {
+
+    private static final String TEST_DATA_FILE = "testdata/workplan-by-test-controller.xml";
+    private static final String VALID_TEST_ID = "70001";
+    private static final String INVALID_TEST_ID = "-1";
+
+    @Autowired
+    private UserService realUserService;
+
+    private WorkPlanByTestController controller;
+    private UserService mockUserService;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        controller = webApplicationContext.getBean(WorkPlanByTestController.class);
+
+        executeDataSetWithStateManagement(TEST_DATA_FILE);
+
+        // Reset static statusList so initialize() re-runs with fresh DB data
+        resetStatusList();
+
+        // Trigger re-initialization
+        java.lang.reflect.Method initMethod = BaseWorkplanController.class.getDeclaredMethod("initialize");
+        initMethod.setAccessible(true);
+        initMethod.invoke(controller);
+
+        // Mock filterResultsByLabUnitRoles to return results unchanged
+        mockUserService = mock(UserService.class);
+        doAnswer(invocation -> invocation.getArgument(1)).when(mockUserService).filterResultsByLabUnitRoles(anyString(),
+                anyList(), anyString());
+        when(mockUserService.getAllDisplayUserTestsByLabUnit(anyString(), anyString()))
+                .thenReturn(Collections.emptyList());
+        injectField(controller, WorkPlanByTestController.class, "userService", mockUserService);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        injectField(controller, WorkPlanByTestController.class, "userService", realUserService);
+        resetStatusList();
+    }
+
+    private void resetStatusList() throws Exception {
+        Field statusListField = BaseWorkplanController.class.getDeclaredField("statusList");
+        statusListField.setAccessible(true);
+        statusListField.set(null, null);
+    }
+
+    private void injectField(Object target, Class<?> declaringClass, String fieldName, Object value) throws Exception {
+        Field field = declaringClass.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    /**
+     * TEST: Valid test ID returns workplan with analyses. EXPECTED: Non-empty
+     * workplan with analyses sorted by accession number.
+     */
+    @Test
+    public void testShowWorkPlanByTest_withValidTestId_returnsAnalyses() throws Exception {
+        MvcResult result = mockMvc.perform(get("/WorkPlanByTest").param("selectedSearchID", VALID_TEST_ID)
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, createSessionData())
+                .sessionAttr(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, createSecurityContext()))
+                .andExpect(status().isOk()).andReturn();
+
+        WorkplanForm form = (WorkplanForm) result.getModelAndView().getModel().get("form");
+        assertNotNull("Form should not be null", form);
+        assertTrue("Search should be marked finished", form.getSearchFinished());
+        assertNotNull("Workplan tests should not be null", form.getWorkplanTests());
+        assertFalse("Workplan should not be empty for valid test ID", form.getWorkplanTests().isEmpty());
+    }
+
+    /**
+     * TEST: Workplan items have correct accession numbers sorted in order.
+     */
+    @Test
+    public void testShowWorkPlanByTest_resultsAreSortedByAccession() throws Exception {
+        MvcResult result = mockMvc.perform(get("/WorkPlanByTest").param("selectedSearchID", VALID_TEST_ID)
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, createSessionData())
+                .sessionAttr(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, createSecurityContext()))
+                .andExpect(status().isOk()).andReturn();
+
+        WorkplanForm form = (WorkplanForm) result.getModelAndView().getModel().get("form");
+        List<TestResultItem> tests = form.getWorkplanTests();
+
+        assertTrue("Should have at least 2 analyses", tests.size() >= 2);
+        assertEquals("First accession should be 33000000001", "33000000001", tests.get(0).getAccessionNumber());
+        assertEquals("Second accession should be 33000000002", "33000000002", tests.get(1).getAccessionNumber());
+    }
+
+    /**
+     * TEST: Empty/blank test ID returns empty workplan without error.
+     */
+    @Test
+    public void testShowWorkPlanByTest_withNoTestId_returnsEmptyWorkplan() throws Exception {
+        MvcResult result = mockMvc.perform(
+                get("/WorkPlanByTest").sessionAttr(IActionConstants.USER_SESSION_DATA, createSessionData()).sessionAttr(
+                        HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, createSecurityContext()))
+                .andExpect(status().isOk()).andReturn();
+
+        WorkplanForm form = (WorkplanForm) result.getModelAndView().getModel().get("form");
+        assertNotNull("Form should not be null", form);
+        assertFalse("Search should not be marked finished", form.getSearchFinished());
+        assertTrue("Workplan should be empty when no test selected", form.getWorkplanTests().isEmpty());
+    }
+
+    /**
+     * TEST: Invalid test ID returns empty workplan without error.
+     */
+    @Test
+    public void testShowWorkPlanByTest_withInvalidTestId_returnsEmptyWorkplan() throws Exception {
+        MvcResult result = mockMvc.perform(get("/WorkPlanByTest").param("selectedSearchID", INVALID_TEST_ID)
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, createSessionData())
+                .sessionAttr(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, createSecurityContext()))
+                .andExpect(status().isOk()).andReturn();
+
+        WorkplanForm form = (WorkplanForm) result.getModelAndView().getModel().get("form");
+        assertNotNull("Form should not be null", form);
+        assertTrue("Workplan should be empty for invalid test ID",
+                form.getWorkplanTests() == null || form.getWorkplanTests().isEmpty());
+    }
+
+    /**
+     * TEST: Workplan items grouped correctly by accession number.
+     */
+    @Test
+    public void testShowWorkPlanByTest_itemsGroupedByAccessionNumber() throws Exception {
+        MvcResult result = mockMvc.perform(get("/WorkPlanByTest").param("selectedSearchID", VALID_TEST_ID)
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, createSessionData())
+                .sessionAttr(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, createSecurityContext()))
+                .andExpect(status().isOk()).andReturn();
+
+        WorkplanForm form = (WorkplanForm) result.getModelAndView().getModel().get("form");
+        List<TestResultItem> tests = form.getWorkplanTests();
+
+        assertTrue("Should have analyses", tests.size() > 0);
+        for (int i = 1; i < tests.size(); i++) {
+            TestResultItem current = tests.get(i);
+            TestResultItem previous = tests.get(i - 1);
+            if (current.getAccessionNumber().equals(previous.getAccessionNumber())) {
+                assertEquals("Same accession should have same grouping number", previous.getSampleGroupingNumber(),
+                        current.getSampleGroupingNumber());
+            } else {
+                assertTrue("Different accessions should have different grouping numbers",
+                        current.getSampleGroupingNumber() != previous.getSampleGroupingNumber());
+            }
+        }
+    }
+
+    /**
+     * TEST: Workplan items have required non-null fields.
+     */
+    @Test
+    public void testShowWorkPlanByTest_itemsHaveRequiredFields() throws Exception {
+        MvcResult result = mockMvc.perform(get("/WorkPlanByTest").param("selectedSearchID", VALID_TEST_ID)
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, createSessionData())
+                .sessionAttr(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, createSecurityContext()))
+                .andExpect(status().isOk()).andReturn();
+
+        WorkplanForm form = (WorkplanForm) result.getModelAndView().getModel().get("form");
+        List<TestResultItem> tests = form.getWorkplanTests();
+
+        assertFalse("Should have test items", tests.isEmpty());
+        for (TestResultItem item : tests) {
+            assertNotNull("Accession number must exist", item.getAccessionNumber());
+            assertNotNull("Test ID must exist", item.getTestId());
+            assertNotNull("Received date must exist", item.getReceivedDate());
+        }
+    }
+
+    /**
+     * TEST: Form type is set to "test" for WorkPlanByTest.
+     */
+    @Test
+    public void testShowWorkPlanByTest_formTypeIsTest() throws Exception {
+        MvcResult result = mockMvc.perform(get("/WorkPlanByTest").param("selectedSearchID", VALID_TEST_ID)
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, createSessionData())
+                .sessionAttr(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, createSecurityContext()))
+                .andExpect(status().isOk()).andReturn();
+
+        WorkplanForm form = (WorkplanForm) result.getModelAndView().getModel().get("form");
+        assertEquals("Form type should be 'test'", "test", form.getType());
+    }
+
+    private UserSessionData createSessionData() {
+        UserSessionData sessionData = new UserSessionData();
+        sessionData.setSytemUserId(1);
+        return sessionData;
+    }
+
+    private SecurityContext createSecurityContext() {
+        SecurityContext securityContext = new SecurityContextImpl();
+        securityContext.setAuthentication(
+                new UsernamePasswordAuthenticationToken("testuser", "password", Collections.emptyList()));
+        return securityContext;
+    }
+}

--- a/src/test/resources/testdata/workplan-by-test-controller.xml
+++ b/src/test/resources/testdata/workplan-by-test-controller.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- DBUnit Flat-XML fixture for WorkPlanByTestControllerTest. PURPOSE: Test
+    data for WorkPlanByTest endpoint querying analyses by test ID. FIXTURE ID
+    RANGES (avoid collisions with other fixtures): - 60001-60999: Core domain
+    objects - 70001-70999: Test definitions - 80001-80999: Sample and analysis
+    data TABLE DEPENDENCY ORDER (parents before children): 1. localization 2.
+    supported_locale, localization_value 3. status_of_sample (NotStarted = "Not
+    Tested") 4. test_section 5. test 6. type_of_sample 7. sample, sample_item
+    8. analysis -->
+<dataset>
+
+    <!-- LOCALIZATION -->
+    <localization id="60001" description="Glucose Test" />
+    <localization id="60002" description="Chemistry Section" />
+
+    <!-- SUPPORTED LOCALE -->
+    <supported_locale id="60001" locale_code="en"
+        display_name="English" is_active="true" is_fallback="true"
+        sort_order="1" />
+
+    <!-- LOCALIZATION VALUES -->
+    <localization_value id="60001"
+        localization_id="60001" locale="en" value="Glucose" />
+    <localization_value id="60002"
+        localization_id="60002" locale="en" value="Chemistry" />
+
+    <!-- STATUS OF SAMPLE - "Not Tested" maps to AnalysisStatus.NotStarted -->
+    <status_of_sample id="1"
+        description="Analysis not started" code="1" status_type="ANALYSIS"
+        lastupdated="2024-01-01 00:00:00" name="Not Tested"
+        display_key="status.analysis.notStarted" is_active="Y" />
+
+    <status_of_sample id="2"
+        description="Biologist Rejection" code="2" status_type="ANALYSIS"
+        lastupdated="2024-01-01 00:00:00" name="Biologist Rejection"
+        display_key="status.analysis.biologistRejection" is_active="Y" />
+
+    <status_of_sample id="3"
+        description="Technical Rejected" code="3" status_type="ANALYSIS"
+        lastupdated="2024-01-01 00:00:00" name="Technical Rejected"
+        display_key="status.analysis.technicalRejected" is_active="Y" />
+
+    <status_of_sample id="4" description="NonConforming"
+        code="4" status_type="ANALYSIS" lastupdated="2024-01-01 00:00:00"
+        name="NonConforming" display_key="status.analysis.nonConforming"
+        is_active="Y" />
+
+    <!-- TEST SECTION -->
+    <test_section id="70001" name="Chemistry"
+        description="Chemistry Section" is_external="N"
+        lastupdated="2024-01-01 00:00:00.0" sort_order="1"
+        name_localization_id="60002" display_key="Chemistry" />
+
+    <!-- TEST DEFINITIONS -->
+    <test id="70001" description="Glucose" loinc="222111"
+        reporting_description="Glucose Test"
+        active_begin="2024-01-01 00:00:00" active_end="2099-12-31 00:00:00"
+        time_holding="30" time_wait="15" time_ta_average="60"
+        time_ta_warning="90" time_ta_max="120" label_qty="1"
+        lastupdated="2024-01-01 00:00:00" test_section_id="70001"
+        local_code="GLU2" sort_order="1" name="Glucose" orderable="true"
+        guid="bbb-70001" name_localization_id="60001"
+        antimicrobial_resistance="false" />
+
+    <!-- TYPE OF SAMPLE -->
+    <type_of_sample id="60001" description="Blood"
+        domain="H" name_localization_id="60002"
+        lastupdated="2024-01-01 00:00:00" />
+
+    <!-- SAMPLES -->
+    <sample id="80001" accession_number="33000000001" status_id="1"
+        received_date="2024-07-01 00:00:00.0"
+        entered_date="2024-07-01 00:00:00.0"
+        collection_date="2024-07-01 00:00:00.0"
+        lastupdated="2024-01-01 00:00:00" />
+
+    <sample id="80002" accession_number="33000000002" status_id="1"
+        received_date="2024-07-02 00:00:00.0"
+        entered_date="2024-07-02 00:00:00.0"
+        collection_date="2024-07-02 00:00:00.0"
+        lastupdated="2024-01-01 00:00:00" />
+
+    <!-- SAMPLE ITEMS -->
+    <sample_item id="80001" sort_order="1" status_id="1"
+        samp_id="80001" typeosamp_id="60001"
+        collection_date="2024-07-01 00:00:00"
+        lastupdated="2024-01-01 00:00:00" />
+
+    <sample_item id="80002" sort_order="1" status_id="1"
+        samp_id="80002" typeosamp_id="60001"
+        collection_date="2024-07-02 00:00:00"
+        lastupdated="2024-01-01 00:00:00" />
+
+    <!-- ANALYSES - status_id=1 = "Not Tested" = NotStarted -->
+    <analysis id="80001" sampitem_id="80001" test_sect_id="70001"
+        test_id="70001" revision="0" status="1" status_id="1"
+        analysis_type="ROUTINE" started_date="2024-07-01 00:00:00"
+        entry_date="2024-07-01 00:00:00" lastupdated="2024-01-01 00:00:00"
+        reflex_trigger="false" referred_out="false" corrected="false"
+        result_calculated="false"
+        fhir_uuid="b0000001-0000-0000-0000-000000080001" />
+
+    <analysis id="80002" sampitem_id="80002" test_sect_id="70001"
+        test_id="70001" revision="0" status="1" status_id="1"
+        analysis_type="ROUTINE" started_date="2024-07-02 00:00:00"
+        entry_date="2024-07-02 00:00:00" lastupdated="2024-01-01 00:00:00"
+        reflex_trigger="false" referred_out="false" corrected="false"
+        result_calculated="false"
+        fhir_uuid="b0000002-0000-0000-0000-000000080002" />
+
+</dataset>


### PR DESCRIPTION
## Description

This PR adds integration tests for the WorkPlanByTestController.

### Changes:
- Added `WorkPlanByTestControllerTest` to cover controller endpoints
- Created dataset `workplan-by-test-controller.xml` for test setup
- Updated `AppTestConfig` to include the new dataset

### Test Coverage:
- Valid request scenarios
- Edge cases (empty results)
- Data setup validation

### Notes:
- All relevant workplan tests pass locally
- Branch is rebased on latest `develop`
- Spotless formatting applied

## Impact
Improves test coverage for workplan controller functionality and ensures stability of related endpoints.