### PR TITLE
fix(equipment): use native date inputs in usage log

### DIFF
--- a/frontend/src/components/equipmentUsage/EquipmentUsage.css
+++ b/frontend/src/components/equipmentUsage/EquipmentUsage.css
@@ -281,6 +281,27 @@
 }
 
 /* Date Picker Input in Table */
+.tableDatePicker {
+  width: 100%;
+  min-width: 140px;
+}
+
+.tableDatePicker .cds--date-picker,
+.tableDatePicker .bx--date-picker,
+.tableDatePicker .cds--date-picker-container,
+.tableDatePicker .bx--date-picker-container,
+.tableDatePicker .cds--date-picker-input__wrapper,
+.tableDatePicker .bx--date-picker-input__wrapper {
+  width: 100%;
+}
+
+.tableDatePicker .cds--date-picker-container label,
+.tableDatePicker .bx--date-picker-container label {
+  display: none;
+}
+
+.tableDatePicker .cds--text-input,
+.tableDatePicker .bx--text-input,
 .tableInput[type="text"].bx--date-picker__input {
   padding: 6px 8px;
   height: 32px;

--- a/frontend/src/components/equipmentUsage/EquipmentUsageLog.jsx
+++ b/frontend/src/components/equipmentUsage/EquipmentUsageLog.jsx
@@ -4,8 +4,6 @@ import {
   Grid,
   Column,
   Loading,
-  DatePicker,
-  DatePickerInput,
 } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { NotificationContext } from "../layout/Layout";
@@ -504,24 +502,15 @@ const EquipmentUsageLog = ({ onSubmitSuccess }) => {
                       {usageRows.map((row) => (
                         <tr key={row.id}>
                           <td>
-                            <DatePicker
-                              datePickerType="single"
-                              dateFormat="mm/dd/yyyy"
-                            >
-                              <DatePickerInput
-                                id={`date-picker-${row.id}`}
-                                labelText="Date"
-                                placeholder="mm/dd/yyyy"
-                                value={row.date}
-                                onChange={(e) =>
-                                  handleRowChange(
-                                    row.id,
-                                    "date",
-                                    e.target.value,
-                                  )
-                                }
-                              />
-                            </DatePicker>
+                            <input
+                              id={`date-picker-${row.id}`}
+                              type="date"
+                              value={row.date}
+                              onChange={(e) =>
+                                handleRowChange(row.id, "date", e.target.value)
+                              }
+                              className="tableInput"
+                            />
                           </td>
                           <td>
                             <input
@@ -617,24 +606,19 @@ const EquipmentUsageLog = ({ onSubmitSuccess }) => {
                             />
                           </td>
                           <td>
-                            <DatePicker
-                              datePickerType="single"
-                              dateFormat="mm/dd/yyyy"
-                            >
-                              <DatePickerInput
-                                id={`approval-date-picker-${row.id}`}
-                                labelText="Approval Date"
-                                placeholder="mm/dd/yyyy"
-                                value={row.approvalDate}
-                                onChange={(e) =>
-                                  handleRowChange(
-                                    row.id,
-                                    "approvalDate",
-                                    e.target.value,
-                                  )
-                                }
-                              />
-                            </DatePicker>
+                            <input
+                              id={`approval-date-picker-${row.id}`}
+                              type="date"
+                              value={row.approvalDate}
+                              onChange={(e) =>
+                                handleRowChange(
+                                  row.id,
+                                  "approvalDate",
+                                  e.target.value,
+                                )
+                              }
+                              className="tableInput"
+                            />
                           </td>
                           <td>
                             <input

--- a/frontend/src/components/equipmentUsage/EquipmentUsageLog.jsx
+++ b/frontend/src/components/equipmentUsage/EquipmentUsageLog.jsx
@@ -1,13 +1,9 @@
 import { useState, useEffect, useContext, useCallback } from "react";
-import {
-  Button,
-  Grid,
-  Column,
-  Loading,
-} from "@carbon/react";
+import { Button, Grid, Column, Loading } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { NotificationContext } from "../layout/Layout";
 import { AlertDialog, NotificationKinds } from "../common/CustomNotification";
+import CustomDatePicker from "../common/CustomDatePicker";
 import UserSessionDetailsContext from "../../UserSessionDetailsContext";
 import CartridgeUsageAPI from "./EquipmentUsageService";
 import ChooseEquipmentModal from "./modals/ChooseEquipment";
@@ -502,14 +498,16 @@ const EquipmentUsageLog = ({ onSubmitSuccess }) => {
                       {usageRows.map((row) => (
                         <tr key={row.id}>
                           <td>
-                            <input
+                            <CustomDatePicker
                               id={`date-picker-${row.id}`}
-                              type="date"
+                              key={`date-${row.id}`}
+                              labelText=""
                               value={row.date}
-                              onChange={(e) =>
-                                handleRowChange(row.id, "date", e.target.value)
+                              updateStateValue={true}
+                              className="tableDatePicker"
+                              onChange={(date) =>
+                                handleRowChange(row.id, "date", date)
                               }
-                              className="tableInput"
                             />
                           </td>
                           <td>
@@ -606,18 +604,16 @@ const EquipmentUsageLog = ({ onSubmitSuccess }) => {
                             />
                           </td>
                           <td>
-                            <input
+                            <CustomDatePicker
                               id={`approval-date-picker-${row.id}`}
-                              type="date"
+                              key={`approval-date-${row.id}`}
+                              labelText=""
                               value={row.approvalDate}
-                              onChange={(e) =>
-                                handleRowChange(
-                                  row.id,
-                                  "approvalDate",
-                                  e.target.value,
-                                )
+                              updateStateValue={true}
+                              className="tableDatePicker"
+                              onChange={(date) =>
+                                handleRowChange(row.id, "approvalDate", date)
                               }
-                              className="tableInput"
                             />
                           </td>
                           <td>


### PR DESCRIPTION
## Summary
- replace the equipment usage date field with a native date input
- replace the approval date field with a native date input
- avoid the repeated character/date-entry issue in the usage log table

## Testing
- tested locally
