### PR TITLE
inventory: add next maintenance date for equipment

### DIFF
--- a/frontend/src/components/inventory/InventoryCatalog.jsx
+++ b/frontend/src/components/inventory/InventoryCatalog.jsx
@@ -166,7 +166,7 @@ const InventoryCatalog = () => {
     const labels = {
       REAGENT: "Reagent",
       RDT: "RDT (Rapid Diagnostic Test)",
-      CARTRIDGE: "Analyzer Cartridge",
+      CARTRIDGE: "Equipment",
       HIV_KIT: "HIV Test Kit",
       SYPHILIS_KIT: "Syphilis Test Kit",
       ENZYME: "Enzyme",

--- a/frontend/src/components/inventory/InventoryDashboard.jsx
+++ b/frontend/src/components/inventory/InventoryDashboard.jsx
@@ -171,7 +171,10 @@ const InventoryDashboard = () => {
     },
     {
       key: "nextMaintenanceDate",
-      header: "Next Maintenance Date",
+      header: intl.formatMessage({
+        id: "catalog.item.nextMaintenanceDate",
+        defaultMessage: "Next Maintenance Date",
+      }),
     },
     {
       key: "actions",

--- a/frontend/src/components/inventory/InventoryDashboard.jsx
+++ b/frontend/src/components/inventory/InventoryDashboard.jsx
@@ -170,6 +170,10 @@ const InventoryDashboard = () => {
       header: "Last Maintenance Date",
     },
     {
+      key: "nextMaintenanceDate",
+      header: "Next Maintenance Date",
+    },
+    {
       key: "actions",
       header: "Action",
     },
@@ -632,6 +636,9 @@ const InventoryDashboard = () => {
           : "N/A",
         lastMaintenanceDate: item?.lastMaintenanceDate
           ? formatDate(item.lastMaintenanceDate)
+          : "N/A",
+        nextMaintenanceDate: item?.nextMaintenanceDate
+          ? formatDate(item.nextMaintenanceDate)
           : "N/A",
       };
     }

--- a/frontend/src/components/inventory/InventoryItemForm.jsx
+++ b/frontend/src/components/inventory/InventoryItemForm.jsx
@@ -803,7 +803,10 @@ const InventoryItemForm = ({ open, onClose, onSave, item = null }) => {
                 <DatePickerInput
                   id="nextMaintenanceDate"
                   placeholder="mm/dd/yyyy"
-                  labelText="Next Maintenance Date"
+                  labelText={intl.formatMessage({
+                    id: "catalog.item.nextMaintenanceDate",
+                    defaultMessage: "Next Maintenance Date",
+                  })}
                   value={formData.nextMaintenanceDate}
                   onChange={(e) =>
                     handleChange("nextMaintenanceDate", e.target.value)

--- a/frontend/src/components/inventory/InventoryItemForm.jsx
+++ b/frontend/src/components/inventory/InventoryItemForm.jsx
@@ -197,7 +197,7 @@ const InventoryItemForm = ({ open, onClose, onSave, item = null }) => {
     const labels = {
       REAGENT: "Reagent",
       RDT: "RDT (Rapid Diagnostic Test)",
-      CARTRIDGE: "Analyzer Cartridge",
+      CARTRIDGE: "Equipment",
       HIV_KIT: "HIV Test Kit",
       SYPHILIS_KIT: "Syphilis Test Kit",
     };
@@ -274,6 +274,8 @@ const InventoryItemForm = ({ open, onClose, onSave, item = null }) => {
         lastServiceDate: convertFromISODateTime(item.lastServiceDate) || "",
         lastMaintenanceDate:
           convertFromISODateTime(item.lastMaintenanceDate) || "",
+        nextMaintenanceDate:
+          convertFromISODateTime(item.nextMaintenanceDate) || "",
         // Reagent-specific additional fields
         concentration: item.concentration || "",
         // RDT-specific
@@ -308,6 +310,7 @@ const InventoryItemForm = ({ open, onClose, onSave, item = null }) => {
         installationDate: "",
         lastServiceDate: "",
         lastMaintenanceDate: "",
+        nextMaintenanceDate: "",
         // Reagent-specific additional fields
         concentration: "",
         // RDT-specific
@@ -494,6 +497,11 @@ const InventoryItemForm = ({ open, onClose, onSave, item = null }) => {
         if (formData.lastMaintenanceDate) {
           sanitizedData.lastMaintenanceDate = convertToISODateTime(
             formData.lastMaintenanceDate,
+          );
+        }
+        if (formData.nextMaintenanceDate) {
+          sanitizedData.nextMaintenanceDate = convertToISODateTime(
+            formData.nextMaintenanceDate,
           );
         }
       } else if (formData.itemType === "RDT") {
@@ -787,6 +795,18 @@ const InventoryItemForm = ({ open, onClose, onSave, item = null }) => {
                   value={formData.lastMaintenanceDate}
                   onChange={(e) =>
                     handleChange("lastMaintenanceDate", e.target.value)
+                  }
+                />
+              </DatePicker>
+
+              <DatePicker datePickerType="single">
+                <DatePickerInput
+                  id="nextMaintenanceDate"
+                  placeholder="mm/dd/yyyy"
+                  labelText="Next Maintenance Date"
+                  value={formData.nextMaintenanceDate}
+                  onChange={(e) =>
+                    handleChange("nextMaintenanceDate", e.target.value)
                   }
                 />
               </DatePicker>

--- a/frontend/src/components/inventory/InventoryList.jsx
+++ b/frontend/src/components/inventory/InventoryList.jsx
@@ -223,7 +223,7 @@ const InventoryList = () => {
     const labels = {
       REAGENT: "Reagent",
       RDT: "RDT (Rapid Diagnostic Test)",
-      CARTRIDGE: "Analyzer Cartridge",
+      CARTRIDGE: "Equipment",
       HIV_KIT: "HIV Test Kit",
       SYPHILIS_KIT: "Syphilis Test Kit",
     };

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -272,6 +272,7 @@
   "catalog.item.lowStockThreshold": "Low Stock Threshold",
   "catalog.item.manufacturer": "Manufacturer",
   "catalog.item.minimumStock": "Minimum Stock Level",
+  "catalog.item.nextMaintenanceDate": "Next Maintenance Date",
   "catalog.item.name": "Item Name",
   "catalog.item.reorderLevel": "Reorder Level",
   "catalog.item.reorderQuantity": "Reorder Quantity",

--- a/src/main/java/org/openelisglobal/inventory/daoimpl/InventoryItemDAOImpl.java
+++ b/src/main/java/org/openelisglobal/inventory/daoimpl/InventoryItemDAOImpl.java
@@ -266,6 +266,9 @@ public class InventoryItemDAOImpl extends BaseDAOImpl<InventoryItem, Long> imple
         case "lastmaintenancedate":
         case "last_maintenance_date":
             return "lastMaintenanceDate";
+        case "nextmaintenancedate":
+        case "next_maintenance_date":
+            return "nextMaintenanceDate";
         case "currentlocation":
         case "current_location":
             return "currentLocation";

--- a/src/main/java/org/openelisglobal/inventory/valueholder/InventoryItem.java
+++ b/src/main/java/org/openelisglobal/inventory/valueholder/InventoryItem.java
@@ -128,6 +128,10 @@ public class InventoryItem extends BaseObject<Long> {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime lastMaintenanceDate;
 
+    @Column(name = "next_maintenance_date")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime nextMaintenanceDate;
+
     @Column(name = "current_location", length = 255)
     private String currentLocation;
 

--- a/src/main/resources/liquibase/3.5.x.x/032-add-next-maintenance-date-to-inventory-item.xml
+++ b/src/main/resources/liquibase/3.5.x.x/032-add-next-maintenance-date-to-inventory-item.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="032-add-next-maintenance-date-to-inventory-item" author="codex">
+        <addColumn tableName="inventory_item">
+            <column name="next_maintenance_date" type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -87,5 +87,6 @@
 
     <include file="liquibase/3.5.x.x/029-electronic-signature.xml"/>
     <include file="liquibase/3.5.x.x/030-fix-biorepository-approved-sample-type-lastupdated.xml"/>
+    <include file="liquibase/3.5.x.x/032-add-next-maintenance-date-to-inventory-item.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Adds an optional Next Maintenance Date field for equipment inventory items and shows it in the equipment dashboard view.

This also updates the inventory UI so users see Equipment instead of Analyzer Cartridge, while keeping the backend item type unchanged.

Tested locally.