### PR TITLE
fix(ci): remove pre-start bridge restart

### DIFF
--- a/.github/workflows/e2e-playwright-reusable.yml
+++ b/.github/workflows/e2e-playwright-reusable.yml
@@ -192,9 +192,6 @@ jobs:
             mkdir -p "projects/analyzer-harness/volume/analyzer-imports/$slug/incoming"
           done
           sudo chmod -R a+rwX projects/analyzer-harness/volume/analyzer-imports
-          # Restart bridge so it re-bootstraps watch directories for all seeded analyzers
-          docker restart openelis-analyzer-bridge
-          sleep 10
 
       # ── Container Startup ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Remove `docker restart openelis-analyzer-bridge` from the pre-start setup step (line 196) where containers don't exist yet
- The post-seeding restart at line 292 (after containers are healthy) is the correct one and remains

## Root cause
The pre-start restart was added during #3322 but placed in the wrong workflow step. It runs before `docker compose up`, so the bridge container doesn't exist → `No such container` error on develop.

## Test plan
- [ ] E2E harness tests pass (both shards)
- [ ] No `No such container` errors in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)