### PR TITLE
feat(fhir): OGC-530 — analyzer metadata to FHIR Observation.device

### DIFF
--- a/src/main/java/org/openelisglobal/analysis/valueholder/Analysis.java
+++ b/src/main/java/org/openelisglobal/analysis/valueholder/Analysis.java
@@ -85,6 +85,7 @@ public class Analysis extends BaseObject<String> implements NoteObject {
     private boolean correctedSincePatientReport;
     private ValueHolderInterface method;
     private ResultFile resultFile;
+    private String analyzerId;
 
     public Analysis() {
         super();
@@ -544,6 +545,14 @@ public class Analysis extends BaseObject<String> implements NoteObject {
 
     public void setResultFile(ResultFile resultFile) {
         this.resultFile = resultFile;
+    }
+
+    public String getAnalyzerId() {
+        return analyzerId;
+    }
+
+    public void setAnalyzerId(String analyzerId) {
+        this.analyzerId = analyzerId;
     }
 
 }

--- a/src/main/java/org/openelisglobal/analyzer/valueholder/Analyzer.java
+++ b/src/main/java/org/openelisglobal/analyzer/valueholder/Analyzer.java
@@ -34,6 +34,7 @@ import jakarta.validation.constraints.Pattern;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
@@ -154,6 +155,9 @@ public class Analyzer extends BaseObject<String> {
     @Column(name = "last_activated_date")
     @Temporal(TemporalType.TIMESTAMP)
     private Date lastActivatedDate;
+
+    @Column(name = "fhir_uuid")
+    private UUID fhirUuid;
 
     @Override
     public String getId() {
@@ -428,6 +432,33 @@ public class Analyzer extends BaseObject<String> {
 
     public void setDiscoveredSourceId(String discoveredSourceId) {
         this.discoveredSourceId = discoveredSourceId;
+    }
+
+    public UUID getFhirUuid() {
+        return fhirUuid;
+    }
+
+    public void setFhirUuid(UUID fhirUuid) {
+        this.fhirUuid = fhirUuid;
+    }
+
+    /**
+     * Returns the fhirUuid as a String, or null if not yet assigned. Use
+     * {@link #ensureFhirUuid()} to generate and persist a UUID if needed.
+     */
+    public String getFhirUuidAsString() {
+        return fhirUuid != null ? fhirUuid.toString() : null;
+    }
+
+    /**
+     * Ensures this analyzer has a stable FHIR UUID. If none exists, generates one.
+     * Callers should persist the entity after calling this in a write transaction.
+     */
+    public String ensureFhirUuid() {
+        if (fhirUuid == null) {
+            fhirUuid = UUID.randomUUID();
+        }
+        return fhirUuid.toString();
     }
 
     /**

--- a/src/main/java/org/openelisglobal/analyzerimport/action/AnalyzerFhirImportController.java
+++ b/src/main/java/org/openelisglobal/analyzerimport/action/AnalyzerFhirImportController.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Device;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Specimen;
@@ -96,6 +97,40 @@ public class AnalyzerFhirImportController extends org.openelisglobal.common.rest
                 if (analyzer == null) {
                     // Try by name
                     analyzer = analyzerService.getByName(analyzerId).orElse(null);
+                }
+            }
+
+            // Fallback: try to resolve analyzer from Device resource in the bundle.
+            // Prefer identifier-based resolution (stable) over device name (display-only).
+            if (analyzer == null) {
+                for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+                    Resource resource = entry.getResource();
+                    if (resource instanceof Device device) {
+                        // Try identifiers first (machineId, sourceId, pattern match)
+                        if (device.hasIdentifier()) {
+                            List<String> identifierValues = device.getIdentifier().stream()
+                                    .map(org.hl7.fhir.r4.model.Identifier::getValue)
+                                    .filter(v -> v != null && !v.isBlank()).toList();
+                            analyzer = analyzerService.findByIdentifierPatternMatch(identifierValues).orElse(null);
+                        }
+                        // Fall back to serial number (machineId)
+                        if (analyzer == null && device.hasSerialNumber()) {
+                            analyzer = analyzerService.findByIdentifierPatternMatch(device.getSerialNumber())
+                                    .orElse(null);
+                        }
+                        // Last resort: device display name
+                        if (analyzer == null && device.hasDeviceName()) {
+                            String deviceName = device.getDeviceNameFirstRep().getName();
+                            if (deviceName != null && !deviceName.isBlank()) {
+                                analyzer = analyzerService.getByName(deviceName).orElse(null);
+                            }
+                        }
+                        if (analyzer != null) {
+                            LogEvent.logInfo(CLASS_NAME, "importFhirBundle",
+                                    "Resolved analyzer from bundle Device resource");
+                            break;
+                        }
+                    }
                 }
             }
 

--- a/src/main/java/org/openelisglobal/analyzerresults/service/AnalyzerResultsAcceptServiceImpl.java
+++ b/src/main/java/org/openelisglobal/analyzerresults/service/AnalyzerResultsAcceptServiceImpl.java
@@ -602,6 +602,7 @@ public class AnalyzerResultsAcceptServiceImpl implements AnalyzerResultsAcceptSe
                         .getStatusID(resultItem.getIsAccepted() ? AnalysisStatus.TechnicalAcceptance
                                 : AnalysisStatus.TechnicalRejected);
                 analysis.setStatusId(statusId);
+                analysis.setAnalyzerId(resultItem.getAnalyzerId());
             }
 
             analysis.setSysUserId(sysUserId);
@@ -695,6 +696,7 @@ public class AnalyzerResultsAcceptServiceImpl implements AnalyzerResultsAcceptSe
             analysis.setTestSection(test.getTestSection());
             analysis.setIsReportable(test.getIsReportable());
             analysis.setRevision("0");
+            analysis.setAnalyzerId(resultItem.getAnalyzerId());
         }
     }
 

--- a/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
@@ -35,6 +35,9 @@ import org.hl7.fhir.r4.model.ContactPoint.ContactPointUse;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.DecimalType;
+import org.hl7.fhir.r4.model.Device;
+import org.hl7.fhir.r4.model.Device.DeviceDeviceNameComponent;
+import org.hl7.fhir.r4.model.Device.DeviceNameType;
 import org.hl7.fhir.r4.model.DiagnosticReport;
 import org.hl7.fhir.r4.model.DiagnosticReport.DiagnosticReportStatus;
 import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
@@ -67,6 +70,8 @@ import org.openelisglobal.address.valueholder.AddressPart;
 import org.openelisglobal.address.valueholder.PersonAddress;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.analyzer.service.AnalyzerService;
+import org.openelisglobal.analyzer.valueholder.Analyzer;
 import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.provider.query.PatientSearchResults;
@@ -189,6 +194,8 @@ public class FhirTransformServiceImpl implements FhirTransformService {
     private FhirFacilityOrganizationService facilityOrganizationService;
     @Autowired
     private TestResultService testResultService;
+    @Autowired
+    private AnalyzerService analyzerService;
 
     private String ADDRESS_PART_VILLAGE_ID;
     private String ADDRESS_PART_COMMUNE_ID;
@@ -258,6 +265,8 @@ public class FhirTransformServiceImpl implements FhirTransformService {
         Map<String, DiagnosticReport> diagnosticReports = new HashMap<>();
         Map<String, Observation> observations = new HashMap<>();
         Map<String, Practitioner> requesters = new HashMap<>();
+        Set<String> includedAnalyzerIds = new HashSet<>();
+        Map<String, Analyzer> analyzerCache = new HashMap<>();
         for (String sampleId : sampleIds) {
             LogEvent.logDebug(this.getClass().getSimpleName(), "transformPersistObjectsUnderSamples",
                     "transforming sampleId: " + sampleId);
@@ -374,6 +383,8 @@ public class FhirTransformServiceImpl implements FhirTransformService {
                         LogEvent.logWarn(this.getClass().getSimpleName(), "transformPersistObjectsUnderSamples",
                                 "observation collision with id: " + observation.getIdElement().getIdPart());
                     }
+                    setDeviceReferenceAndInclude(observation, result.getAnalysis(), fhirOperations, tempIdGenerator,
+                            analyzerCache, includedAnalyzerIds);
                     observations.put(observation.getIdElement().getIdPart(), observation);
                 }
             }
@@ -1284,12 +1295,19 @@ public class FhirTransformServiceImpl implements FhirTransformService {
 
         CountingTempIdGenerator tempIdGenerator = new CountingTempIdGenerator();
         FhirOperations fhirOperations = new FhirOperations();
+        Set<String> includedAnalyzerIds = new HashSet<>();
+        Map<String, Analyzer> analyzerCache = new HashMap<>();
+
         for (ResultSet resultSet : actionDataSet.getNewResults()) {
             Observation observation = transformResultToObservation(resultSet.result.getId());
+            setDeviceReferenceAndInclude(observation, resultSet.result.getAnalysis(), fhirOperations, tempIdGenerator,
+                    analyzerCache, includedAnalyzerIds);
             this.addToOperations(fhirOperations, tempIdGenerator, observation);
         }
         for (ResultSet resultSet : actionDataSet.getModifiedResults()) {
             Observation observation = this.transformResultToObservation(resultSet.result.getId());
+            setDeviceReferenceAndInclude(observation, resultSet.result.getAnalysis(), fhirOperations, tempIdGenerator,
+                    analyzerCache, includedAnalyzerIds);
             this.addToOperations(fhirOperations, tempIdGenerator, observation);
         }
 
@@ -1300,6 +1318,7 @@ public class FhirTransformServiceImpl implements FhirTransformService {
                 DiagnosticReport diagnosticReport = this.transformResultToDiagnosticReport(analysis.getId());
                 this.addToOperations(fhirOperations, tempIdGenerator, diagnosticReport);
             }
+            includeDeviceIfNeeded(analysis, fhirOperations, tempIdGenerator, analyzerCache, includedAnalyzerIds);
         }
         try {
             Bundle responseBundle = fhirPersistanceService.createUpdateFhirResourcesInFhirStore(fhirOperations);
@@ -1492,6 +1511,8 @@ public class FhirTransformServiceImpl implements FhirTransformService {
 
         CountingTempIdGenerator tempIdGenerator = new CountingTempIdGenerator();
         FhirOperations fhirOperations = new FhirOperations();
+        Set<String> includedAnalyzerIds = new HashSet<>();
+        Map<String, Analyzer> analyzerCache = new HashMap<>();
 
         for (Result result : deletableList) {
             Observation observation = transformResultToObservation(result.getId());
@@ -1501,6 +1522,8 @@ public class FhirTransformServiceImpl implements FhirTransformService {
 
         for (Result result : resultUpdateList) {
             Observation observation = this.transformResultToObservation(result.getId());
+            setDeviceReferenceAndInclude(observation, result.getAnalysis(), fhirOperations, tempIdGenerator,
+                    analyzerCache, includedAnalyzerIds);
             this.addToOperations(fhirOperations, tempIdGenerator, observation);
         }
 
@@ -1511,6 +1534,7 @@ public class FhirTransformServiceImpl implements FhirTransformService {
                 DiagnosticReport diagnosticReport = this.transformResultToDiagnosticReport(analysis.getId());
                 this.addToOperations(fhirOperations, tempIdGenerator, diagnosticReport);
             }
+            includeDeviceIfNeeded(analysis, fhirOperations, tempIdGenerator, analyzerCache, includedAnalyzerIds);
         }
 
         Map<String, Task> referingTaskMap = new HashMap<>();
@@ -1572,6 +1596,49 @@ public class FhirTransformServiceImpl implements FhirTransformService {
         }
     }
 
+    /**
+     * Resolves the analyzer for an analysis, sets Observation.device reference, and
+     * ensures the corresponding Device resource is included in the bundle (once per
+     * analyzer). Single DB lookup per unique analyzerId.
+     */
+    private void setDeviceReferenceAndInclude(Observation observation, Analysis analysis, FhirOperations fhirOperations,
+            TempIdGenerator tempIdGenerator, Map<String, Analyzer> analyzerCache, Set<String> includedAnalyzerIds) {
+        if (analysis == null || GenericValidator.isBlankOrNull(analysis.getAnalyzerId())) {
+            return;
+        }
+        Analyzer analyzer = analyzerCache.computeIfAbsent(analysis.getAnalyzerId(), id -> analyzerService.get(id));
+        if (analyzer == null) {
+            return;
+        }
+        String fhirUuid = analyzer.ensureFhirUuid();
+        observation.setDevice(this.createReferenceFor(ResourceType.Device, fhirUuid));
+        if (!includedAnalyzerIds.contains(analysis.getAnalyzerId())) {
+            Device device = this.transformAnalyzerToDevice(analyzer);
+            this.addToOperations(fhirOperations, tempIdGenerator, device);
+            includedAnalyzerIds.add(analysis.getAnalyzerId());
+        }
+    }
+
+    /**
+     * Ensures the Device resource for an analysis's analyzer is included in the
+     * bundle. Use when no Observation is available (e.g., DiagnosticReport paths).
+     */
+    private void includeDeviceIfNeeded(Analysis analysis, FhirOperations fhirOperations,
+            TempIdGenerator tempIdGenerator, Map<String, Analyzer> analyzerCache, Set<String> includedAnalyzerIds) {
+        if (analysis == null || GenericValidator.isBlankOrNull(analysis.getAnalyzerId())) {
+            return;
+        }
+        if (includedAnalyzerIds.contains(analysis.getAnalyzerId())) {
+            return;
+        }
+        Analyzer analyzer = analyzerCache.computeIfAbsent(analysis.getAnalyzerId(), id -> analyzerService.get(id));
+        if (analyzer != null) {
+            Device device = this.transformAnalyzerToDevice(analyzer);
+            this.addToOperations(fhirOperations, tempIdGenerator, device);
+            includedAnalyzerIds.add(analysis.getAnalyzerId());
+        }
+    }
+
     private DiagnosticReport transformResultToDiagnosticReport(String analysisId) {
         return transformResultToDiagnosticReport(analysisService.get(analysisId));
     }
@@ -1611,6 +1678,43 @@ public class FhirTransformServiceImpl implements FhirTransformService {
         diagnosticReport.setCode(transformTestToCodeableConcept(test.getId()));
 
         return diagnosticReport;
+    }
+
+    private Device transformAnalyzerToDevice(Analyzer analyzer) {
+        Device device = new Device();
+        // ensureFhirUuid() generates a UUID if missing (shouldn't happen with backfill
+        // migration)
+        String fhirUuid = analyzer.ensureFhirUuid();
+        device.setId(fhirUuid);
+
+        device.addIdentifier(this.createIdentifier(fhirConfig.getOeFhirSystem() + "/analyzer_uuid", fhirUuid));
+
+        if (!GenericValidator.isBlankOrNull(analyzer.getMachineId())) {
+            device.addIdentifier(this.createIdentifier(fhirConfig.getOeFhirSystem() + "/analyzer_machineId",
+                    analyzer.getMachineId()));
+            device.setSerialNumber(analyzer.getMachineId());
+        }
+
+        if (!GenericValidator.isBlankOrNull(analyzer.getDiscoveredSourceId())) {
+            device.addIdentifier(this.createIdentifier(fhirConfig.getOeFhirSystem() + "/analyzer_sourceId",
+                    analyzer.getDiscoveredSourceId()));
+        }
+
+        if (!GenericValidator.isBlankOrNull(analyzer.getName())) {
+            device.addDeviceName(new DeviceDeviceNameComponent().setName(analyzer.getName())
+                    .setType(DeviceNameType.USERFRIENDLYNAME));
+        }
+
+        if (!GenericValidator.isBlankOrNull(analyzer.getType())) {
+            device.setType(new CodeableConcept().setText(analyzer.getType()));
+        }
+
+        Identifier facilityId = createFacilityIdentifier();
+        if (facilityId != null) {
+            device.setOwner(new Reference().setIdentifier(facilityId));
+        }
+
+        return device;
     }
 
     private DiagnosticReport genNewDiagnosticReport(Analysis analysis) {
@@ -1721,6 +1825,7 @@ public class FhirTransformServiceImpl implements FhirTransformService {
             observation.setEffective(new DateTimeType(analysis.getStartedDate()));
         }
         // observation.setIssued(new Date());
+
         return observation;
     }
 

--- a/src/main/resources/hibernate/hbm/Analysis.hbm.xml
+++ b/src/main/resources/hibernate/hbm/Analysis.hbm.xml
@@ -120,6 +120,9 @@
             fetch="join" lazy="false" cascade="all">
             <column name="result_file_id" not-null="false" unique="true" />
         </many-to-one>
+        <property name="analyzerId"
+            type="org.openelisglobal.hibernate.resources.usertype.LIMSStringNumberUserType"
+            column="analyzer_id" precision="10" />
 
     </class>
 

--- a/src/main/resources/liquibase/3.5.x.x/004-analysis-analyzer-id.xml
+++ b/src/main/resources/liquibase/3.5.x.x/004-analysis-analyzer-id.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+        OGC-530: Analyzer metadata not flowing through FHIR Observation.device
+
+        1. Adds analyzer_id column to analysis table so accepted analyzer results
+           preserve their source instrument.
+        2. Adds fhir_uuid to the analyzer table with backfill, NOT NULL, and
+           UNIQUE so each analyzer gets a stable FHIR Device resource identity.
+    -->
+
+    <!-- Step 1: Add the analysis.analyzer_id column -->
+    <changeSet author="pmanko" id="3.5.0-003-add-analysis-analyzer-id-column">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="analysis" columnName="analyzer_id" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="analysis" schemaName="clinlims">
+            <column name="analyzer_id" type="numeric(10)"/>
+        </addColumn>
+    </changeSet>
+
+    <!-- Step 2: Add the FK constraint separately so partial migrations are safe -->
+    <changeSet author="pmanko" id="3.5.0-003-add-analysis-analyzer-id-fk">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_analysis_analyzer" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <addForeignKeyConstraint
+            baseTableSchemaName="clinlims"
+            baseTableName="analysis"
+            baseColumnNames="analyzer_id"
+            referencedTableSchemaName="clinlims"
+            referencedTableName="analyzer"
+            referencedColumnNames="id"
+            constraintName="fk_analysis_analyzer"/>
+    </changeSet>
+
+    <!-- Step 3: Add the analyzer.fhir_uuid column -->
+    <changeSet author="pmanko" id="3.5.0-003-add-analyzer-fhir-uuid">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="analyzer" columnName="fhir_uuid" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="analyzer" schemaName="clinlims">
+            <column name="fhir_uuid" type="uuid"/>
+        </addColumn>
+    </changeSet>
+
+    <!-- Step 4: Backfill existing analyzers with stable UUIDs, then enforce constraints -->
+    <changeSet author="pmanko" id="3.5.0-003-backfill-analyzer-fhir-uuid">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="analyzer" columnName="fhir_uuid" schemaName="clinlims"/>
+            <not>
+                <sqlCheck expectedResult="0">
+                    SELECT count(*) FROM clinlims.analyzer WHERE fhir_uuid IS NULL
+                </sqlCheck>
+            </not>
+        </preConditions>
+        <sql schemaName="clinlims">
+            UPDATE clinlims.analyzer SET fhir_uuid = gen_random_uuid() WHERE fhir_uuid IS NULL;
+        </sql>
+        <addNotNullConstraint
+            tableName="analyzer"
+            columnName="fhir_uuid"
+            schemaName="clinlims"
+            columnDataType="uuid"/>
+        <addUniqueConstraint
+            tableName="analyzer"
+            columnNames="fhir_uuid"
+            schemaName="clinlims"
+            constraintName="uq_analyzer_fhir_uuid"/>
+        <rollback>
+            <dropUniqueConstraint
+                tableName="analyzer"
+                schemaName="clinlims"
+                constraintName="uq_analyzer_fhir_uuid"/>
+            <dropNotNullConstraint
+                tableName="analyzer"
+                columnName="fhir_uuid"
+                schemaName="clinlims"
+                columnDataType="uuid"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -19,4 +19,7 @@
   <!-- Add Audit Trail menu under Reports, deactivate old entries -->
   <include relativeToChangelogFile="true" file="003-audit-trail-menu.xml"/>
 
+  <!-- OGC-530: Analyzer metadata on Analysis + FHIR Device identity -->
+  <include relativeToChangelogFile="true" file="004-analysis-analyzer-id.xml"/>
+
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/dataexchange/fhir/FhirDeviceTransformTest.java
+++ b/src/test/java/org/openelisglobal/dataexchange/fhir/FhirDeviceTransformTest.java
@@ -1,0 +1,87 @@
+package org.openelisglobal.dataexchange.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.analyzer.service.AnalyzerService;
+import org.openelisglobal.analyzer.valueholder.Analyzer;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests persistence of Analysis.analyzerId and generation/persistence of
+ * Analyzer FHIR UUID metadata used to support analyzer device references in
+ * FHIR R4 Observation transformations.
+ *
+ * OGC-530: Analyzer metadata not flowing through FHIR Observation
+ */
+public class FhirDeviceTransformTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private AnalysisService analysisService;
+    @Autowired
+    private AnalyzerService analyzerService;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/fhir-device-transform.xml");
+    }
+
+    @Test
+    public void analysisWithAnalyzerId_shouldHaveFieldPersisted() {
+        Analysis analysis = analysisService.get("1");
+        assertNotNull("Analysis should exist", analysis);
+        analysis.setAnalyzerId("1");
+        analysisService.update(analysis);
+
+        Analysis reloaded = analysisService.get("1");
+        assertEquals("analyzerId should persist", "1", reloaded.getAnalyzerId());
+    }
+
+    @Test
+    public void analysisWithoutAnalyzerId_shouldHaveNullAnalyzerId() {
+        Analysis analysis = analysisService.get("1");
+        assertNotNull("Analysis should exist", analysis);
+        assertNull("New analysis should have null analyzerId", analysis.getAnalyzerId());
+    }
+
+    @Test
+    public void analyzerFhirUuid_shouldBeGeneratedViaEnsureAndPersisted() {
+        Analyzer analyzer = analyzerService.get("1");
+        assertNotNull("Analyzer should exist", analyzer);
+
+        // getFhirUuidAsString() is a pure getter — returns null when unset
+        assertNull("fhirUuid should initially be null", analyzer.getFhirUuidAsString());
+
+        // ensureFhirUuid() generates if missing
+        String uuidStr = analyzer.ensureFhirUuid();
+        assertNotNull("ensureFhirUuid should generate UUID", uuidStr);
+        UUID.fromString(uuidStr); // validates format
+
+        analyzerService.update(analyzer);
+        Analyzer reloaded = analyzerService.get("1");
+        assertEquals("fhirUuid should persist", uuidStr, reloaded.getFhirUuidAsString());
+    }
+
+    @Test
+    public void analyzerFhirUuid_getFhirUuidAsString_returnsNullWhenUnset() {
+        Analyzer analyzer = analyzerService.get("1");
+        assertNotNull("Analyzer should exist", analyzer);
+
+        // Pure getter returns null when fhirUuid is not set
+        assertNull("getFhirUuidAsString should return null for unset uuid", analyzer.getFhirUuidAsString());
+
+        // ensureFhirUuid generates and returns a valid UUID
+        String uuid = analyzer.ensureFhirUuid();
+        assertNotNull("ensureFhirUuid should generate UUID", uuid);
+
+        // Subsequent calls to getter return the same value
+        assertEquals("getter should now return the generated uuid", uuid, analyzer.getFhirUuidAsString());
+    }
+}

--- a/src/test/resources/testdata/fhir-device-transform.xml
+++ b/src/test/resources/testdata/fhir-device-transform.xml
@@ -1,0 +1,36 @@
+<dataset>
+    <status_of_sample id="8001"
+        description="Sample Status" code="1" status_type="SampleType1"
+        lastupdated="2025-03-18" name="Status 1"
+        display_key="sample_display_key_1" is_active="Y" />
+
+    <test id="5001" description="Glucose Test" loinc="2345-7"
+        reporting_description="Glucose" sticker_req_flag="N" is_active="Y"
+        active_begin="2025-01-01 12:00:00" active_end="2026-12-31 12:00:00"
+        is_reportable="Y" time_holding="30" time_wait="15"
+        time_ta_average="60" time_ta_warning="90" time_ta_max="120"
+        label_qty="1" lastupdated="2025-03-20 12:00:00" local_code="GLU"
+        sort_order="2147483646" name="Glucose" orderable="true" guid="glu-001"
+        antimicrobial_resistance="false" />
+
+    <analyzer id="1" name="Mindray BC-5380"
+        machine_id="MINDRAY-5380-001" analyzer_type="HEMATOLOGY"
+        description="Hematology analyzer" location="Main Lab" is_active="true"
+        has_setup_page="false" last_updated="2025-01-01 12:00:00" />
+
+    <sample id="9001" accession_number="FHIR-DEV-001"
+        status_id="8001" entered_date="2025-06-01 10:00:00"
+        received_date="2025-06-01 10:00:00"
+        collection_date="2025-06-01 09:00:00"
+        lastupdated="2025-06-01 10:00:00" domain="H" />
+
+    <sample_item id="9001" samp_id="9001" sort_order="1"
+        status_id="8001" collection_date="2025-06-01 09:00:00"
+        lastupdated="2025-06-01 10:00:00"
+        fhir_uuid="11111111-1111-1111-1111-111111111111" />
+
+    <analysis id="1" test_id="5001" sampitem_id="9001"
+        analysis_type="AUTO" revision="0" status_id="8001"
+        lastupdated="2025-06-01 10:00:00"
+        fhir_uuid="22222222-2222-2222-2222-222222222222" />
+</dataset>


### PR DESCRIPTION
## Summary

- **Adds `analyzer_id` column** to the `analysis` table so accepted analyzer results preserve their source instrument (Liquibase migration + HBM mapping)
- **Preserves `analyzerId` during acceptance** — both new-analysis and existing-analysis code paths in `AnalyzerResultsAcceptServiceImpl` now copy the staging `analyzerId` to the permanent `Analysis` record
- **Creates FHIR R4 Device resources** from `Analyzer` metadata (name, machineId, type, discoveredSourceId) with stable identity via new `fhir_uuid` column on `analyzer`
- **Sets `Observation.device`** reference when the source Analysis has an associated analyzer, and includes Device in the FHIR transaction bundle
- **Fallback resolution** — if no `X-Analyzer-Id` header is sent by the bridge, tries to resolve the analyzer from `Device` resources in the incoming bundle

### Data Flow (Before → After)

**Before**: Bridge → staging `analyzer_results.analyzer_id` → acceptance → `Analysis` (no analyzer field) → FHIR `Observation` (no device)

**After**: Bridge → staging `analyzer_results.analyzer_id` → acceptance → `Analysis.analyzer_id` ✓ → FHIR `Observation.device` → `Device` resource ✓

### FHIR R4 Note
`DiagnosticReport` does not have a `device` field in FHIR R4. The device reference is placed on `Observation.device` per the FHIR R4 specification, which is the standard way to indicate which instrument produced the result.

## Test plan
- [ ] Verify Liquibase migration runs without errors on fresh database
- [ ] Accept analyzer results through UI → verify `analysis.analyzer_id` is populated in DB
- [ ] Trigger FHIR export (finalize results) → verify Device resource created in HAPI FHIR store
- [ ] Verify `Observation.device` references the correct Device resource
- [ ] Confirm existing manual/eOrder results (no analyzer) still export without device reference
- [ ] Run integration tests: `FhirDeviceTransformTest`

Closes [OGC-530](https://uwdigi.atlassian.net/browse/OGC-530)

[OGC-530]: https://uwdigi.atlassian.net/browse/OGC-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ