### PR TITLE
fix(fhir): harden ServiceRequest read path for ID validation and duplication

### DIFF
--- a/src/main/java/org/openelisglobal/fhir/providers/ServiceRequestProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/ServiceRequestProvider.java
@@ -54,27 +54,36 @@ public class ServiceRequestProvider implements IResourceProvider {
     @Read
     public ServiceRequest readServiceRequest(@IdParam IdType theId) {
         String method = "readServiceRequest";
-        if (theId == null) {
-            throw new ResourceNotFoundException("The ServiceRequest id should not be null");
-        }
         try {
+            FhirProviderUtils.validateIdParam(theId, "ServiceRequest", this.getClass().getSimpleName(), method);
+
             String analysisUuid = theId.getIdPart();
             List<Analysis> analyses = analysisService.getAllMatching("fhirUuid", UUID.fromString(analysisUuid));
 
             if (analyses == null || analyses.isEmpty()) {
-                // This will now correctly return HTTP 404
                 throw new ResourceNotFoundException("Analysis with FHIR ID: " + analysisUuid + " does not exist");
+            }
+            if (analyses.size() > 1) {
+                LogEvent.logError(this.getClass().getSimpleName(), method,
+                        "Duplicate Analysis records found for fhirUuid=" + analysisUuid);
+                throw new InternalErrorException("Multiple Analysis records found for ServiceRequest UUID");
             }
 
             Analysis analysis = analyses.get(0);
-            return fhirTransformService.transformToServiceRequest(analysis.getId());
+            ServiceRequest serviceRequest = fhirTransformService.transformToServiceRequest(analysis.getId());
+            if (serviceRequest == null) {
+                throw new InternalErrorException("Failed to transform Analysis to ServiceRequest");
+            }
+            return serviceRequest;
 
         } catch (ResourceNotFoundException | InvalidRequestException e) {
-            throw e; // FHIR server will map ResourceNotFoundException to 404
+            throw e;
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("ServiceRequest ID must be a valid UUID");
         } catch (Exception e) {
             LogEvent.logError(this.getClass().getSimpleName(), method,
-                    "Unexpected error while Reading Patient: " + e.getMessage());
-            throw new InternalErrorException("Unexpected server error while Reading Patient", e);
+                    "Unexpected error while Reading ServiceRequest: " + e.getMessage());
+            throw new InternalErrorException("Unexpected server error while Reading ServiceRequest", e);
         }
     }
 

--- a/src/test/java/org/openelisglobal/fhir/ServiceRequestFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/ServiceRequestFacadeTest.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.fhir;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.RestfulServer;
@@ -73,5 +74,32 @@ public class ServiceRequestFacadeTest extends BaseWebContextSensitiveTest {
 
         JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
         assertEquals("OperationOutcome", jsonResponse.get("resourceType").asText());
+    }
+
+    @Test
+    public void readServiceRequest_withInvalidUuid_shouldReturn400() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/ServiceRequest/not-a-uuid");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(400, response.getStatus());
+
+        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
+        assertEquals("OperationOutcome", jsonResponse.get("resourceType").asText());
+    }
+
+    @Test
+    public void searchServiceRequest_endpointExists_shouldNotReturn404() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/ServiceRequest");
+        request.setQueryString("subject=Patient/550e8400-e29b-41d4-a716-446655440001");
+        request.addParameter("subject", "Patient/550e8400-e29b-41d4-a716-446655440001");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertNotNull(response);
+        org.junit.Assert.assertTrue(response.getStatus() != 404);
     }
 }

--- a/src/test/java/org/openelisglobal/fhir/providers/ServiceRequestProviderTest.java
+++ b/src/test/java/org/openelisglobal/fhir/providers/ServiceRequestProviderTest.java
@@ -1,0 +1,80 @@
+package org.openelisglobal.fhir.providers;
+
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceRequestProviderTest {
+
+    @Mock
+    private AnalysisService analysisService;
+
+    @Mock
+    private FhirTransformService fhirTransformService;
+
+    @InjectMocks
+    private ServiceRequestProvider serviceRequestProvider;
+
+    @Test(expected = InternalErrorException.class)
+    public void readServiceRequest_whenDuplicateUuidMatches_shouldReturn500() {
+        String uuid = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+        IdType id = new IdType("ServiceRequest", uuid);
+
+        Analysis first = new Analysis();
+        Analysis second = new Analysis();
+
+        when(analysisService.getAllMatching("fhirUuid", UUID.fromString(uuid)))
+                .thenReturn(Arrays.asList(first, second));
+
+        serviceRequestProvider.readServiceRequest(id);
+    }
+
+    @Test(expected = InternalErrorException.class)
+    public void readServiceRequest_whenTransformReturnsNull_shouldReturn500() {
+        String uuid = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+        IdType id = new IdType("ServiceRequest", uuid);
+
+        Analysis analysis = new Analysis();
+        analysis.setId("1");
+
+        when(analysisService.getAllMatching("fhirUuid", UUID.fromString(uuid)))
+                .thenReturn(Collections.singletonList(analysis));
+        when(fhirTransformService.transformToServiceRequest("1")).thenReturn(null);
+
+        serviceRequestProvider.readServiceRequest(id);
+    }
+
+    @Test
+    public void readServiceRequest_whenSingleMatchAndTransformSuccess_shouldReturnServiceRequest() {
+        String uuid = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+        IdType id = new IdType("ServiceRequest", uuid);
+
+        Analysis analysis = new Analysis();
+        analysis.setId("1");
+
+        ServiceRequest expected = new ServiceRequest();
+        expected.setId(uuid);
+
+        when(analysisService.getAllMatching("fhirUuid", UUID.fromString(uuid)))
+                .thenReturn(Collections.singletonList(analysis));
+        when(fhirTransformService.transformToServiceRequest("1")).thenReturn(expected);
+
+        ServiceRequest actual = serviceRequestProvider.readServiceRequest(id);
+
+        org.junit.Assert.assertEquals(uuid, actual.getIdElement().getIdPart());
+    }
+}


### PR DESCRIPTION
## Summary
This PR hardens `ServiceRequestProvider @Read` to prevent invalid-id crashes and ambiguous UUID reads, and adds targeted tests for those edge cases.

## What changed
- Added strict ID validation in `ServiceRequestProvider.readServiceRequest(...)` via `FhirProviderUtils.validateIdParam(...)`.
- Added explicit handling for invalid UUID format -> `InvalidRequestException` (HTTP 400).
- Added duplicate UUID guard (multiple Analysis rows for one FHIR UUID) -> `InternalErrorException` (HTTP 500).
- Added null-transform guard to fail safely when transformation unexpectedly returns null.
- Corrected provider error logging/messages to consistently reference `ServiceRequest`.

## Tests added/updated
- `ServiceRequestProviderTest` (new):
  - duplicate UUID path -> 500
  - null transform path -> 500
  - successful read path
- `ServiceRequestFacadeTest`:
  - invalid UUID read returns 400
  - search endpoint wiring check (not 404)

## Why this matters
This PR addresses pre-existing reliability and safety gaps in the ServiceRequest read path:
- malformed IDs no longer flow into low-level failures,
- duplicate UUID data-integrity anomalies are surfaced explicitly,
- transformation failures are handled deterministically.

These are hardening fixes for existing behavior; they do not introduce new vulnerability classes.