### PR TITLE
fix(workflow): tighten reagent deductions and MNTD handoff

### DIFF
--- a/frontend/src/components/notebook/pages/immunology/ImmunologyAdditionalAssaysPage.js
+++ b/frontend/src/components/notebook/pages/immunology/ImmunologyAdditionalAssaysPage.js
@@ -449,6 +449,10 @@ function ImmunologyAdditionalAssaysPage({
     const selectedReagentItems = reagents.filter((reagent) =>
       assayValues.selectedReagents.includes(reagent.id),
     );
+    if (reagents.length > 0 && selectedReagentItems.length === 0) {
+      setError("Select at least one reagent before applying assay data.");
+      return;
+    }
     const invalidReagentItems = getInvalidReagentUsageItems(
       selectedReagentItems,
       assayValues.reagentQuantities,

--- a/frontend/src/components/notebook/pages/immunology/ImmunologyAdditionalAssaysPage.js
+++ b/frontend/src/components/notebook/pages/immunology/ImmunologyAdditionalAssaysPage.js
@@ -38,6 +38,11 @@ import {
   postToOpenElisServer,
 } from "../../../utils/Utils";
 import SampleGrid from "../../workflow/SampleGrid";
+import ReagentUsageSelector, {
+  buildSelectedReagentUsages,
+  getInvalidReagentUsageItems,
+  syncReagentUsageQuantities,
+} from "../../workflow/ReagentUsageSelector";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -110,6 +115,7 @@ function ImmunologyAdditionalAssaysPage({
 
     // Reagent & Instrument Selection (from inventory)
     selectedReagents: [],
+    reagentQuantities: {},
     selectedEquipment: [],
 
     // Timing
@@ -337,6 +343,7 @@ function ImmunologyAdditionalAssaysPage({
       operatorName: "",
       operatorInitials: "",
       selectedReagents: [],
+      reagentQuantities: {},
       selectedEquipment: [],
       assayStartTime: "",
       assayEndTime: "",
@@ -439,7 +446,25 @@ function ImmunologyAdditionalAssaysPage({
       return;
     }
 
+    const selectedReagentItems = reagents.filter((reagent) =>
+      assayValues.selectedReagents.includes(reagent.id),
+    );
+    const invalidReagentItems = getInvalidReagentUsageItems(
+      selectedReagentItems,
+      assayValues.reagentQuantities,
+    );
+    if (invalidReagentItems.length > 0) {
+      setError("Enter a quantity greater than 0 for each selected reagent.");
+      return;
+    }
+
     const data = buildAssayData();
+    if (assayValues.selectedReagents.length > 0) {
+      data.selectedReagentUsages = buildSelectedReagentUsages(
+        selectedReagentItems,
+        assayValues.reagentQuantities,
+      );
+    }
 
     if (Object.keys(data).length === 0) {
       setError(
@@ -1396,8 +1421,12 @@ function ImmunologyAdditionalAssaysPage({
             >
               <Grid narrow>
                 <Column lg={8} md={4} sm={4}>
-                  <MultiSelect
-                    id="selectedReagents"
+                  <ReagentUsageSelector
+                    reagents={reagents}
+                    selectedIds={assayValues.selectedReagents}
+                    reagentQuantities={assayValues.reagentQuantities}
+                    sampleCount={selectedSampleIds.length}
+                    disabled={loadingReagents}
                     titleText={intl.formatMessage({
                       id: "notebook.immunology.reagents",
                       defaultMessage: "Reagents Used",
@@ -1406,18 +1435,25 @@ function ImmunologyAdditionalAssaysPage({
                       id: "notebook.immunology.reagents.placeholder",
                       defaultMessage: "Select reagents...",
                     })}
-                    items={reagents}
-                    itemToString={(item) => (item ? item.label : "")}
-                    selectedItems={reagents.filter((r) =>
-                      assayValues.selectedReagents.includes(r.id),
-                    )}
-                    onChange={({ selectedItems }) =>
+                    onSelectionChange={(selectedItems) =>
                       setAssayValues((prev) => ({
                         ...prev,
-                        selectedReagents: selectedItems.map((r) => r.id),
+                        selectedReagents: selectedItems.map((reagent) => reagent.id),
+                        reagentQuantities: syncReagentUsageQuantities(
+                          selectedItems,
+                          prev.reagentQuantities,
+                        ),
                       }))
                     }
-                    disabled={loadingReagents}
+                    onQuantityChange={(reagentId, value) =>
+                      setAssayValues((prev) => ({
+                        ...prev,
+                        reagentQuantities: {
+                          ...prev.reagentQuantities,
+                          [reagentId]: value,
+                        },
+                      }))
+                    }
                   />
                 </Column>
                 <Column lg={8} md={4} sm={4}>

--- a/frontend/src/components/notebook/pages/immunology/ImmunologyAdditionalAssaysPage.js
+++ b/frontend/src/components/notebook/pages/immunology/ImmunologyAdditionalAssaysPage.js
@@ -1,4 +1,11 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  useContext,
+} from "react";
 import {
   Grid,
   Column,
@@ -43,6 +50,8 @@ import ReagentUsageSelector, {
   getInvalidReagentUsageItems,
   syncReagentUsageQuantities,
 } from "../../workflow/ReagentUsageSelector";
+import { NotificationContext } from "../../../layout/Layout";
+import { NotificationKinds } from "../../../common/CustomNotification";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -81,6 +90,8 @@ function ImmunologyAdditionalAssaysPage({
 }) {
   const intl = useIntl();
   const componentMounted = useRef(false);
+  const { addNotification, setNotificationVisible } =
+    useContext(NotificationContext);
 
   const [samples, setSamples] = useState([]);
   const [selectedSampleIds, setSelectedSampleIds] = useState([]);
@@ -211,6 +222,21 @@ function ImmunologyAdditionalAssaysPage({
       },
     ],
     [intl],
+  );
+
+  const notifyError = useCallback(
+    (message) => {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({
+          id: "notification.error",
+          defaultMessage: "Error",
+        }),
+        message,
+      });
+      setNotificationVisible(true);
+    },
+    [addNotification, intl, setNotificationVisible],
   );
 
   // Load reagents from inventory
@@ -450,7 +476,7 @@ function ImmunologyAdditionalAssaysPage({
       assayValues.selectedReagents.includes(reagent.id),
     );
     if (reagents.length > 0 && selectedReagentItems.length === 0) {
-      setError("Select at least one reagent before applying assay data.");
+      notifyError("Select at least one reagent before applying assay data.");
       return;
     }
     const invalidReagentItems = getInvalidReagentUsageItems(
@@ -458,7 +484,7 @@ function ImmunologyAdditionalAssaysPage({
       assayValues.reagentQuantities,
     );
     if (invalidReagentItems.length > 0) {
-      setError("Enter a quantity greater than 0 for each selected reagent.");
+      notifyError("Enter a quantity greater than 0 for each selected reagent.");
       return;
     }
 

--- a/frontend/src/components/notebook/pages/immunology/ImmunologyInitialProcessingPage.js
+++ b/frontend/src/components/notebook/pages/immunology/ImmunologyInitialProcessingPage.js
@@ -36,6 +36,11 @@ import {
   postToOpenElisServer,
 } from "../../../utils/Utils";
 import SampleGrid from "../../workflow/SampleGrid";
+import ReagentUsageSelector, {
+  buildSelectedReagentUsages,
+  getInvalidReagentUsageItems,
+  syncReagentUsageQuantities,
+} from "../../workflow/ReagentUsageSelector";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -127,6 +132,7 @@ function ImmunologyInitialProcessingPage({
     processingTemperature: "",
     temperatureUnit: "C",
     selectedReagents: [],
+    reagentQuantities: {},
     selectedEquipment: [],
     cellViabilityPercentage: "",
     finalCellYield: "",
@@ -290,6 +296,7 @@ function ImmunologyInitialProcessingPage({
       processingTemperature: "",
       temperatureUnit: "C",
       selectedReagents: [],
+      reagentQuantities: {},
       selectedEquipment: [],
       cellViabilityPercentage: "",
       finalCellYield: "",
@@ -376,6 +383,18 @@ function ImmunologyInitialProcessingPage({
       return;
     }
 
+    const selectedReagentItems = reagents.filter((reagent) =>
+      processingValues.selectedReagents.includes(reagent.id),
+    );
+    const invalidReagentItems = getInvalidReagentUsageItems(
+      selectedReagentItems,
+      processingValues.reagentQuantities,
+    );
+    if (invalidReagentItems.length > 0) {
+      setError("Enter a quantity greater than 0 for each selected reagent.");
+      return;
+    }
+
     // Build data object with non-empty values
     const data = {};
 
@@ -422,6 +441,11 @@ function ImmunologyInitialProcessingPage({
       data.temperatureUnit = processingValues.temperatureUnit;
     if (processingValues.selectedReagents.length > 0)
       data.selectedReagents = processingValues.selectedReagents;
+    if (processingValues.selectedReagents.length > 0)
+      data.selectedReagentUsages = buildSelectedReagentUsages(
+        selectedReagentItems,
+        processingValues.reagentQuantities,
+      );
     if (processingValues.selectedEquipment.length > 0)
       data.selectedEquipment = processingValues.selectedEquipment;
     if (processingValues.cellViabilityPercentage)
@@ -1690,8 +1714,12 @@ function ImmunologyInitialProcessingPage({
                   </h6>
                 </Column>
                 <Column lg={8} md={4} sm={4}>
-                  <MultiSelect
-                    id="selectedReagents"
+                  <ReagentUsageSelector
+                    reagents={reagents}
+                    selectedIds={processingValues.selectedReagents}
+                    reagentQuantities={processingValues.reagentQuantities}
+                    sampleCount={selectedSampleIds.length}
+                    disabled={loadingReagents}
                     titleText={intl.formatMessage({
                       id: "notebook.immunology.reagents",
                       defaultMessage: "Reagents",
@@ -1700,18 +1728,25 @@ function ImmunologyInitialProcessingPage({
                       id: "notebook.immunology.reagents.placeholder",
                       defaultMessage: "Select reagents...",
                     })}
-                    items={reagents}
-                    itemToString={(item) => (item ? item.label : "")}
-                    selectedItems={reagents.filter((r) =>
-                      processingValues.selectedReagents.includes(r.id),
-                    )}
-                    onChange={({ selectedItems }) =>
+                    onSelectionChange={(selectedItems) =>
                       setProcessingValues((prev) => ({
                         ...prev,
-                        selectedReagents: selectedItems.map((r) => r.id),
+                        selectedReagents: selectedItems.map((reagent) => reagent.id),
+                        reagentQuantities: syncReagentUsageQuantities(
+                          selectedItems,
+                          prev.reagentQuantities,
+                        ),
                       }))
                     }
-                    disabled={loadingReagents}
+                    onQuantityChange={(reagentId, value) =>
+                      setProcessingValues((prev) => ({
+                        ...prev,
+                        reagentQuantities: {
+                          ...prev.reagentQuantities,
+                          [reagentId]: value,
+                        },
+                      }))
+                    }
                   />
                 </Column>
                 <Column lg={8} md={4} sm={4}>

--- a/frontend/src/components/notebook/pages/immunology/ImmunologyInitialProcessingPage.js
+++ b/frontend/src/components/notebook/pages/immunology/ImmunologyInitialProcessingPage.js
@@ -386,6 +386,10 @@ function ImmunologyInitialProcessingPage({
     const selectedReagentItems = reagents.filter((reagent) =>
       processingValues.selectedReagents.includes(reagent.id),
     );
+    if (reagents.length > 0 && selectedReagentItems.length === 0) {
+      setError("Select at least one reagent before applying processing.");
+      return;
+    }
     const invalidReagentItems = getInvalidReagentUsageItems(
       selectedReagentItems,
       processingValues.reagentQuantities,

--- a/frontend/src/components/notebook/pages/immunology/ImmunologyInitialProcessingPage.js
+++ b/frontend/src/components/notebook/pages/immunology/ImmunologyInitialProcessingPage.js
@@ -1,4 +1,11 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  useContext,
+} from "react";
 import {
   Grid,
   Column,
@@ -41,6 +48,8 @@ import ReagentUsageSelector, {
   getInvalidReagentUsageItems,
   syncReagentUsageQuantities,
 } from "../../workflow/ReagentUsageSelector";
+import { NotificationContext } from "../../../layout/Layout";
+import { NotificationKinds } from "../../../common/CustomNotification";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -88,6 +97,8 @@ function ImmunologyInitialProcessingPage({
 }) {
   const intl = useIntl();
   const componentMounted = useRef(false);
+  const { addNotification, setNotificationVisible } =
+    useContext(NotificationContext);
 
   const [samples, setSamples] = useState([]);
   const [selectedSampleIds, setSelectedSampleIds] = useState([]);
@@ -177,6 +188,21 @@ function ImmunologyInitialProcessingPage({
       },
     );
   }, []);
+
+  const notifyError = useCallback(
+    (message) => {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({
+          id: "notification.error",
+          defaultMessage: "Error",
+        }),
+        message,
+      });
+      setNotificationVisible(true);
+    },
+    [addNotification, intl, setNotificationVisible],
+  );
 
   // Load instruments from template or inventory
   const loadInstruments = useCallback(() => {
@@ -387,7 +413,7 @@ function ImmunologyInitialProcessingPage({
       processingValues.selectedReagents.includes(reagent.id),
     );
     if (reagents.length > 0 && selectedReagentItems.length === 0) {
-      setError("Select at least one reagent before applying processing.");
+      notifyError("Select at least one reagent before applying processing.");
       return;
     }
     const invalidReagentItems = getInvalidReagentUsageItems(
@@ -395,7 +421,7 @@ function ImmunologyInitialProcessingPage({
       processingValues.reagentQuantities,
     );
     if (invalidReagentItems.length > 0) {
-      setError("Enter a quantity greater than 0 for each selected reagent.");
+      notifyError("Enter a quantity greater than 0 for each selected reagent.");
       return;
     }
 

--- a/frontend/src/components/notebook/pages/mntd/MNTDProcessingQCPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDProcessingQCPage.js
@@ -301,6 +301,10 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
     const selectedKitObjects = reagents.filter((r) =>
       extractionData.selectedKits.includes(r.id),
     );
+    if (reagents.length > 0 && selectedKitObjects.length === 0) {
+      setError("Select at least one extraction kit before saving.");
+      return;
+    }
     const invalidKitItems = getInvalidReagentUsageItems(
       selectedKitObjects,
       extractionData.kitQuantities,

--- a/frontend/src/components/notebook/pages/mntd/MNTDProcessingQCPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDProcessingQCPage.js
@@ -31,6 +31,11 @@ import {
   postToOpenElisServer,
 } from "../../../utils/Utils";
 import SampleGrid from "../../workflow/SampleGrid";
+import ReagentUsageSelector, {
+  buildSelectedReagentUsages,
+  getInvalidReagentUsageItems,
+  syncReagentUsageQuantities,
+} from "../../workflow/ReagentUsageSelector";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -122,6 +127,7 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
     extractionMethod: "",
     otherMethodDescription: "",
     selectedKits: [], // Array of selected kit IDs for multiselect
+    kitQuantities: {},
     yield: "",
     yieldUnit: "ng/uL",
     extractionDate: new Date().toISOString().split("T")[0],
@@ -260,6 +266,7 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
       extractionMethod: "",
       otherMethodDescription: "",
       selectedKits: [],
+      kitQuantities: {},
       yield: "",
       yieldUnit: "ng/uL",
       extractionDate: new Date().toISOString().split("T")[0],
@@ -294,6 +301,14 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
     const selectedKitObjects = reagents.filter((r) =>
       extractionData.selectedKits.includes(r.id),
     );
+    const invalidKitItems = getInvalidReagentUsageItems(
+      selectedKitObjects,
+      extractionData.kitQuantities,
+    );
+    if (invalidKitItems.length > 0) {
+      setError("Enter a quantity greater than 0 for each selected extraction kit.");
+      return;
+    }
 
     // Build kit lot numbers string from selected kits
     const kitLotNumbers = selectedKitObjects
@@ -321,6 +336,10 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
       extractionNotes: extractionData.notes,
       // Include selectedReagents for automatic inventory consumption
       selectedReagents: selectedReagents,
+      selectedReagentUsages: buildSelectedReagentUsages(
+        selectedKitObjects,
+        extractionData.kitQuantities,
+      ),
     };
 
     postToOpenElisServer(
@@ -817,8 +836,12 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
               style={{ marginBottom: "1rem" }}
             />
           ) : (
-            <MultiSelect
-              id="kit-lot-number"
+            <ReagentUsageSelector
+              reagents={reagents}
+              selectedIds={extractionData.selectedKits}
+              reagentQuantities={extractionData.kitQuantities}
+              sampleCount={selectedIds.length}
+              disabled={loadingReagents}
               titleText={intl.formatMessage({
                 id: "notebook.mntd.extraction.kitLotNumber",
                 defaultMessage: "Kit Lot Number",
@@ -827,18 +850,25 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
                 id: "notebook.mntd.extraction.selectKits",
                 defaultMessage: "Select extraction kits...",
               })}
-              items={reagents}
-              itemToString={(item) => (item ? item.label : "")}
-              selectedItems={reagents.filter((r) =>
-                extractionData.selectedKits.includes(r.id),
-              )}
-              onChange={({ selectedItems }) =>
-                setExtractionData({
-                  ...extractionData,
+              onSelectionChange={(selectedItems) =>
+                setExtractionData((prev) => ({
+                  ...prev,
                   selectedKits: selectedItems.map((item) => item.id),
-                })
+                  kitQuantities: syncReagentUsageQuantities(
+                    selectedItems,
+                    prev.kitQuantities,
+                  ),
+                }))
               }
-              disabled={loadingReagents}
+              onQuantityChange={(reagentId, value) =>
+                setExtractionData((prev) => ({
+                  ...prev,
+                  kitQuantities: {
+                    ...prev.kitQuantities,
+                    [reagentId]: value,
+                  },
+                }))
+              }
             />
           )}
 

--- a/frontend/src/components/notebook/pages/mntd/MNTDProcessingQCPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDProcessingQCPage.js
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useCallback,
   useMemo,
+  useContext,
 } from "react";
 import {
   Grid,
@@ -36,6 +37,8 @@ import ReagentUsageSelector, {
   getInvalidReagentUsageItems,
   syncReagentUsageQuantities,
 } from "../../workflow/ReagentUsageSelector";
+import { NotificationContext } from "../../../layout/Layout";
+import { NotificationKinds } from "../../../common/CustomNotification";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -110,6 +113,8 @@ const VECTOR_AUTO_METHODS = [
 function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
   const intl = useIntl();
   const componentMounted = useRef(false);
+  const { addNotification, setNotificationVisible } =
+    useContext(NotificationContext);
 
   // State for samples
   const [samples, setSamples] = useState([]);
@@ -152,6 +157,21 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
         : VECTOR_AUTO_METHODS;
     }
   }, [extractionData.sampleType, extractionData.extractionType]);
+
+  const notifyError = useCallback(
+    (message) => {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({
+          id: "notification.error",
+          defaultMessage: "Error",
+        }),
+        message,
+      });
+      setNotificationVisible(true);
+    },
+    [addNotification, intl, setNotificationVisible],
+  );
 
   // Load reagents from inventory (used for kit lot number selection)
   const loadReagents = useCallback(() => {
@@ -302,7 +322,7 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
       extractionData.selectedKits.includes(r.id),
     );
     if (reagents.length > 0 && selectedKitObjects.length === 0) {
-      setError("Select at least one extraction kit before saving.");
+      notifyError("Select at least one extraction kit before saving.");
       return;
     }
     const invalidKitItems = getInvalidReagentUsageItems(
@@ -310,7 +330,7 @@ function MNTDProcessingQCPage({ entryId, pageData, onProgressUpdate }) {
       extractionData.kitQuantities,
     );
     if (invalidKitItems.length > 0) {
-      setError("Enter a quantity greater than 0 for each selected extraction kit.");
+      notifyError("Enter a quantity greater than 0 for each selected extraction kit.");
       return;
     }
 

--- a/frontend/src/components/notebook/pages/mntd/MNTDSampleProcessingPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDSampleProcessingPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useContext } from "react";
 import {
   Grid,
   Column,
@@ -37,6 +37,8 @@ import ReagentUsageSelector, {
   getInvalidReagentUsageItems,
   syncReagentUsageQuantities,
 } from "../../workflow/ReagentUsageSelector";
+import { NotificationContext } from "../../../layout/Layout";
+import { NotificationKinds } from "../../../common/CustomNotification";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -66,6 +68,8 @@ function MNTDSampleProcessingPage({
 }) {
   const intl = useIntl();
   const componentMounted = useRef(false);
+  const { addNotification, setNotificationVisible } =
+    useContext(NotificationContext);
 
   // State for samples
   const [samples, setSamples] = useState([]);
@@ -115,6 +119,21 @@ function MNTDSampleProcessingPage({
     { id: "extraction", label: "Extraction" },
     { id: "culture", label: "Culture" },
   ];
+
+  const notifyError = useCallback(
+    (message) => {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({
+          id: "notification.error",
+          defaultMessage: "Error",
+        }),
+        message,
+      });
+      setNotificationVisible(true);
+    },
+    [addNotification, intl, setNotificationVisible],
+  );
 
   // Set instruments from notebook when prop changes
   useEffect(() => {
@@ -276,7 +295,7 @@ function MNTDSampleProcessingPage({
       bulkApplyValues.selectedReagents.includes(reagent.id),
     );
     if (reagents.length > 0 && selectedReagentItems.length === 0) {
-      setError("Select at least one reagent before applying processing.");
+      notifyError("Select at least one reagent before applying processing.");
       return;
     }
     const invalidReagentItems = getInvalidReagentUsageItems(
@@ -284,7 +303,7 @@ function MNTDSampleProcessingPage({
       bulkApplyValues.reagentQuantities,
     );
     if (invalidReagentItems.length > 0) {
-      setError("Enter a quantity greater than 0 for each selected reagent.");
+      notifyError("Enter a quantity greater than 0 for each selected reagent.");
       return;
     }
 

--- a/frontend/src/components/notebook/pages/mntd/MNTDSampleProcessingPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDSampleProcessingPage.js
@@ -32,6 +32,11 @@ import {
   postToOpenElisServer,
 } from "../../../utils/Utils";
 import SampleGrid from "../../workflow/SampleGrid";
+import ReagentUsageSelector, {
+  buildSelectedReagentUsages,
+  getInvalidReagentUsageItems,
+  syncReagentUsageQuantities,
+} from "../../workflow/ReagentUsageSelector";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -82,6 +87,7 @@ function MNTDSampleProcessingPage({
     technicianName: "",
     processingDate: new Date().toISOString().slice(0, 10),
     selectedReagents: [],
+    reagentQuantities: {},
     selectedInstruments: [],
     batchNumber: "",
     lotNumber: "",
@@ -266,6 +272,18 @@ function MNTDSampleProcessingPage({
       return;
     }
 
+    const selectedReagentItems = reagents.filter((reagent) =>
+      bulkApplyValues.selectedReagents.includes(reagent.id),
+    );
+    const invalidReagentItems = getInvalidReagentUsageItems(
+      selectedReagentItems,
+      bulkApplyValues.reagentQuantities,
+    );
+    if (invalidReagentItems.length > 0) {
+      setError("Enter a quantity greater than 0 for each selected reagent.");
+      return;
+    }
+
     setIsBulkApplying(true);
     setError(null);
 
@@ -277,6 +295,10 @@ function MNTDSampleProcessingPage({
         technicianName: bulkApplyValues.technicianName,
         processingDate: bulkApplyValues.processingDate,
         selectedReagents: bulkApplyValues.selectedReagents,
+        selectedReagentUsages: buildSelectedReagentUsages(
+          selectedReagentItems,
+          bulkApplyValues.reagentQuantities,
+        ),
         selectedInstruments: bulkApplyValues.selectedInstruments,
         batchNumber: bulkApplyValues.batchNumber,
         lotNumber: bulkApplyValues.lotNumber,
@@ -309,6 +331,7 @@ function MNTDSampleProcessingPage({
     selectedSampleIds,
     pageData?.id,
     bulkApplyValues,
+    reagents,
     loadPageSamples,
     onProgressUpdate,
   ]);
@@ -439,6 +462,7 @@ function MNTDSampleProcessingPage({
       technicianName: "",
       processingDate: new Date().toISOString().slice(0, 10),
       selectedReagents: [],
+      reagentQuantities: {},
       selectedInstruments: [],
       batchNumber: "",
       lotNumber: "",
@@ -741,25 +765,36 @@ function MNTDSampleProcessingPage({
           </Column>
 
           <Column lg={8} md={4} sm={4}>
-            <MultiSelect
-              id="selectedReagents"
+            <ReagentUsageSelector
+              reagents={reagents}
+              selectedIds={bulkApplyValues.selectedReagents}
+              reagentQuantities={bulkApplyValues.reagentQuantities}
+              sampleCount={selectedSampleIds.length}
+              disabled={loadingReagents}
               titleText={intl.formatMessage({
                 id: "notebook.mntd.reagents",
                 defaultMessage: "Reagents",
               })}
               label="Select reagents..."
-              items={reagents}
-              itemToString={(item) => (item ? item.label : "")}
-              selectedItems={reagents.filter((r) =>
-                bulkApplyValues.selectedReagents.includes(r.id),
-              )}
-              onChange={({ selectedItems }) =>
+              onSelectionChange={(selectedItems) =>
                 setBulkApplyValues((prev) => ({
                   ...prev,
-                  selectedReagents: selectedItems.map((i) => i.id),
+                  selectedReagents: selectedItems.map((item) => item.id),
+                  reagentQuantities: syncReagentUsageQuantities(
+                    selectedItems,
+                    prev.reagentQuantities,
+                  ),
                 }))
               }
-              disabled={loadingReagents}
+              onQuantityChange={(reagentId, value) =>
+                setBulkApplyValues((prev) => ({
+                  ...prev,
+                  reagentQuantities: {
+                    ...prev.reagentQuantities,
+                    [reagentId]: value,
+                  },
+                }))
+              }
             />
           </Column>
 

--- a/frontend/src/components/notebook/pages/mntd/MNTDSampleProcessingPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDSampleProcessingPage.js
@@ -275,6 +275,10 @@ function MNTDSampleProcessingPage({
     const selectedReagentItems = reagents.filter((reagent) =>
       bulkApplyValues.selectedReagents.includes(reagent.id),
     );
+    if (reagents.length > 0 && selectedReagentItems.length === 0) {
+      setError("Select at least one reagent before applying processing.");
+      return;
+    }
     const invalidReagentItems = getInvalidReagentUsageItems(
       selectedReagentItems,
       bulkApplyValues.reagentQuantities,

--- a/frontend/src/components/notebook/pages/mntd/MNTDTestExecutionPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDTestExecutionPage.js
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useCallback,
   useMemo,
+  useContext,
 } from "react";
 import {
   Grid,
@@ -65,6 +66,8 @@ import ReagentUsageSelector, {
   getInvalidReagentUsageItems,
   syncReagentUsageQuantities,
 } from "../../workflow/ReagentUsageSelector";
+import { NotificationContext } from "../../../layout/Layout";
+import { NotificationKinds } from "../../../common/CustomNotification";
 import config from "../../../../config.json";
 import "../../workflow/NotebookWorkflow.css";
 
@@ -105,6 +108,8 @@ function MNTDTestExecutionPage({
 }) {
   const intl = useIntl();
   const componentMounted = useRef(false);
+  const { addNotification, setNotificationVisible } =
+    useContext(NotificationContext);
 
   // State for samples
   const [samples, setSamples] = useState([]);
@@ -117,6 +122,21 @@ function MNTDTestExecutionPage({
   // Reagents from inventory (for kit lot number selection)
   const [reagents, setReagents] = useState([]);
   const [loadingReagents, setLoadingReagents] = useState(false);
+
+  const notifyError = useCallback(
+    (message) => {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({
+          id: "notification.error",
+          defaultMessage: "Error",
+        }),
+        message,
+      });
+      setNotificationVisible(true);
+    },
+    [addNotification, intl, setNotificationVisible],
+  );
 
   // Execution confirmation modal state
   const [showExecutionModal, setShowExecutionModal] = useState(false);
@@ -354,7 +374,7 @@ function MNTDTestExecutionPage({
       executionData.selectedKits.includes(r.id),
     );
     if (reagents.length > 0 && selectedKitObjects.length === 0) {
-      setError("Select at least one kit before saving execution data.");
+      notifyError("Select at least one kit before saving execution data.");
       return;
     }
     const invalidKitItems = getInvalidReagentUsageItems(
@@ -362,7 +382,7 @@ function MNTDTestExecutionPage({
       executionData.kitQuantities,
     );
     if (invalidKitItems.length > 0) {
-      setError("Enter a quantity greater than 0 for each selected kit.");
+      notifyError("Enter a quantity greater than 0 for each selected kit.");
       return;
     }
 

--- a/frontend/src/components/notebook/pages/mntd/MNTDTestExecutionPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDTestExecutionPage.js
@@ -60,6 +60,11 @@ import {
   postToOpenElisServerJsonResponse,
 } from "../../../utils/Utils";
 import SampleGrid from "../../workflow/SampleGrid";
+import ReagentUsageSelector, {
+  buildSelectedReagentUsages,
+  getInvalidReagentUsageItems,
+  syncReagentUsageQuantities,
+} from "../../workflow/ReagentUsageSelector";
 import config from "../../../../config.json";
 import "../../workflow/NotebookWorkflow.css";
 
@@ -120,6 +125,7 @@ function MNTDTestExecutionPage({
     runIssues: "",
     runId: "",
     selectedKits: [], // Array of selected kit IDs for multiselect
+    kitQuantities: {},
     operator: "",
     executionDate: new Date().toISOString().split("T")[0],
     executionTime: "",
@@ -323,6 +329,7 @@ function MNTDTestExecutionPage({
       runIssues: "",
       runId: "",
       selectedKits: [],
+      kitQuantities: {},
       operator: "",
       executionDate: new Date().toISOString().split("T")[0],
       executionTime: "",
@@ -346,6 +353,14 @@ function MNTDTestExecutionPage({
     const selectedKitObjects = reagents.filter((r) =>
       executionData.selectedKits.includes(r.id),
     );
+    const invalidKitItems = getInvalidReagentUsageItems(
+      selectedKitObjects,
+      executionData.kitQuantities,
+    );
+    if (invalidKitItems.length > 0) {
+      setError("Enter a quantity greater than 0 for each selected kit.");
+      return;
+    }
 
     // Build kit lot numbers string from selected kits
     const kitLotNumbers = selectedKitObjects
@@ -365,6 +380,10 @@ function MNTDTestExecutionPage({
       kitLot: kitLotNumbers,
       selectedKitIds: executionData.selectedKits,
       selectedReagents: selectedReagents,
+      selectedReagentUsages: buildSelectedReagentUsages(
+        selectedKitObjects,
+        executionData.kitQuantities,
+      ),
       operator: executionData.operator,
       executionDate: executionData.executionDate,
       executionTime: executionData.executionTime,
@@ -406,6 +425,7 @@ function MNTDTestExecutionPage({
                   runIssues: "",
                   runId: "",
                   selectedKits: [],
+                  kitQuantities: {},
                   operator: "",
                   executionDate: new Date().toISOString().split("T")[0],
                   executionTime: "",
@@ -1250,8 +1270,12 @@ function MNTDTestExecutionPage({
                     })}
                   />
                 ) : (
-                  <MultiSelect
-                    id="kit-lot"
+                  <ReagentUsageSelector
+                    reagents={reagents}
+                    selectedIds={executionData.selectedKits}
+                    reagentQuantities={executionData.kitQuantities}
+                    sampleCount={selectedIds.length}
+                    disabled={loadingReagents}
                     titleText={intl.formatMessage({
                       id: "notebook.mntd.testexecution.kitLot",
                       defaultMessage: "Kit Lot Number",
@@ -1260,18 +1284,25 @@ function MNTDTestExecutionPage({
                       id: "notebook.mntd.testexecution.selectKits",
                       defaultMessage: "Select kits...",
                     })}
-                    items={reagents}
-                    itemToString={(item) => (item ? item.label : "")}
-                    selectedItems={reagents.filter((r) =>
-                      executionData.selectedKits.includes(r.id),
-                    )}
-                    onChange={({ selectedItems }) =>
-                      setExecutionData({
-                        ...executionData,
+                    onSelectionChange={(selectedItems) =>
+                      setExecutionData((prev) => ({
+                        ...prev,
                         selectedKits: selectedItems.map((item) => item.id),
-                      })
+                        kitQuantities: syncReagentUsageQuantities(
+                          selectedItems,
+                          prev.kitQuantities,
+                        ),
+                      }))
                     }
-                    disabled={loadingReagents}
+                    onQuantityChange={(reagentId, value) =>
+                      setExecutionData((prev) => ({
+                        ...prev,
+                        kitQuantities: {
+                          ...prev.kitQuantities,
+                          [reagentId]: value,
+                        },
+                      }))
+                    }
                   />
                 )}
               </Column>

--- a/frontend/src/components/notebook/pages/mntd/MNTDTestExecutionPage.js
+++ b/frontend/src/components/notebook/pages/mntd/MNTDTestExecutionPage.js
@@ -353,6 +353,10 @@ function MNTDTestExecutionPage({
     const selectedKitObjects = reagents.filter((r) =>
       executionData.selectedKits.includes(r.id),
     );
+    if (reagents.length > 0 && selectedKitObjects.length === 0) {
+      setError("Select at least one kit before saving execution data.");
+      return;
+    }
     const invalidKitItems = getInvalidReagentUsageItems(
       selectedKitObjects,
       executionData.kitQuantities,

--- a/frontend/src/components/notebook/pages/pharma/PharmaceuticalProcessingPage.js
+++ b/frontend/src/components/notebook/pages/pharma/PharmaceuticalProcessingPage.js
@@ -381,6 +381,10 @@ function PharmaceuticalProcessingPage({
     const selectedReagentItems = reagents.filter((reagent) =>
       bulkPrepareValues.selectedReagents.includes(reagent.id),
     );
+    if (reagents.length > 0 && selectedReagentItems.length === 0) {
+      setError("Select at least one reagent before preparing samples.");
+      return;
+    }
     const invalidReagentItems = getInvalidReagentUsageItems(
       selectedReagentItems,
       bulkPrepareValues.reagentQuantities,

--- a/frontend/src/components/notebook/pages/pharma/PharmaceuticalProcessingPage.js
+++ b/frontend/src/components/notebook/pages/pharma/PharmaceuticalProcessingPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useContext } from "react";
 import {
   Grid,
   Column,
@@ -42,6 +42,8 @@ import ReagentUsageSelector, {
   getInvalidReagentUsageItems,
   syncReagentUsageQuantities,
 } from "../../workflow/ReagentUsageSelector";
+import { NotificationContext } from "../../../layout/Layout";
+import { NotificationKinds } from "../../../common/CustomNotification";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -64,6 +66,8 @@ function PharmaceuticalProcessingPage({
 }) {
   const intl = useIntl();
   const componentMounted = useRef(false);
+  const { addNotification, setNotificationVisible } =
+    useContext(NotificationContext);
 
   // State
   const [samples, setSamples] = useState([]);
@@ -120,6 +124,21 @@ function PharmaceuticalProcessingPage({
     { value: "derivatization", label: "Derivatization" },
     { value: "sonication", label: "Sonication" },
   ];
+
+  const notifyError = useCallback(
+    (message) => {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({
+          id: "notification.error",
+          defaultMessage: "Error",
+        }),
+        message,
+      });
+      setNotificationVisible(true);
+    },
+    [addNotification, intl, setNotificationVisible],
+  );
 
   // Load samples and reference data
   useEffect(() => {
@@ -382,7 +401,7 @@ function PharmaceuticalProcessingPage({
       bulkPrepareValues.selectedReagents.includes(reagent.id),
     );
     if (reagents.length > 0 && selectedReagentItems.length === 0) {
-      setError("Select at least one reagent before preparing samples.");
+      notifyError("Select at least one reagent before preparing samples.");
       return;
     }
     const invalidReagentItems = getInvalidReagentUsageItems(
@@ -390,7 +409,7 @@ function PharmaceuticalProcessingPage({
       bulkPrepareValues.reagentQuantities,
     );
     if (invalidReagentItems.length > 0) {
-      setError("Enter a quantity greater than 0 for each selected reagent.");
+      notifyError("Enter a quantity greater than 0 for each selected reagent.");
       return;
     }
 

--- a/frontend/src/components/notebook/pages/pharma/PharmaceuticalProcessingPage.js
+++ b/frontend/src/components/notebook/pages/pharma/PharmaceuticalProcessingPage.js
@@ -37,6 +37,11 @@ import {
   postToOpenElisServerJsonResponse,
 } from "../../../utils/Utils";
 import SampleGrid from "../../workflow/SampleGrid";
+import ReagentUsageSelector, {
+  buildSelectedReagentUsages,
+  getInvalidReagentUsageItems,
+  syncReagentUsageQuantities,
+} from "../../workflow/ReagentUsageSelector";
 import "../../workflow/NotebookWorkflow.css";
 
 /**
@@ -82,6 +87,7 @@ function PharmaceuticalProcessingPage({
     technicianName: "",
     processingDate: new Date().toISOString().slice(0, 10),
     selectedReagents: [],
+    reagentQuantities: {},
     selectedInstruments: [],
     batchNumber: "",
     lotNumber: "",
@@ -331,6 +337,7 @@ function PharmaceuticalProcessingPage({
       technicianName: "",
       processingDate: new Date().toISOString().slice(0, 10),
       selectedReagents: [],
+      reagentQuantities: {},
       selectedInstruments: [],
       batchNumber: "",
       lotNumber: "",
@@ -371,6 +378,18 @@ function PharmaceuticalProcessingPage({
       return;
     }
 
+    const selectedReagentItems = reagents.filter((reagent) =>
+      bulkPrepareValues.selectedReagents.includes(reagent.id),
+    );
+    const invalidReagentItems = getInvalidReagentUsageItems(
+      selectedReagentItems,
+      bulkPrepareValues.reagentQuantities,
+    );
+    if (invalidReagentItems.length > 0) {
+      setError("Enter a quantity greater than 0 for each selected reagent.");
+      return;
+    }
+
     setIsBulkApplying(true);
     setError(null);
 
@@ -389,6 +408,10 @@ function PharmaceuticalProcessingPage({
         technicianName: bulkPrepareValues.technicianName,
         processingDate: bulkPrepareValues.processingDate,
         selectedReagents: bulkPrepareValues.selectedReagents,
+        selectedReagentUsages: buildSelectedReagentUsages(
+          selectedReagentItems,
+          bulkPrepareValues.reagentQuantities,
+        ),
         selectedInstruments: bulkPrepareValues.selectedInstruments,
         batchNumber: bulkPrepareValues.batchNumber,
         lotNumber: bulkPrepareValues.lotNumber,
@@ -1018,25 +1041,36 @@ function PharmaceuticalProcessingPage({
           </Column>
 
           <Column lg={8} md={4} sm={4}>
-            <MultiSelect
-              id="selectedReagents"
+            <ReagentUsageSelector
+              reagents={reagents}
+              selectedIds={bulkPrepareValues.selectedReagents}
+              reagentQuantities={bulkPrepareValues.reagentQuantities}
+              sampleCount={selectedParentIds.length}
+              disabled={loadingReagents}
               titleText={intl.formatMessage({
                 id: "notebook.pharma.reagents",
                 defaultMessage: "Reagents",
               })}
               label="Select reagents..."
-              items={reagents}
-              itemToString={(item) => (item ? item.label : "")}
-              selectedItems={reagents.filter((r) =>
-                bulkPrepareValues.selectedReagents.includes(r.id),
-              )}
-              onChange={({ selectedItems }) =>
+              onSelectionChange={(selectedItems) =>
                 setBulkPrepareValues((prev) => ({
                   ...prev,
-                  selectedReagents: selectedItems.map((i) => i.id),
+                  selectedReagents: selectedItems.map((item) => item.id),
+                  reagentQuantities: syncReagentUsageQuantities(
+                    selectedItems,
+                    prev.reagentQuantities,
+                  ),
                 }))
               }
-              disabled={loadingReagents}
+              onQuantityChange={(reagentId, value) =>
+                setBulkPrepareValues((prev) => ({
+                  ...prev,
+                  reagentQuantities: {
+                    ...prev.reagentQuantities,
+                    [reagentId]: value,
+                  },
+                }))
+              }
             />
           </Column>
 

--- a/frontend/src/components/notebook/pages/pharma/PharmaceuticalTestingPage.js
+++ b/frontend/src/components/notebook/pages/pharma/PharmaceuticalTestingPage.js
@@ -31,6 +31,11 @@ import {
   postToOpenElisServer,
 } from "../../../utils/Utils";
 import SampleGrid from "../../workflow/SampleGrid";
+import ReagentUsageSelector, {
+  buildSelectedReagentUsages,
+  getInvalidReagentUsageItems,
+  syncReagentUsageQuantities,
+} from "../../workflow/ReagentUsageSelector";
 import "../../workflow/NotebookWorkflow.css";
 import {
   ESignatureModal,
@@ -88,6 +93,7 @@ function PharmaceuticalTestingPage({
     performedDate: new Date().toISOString().split("T")[0],
     instrumentsUsed: [],
     reagentsUsed: [],
+    reagentQuantities: {},
     // QC fields
     qcData: {
       positiveControlResult: "",
@@ -439,6 +445,7 @@ function PharmaceuticalTestingPage({
       performedDate: new Date().toISOString().split("T")[0],
       instrumentsUsed: [],
       reagentsUsed: [],
+      reagentQuantities: {},
       qcData: {
         positiveControlResult: "",
         negativeControlResult: "",
@@ -493,6 +500,34 @@ function PharmaceuticalTestingPage({
       return;
     }
 
+    const selectedReagentItems = reagents.filter((reagent) =>
+      testExecutionData.reagentsUsed.includes(reagent.id),
+    );
+    if (reagents.length > 0 && selectedReagentItems.length === 0) {
+      setError(
+        intl.formatMessage({
+          id: "notebook.pharma.testing.reagentsRequired",
+          defaultMessage: "Select at least one reagent before saving.",
+        }),
+      );
+      return;
+    }
+
+    const invalidReagentItems = getInvalidReagentUsageItems(
+      selectedReagentItems,
+      testExecutionData.reagentQuantities,
+    );
+    if (invalidReagentItems.length > 0) {
+      setError(
+        intl.formatMessage({
+          id: "notebook.pharma.testing.reagentQuantityRequired",
+          defaultMessage:
+            "Enter a quantity greater than 0 for each selected reagent.",
+        }),
+      );
+      return;
+    }
+
     // Convert selected IDs to sampleItemIds for the backend API
     const sampleItemIds = selectedIds
       .map((id) => {
@@ -510,6 +545,11 @@ function PharmaceuticalTestingPage({
         performedDate: testExecutionData.performedDate,
         instrumentsUsed: testExecutionData.instrumentsUsed,
         reagentsUsed: testExecutionData.reagentsUsed,
+        selectedReagents: testExecutionData.reagentsUsed,
+        selectedReagentUsages: buildSelectedReagentUsages(
+          selectedReagentItems,
+          testExecutionData.reagentQuantities,
+        ),
         qcData: testExecutionData.qcData,
         hasDeviation: testExecutionData.hasDeviation,
         deviation: testExecutionData.hasDeviation
@@ -1270,8 +1310,12 @@ function PharmaceuticalTestingPage({
             </h5>
             <Grid fullWidth narrow>
               <Column lg={8} md={4} sm={4}>
-                <MultiSelect
-                  id="selectedReagents"
+                <ReagentUsageSelector
+                  reagents={reagents}
+                  selectedIds={testExecutionData.reagentsUsed}
+                  reagentQuantities={testExecutionData.reagentQuantities}
+                  sampleCount={selectedIds.length}
+                  disabled={loadingReagents}
                   titleText={intl.formatMessage({
                     id: "notebook.pharma.testing.reagentsUsed",
                     defaultMessage: "Reagents Used",
@@ -1280,18 +1324,25 @@ function PharmaceuticalTestingPage({
                     id: "notebook.pharma.testing.reagents.placeholder",
                     defaultMessage: "Select reagents...",
                   })}
-                  items={reagents}
-                  itemToString={(item) => (item ? item.label : "")}
-                  selectedItems={reagents.filter((r) =>
-                    testExecutionData.reagentsUsed.includes(r.id),
-                  )}
-                  onChange={({ selectedItems }) =>
-                    setTestExecutionData({
-                      ...testExecutionData,
+                  onSelectionChange={(selectedItems) =>
+                    setTestExecutionData((prev) => ({
+                      ...prev,
                       reagentsUsed: selectedItems.map((r) => r.id),
-                    })
+                      reagentQuantities: syncReagentUsageQuantities(
+                        selectedItems,
+                        prev.reagentQuantities,
+                      ),
+                    }))
                   }
-                  disabled={loadingReagents}
+                  onQuantityChange={(reagentId, quantity) =>
+                    setTestExecutionData((prev) => ({
+                      ...prev,
+                      reagentQuantities: {
+                        ...prev.reagentQuantities,
+                        [reagentId]: quantity,
+                      },
+                    }))
+                  }
                 />
               </Column>
               <Column lg={8} md={4} sm={4}>

--- a/frontend/src/components/notebook/pages/pharma/PharmaceuticalTestingPage.js
+++ b/frontend/src/components/notebook/pages/pharma/PharmaceuticalTestingPage.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useContext } from "react";
 import {
   Grid,
   Column,
@@ -36,6 +36,8 @@ import ReagentUsageSelector, {
   getInvalidReagentUsageItems,
   syncReagentUsageQuantities,
 } from "../../workflow/ReagentUsageSelector";
+import { NotificationContext } from "../../../layout/Layout";
+import { NotificationKinds } from "../../../common/CustomNotification";
 import "../../workflow/NotebookWorkflow.css";
 import {
   ESignatureModal,
@@ -69,6 +71,8 @@ function PharmaceuticalTestingPage({
 }) {
   const componentMounted = useRef(true);
   const intl = useIntl();
+  const { addNotification, setNotificationVisible } =
+    useContext(NotificationContext);
 
   // State
   const [loading, setLoading] = useState(true);
@@ -83,6 +87,21 @@ function PharmaceuticalTestingPage({
   const [loadingInstruments, setLoadingInstruments] = useState(false);
   const [reagents, setReagents] = useState([]);
   const [loadingReagents, setLoadingReagents] = useState(false);
+
+  const notifyError = useCallback(
+    (message) => {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({
+          id: "notification.error",
+          defaultMessage: "Error",
+        }),
+        message,
+      });
+      setNotificationVisible(true);
+    },
+    [addNotification, intl, setNotificationVisible],
+  );
 
   // Test Execution modal state (Phase 1)
   const [showExecutionModal, setShowExecutionModal] = useState(false);
@@ -504,7 +523,7 @@ function PharmaceuticalTestingPage({
       testExecutionData.reagentsUsed.includes(reagent.id),
     );
     if (reagents.length > 0 && selectedReagentItems.length === 0) {
-      setError(
+      notifyError(
         intl.formatMessage({
           id: "notebook.pharma.testing.reagentsRequired",
           defaultMessage: "Select at least one reagent before saving.",
@@ -518,7 +537,7 @@ function PharmaceuticalTestingPage({
       testExecutionData.reagentQuantities,
     );
     if (invalidReagentItems.length > 0) {
-      setError(
+      notifyError(
         intl.formatMessage({
           id: "notebook.pharma.testing.reagentQuantityRequired",
           defaultMessage:

--- a/frontend/src/components/notebook/workflow/ReagentUsageSelector.jsx
+++ b/frontend/src/components/notebook/workflow/ReagentUsageSelector.jsx
@@ -98,48 +98,45 @@ function ReagentUsageSelector({
               Number.isFinite(quantityPerSample) && sampleCount > 0
                 ? quantityPerSample * sampleCount
                 : null;
-            const helperParts = [];
-            if (item.lotNumber) {
-              helperParts.push(
-                intl.formatMessage(
+            const lotText = item.lotNumber
+              ? intl.formatMessage(
                   {
                     id: "notebook.reagentUsage.lot",
                     defaultMessage: "FEFO lot shown: {lot}",
                   },
                   { lot: item.lotNumber },
-                ),
-              );
-            }
-            if (item.currentQuantity !== undefined && item.currentQuantity !== null) {
-              helperParts.push(
-                intl.formatMessage(
-                  {
-                    id: "notebook.reagentUsage.available",
-                    defaultMessage: "Available: {quantity} {units}",
-                  },
-                  {
-                    quantity: item.currentQuantity,
-                    units: item.units || "",
-                  },
-                ),
-              );
-            }
-            if (totalQuantity !== null) {
-              helperParts.push(
-                intl.formatMessage(
-                  {
-                    id: "notebook.reagentUsage.totalDeduction",
-                    defaultMessage:
-                      "Total deduction for {count} sample(s): {total} {units}",
-                  },
-                  {
-                    count: sampleCount,
-                    total: totalQuantity,
-                    units: item.units || "",
-                  },
-                ),
-              );
-            }
+                )
+              : null;
+            const availableText =
+              item.currentQuantity !== undefined && item.currentQuantity !== null
+                ? intl.formatMessage(
+                    {
+                      id: "notebook.reagentUsage.available",
+                      defaultMessage: "Available stock: {quantity} {units}",
+                    },
+                    {
+                      quantity: item.currentQuantity,
+                      units: item.units || "",
+                    },
+                  )
+                : null;
+            const totalDeductionText =
+              totalQuantity !== null
+                ? intl.formatMessage(
+                    {
+                      id: "notebook.reagentUsage.totalDeduction",
+                      defaultMessage:
+                        "Total deduction for {count} sample(s): {total}",
+                    },
+                    {
+                      count: sampleCount,
+                      total: totalQuantity,
+                    },
+                  )
+                : intl.formatMessage({
+                    id: "notebook.reagentUsage.totalDeductionPending",
+                    defaultMessage: "Enter quantity to calculate total deduction",
+                  });
 
             return (
               <div
@@ -153,6 +150,19 @@ function ReagentUsageSelector({
               >
                 <div style={{ marginBottom: "0.5rem", fontWeight: 600 }}>
                   {item.label || item.name}
+                </div>
+                <div
+                  style={{
+                    marginBottom: "0.5rem",
+                    fontSize: "0.875rem",
+                    color: "#525252",
+                    display: "grid",
+                    gap: "0.25rem",
+                  }}
+                >
+                  {lotText && <div>{lotText}</div>}
+                  {availableText && <div>{availableText}</div>}
+                  <div style={{ fontWeight: 600 }}>{totalDeductionText}</div>
                 </div>
                 <TextInput
                   id={`reagent-quantity-${item.id}`}
@@ -175,7 +185,6 @@ function ReagentUsageSelector({
                     id: "notebook.reagentUsage.quantityInvalid",
                     defaultMessage: "Enter a number greater than 0",
                   })}
-                  helperText={helperParts.join(" | ")}
                 />
               </div>
             );

--- a/frontend/src/components/notebook/workflow/ReagentUsageSelector.jsx
+++ b/frontend/src/components/notebook/workflow/ReagentUsageSelector.jsx
@@ -1,0 +1,189 @@
+import React from "react";
+import { MultiSelect, TextInput } from "@carbon/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+export const syncReagentUsageQuantities = (
+  selectedItems,
+  currentQuantities = {},
+  defaultValue = "1",
+) => {
+  const nextQuantities = {};
+  selectedItems.forEach((item) => {
+    const key = String(item.id);
+    nextQuantities[key] =
+      currentQuantities[key] !== undefined ? currentQuantities[key] : defaultValue;
+  });
+  return nextQuantities;
+};
+
+export const buildSelectedReagentUsages = (
+  selectedItems,
+  reagentQuantities = {},
+) =>
+  selectedItems
+    .map((item) => {
+      const quantityValue = reagentQuantities[String(item.id)];
+      const quantityPerSample = Number.parseFloat(quantityValue);
+      if (!Number.isFinite(quantityPerSample) || quantityPerSample <= 0) {
+        return null;
+      }
+
+      return {
+        itemId: item.itemId ?? item.id,
+        quantityPerSample,
+        name: item.name ?? item.label ?? item.text ?? "",
+        lotNumber: item.lotNumber ?? "",
+        units: item.units ?? "",
+      };
+    })
+    .filter(Boolean);
+
+export const getInvalidReagentUsageItems = (
+  selectedItems,
+  reagentQuantities = {},
+) =>
+  selectedItems.filter((item) => {
+    const quantityValue = reagentQuantities[String(item.id)];
+    const quantityPerSample = Number.parseFloat(quantityValue);
+    return !Number.isFinite(quantityPerSample) || quantityPerSample <= 0;
+  });
+
+function ReagentUsageSelector({
+  reagents,
+  selectedIds,
+  reagentQuantities,
+  sampleCount = 0,
+  disabled = false,
+  titleText,
+  label,
+  onSelectionChange,
+  onQuantityChange,
+}) {
+  const intl = useIntl();
+  const selectedItems = reagents.filter((item) => selectedIds.includes(item.id));
+
+  return (
+    <div>
+      <MultiSelect
+        id="selectedReagents"
+        titleText={titleText}
+        label={label}
+        items={reagents}
+        itemToString={(item) => (item ? item.label || item.name || "" : "")}
+        selectedItems={selectedItems}
+        onChange={({ selectedItems: nextSelectedItems }) =>
+          onSelectionChange(nextSelectedItems)
+        }
+        disabled={disabled}
+      />
+
+      {selectedItems.length > 0 && (
+        <div style={{ marginTop: "1rem" }}>
+          <p
+            style={{
+              marginBottom: "0.75rem",
+              fontWeight: 600,
+            }}
+          >
+            <FormattedMessage
+              id="notebook.reagentUsage.sectionTitle"
+              defaultMessage="Reagent usage"
+            />
+          </p>
+
+          {selectedItems.map((item) => {
+            const quantityValue = reagentQuantities[String(item.id)] ?? "";
+            const quantityPerSample = Number.parseFloat(quantityValue);
+            const totalQuantity =
+              Number.isFinite(quantityPerSample) && sampleCount > 0
+                ? quantityPerSample * sampleCount
+                : null;
+            const helperParts = [];
+            if (item.lotNumber) {
+              helperParts.push(
+                intl.formatMessage(
+                  {
+                    id: "notebook.reagentUsage.lot",
+                    defaultMessage: "FEFO lot shown: {lot}",
+                  },
+                  { lot: item.lotNumber },
+                ),
+              );
+            }
+            if (item.currentQuantity !== undefined && item.currentQuantity !== null) {
+              helperParts.push(
+                intl.formatMessage(
+                  {
+                    id: "notebook.reagentUsage.available",
+                    defaultMessage: "Available: {quantity} {units}",
+                  },
+                  {
+                    quantity: item.currentQuantity,
+                    units: item.units || "",
+                  },
+                ),
+              );
+            }
+            if (totalQuantity !== null) {
+              helperParts.push(
+                intl.formatMessage(
+                  {
+                    id: "notebook.reagentUsage.totalDeduction",
+                    defaultMessage:
+                      "Total deduction for {count} sample(s): {total} {units}",
+                  },
+                  {
+                    count: sampleCount,
+                    total: totalQuantity,
+                    units: item.units || "",
+                  },
+                ),
+              );
+            }
+
+            return (
+              <div
+                key={item.id}
+                style={{
+                  marginBottom: "0.75rem",
+                  padding: "0.75rem",
+                  border: "1px solid #e0e0e0",
+                  borderRadius: "4px",
+                }}
+              >
+                <div style={{ marginBottom: "0.5rem", fontWeight: 600 }}>
+                  {item.label || item.name}
+                </div>
+                <TextInput
+                  id={`reagent-quantity-${item.id}`}
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  labelText={intl.formatMessage({
+                    id: "notebook.reagentUsage.quantityPerSample",
+                    defaultMessage: "Quantity used per sample",
+                  })}
+                  value={quantityValue}
+                  onChange={(event) =>
+                    onQuantityChange(String(item.id), event.target.value)
+                  }
+                  invalid={
+                    quantityValue !== "" &&
+                    (!Number.isFinite(quantityPerSample) || quantityPerSample <= 0)
+                  }
+                  invalidText={intl.formatMessage({
+                    id: "notebook.reagentUsage.quantityInvalid",
+                    defaultMessage: "Enter a number greater than 0",
+                  })}
+                  helperText={helperParts.join(" | ")}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ReagentUsageSelector;

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryReagentRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryReagentRestController.java
@@ -68,6 +68,7 @@ public class InventoryReagentRestController extends BaseRestController {
                 dto.setManufacturer(item.getManufacturer());
                 dto.setCategory(item.getCategory());
                 dto.setStorageRequirements(item.getStorageRequirements());
+                dto.setUnits(item.getUnits());
 
                 if (!lots.isEmpty()) {
                     // Use the first lot (FEFO - earliest expiring) for display
@@ -173,6 +174,7 @@ public class InventoryReagentRestController extends BaseRestController {
         private String manufacturer;
         private String category;
         private String storageRequirements;
+        private String units;
         private String lotNumber;
         private String expirationDate;
         private Double currentQuantity;

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryReagentRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryReagentRestController.java
@@ -59,6 +59,9 @@ public class InventoryReagentRestController extends BaseRestController {
             // For each reagent item, get available lots and aggregate info
             for (InventoryItem item : reagentItems) {
                 List<InventoryLot> lots = inventoryLotService.getAvailableLotsByItemFEFO(item.getId());
+                if ("active".equalsIgnoreCase(status) && lots.isEmpty()) {
+                    continue;
+                }
 
                 ReagentDTO dto = new ReagentDTO();
                 dto.setId(String.valueOf(item.getId()));
@@ -122,6 +125,9 @@ public class InventoryReagentRestController extends BaseRestController {
             // For each cartridge item, get available lots and aggregate info
             for (InventoryItem item : cartridgeItems) {
                 List<InventoryLot> lots = inventoryLotService.getAvailableLotsByItemFEFO(item.getId());
+                if ("active".equalsIgnoreCase(status) && lots.isEmpty()) {
+                    continue;
+                }
 
                 InstrumentDTO dto = new InstrumentDTO();
                 dto.setId(String.valueOf(item.getId()));

--- a/src/main/java/org/openelisglobal/notebook/service/NotebookBulkOperationServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NotebookBulkOperationServiceImpl.java
@@ -235,18 +235,16 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
             NotebookPageSample nps = notebookPageSampleService.getByPageIdAndSampleItemId(pageId, sampleId);
             if (nps != null) {
                 Map<String, Object> existingData = nps.getData();
-                // Sample needs reagents if it has no data or no selectedReagents key,
-                // or if selectedReagents is an empty list
                 if (existingData == null) {
                     count++;
                 } else {
-                    Object selectedReagents = existingData.get("selectedReagents");
-                    if (selectedReagents == null) {
-                        count++;
-                    } else if (selectedReagents instanceof List && ((List<?>) selectedReagents).isEmpty()) {
-                        count++;
-                    } else {
+                    boolean hasSelectedReagents = hasNonEmptyList(existingData.get("selectedReagents"));
+                    boolean hasSelectedReagentUsages = hasNonEmptyList(existingData.get("selectedReagentUsages"));
+
+                    if (hasSelectedReagents || hasSelectedReagentUsages) {
                         samplesWithReagents++;
+                    } else {
+                        count++;
                     }
                 }
             } else {
@@ -261,19 +259,31 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
         return count;
     }
 
+    private boolean hasNonEmptyList(Object value) {
+        return value instanceof List && !((List<?>) value).isEmpty();
+    }
+
     /**
-     * Consume reagents from inventory when they are applied to samples. Each
-     * reagent is consumed once per sample being processed.
+     * Consume reagents from inventory when they are applied to samples.
      *
-     * @param data        the data map containing selectedReagents list
+     * <p>
+     * If the caller provides {@code selectedReagentUsages}, those explicit
+     * per-sample quantities are used. Otherwise the legacy behavior of consuming
+     * one unit per sample for each selected reagent is preserved.
+     *
+     * @param data        the data map containing selected reagents and optional
+     *                    per-sample quantities
      * @param sampleCount number of samples being processed
      * @param userId      user performing the operation
      */
     @SuppressWarnings("unchecked")
     private void consumeReagentsFromInventory(Map<String, Object> data, int sampleCount, String userId) {
         LogEvent.logInfo(this.getClass().getName(), "consumeReagentsFromInventory",
-                "Starting inventory consumption for " + sampleCount + " samples. Data keys: " + data.keySet()
-                        + ". NOTE: Each reagent will consume " + sampleCount + " units (1 per sample).");
+                "Starting inventory consumption for " + sampleCount + " samples. Data keys: " + data.keySet());
+
+        if (consumeExplicitReagentUsages(data, sampleCount, userId)) {
+            return;
+        }
 
         // Check for selected reagents in the data
         Object selectedReagentsObj = data.get("selectedReagents");
@@ -326,25 +336,8 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
                     continue;
                 }
 
-                LogEvent.logInfo(this.getClass().getName(), "consumeReagentsFromInventory",
-                        "Processing reagent itemId: " + itemId + ", quantity: " + totalQuantity);
-
-                // Check if sufficient inventory is available
-                if (inventoryManagementService.isSufficientInventoryAvailable(itemId, totalQuantity)) {
-                    // Consume inventory using FEFO (First Expired, First Out)
-                    inventoryManagementService.consumeInventoryFEFO(itemId, totalQuantity, null, // testResultId - not
-                                                                                                 // applicable for
-                                                                                                 // sample preparation
-                            null, // analysisId - not applicable for sample preparation
-                            userId);
-
-                    LogEvent.logInfo(this.getClass().getName(), "consumeReagentsFromInventory", "Successfully consumed "
-                            + totalQuantity + " units of reagent ID " + itemId + " for " + sampleCount + " samples");
-                } else {
-                    LogEvent.logWarn(this.getClass().getName(), "consumeReagentsFromInventory",
-                            "Insufficient inventory for reagent ID " + itemId + " - needed " + totalQuantity
-                                    + " units");
-                }
+                consumeInventoryOrThrow(itemId, totalQuantity, userId,
+                        "for " + sampleCount + " sample(s) using legacy per-sample quantity");
             } catch (NumberFormatException e) {
                 LogEvent.logWarn(this.getClass().getName(), "consumeReagentsFromInventory",
                         "Invalid reagent ID format: " + reagentIdObj + " - " + e.getMessage());
@@ -354,6 +347,80 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
                 e.printStackTrace();
             }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean consumeExplicitReagentUsages(Map<String, Object> data, int sampleCount, String userId) {
+        Object selectedReagentUsagesObj = data.get("selectedReagentUsages");
+        if (!(selectedReagentUsagesObj instanceof List<?> rawUsages) || rawUsages.isEmpty()) {
+            return false;
+        }
+
+        LogEvent.logInfo(this.getClass().getName(), "consumeReagentsFromInventory",
+                "Using explicit selectedReagentUsages payload for " + rawUsages.size() + " reagent(s)");
+
+        for (Object usageObj : rawUsages) {
+            if (!(usageObj instanceof Map<?, ?> usageMap)) {
+                LogEvent.logWarn(this.getClass().getName(), "consumeReagentsFromInventory",
+                        "Skipping unsupported reagent usage payload entry: " + usageObj);
+                continue;
+            }
+
+            Long itemId = parseLongValue(usageMap.get("itemId"));
+            Double quantityPerSample = parseDoubleValue(usageMap.get("quantityPerSample"));
+            if (itemId == null || quantityPerSample == null || quantityPerSample <= 0) {
+                throw new IllegalArgumentException("Invalid reagent usage payload: " + usageMap);
+            }
+
+            double totalQuantity = quantityPerSample * sampleCount;
+            consumeInventoryOrThrow(itemId, totalQuantity, userId,
+                    "using explicit quantity " + quantityPerSample + " per sample");
+        }
+
+        return true;
+    }
+
+    private void consumeInventoryOrThrow(Long itemId, double totalQuantity, String userId, String context) {
+        LogEvent.logInfo(this.getClass().getName(), "consumeReagentsFromInventory",
+                "Processing reagent itemId: " + itemId + ", quantity: " + totalQuantity + " " + context);
+
+        if (!inventoryManagementService.isSufficientInventoryAvailable(itemId, totalQuantity)) {
+            throw new IllegalStateException(
+                    "Insufficient inventory for reagent ID " + itemId + ". Needed: " + totalQuantity);
+        }
+
+        inventoryManagementService.consumeInventoryFEFO(itemId, totalQuantity, null, null, userId);
+
+        LogEvent.logInfo(this.getClass().getName(), "consumeReagentsFromInventory",
+                "Successfully consumed " + totalQuantity + " units of reagent ID " + itemId + " " + context);
+    }
+
+    private Long parseLongValue(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            try {
+                return Long.valueOf(stringValue);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Double parseDoubleValue(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            try {
+                return Double.valueOf(stringValue);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/notebook/service/NotebookPageSampleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NotebookPageSampleServiceImpl.java
@@ -199,14 +199,19 @@ public class NotebookPageSampleServiceImpl extends AuditableBaseObjectServiceImp
                 // Check if this is a routing page or storage page
                 boolean isRoutingPage = noteBookService.isRoutingPage(pageId);
                 boolean isStoragePage = noteBookService.isStoragePage(pageId);
+                boolean shouldSkipStoragePageToArchiving = isStoragePage
+                        && nextPage != null
+                        && nextPage.getTitle() != null
+                        && nextPage.getTitle().toLowerCase().contains("report");
                 LogEvent.logInfo(this.getClass().getName(), "bulkUpdateStatus", "T150: pageId=" + pageId
-                        + " isRoutingPage=" + isRoutingPage + " isStoragePage=" + isStoragePage);
+                        + " isRoutingPage=" + isRoutingPage + " isStoragePage=" + isStoragePage
+                        + " shouldSkipStoragePageToArchiving=" + shouldSkipStoragePageToArchiving);
                 NoteBookPage archivingPage = null;
                 Integer notebookId = null;
 
                 // For both routing pages and storage pages, we need the archiving page
                 // Always ensure page is loaded for routing/storage pages
-                if (isRoutingPage || isStoragePage) {
+                if (isRoutingPage || shouldSkipStoragePageToArchiving) {
                     if (page == null) {
                         page = noteBookService.getPage(pageId);
                     }
@@ -255,7 +260,7 @@ public class NotebookPageSampleServiceImpl extends AuditableBaseObjectServiceImp
 
                     // For storage pages, always skip to archiving page (Disposal & Archiving)
                     // Storage samples skip the Reporting page
-                    if (isStoragePage && archivingPage != null) {
+                    if (shouldSkipStoragePageToArchiving && archivingPage != null) {
                         targetPage = archivingPage;
                         LogEvent.logInfo(this.getClass().getName(), "bulkUpdateStatus",
                                 "Sample " + sampleId + " on storage page, skipping to archiving page");


### PR DESCRIPTION
## Summary
- require reagent selection and per-sample quantity entry on the updated workflow pages
- align pharmaceutical testing with the shared reagent usage and deduction flow
- hide active reagents and instruments that do not have available lots
- fix MNTD temporary storage completion so samples move to processing instead of skipping ahead
- clean up reagent usage display so total deduction is shown clearly

## Testing
- built frontend and backend locally
- verified localhost startup
- tested reagent usage flow in MNTD, Immunology, and Pharmaceuticals
- verified MNTD temporary storage now advances fresh samples to Sample Processing Preparation
- verified invalid no-lot reagents are filtered from active workflow selection