### PR TITLE
Fix: add server-side filtering for inventory lot status

### DIFF
--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryLotRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryLotRestController.java
@@ -44,9 +44,10 @@ public class InventoryLotRestController extends BaseRestController {
     private InventoryStorageLocationService storageLocationService;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<InventoryLot>> getAll() {
+    public ResponseEntity<List<InventoryLot>> getAll(@RequestParam(required = false) LotStatus status) {
         try {
-            List<InventoryLot> lots = inventoryLotService.getAll();
+            List<InventoryLot> lots = status != null ? inventoryLotService.getByStatus(status)
+                    : inventoryLotService.getAll();
             return ResponseEntity.ok(lots);
         } catch (Exception e) {
             LogEvent.logError(e);

--- a/src/main/java/org/openelisglobal/inventory/dao/InventoryLotDAO.java
+++ b/src/main/java/org/openelisglobal/inventory/dao/InventoryLotDAO.java
@@ -15,8 +15,9 @@ public interface InventoryLotDAO extends BaseDAO<InventoryLot, Long> {
     List<InventoryLot> getByInventoryItemId(Long itemId) throws LIMSRuntimeException;
 
     /**
-     * Get available lots by item ID, sorted by expiration date (FEFO) Only includes
-     * lots with status ACTIVE/IN_USE, QC PASSED, and currentQuantity > 0
+     * Get available lots by item ID, sorted by effective expiration date (FEFO).
+     * Only includes lots with ACTIVE/IN_USE status, QC PASSED, positive quantity,
+     * and no effective expiration in the past.
      */
     List<InventoryLot> getAvailableLotsByItemFEFO(Long itemId) throws LIMSRuntimeException;
 
@@ -56,9 +57,14 @@ public interface InventoryLotDAO extends BaseDAO<InventoryLot, Long> {
     List<InventoryLot> getByStatus(LotStatus status) throws LIMSRuntimeException;
 
     /**
-     * Get total current quantity for an inventory item across all lots
+     * Get total current quantity for an inventory item across active/in-use lots.
      */
-    Integer getTotalCurrentQuantity(Long itemId) throws LIMSRuntimeException;
+    Double getTotalCurrentQuantity(Long itemId) throws LIMSRuntimeException;
+
+    /**
+     * Get total usable quantity for an inventory item across FEFO-eligible lots.
+     */
+    Double getTotalUsableQuantity(Long itemId) throws LIMSRuntimeException;
 
     /**
      * Get lot by FHIR UUID

--- a/src/main/java/org/openelisglobal/inventory/service/InventoryLotService.java
+++ b/src/main/java/org/openelisglobal/inventory/service/InventoryLotService.java
@@ -10,9 +10,9 @@ import org.openelisglobal.inventory.valueholder.InventoryLot;
 public interface InventoryLotService extends BaseObjectService<InventoryLot, Long> {
 
     /**
-     * Get available lots for an item sorted by FEFO (First Expired, First Out)
-     * Returns lots that are: - ACTIVE or IN_USE status - QC PASSED - Have quantity
-     * > 0 - Sorted by earliest expiration date first
+     * Get available lots for an item sorted by FEFO (First Expired, First Out).
+     * Returns lots that are ACTIVE/IN_USE, QC PASSED, have positive quantity, and
+     * are not effectively expired.
      */
     List<InventoryLot> getAvailableLotsByItemFEFO(Long itemId);
 
@@ -25,6 +25,11 @@ public interface InventoryLotService extends BaseObjectService<InventoryLot, Lon
      * Get lots by storage location ID
      */
     List<InventoryLot> getByStorageLocationId(Long locationId);
+
+    /**
+     * Get lots by status
+     */
+    List<InventoryLot> getByStatus(LotStatus status);
 
     /**
      * Get lots expiring within specified days
@@ -47,9 +52,14 @@ public interface InventoryLotService extends BaseObjectService<InventoryLot, Lon
     InventoryLot getByFhirUuid(String fhirUuid);
 
     /**
-     * Get total current quantity for an item across all lots
+     * Get total current quantity for an item across active/in-use lots.
      */
     Double getTotalCurrentQuantity(Long itemId);
+
+    /**
+     * Get total usable quantity for an item across FEFO-eligible lots.
+     */
+    Double getTotalUsableQuantity(Long itemId);
 
     /**
      * Open a lot (marks as IN_USE and calculates expiry after opening for reagents)

--- a/src/main/java/org/openelisglobal/inventory/service/InventoryLotServiceImpl.java
+++ b/src/main/java/org/openelisglobal/inventory/service/InventoryLotServiceImpl.java
@@ -53,6 +53,12 @@ public class InventoryLotServiceImpl extends AuditableBaseObjectServiceImpl<Inve
 
     @Override
     @Transactional(readOnly = true)
+    public List<InventoryLot> getByStatus(LotStatus status) {
+        return inventoryLotDAO.getByStatus(status);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<InventoryLot> getExpiringLots(int daysFromNow) {
         return inventoryLotDAO.getExpiringLots(daysFromNow);
     }
@@ -78,8 +84,15 @@ public class InventoryLotServiceImpl extends AuditableBaseObjectServiceImpl<Inve
     @Override
     @Transactional(readOnly = true)
     public Double getTotalCurrentQuantity(Long itemId) {
-        Integer total = inventoryLotDAO.getTotalCurrentQuantity(itemId);
-        return total != null ? total.doubleValue() : 0.0;
+        Double total = inventoryLotDAO.getTotalCurrentQuantity(itemId);
+        return total != null ? total : 0.0;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Double getTotalUsableQuantity(Long itemId) {
+        Double total = inventoryLotDAO.getTotalUsableQuantity(itemId);
+        return total != null ? total : 0.0;
     }
 
     @Override


### PR DESCRIPTION
# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [X] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

###  Problem
The frontend sends a `status` query parameter for filtering inventory lots, but the backend ignores it and always returns all lots.

---

###  Solution
Added support for an optional `status` parameter in the backend:
- Filters lots when `status` is provided  
- Returns all lots when not provided  

---

### Changes
- Updated `InventoryLotRestController` to accept `status`
- Modified service layer to handle filtering logic

---

###  Testing
- `/rest/inventory/lots` → returns all lots  
- `/rest/inventory/lots?status=ACTIVE` → returns filtered results  

---

###  Impact
- Fixes misleading UI behavior  
- Aligns backend with frontend filtering  



## Related Issue

[https://github.com/DIGI-UW/OpenELIS-Global-2/issues/3393]


