### PR TITLE
ci: update GitHub Actions to support Node.js 24 (#3277)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Checkout OpenELIS-Global2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{github.repository}}
           submodules: recursive

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
       - name: Checkout OpenELIS-Global2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{github.repository}}
           submodules: recursive

--- a/.github/workflows/catalyst-ci.yml
+++ b/.github/workflows/catalyst-ci.yml
@@ -28,7 +28,7 @@ jobs:
             display: MCP
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-uv-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: projects/catalyst/${{ matrix.project }}/.venv
           key: venv-${{ runner.os }}-${{ matrix.project }}-${{ hashFiles('projects/catalyst/${{ matrix.project }}/uv.lock') }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pytest-results-${{ matrix.project }}
           path: projects/catalyst/${{ matrix.project }}/.pytest_cache

--- a/.github/workflows/e2e-cache-cleanup.yml
+++ b/.github/workflows/e2e-cache-cleanup.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Delete old GHCR e2e-cache package versions
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/e2e-cypress-deprecated.yml
+++ b/.github/workflows/e2e-cypress-deprecated.yml
@@ -97,7 +97,7 @@ jobs:
             specs: ""
     steps:
       - name: Checkout OpenELIS-Global2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.head_sha || github.sha }}
           repository: ${{github.repository}}
@@ -105,7 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -125,7 +125,7 @@ jobs:
 
       - name: Download image map from build workflow (non-fork)
         if: inputs.is_fork != 'true' && inputs.build_run_id != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-image-map-base
           path: /tmp/e2e-image-map
@@ -134,7 +134,7 @@ jobs:
 
       - name: Download image map from fork-rebuild (fork)
         if: inputs.is_fork == 'true' || inputs.build_run_id == ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-image-map-base
           path: /tmp/e2e-image-map
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload Cypress screenshots (${{ matrix.shard }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cypress-screenshots-${{ matrix.shard }}
           path: frontend/cypress/screenshots/**/*.png

--- a/.github/workflows/e2e-playwright-reusable.yml
+++ b/.github/workflows/e2e-playwright-reusable.yml
@@ -73,7 +73,7 @@ jobs:
         shard_index: [1, 2]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
           submodules: recursive
@@ -89,7 +89,7 @@ jobs:
           sudo swapon /swapfile 2>/dev/null || true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -100,7 +100,7 @@ jobs:
         working-directory: frontend
 
       - name: Restore Playwright browser cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Download image map (cross-run)
         if: inputs.artifact_source_mode == 'cross_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.setup_analyzer_harness && 'e2e-image-map' || 'e2e-image-map-base' }}
           path: /tmp/e2e-image-map
@@ -127,14 +127,14 @@ jobs:
 
       - name: Download image map (same-run)
         if: inputs.artifact_source_mode == 'same_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.setup_analyzer_harness && 'e2e-image-map' || 'e2e-image-map-base' }}
           path: /tmp/e2e-image-map
 
       - name: Download plugin jars (cross-run)
         if: inputs.setup_analyzer_harness && inputs.artifact_source_mode == 'cross_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-plugin-jars
           path: /tmp/e2e-plugin-jars
@@ -143,7 +143,7 @@ jobs:
 
       - name: Download plugin jars (same-run)
         if: inputs.setup_analyzer_harness && inputs.artifact_source_mode == 'same_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-plugin-jars
           path: /tmp/e2e-plugin-jars
@@ -325,7 +325,7 @@ jobs:
 
       - name: Upload blob report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_prefix }}-blob-report-${{ matrix.shard_index }}
           path: frontend/blob-report
@@ -334,7 +334,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_prefix }}-screenshots-${{ matrix.shard_index }}
           path: frontend/test-results/**/test-failed-*.png
@@ -343,7 +343,7 @@ jobs:
 
       - name: Upload test traces
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_prefix }}-traces-${{ matrix.shard_index }}
           path: frontend/test-results/**/trace.zip
@@ -381,19 +381,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 
       - name: Download blob reports from shards
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: frontend/all-blob-reports
           pattern: ${{ inputs.artifact_prefix }}-blob-report-*
@@ -426,7 +426,7 @@ jobs:
 
       - name: Upload merged HTML report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_prefix }}-playwright-report-html-attempt-${{ github.run_attempt }}
           path: frontend/playwright-report/

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -31,20 +31,20 @@ jobs:
       image_transfer: ${{ steps.transfer-mode.outputs.mode }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
           cache: maven
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -108,7 +108,7 @@ jobs:
           echo "Early context: event=${{ github.event_name }} fork=$IS_FORK pr=#$PR_NUMBER"
 
       - name: Upload early build context
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-build-context-core
           path: /tmp/e2e-build-context-core/
@@ -254,7 +254,7 @@ jobs:
 
       - name: Upload transfer state for E2E wrapper workflow
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-build-transfer-state
           path: /tmp/e2e-transfer-state/
@@ -262,7 +262,7 @@ jobs:
 
       - name: Upload fork image handoff artifact
         if: steps.transfer-mode.outputs.mode == 'fork-handoff'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-image-handoff
           path: /tmp/e2e-image-handoff/
@@ -270,7 +270,7 @@ jobs:
 
       - name: Upload plugin jars artifact
         if: steps.transfer-mode.outputs.mode == 'ghcr' || steps.transfer-mode.outputs.mode == 'fork-handoff'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-plugin-jars
           path: volume/plugins/*.jar
@@ -279,7 +279,7 @@ jobs:
 
       - name: Upload Docker image map artifact
         if: steps.transfer-mode.outputs.mode == 'ghcr'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-image-map
           path: /tmp/e2e-image-map.txt
@@ -288,7 +288,7 @@ jobs:
 
       - name: Upload base Docker image map artifact
         if: steps.transfer-mode.outputs.mode == 'ghcr'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-image-map-base
           path: /tmp/e2e-image-map-base.txt

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Download early build context artifact
         id: download_context
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-build-context-core
           path: /tmp/e2e-build-context
@@ -50,7 +50,7 @@ jobs:
 
       - name: Download transfer-state artifact
         id: download_transfer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-build-transfer-state
           path: /tmp/e2e-transfer-state
@@ -129,7 +129,7 @@ jobs:
       statuses: write
     steps:
       - name: Post checkpoint status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const sha = '${{ needs.setup.outputs.status_sha }}';
@@ -160,7 +160,7 @@ jobs:
       actions: read
     steps:
       - name: Download fork image handoff from build workflow
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-image-handoff
           path: /tmp/e2e-image-handoff
@@ -168,7 +168,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download plugin jars from build workflow
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-plugin-jars
           path: /tmp/e2e-plugin-jars
@@ -238,7 +238,7 @@ jobs:
           cat /tmp/e2e-image-map.txt
 
       - name: Upload plugin jars artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-plugin-jars
           path: /tmp/e2e-plugin-jars/*.jar
@@ -246,7 +246,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Docker image map artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-image-map
           path: /tmp/e2e-image-map.txt
@@ -254,7 +254,7 @@ jobs:
           retention-days: 1
 
       - name: Upload base Docker image map artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-image-map-base
           path: /tmp/e2e-image-map-base.txt
@@ -371,7 +371,7 @@ jobs:
       statuses: write
     steps:
       - name: Update checkpoint status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const sha = '${{ needs.setup.outputs.status_sha }}';

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout OpenELIS-Global2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -10,7 +10,7 @@ jobs:
     name: Duplicate key check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check for duplicate i18n keys
         run: |
@@ -34,7 +34,7 @@ jobs:
     if: github.head_ref != 'chore/update-transifex'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-dev-backend-images.yml
+++ b/.github/workflows/publish-dev-backend-images.yml
@@ -34,7 +34,7 @@ jobs:
           platform=linux/${{ matrix.platform }}
           echo "PLATFORM_PAIR_BACKEND=${platform//\//-}" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
         # Add support for more platforms with QEMU (optional)
@@ -74,7 +74,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/backend/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR_BACKEND }}-backend
           path: /tmp/digests/backend/*
@@ -88,7 +88,7 @@ jobs:
       - build-and-push-image-backend-dev
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: /tmp/digests/backend
           pattern: digests-*

--- a/.github/workflows/publish-dev-frontend-images.yml
+++ b/.github/workflows/publish-dev-frontend-images.yml
@@ -35,7 +35,7 @@ jobs:
           echo "PLATFORM_PAIR_FRONTEND=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
         # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
@@ -76,7 +76,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/frontend/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR_FRONTEND }}-frontend
           path: /tmp/digests/frontend/*
@@ -90,7 +90,7 @@ jobs:
       - build-and-push-image-frontend-dev
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: /tmp/digests/frontend
           pattern: digests-*

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -55,7 +55,7 @@ jobs:
       statuses: read
     steps:
       - name: Wait for E2E checkpoint success
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -118,7 +118,7 @@ jobs:
             dockerhub_suffix: database
     steps:
       - name: Download image map from triggering build workflow
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-image-map
           path: /tmp/e2e-image-map

--- a/.github/workflows/speckit-validate.yml
+++ b/.github/workflows/speckit-validate.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tx-pull.yml
+++ b/.github/workflows/tx-pull.yml
@@ -20,7 +20,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/tx-push.yml
+++ b/.github/workflows/tx-push.yml
@@ -15,7 +15,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Push source file using transifex client
         uses: transifex/cli-action@v2
         with:


### PR DESCRIPTION
## Summary

Updates all GitHub Actions workflow files to use versions that support 
Node.js 24, resolving deprecation warnings that will become CI failures 
after June 2, 2026.

### Changes
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `actions/setup-java@v4` → `@v5`
- `actions/cache@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v6`
- `actions/download-artifact@v4` → `@v5`
- `actions/github-script@v7` → `@v8`

Fixes #3277

### Affected Workflows
- `backend.yml`
- `frontend.yml`
- `e2e-tests.yml`
- `e2e-playwright.yml`
- `e2e-playwright-reusable.yml`
- `e2e-cypress-deprecated.yml`
- `catalyst-ci.yml`
- `publish-dev-backend-images.yml`
- `publish-dev-frontend-images.yml`
- `publish-images.yml`
- `i18n-check.yml`
- `speckit-validate.yml`
- `tx-pull.yml`, `tx-push.yml`

## Screenshots
N/A — CI/workflow-only change, no UI changes.