### PR TITLE
feat(biorepository): support intake-only legacy manifest imports

### DIFF
--- a/frontend/src/components/notebook/pages/biorepository/BiorepositoryIntakePage.js
+++ b/frontend/src/components/notebook/pages/biorepository/BiorepositoryIntakePage.js
@@ -41,6 +41,9 @@ import ManifestUploadModal from "./ManifestUploadModal";
 import SampleTransferTab from "./SampleTransferTab";
 import RetentionPolicySection from "./RetentionPolicySection";
 
+const INVENTORY_SAMPLE_FETCH_LIMIT = 5000;
+const SHIPMENT_SAMPLE_FETCH_LIMIT = 5000;
+
 /**
  * BiorepositoryIntakePage - Sample Intake & Registration workflow page
  * Stage 1 of the Biorepository workflow with 5 sub-stages:
@@ -167,8 +170,7 @@ function BiorepositoryIntakePage({
     setSubStageComplete((prev) => ({ ...prev, registration: true }));
   }, []);
 
-  const handleBulkImportComplete = useCallback((samples) => {
-    setRegisteredSamples((prev) => [...prev, ...samples]);
+  const handleBulkImportComplete = useCallback(() => {
     setSubStageComplete((prev) => ({ ...prev, registration: true }));
     setManifestModalOpen(false);
   }, []);
@@ -198,7 +200,7 @@ function BiorepositoryIntakePage({
   const loadAllBioSamples = useCallback(() => {
     setLoadingSamples(true);
     getFromOpenElisServer(
-      `/rest/biorepository/sample?limit=500&workflowStatus=REGISTERED`,
+      `/rest/biorepository/sample?limit=${INVENTORY_SAMPLE_FETCH_LIMIT}&workflowStatus=REGISTERED`,
       (data) => {
         setLoadingSamples(false);
         if (data && Array.isArray(data)) {
@@ -217,7 +219,7 @@ function BiorepositoryIntakePage({
   useEffect(() => {
     if (currentShipment?.id) {
       getFromOpenElisServer(
-        `/rest/biorepository/sample?shipmentId=${currentShipment.id}&limit=100`,
+        `/rest/biorepository/sample?shipmentId=${currentShipment.id}&limit=${SHIPMENT_SAMPLE_FETCH_LIMIT}`,
         (data) => {
           if (data && Array.isArray(data)) {
             setRegisteredSamples(data);
@@ -232,12 +234,30 @@ function BiorepositoryIntakePage({
 
   // Refresh inventory after bulk import
   const handleBulkImportCompleteWithRefresh = useCallback(
-    (samples) => {
-      handleBulkImportComplete(samples);
+    () => {
+      handleBulkImportComplete();
       // Refresh all samples list
       loadAllBioSamples();
+
+      // Refresh shipment-specific registration count if this intake page is linked to a shipment
+      if (currentShipment?.id) {
+        getFromOpenElisServer(
+          `/rest/biorepository/sample?shipmentId=${currentShipment.id}&limit=${SHIPMENT_SAMPLE_FETCH_LIMIT}`,
+          (data) => {
+            if (data && Array.isArray(data)) {
+              setRegisteredSamples(data);
+              if (data.length > 0) {
+                setSubStageComplete((prev) => ({
+                  ...prev,
+                  registration: true,
+                }));
+              }
+            }
+          },
+        );
+      }
     },
-    [handleBulkImportComplete, loadAllBioSamples],
+    [currentShipment?.id, handleBulkImportComplete, loadAllBioSamples],
   );
 
   // Advance selected samples to Storage Assignment page (page 2)

--- a/frontend/src/components/notebook/pages/biorepository/ManifestUploadModal.js
+++ b/frontend/src/components/notebook/pages/biorepository/ManifestUploadModal.js
@@ -17,14 +17,181 @@ import {
 import { Checkmark, Warning, Download } from "@carbon/icons-react";
 import { FormattedMessage, useIntl } from "react-intl";
 import PropTypes from "prop-types";
+import * as XLSX from "xlsx";
 import { postToOpenElisServerJsonResponse } from "../../../utils/Utils";
 
+const MANIFEST_FIELDS = [
+  "barcode",
+  "externalId",
+  "sampleType",
+  "projectId",
+  "originLab",
+  "receiptDate",
+  "requiredTempMin",
+  "requiredTempMax",
+  "biosafetyLevel",
+  "collectionDate",
+  "principalInvestigator",
+  "consentId",
+  "ethicsApprovalRef",
+  "mtaReference",
+  "preservationMedium",
+  "arrivalCondition",
+  "specialHandling",
+];
+
+const REQUIRED_FIELDS = [
+  "barcode",
+  "sampleType",
+  "originLab",
+  "receiptDate",
+  "requiredTempMin",
+  "requiredTempMax",
+];
+
+const CONDITIONAL_FIELDS = [
+  { name: "consentId", description: "Required for human samples" },
+  { name: "ethicsApprovalRef", description: "Required for human samples" },
+  { name: "mtaReference", description: "Required for external samples" },
+];
+
+const OPTIONAL_FIELDS = MANIFEST_FIELDS.filter(
+  (field) => !REQUIRED_FIELDS.includes(field),
+);
+
+const HEADER_ALIASES = {
+  barcode: "barcode",
+  sampleid: "barcode",
+  samplebarcode: "barcode",
+  externalid: "externalId",
+  labid: "externalId",
+  sampletype: "sampleType",
+  samplegiventobiorepository: "biorepositorySampleType",
+  sampletypeid: "sampleType",
+  projectid: "projectId",
+  projectname: "projectId",
+  originlab: "originLab",
+  transferingunit: "originLab",
+  receiptdate: "receiptDate",
+  requestdate: "receiptDate",
+  transferdate: "receiptDate",
+  requiredtempmin: "requiredTempMin",
+  requiredtempmax: "requiredTempMax",
+  biosafetylevel: "biosafetyLevel",
+  collectiondate: "collectionDate",
+  principalinvestigator: "principalInvestigator",
+  consentid: "consentId",
+  ethicsapprovalref: "ethicsApprovalRef",
+  mtareference: "mtaReference",
+  preservationmedium: "preservationMedium",
+  preservativeormedium: "preservationMedium",
+  arrivalcondition: "arrivalCondition",
+  samplecondition: "arrivalCondition",
+  specialhandling: "specialHandling",
+  notes: "specialHandling",
+  comments: "specialHandling",
+  volume: "volume",
+};
+
+const normalizeHeaderToken = (header) =>
+  String(header || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9]/g, "")
+    .toLowerCase();
+
+const normalizeCellValue = (value) => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 19).replace("T", " ");
+  }
+  return String(value).trim();
+};
+
+const formatCurrentReceiptDate = () =>
+  new Date().toISOString().slice(0, 19).replace("T", " ");
+
+const firstNonEmptyValue = (...values) =>
+  values.find(
+    (value) =>
+      value !== undefined && value !== null && String(value).trim() !== "",
+  ) || "";
+
+const inferLegacyTemperatureRange = (sampleType, sheetName) => {
+  const normalized = `${sampleType || ""} ${sheetName || ""}`.toLowerCase();
+
+  if (normalized.includes("pbmc") || normalized.includes("cell line")) {
+    return { min: "-196", max: "-150" };
+  }
+
+  if (
+    normalized.includes("ffpe") ||
+    normalized.includes("block") ||
+    normalized.includes("paraffin")
+  ) {
+    return { min: "20", max: "25" };
+  }
+
+  return { min: "-80", max: "-20" };
+};
+
+const inferLegacyBiosafetyLevel = (sampleType, sheetName) => {
+  const normalized = `${sampleType || ""} ${sheetName || ""}`.toLowerCase();
+  if (
+    normalized.includes("bacter") ||
+    normalized.includes("culture") ||
+    normalized.includes("isolate") ||
+    normalized.includes("pseudomonas") ||
+    normalized.includes("k.") ||
+    normalized.includes("e. coli") ||
+    normalized.includes("staph") ||
+    normalized.includes("enterococcus")
+  ) {
+    return "BSL_2";
+  }
+  return "BSL_2";
+};
+
+const normalizeLegacyDuplicateBarcodes = (rows) => {
+  const seen = new Map();
+
+  return rows.map((row) => {
+    const normalizedRow = Array.isArray(row) ? [...row] : row;
+    const barcode = normalizeCellValue(normalizedRow[0]);
+
+    if (!barcode) {
+      return normalizedRow;
+    }
+
+    const seenCount = seen.get(barcode) || 0;
+    seen.set(barcode, seenCount + 1);
+
+    if (seenCount === 0) {
+      normalizedRow[1] = normalizeCellValue(normalizedRow[1]) || barcode;
+      return normalizedRow;
+    }
+
+    const duplicateIndex = seenCount + 1;
+    normalizedRow[0] = `${barcode}-R${duplicateIndex}`;
+    normalizedRow[1] = normalizeCellValue(normalizedRow[1]) || barcode;
+
+    const duplicateNote = `Original Sample ID: ${barcode}`;
+    const existingSpecialHandling = normalizeCellValue(normalizedRow[16]);
+    normalizedRow[16] = existingSpecialHandling
+      ? `${existingSpecialHandling} | ${duplicateNote}`
+      : duplicateNote;
+
+    return normalizedRow;
+  });
+};
+
 /**
- * ManifestUploadModal - CSV manifest upload modal for bulk sample import
+ * ManifestUploadModal - manifest upload modal for bulk sample import
  * Part of Sub-stage 1b of the Biorepository Intake workflow
  *
- * Expected CSV format:
- * externalId,sampleType,projectId,collectionDate,biosafetyLevel,originLab,consentId,ethicsApprovalRef,mtaReference
+ * Expected manifest format:
+ * barcode,externalId,sampleType,projectId,originLab,receiptDate,requiredTempMin,requiredTempMax,...
  *
  * @param {Object} props
  * @param {boolean} props.open - Whether the modal is open
@@ -42,56 +209,12 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
   const [error, setError] = useState(null);
   const [importStatus, setImportStatus] = useState(null); // null, 'parsed', 'validating', 'preview', 'importing', 'complete'
   const [backendValidationDone, setBackendValidationDone] = useState(false);
+  const [importResult, setImportResult] = useState(null);
 
-  // ============================================================
-  // FIELD DEFINITIONS - Must match backend SampleRegistrationDTO
-  // ============================================================
-  // Backend DTO: src/main/java/org/openelisglobal/biorepository/controller/rest/dto/SampleRegistrationDTO.java
-
-  // Required fields per spec FR-MAN-003
-  const requiredFields = [
-    "externalId",
-    "sampleType",
-    "biosafetyLevel",
-    "collectionDate",
-    "originLab",
-  ];
-
-  // Conditional fields (required based on sample type/source)
-  const conditionalFields = [
-    { name: "consentId", description: "Required for human samples" },
-    { name: "ethicsApprovalRef", description: "Required for human samples" },
-    { name: "mtaReference", description: "Required for external samples" },
-  ];
-
-  // Optional fields
-  const optionalFields = [
-    "projectId",
-    "principalInvestigator",
-    "preservationMedium",
-    "arrivalCondition",
-    "notes",
-  ];
-
-  // CSV column to backend field mapping
-  const csvToBackendFieldMap = {
-    externalId: "externalId",
-    sampleType: "sampleTypeId",
-    projectId: "projectId",
-    collectionDate: "collectionDate",
-    biosafetyLevel: "biosafetyLevel",
-    originLab: "originLab",
-    principalInvestigator: "principalInvestigator",
-    consentId: "consentId",
-    ethicsApprovalRef: "ethicsApprovalRef",
-    mtaReference: "mtaReference",
-    preservationMedium: "preservationMedium",
-    arrivalCondition: "arrivalCondition",
-    notes: "specialHandling",
-  };
-
-  // All expected CSV headers (for template generation)
-  const expectedHeaders = Object.keys(csvToBackendFieldMap);
+  const requiredFields = REQUIRED_FIELDS;
+  const conditionalFields = CONDITIONAL_FIELDS;
+  const optionalFields = OPTIONAL_FIELDS;
+  const expectedHeaders = MANIFEST_FIELDS;
 
   /**
    * Generate and download CSV template per spec FR-MAN-002
@@ -100,7 +223,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     const headers = expectedHeaders.join(",");
     // Example row matching the header order
     const exampleRow =
-      "SAMPLE-001,Serum,PROJ-123,2026-01-09,BSL_2,AHRI Lab,Dr. Smith,CONSENT-001,ETH-2025-001,MTA-001,EDTA,Good,Sample notes";
+      "BIO-2026-001,PARTICIPANT-001,Serum,PROJ-123,AHRI Lab,2026-01-09 09:30:00,2,8,BSL_2,2026-01-08,Dr. Smith,CONSENT-001,ETH-2025-001,MTA-001,EDTA,Good,Keep upright during transport";
     const csvContent = `${headers}\n${exampleRow}`;
 
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
@@ -114,24 +237,196 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     document.body.removeChild(link);
   }, [expectedHeaders]);
 
-  const parseCSV = useCallback(
-    (csvText) => {
-      const lines = csvText.split(/\r?\n/).filter((line) => line.trim());
-      if (lines.length < 2) {
+  const isSupportedDateValue = useCallback((value, allowTime = false) => {
+    if (!value) {
+      return false;
+    }
+
+    const patterns = allowTime
+      ? [
+          /^\d{4}-\d{2}-\d{2}$/,
+          /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(:\d{2})?$/,
+          /^\d{2}\/\d{2}\/\d{4}$/,
+          /^\d{2}\/\d{2}\/\d{4}[ T]\d{2}:\d{2}(:\d{2})?$/,
+          /^\d{2}-\d{2}-\d{4}$/,
+          /^\d{2}-\d{2}-\d{4}[ T]\d{2}:\d{2}(:\d{2})?$/,
+        ]
+      : [/^\d{4}-\d{2}-\d{2}$/, /^\d{2}\/\d{2}\/\d{4}$/, /^\d{2}-\d{2}-\d{4}$/];
+
+    return patterns.some((pattern) => pattern.test(value));
+  }, []);
+
+  const convertLegacyWorksheetRows = useCallback((rows, sheetName) => {
+    const normalizedRows = rows
+      .map((row) =>
+        Array.isArray(row) ? row.map((value) => normalizeCellValue(value)) : [],
+      )
+      .filter((row) => row.some((value) => value !== ""));
+
+    if (normalizedRows.length < 2) {
+      return [];
+    }
+
+    const rawHeaders = normalizedRows[0];
+    const mappedHeaders = rawHeaders.map(
+      (header) => HEADER_ALIASES[normalizeHeaderToken(header)] || null,
+    );
+
+    const looksLegacyWorkbook =
+      mappedHeaders.includes("barcode") &&
+      mappedHeaders.includes("originLab") &&
+      mappedHeaders.includes("projectId");
+
+    if (!looksLegacyWorkbook) {
+      return [];
+    }
+
+    const convertedRows = [];
+
+    for (let i = 1; i < normalizedRows.length; i++) {
+      const values = normalizedRows[i];
+      const row = {};
+
+      mappedHeaders.forEach((header, index) => {
+        if (!header) {
+          return;
+        }
+        const nextValue = values[index] || "";
+        if (row[header] && !nextValue) {
+          return;
+        }
+        row[header] = nextValue || row[header] || "";
+      });
+
+      const sampleType = firstNonEmptyValue(
+        row.biorepositorySampleType,
+        row.sampleType,
+      );
+      const barcode = row.barcode || "";
+      if (!barcode) {
+        continue;
+      }
+      const tempRange = inferLegacyTemperatureRange(sampleType, sheetName);
+      const specialHandling = [
+        row.specialHandling,
+        row.volume && row.volume.toLowerCase() !== "sufficient"
+          ? `Volume: ${row.volume}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join(" | ");
+
+      convertedRows.push([
+        barcode,
+        row.externalId,
+        sampleType,
+        row.projectId,
+        row.originLab,
+        firstNonEmptyValue(
+          row.receiptDate,
+          row.collectionDate,
+          formatCurrentReceiptDate(),
+        ),
+        firstNonEmptyValue(row.requiredTempMin, tempRange.min),
+        firstNonEmptyValue(row.requiredTempMax, tempRange.max),
+        firstNonEmptyValue(
+          row.biosafetyLevel,
+          inferLegacyBiosafetyLevel(sampleType, sheetName),
+        ),
+        row.collectionDate,
+        row.principalInvestigator,
+        row.consentId,
+        row.ethicsApprovalRef,
+        row.mtaReference,
+        row.preservationMedium,
+        row.arrivalCondition,
+        specialHandling,
+      ]);
+    }
+
+    return convertedRows;
+  }, []);
+
+  const extractWorkbookRows = useCallback(
+    (workbook) => {
+      const sheetNames = workbook.SheetNames.filter(
+        (name) => name.trim().toLowerCase() !== "key",
+      );
+
+      let legacyRows = [];
+
+      for (const sheetName of sheetNames) {
+        const sheet = workbook.Sheets[sheetName];
+        const rows = XLSX.utils.sheet_to_json(sheet, {
+          header: 1,
+          defval: "",
+          raw: false,
+          dateNF: "yyyy-mm-dd hh:mm:ss",
+        });
+
+        const convertedLegacyRows = convertLegacyWorksheetRows(rows, sheetName);
+        if (convertedLegacyRows.length > 0) {
+          legacyRows = legacyRows.concat(convertedLegacyRows);
+        }
+      }
+
+      if (legacyRows.length > 0) {
+        return [
+          MANIFEST_FIELDS,
+          ...normalizeLegacyDuplicateBarcodes(legacyRows),
+        ];
+      }
+
+      const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
+      return XLSX.utils.sheet_to_json(firstSheet, {
+        header: 1,
+        defval: "",
+        raw: false,
+        dateNF: "yyyy-mm-dd hh:mm:ss",
+      });
+    },
+    [convertLegacyWorksheetRows],
+  );
+
+  const parseManifestRows = useCallback(
+    (rows) => {
+      const normalizedRows = rows
+        .map((row) =>
+          Array.isArray(row)
+            ? row.map((value) => normalizeCellValue(value))
+            : [],
+        )
+        .filter((row) => row.some((value) => value !== ""));
+
+      if (normalizedRows.length === 0) {
         throw new Error(
           intl.formatMessage({
-            id: "biorepository.manifest.error.emptyFile",
+            id: "biorepository.manifest.error.noCellData",
             defaultMessage:
-              "CSV must contain at least a header row and one data row",
+              "No spreadsheet cell data found. This file may contain only an image or formatting. Please upload a sheet with header and sample rows.",
           }),
         );
       }
 
-      const headers = lines[0].split(",").map((h) => h.trim());
+      if (normalizedRows.length < 2) {
+        throw new Error(
+          intl.formatMessage({
+            id: "biorepository.manifest.error.emptyFile",
+            defaultMessage:
+              "Manifest must contain at least a header row and one data row",
+          }),
+        );
+      }
 
-      // Validate required headers per spec FR-MAN-003
-      const missingHeaders = requiredFields.filter(
-        (field) => !headers.includes(field),
+      const rawHeaders = normalizedRows[0];
+      const headers = rawHeaders.map(
+        (header) => HEADER_ALIASES[normalizeHeaderToken(header)] || null,
+      );
+
+      const missingHeaders = requiredFields.filter((field) =>
+        field === "barcode"
+          ? !headers.includes("barcode") && !headers.includes("externalId")
+          : !headers.includes(field),
       );
       if (missingHeaders.length > 0) {
         throw new Error(
@@ -146,18 +441,14 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
         );
       }
 
-      // Validate that all CSV columns are supported (prevents backend DTO mismatch)
-      const supportedCsvColumns = new Set(Object.keys(csvToBackendFieldMap));
-      const unknownColumns = headers.filter(
-        (header) => !supportedCsvColumns.has(header),
-      );
+      const unknownColumns = rawHeaders.filter((_, index) => !headers[index]);
       if (unknownColumns.length > 0) {
         throw new Error(
           intl.formatMessage(
             {
               id: "biorepository.manifest.error.unknownColumns",
               defaultMessage:
-                "Unknown columns in CSV: {columns}. These fields are not supported. Please use the template.",
+                "Unknown columns in manifest: {columns}. Please use the current template.",
             },
             { columns: unknownColumns.join(", ") },
           ),
@@ -167,17 +458,26 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
       const data = [];
       const errors = [];
 
-      for (let i = 1; i < lines.length; i++) {
-        const values = lines[i].split(",").map((v) => v.trim());
+      for (let i = 1; i < normalizedRows.length; i++) {
+        const values = normalizedRows[i];
         const row = {};
 
         headers.forEach((header, index) => {
-          row[header] = values[index] || "";
+          if (!header) {
+            return;
+          }
+          const nextValue = values[index] || "";
+          if (row[header] && !nextValue) {
+            return;
+          }
+          row[header] = nextValue || row[header] || "";
         });
 
-        // Validate required fields
+        row.barcode = row.barcode || row.externalId || "";
+
         requiredFields.forEach((field) => {
-          if (!row[field]) {
+          const value = field === "barcode" ? row.barcode : row[field];
+          if (!value) {
             errors.push({
               row: i + 1,
               field,
@@ -192,7 +492,6 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
           }
         });
 
-        // Validate biosafety level per spec FR-MAN-003
         if (
           row.biosafetyLevel &&
           !["BSL_1", "BSL_2", "BSL_3", "BSL_4"].includes(row.biosafetyLevel)
@@ -211,21 +510,74 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
           });
         }
 
-        // Validate date format (supporting multiple formats per spec FR-MAN-004)
-        if (row.collectionDate) {
-          const dateRegex =
-            /^\d{4}-\d{2}-\d{2}$|^\d{2}\/\d{2}\/\d{4}$|^\d{2}-\d{2}-\d{4}$/;
-          if (!dateRegex.test(row.collectionDate)) {
-            errors.push({
-              row: i + 1,
-              field: "collectionDate",
-              message: intl.formatMessage({
-                id: "biorepository.manifest.error.invalidDate",
-                defaultMessage:
-                  "Invalid date format. Use yyyy-MM-dd, dd/MM/yyyy, or dd-MM-yyyy",
-              }),
-            });
-          }
+        if (row.receiptDate && !isSupportedDateValue(row.receiptDate, true)) {
+          errors.push({
+            row: i + 1,
+            field: "receiptDate",
+            message: intl.formatMessage({
+              id: "biorepository.manifest.error.invalidReceiptDate",
+              defaultMessage:
+                "Invalid receipt date format. Use yyyy-MM-dd or yyyy-MM-dd HH:mm:ss",
+            }),
+          });
+        }
+
+        if (
+          row.collectionDate &&
+          !isSupportedDateValue(row.collectionDate, false)
+        ) {
+          errors.push({
+            row: i + 1,
+            field: "collectionDate",
+            message: intl.formatMessage({
+              id: "biorepository.manifest.error.invalidDate",
+              defaultMessage:
+                "Invalid collection date format. Use yyyy-MM-dd, dd/MM/yyyy, or dd-MM-yyyy",
+            }),
+          });
+        }
+
+        const minTemp =
+          row.requiredTempMin === "" ? Number.NaN : Number(row.requiredTempMin);
+        const maxTemp =
+          row.requiredTempMax === "" ? Number.NaN : Number(row.requiredTempMax);
+
+        if (row.requiredTempMin !== "" && Number.isNaN(minTemp)) {
+          errors.push({
+            row: i + 1,
+            field: "requiredTempMin",
+            message: intl.formatMessage({
+              id: "biorepository.manifest.error.invalidMinTemp",
+              defaultMessage: "requiredTempMin must be a number",
+            }),
+          });
+        }
+
+        if (row.requiredTempMax !== "" && Number.isNaN(maxTemp)) {
+          errors.push({
+            row: i + 1,
+            field: "requiredTempMax",
+            message: intl.formatMessage({
+              id: "biorepository.manifest.error.invalidMaxTemp",
+              defaultMessage: "requiredTempMax must be a number",
+            }),
+          });
+        }
+
+        if (
+          !Number.isNaN(minTemp) &&
+          !Number.isNaN(maxTemp) &&
+          minTemp > maxTemp
+        ) {
+          errors.push({
+            row: i + 1,
+            field: "requiredTempMax",
+            message: intl.formatMessage({
+              id: "biorepository.manifest.error.invalidTempRange",
+              defaultMessage:
+                "requiredTempMax must be greater than or equal to requiredTempMin",
+            }),
+          });
         }
 
         row._rowNumber = i + 1;
@@ -235,7 +587,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
 
       return { data, errors };
     },
-    [intl, requiredFields],
+    [intl, isSupportedDateValue, requiredFields],
   );
 
   const handleFileChange = useCallback(
@@ -243,11 +595,16 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
       const uploadedFile = event.target.files?.[0];
       if (!uploadedFile) return;
 
-      if (!uploadedFile.name.endsWith(".csv")) {
+      const fileName = uploadedFile.name.toLowerCase();
+      if (
+        !fileName.endsWith(".csv") &&
+        !fileName.endsWith(".xlsx") &&
+        !fileName.endsWith(".xls")
+      ) {
         setError(
           intl.formatMessage({
             id: "biorepository.manifest.error.invalidFormat",
-            defaultMessage: "Please upload a CSV file",
+            defaultMessage: "Please upload a CSV or Excel file",
           }),
         );
         return;
@@ -258,12 +615,16 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
       const reader = new FileReader();
       reader.onload = (e) => {
         try {
-          const { data, errors } = parseCSV(e.target.result);
+          const workbook = XLSX.read(e.target.result, {
+            type: "array",
+            cellDates: true,
+          });
+          const rows = extractWorkbookRows(workbook);
+          const { data, errors } = parseManifestRows(rows);
           setParsedData(data);
           setValidationErrors(errors);
           setValidationWarnings([]);
           setBackendValidationDone(false);
-          // Set to 'parsed' - user must click Preview & Validate to proceed
           setImportStatus("parsed");
         } catch (err) {
           setError(err.message);
@@ -279,9 +640,9 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
           }),
         );
       };
-      reader.readAsText(uploadedFile);
+      reader.readAsArrayBuffer(uploadedFile);
     },
-    [intl, parseCSV],
+    [extractWorkbookRows, intl, parseManifestRows],
   );
 
   /**
@@ -289,19 +650,51 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
    */
   const transformToBackendFormat = useCallback((data) => {
     return data.map((row) => {
-      const sample = {};
-      // Map each CSV column to its backend field name
-      Object.entries(csvToBackendFieldMap).forEach(
-        ([csvField, backendField]) => {
-          const value = row[csvField];
-          // Only include non-empty values
-          if (value !== undefined && value !== "") {
-            sample[backendField] = value;
-          }
-        },
-      );
-      // Default biosafety level if not provided
-      if (!sample.biosafetyLevel) {
+      const barcode = row.barcode || row.externalId || "";
+      const sample = {
+        barcode,
+        externalId: row.externalId || barcode,
+        sampleType: row.sampleType,
+        originLab: row.originLab,
+        receiptDate: row.receiptDate,
+      };
+
+      if (row.projectId) {
+        sample.projectId = row.projectId;
+      }
+      if (row.requiredTempMin !== "") {
+        sample.requiredTempMin = Number(row.requiredTempMin);
+      }
+      if (row.requiredTempMax !== "") {
+        sample.requiredTempMax = Number(row.requiredTempMax);
+      }
+      if (row.collectionDate) {
+        sample.collectionDate = row.collectionDate;
+      }
+      if (row.principalInvestigator) {
+        sample.principalInvestigator = row.principalInvestigator;
+      }
+      if (row.consentId) {
+        sample.consentId = row.consentId;
+      }
+      if (row.ethicsApprovalRef) {
+        sample.ethicsApprovalRef = row.ethicsApprovalRef;
+      }
+      if (row.mtaReference) {
+        sample.mtaReference = row.mtaReference;
+      }
+      if (row.preservationMedium) {
+        sample.preservationMedium = row.preservationMedium;
+      }
+      if (row.arrivalCondition) {
+        sample.arrivalCondition = row.arrivalCondition;
+      }
+      if (row.specialHandling) {
+        sample.specialHandling = row.specialHandling;
+      }
+      if (row.biosafetyLevel) {
+        sample.biosafetyLevel = row.biosafetyLevel;
+      } else {
         sample.biosafetyLevel = "BSL_1";
       }
       return sample;
@@ -459,6 +852,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     setLoading(true);
     setError(null);
     setImportStatus("importing");
+    setImportResult(null);
 
     // Only send valid samples to backend
     const samples = transformToBackendFormat(validSamples);
@@ -484,14 +878,41 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
           setError(response.message || response.error);
           setImportStatus("preview");
         } else {
+          const rowErrors = Array.isArray(response?.rowErrors)
+            ? response.rowErrors
+            : [];
+          const registeredCount = Number(
+            response?.registeredCount ?? response?.samples?.length ?? 0,
+          );
+          const failedCount = Number(
+            response?.failedCount ?? rowErrors.length ?? 0,
+          );
+
+          setImportResult({
+            registeredCount,
+            failedCount,
+            rowErrors,
+          });
           setImportStatus("complete");
           if (onImportComplete) {
-            onImportComplete(response?.samples || []);
+            try {
+              onImportComplete(response?.samples || []);
+            } catch (callbackError) {
+              // Preserve successful imports even if a follow-up UI refresh fails.
+              // The intake page can still be refreshed manually without losing the import.
+              // eslint-disable-next-line no-console
+              console.error(
+                "Biorepository manifest import completed, but follow-up refresh failed:",
+                callbackError,
+              );
+            }
           }
-          // Close modal after successful import
-          setTimeout(() => {
-            handleClose();
-          }, 2000);
+          if (rowErrors.length === 0) {
+            // Close modal after a fully successful import
+            setTimeout(() => {
+              handleClose();
+            }, 2000);
+          }
         }
       },
     );
@@ -511,6 +932,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     setImportStatus(null);
     setError(null);
     setBackendValidationDone(false);
+    setImportResult(null);
   }, []);
 
   const handleClose = useCallback(() => {
@@ -521,10 +943,10 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
   const tableHeaders = [
     { key: "row", header: "#" },
     {
-      key: "externalId",
+      key: "barcode",
       header: intl.formatMessage({
-        id: "biorepository.manifest.column.externalId",
-        defaultMessage: "External ID",
+        id: "biorepository.manifest.column.barcode",
+        defaultMessage: "Sample ID",
       }),
     },
     {
@@ -539,6 +961,13 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
       header: intl.formatMessage({
         id: "biorepository.manifest.column.originLab",
         defaultMessage: "Origin Lab",
+      }),
+    },
+    {
+      key: "receiptDate",
+      header: intl.formatMessage({
+        id: "biorepository.manifest.column.receiptDate",
+        defaultMessage: "Receipt Date",
       }),
     },
     {
@@ -560,9 +989,10 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
   const tableRows = parsedData.map((row) => ({
     id: String(row._rowNumber),
     row: row._rowNumber,
-    externalId: row.externalId,
+    barcode: row.barcode || row.externalId || "-",
     sampleType: row.sampleType || "-",
     originLab: row.originLab || "-",
+    receiptDate: row.receiptDate || "-",
     biosafetyLevel: row.biosafetyLevel || "BSL_1",
     status: row._valid
       ? row._backendWarnings?.length > 0
@@ -578,6 +1008,18 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
 
   const getRowWarnings = (rowNumber) => {
     return validationWarnings.filter((e) => e.row === rowNumber);
+  };
+
+  const formatRowError = (error) => {
+    if (!error) {
+      return "";
+    }
+
+    if (error.field === "backend") {
+      return error.message;
+    }
+
+    return `${error.field}: ${error.message}`;
   };
 
   return (
@@ -657,13 +1099,16 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
             {
               id: "biorepository.manifest.success.message",
               defaultMessage:
-                "{importedCount} samples imported successfully.{skippedMessage}",
+                "{importedCount} samples registered in intake successfully.{skippedMessage}",
             },
             {
-              importedCount: validSampleCount,
+              importedCount:
+                importResult?.registeredCount ?? validSampleCount,
               skippedMessage:
-                parsedData.length > validSampleCount
-                  ? ` ${parsedData.length - validSampleCount} invalid sample(s) were skipped.`
+                (importResult?.failedCount ?? 0) > 0
+                  ? ` ${importResult.failedCount} sample(s) could not be imported.`
+                  : parsedData.length > validSampleCount
+                    ? ` ${parsedData.length - validSampleCount} invalid sample(s) were skipped.`
                   : "",
             },
           )}
@@ -673,12 +1118,32 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
         />
       )}
 
+      {importStatus === "complete" && (importResult?.failedCount ?? 0) > 0 && (
+        <InlineNotification
+          kind="warning"
+          title={intl.formatMessage({
+            id: "biorepository.manifest.partialImport.title",
+            defaultMessage: "Some Samples Were Not Imported",
+          })}
+          subtitle={
+            importResult?.rowErrors?.slice(0, 3).join("; ") ||
+            intl.formatMessage({
+              id: "biorepository.manifest.partialImport.message",
+              defaultMessage:
+                "One or more samples could not be imported. Please review the failed rows and try again.",
+            })
+          }
+          lowContrast
+          style={{ marginBottom: "1rem" }}
+        />
+      )}
+
       {importStatus === null && (
         <div style={{ marginBottom: "1.5rem" }}>
           <p style={{ marginBottom: "1rem" }}>
             <FormattedMessage
               id="biorepository.manifest.instructions"
-              defaultMessage="Upload a CSV file containing sample data. Download the template below for the correct format."
+              defaultMessage="Upload a CSV or Excel manifest to register samples on the intake page. Later storage, QC, retrieval, and disposal steps remain manual."
             />
           </p>
           <div style={{ marginBottom: "1rem" }}>
@@ -690,7 +1155,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
             >
               <FormattedMessage
                 id="biorepository.manifest.button.downloadTemplate"
-                defaultMessage="Download CSV Template"
+                defaultMessage="Download Manifest Template"
               />
             </Button>
           </div>
@@ -772,17 +1237,17 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
             })}
             labelDescription={intl.formatMessage({
               id: "biorepository.manifest.upload.description",
-              defaultMessage: "Upload CSV file with sample data",
+              defaultMessage: "Upload CSV, XLSX, or XLS file with sample data",
             })}
             buttonLabel={intl.formatMessage({
               id: "biorepository.manifest.upload.button",
-              defaultMessage: "Select CSV file",
+              defaultMessage: "Select manifest file",
             })}
             iconDescription={intl.formatMessage({
               id: "biorepository.manifest.upload.iconDescription",
               defaultMessage: "Delete file",
             })}
-            accept={[".csv"]}
+            accept={[".csv", ".xlsx", ".xls"]}
             multiple={false}
             onChange={handleFileChange}
             filenameStatus="edit"
@@ -831,7 +1296,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                 subtitle={intl.formatMessage({
                   id: "biorepository.manifest.formatErrors.subtitle",
                   defaultMessage:
-                    "Please fix these errors before validation. You may need to upload a corrected CSV.",
+                    "Please fix these errors before validation. You may need to upload a corrected manifest file.",
                 })}
                 lowContrast
                 hideCloseButton
@@ -1174,9 +1639,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
                                   }}
                                 >
                                   {rowErrors.map((err, idx) => (
-                                    <div key={idx}>
-                                      • {err.field}: {err.message}
-                                    </div>
+                                    <div key={idx}>• {formatRowError(err)}</div>
                                   ))}
                                 </div>
                               </TableCell>

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/BioSampleRestController.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/BioSampleRestController.java
@@ -1,8 +1,14 @@
 package org.openelisglobal.biorepository.controller.rest;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -30,15 +36,23 @@ import org.openelisglobal.common.rest.BaseRestController;
 import org.openelisglobal.common.services.DisplayListService;
 import org.openelisglobal.localization.service.LocalizationService;
 import org.openelisglobal.localization.valueholder.Localization;
+import org.openelisglobal.sample.dao.SampleDAO;
 import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.util.AccessionNumberHandler;
 import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.sampleitem.service.SampleItemService;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.typeofsample.service.TypeOfSampleService;
 import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -64,6 +78,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/rest/biorepository/sample")
 public class BioSampleRestController extends BaseRestController {
 
+    private static final Logger logger = LoggerFactory.getLogger(BioSampleRestController.class);
+
     @Autowired
     private BioSampleService bioSampleService;
 
@@ -72,6 +88,9 @@ public class BioSampleRestController extends BaseRestController {
 
     @Autowired
     private SampleService sampleService;
+
+    @Autowired
+    private SampleDAO sampleDAO;
 
     @Autowired
     private SampleItemService sampleItemService;
@@ -87,6 +106,12 @@ public class BioSampleRestController extends BaseRestController {
 
     @Autowired
     private LocalizationService localizationService;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     /**
      * Get a BioSample extension by ID.
@@ -877,6 +902,7 @@ public class BioSampleRestController extends BaseRestController {
      * records.
      */
     @PostMapping(value = "/register", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Transactional
     public ResponseEntity<?> registerSample(@RequestBody SampleRegistrationRequest request,
             HttpServletRequest httpRequest) {
 
@@ -901,14 +927,9 @@ public class BioSampleRestController extends BaseRestController {
             }
 
             // Create Sample (accession-level record)
-            Sample sample = new Sample();
-            sample.setAccessionNumber(generateAccessionNumber());
-            sample.setReceivedTimestamp(request.getReceiptDate() != null ? Timestamp.valueOf(request.getReceiptDate())
-                    : new Timestamp(System.currentTimeMillis()));
-            sample.setEnteredDate(new java.sql.Date(System.currentTimeMillis()));
-            sample.setDomain("H"); // Human domain
-            sample.setSysUserId(sysUserId);
-            Sample savedSample = sampleService.save(sample);
+            Timestamp receiptTimestamp = request.getReceiptDate() != null ? Timestamp.valueOf(request.getReceiptDate())
+                    : new Timestamp(System.currentTimeMillis());
+            Sample savedSample = createSampleWithGeneratedAccession(receiptTimestamp, sysUserId);
 
             // Create SampleItem (aliquot-level record)
             SampleItem sampleItem = new SampleItem();
@@ -930,7 +951,9 @@ public class BioSampleRestController extends BaseRestController {
                             : BiosafetyLevel.BSL_1);
             bioSample.setEthicsApprovalRef(request.getEthicsApprovalRef());
             bioSample.setMtaReference(request.getMtaReference());
-            bioSample.setSpecialHandling(request.getSpecialHandling());
+            bioSample.setSpecialHandling(
+                    mergeExternalIdIntoSpecialHandling(request.getSpecialHandling(), request.getExternalId(),
+                            request.getBarcode()));
             bioSample.setOriginLab(request.getOriginLab());
             bioSample.setProjectId(request.getProjectId());
             if (request.getRequiredTempMin() != null) {
@@ -962,13 +985,17 @@ public class BioSampleRestController extends BaseRestController {
         }
     }
 
-    /**
-     * Generate a unique accession number for samples.
-     */
-    private String generateAccessionNumber() {
-        String datePart = java.time.LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
-        String randomPart = String.valueOf(System.currentTimeMillis() % 100000);
-        return datePart + randomPart;
+    private Sample createSampleWithGeneratedAccession(Timestamp receiptTimestamp, String sysUserId) {
+        Sample sample = new Sample();
+        sample.setReceivedTimestamp(receiptTimestamp);
+        sample.setEnteredDate(new java.sql.Date(receiptTimestamp.getTime()));
+        sample.setDomain("H");
+        sample.setSysUserId(sysUserId);
+
+        AccessionNumberHandler accessionNumberHandler = new AccessionNumberHandler(sampleService, sampleDAO,
+                entityManager, BioSampleRestController.class);
+        String sampleId = accessionNumberHandler.generateAndInsertWithUniqueAccessionNumber(sample);
+        return sampleService.get(sampleId);
     }
 
     /**
@@ -1131,20 +1158,20 @@ public class BioSampleRestController extends BaseRestController {
                     i);
 
             // Validate required fields
-            String barcode = sample.getExternalId();
+            String barcode = firstNonBlank(sample.getBarcode(), sample.getExternalId());
             if (barcode == null || barcode.trim().isEmpty()) {
-                rowResult.addError("External ID (barcode) is required");
+                rowResult.addError("Barcode is required");
             } else {
                 barcode = barcode.trim();
                 // Check for duplicates within the manifest
                 if (seenBarcodes.contains(barcode)) {
-                    rowResult.addError("Duplicate barcode in manifest: " + barcode);
+                    rowResult.addError("Duplicate sample ID in manifest: " + barcode);
                 } else {
                     seenBarcodes.add(barcode);
                 }
                 // Check for existing barcode in database
                 if (bioSampleService.barcodeExists(barcode)) {
-                    rowResult.addError("Barcode already exists in system: " + barcode);
+                    rowResult.addError("Sample ID already exists: " + barcode);
                 }
             }
 
@@ -1166,9 +1193,7 @@ public class BioSampleRestController extends BaseRestController {
 
             // Validate biosafety level
             String bsl = sample.getBiosafetyLevel();
-            if (bsl == null || bsl.trim().isEmpty()) {
-                rowResult.addError("Biosafety level is required");
-            } else {
+            if (bsl != null && !bsl.trim().isEmpty()) {
                 try {
                     BiosafetyLevel.valueOf(bsl.trim());
                 } catch (IllegalArgumentException e) {
@@ -1179,6 +1204,25 @@ public class BioSampleRestController extends BaseRestController {
             // Validate origin lab
             if (sample.getOriginLab() == null || sample.getOriginLab().trim().isEmpty()) {
                 rowResult.addError("Origin lab is required");
+            }
+
+            if (sample.getReceiptDate() == null || sample.getReceiptDate().trim().isEmpty()) {
+                rowResult.addError("Receipt date is required");
+            } else if (!isValidDateFormat(sample.getReceiptDate().trim())) {
+                rowResult.addError("Invalid receipt date format: " + sample.getReceiptDate());
+            }
+
+            if (sample.getRequiredTempMin() == null) {
+                rowResult.addError("Minimum storage temperature is required");
+            }
+
+            if (sample.getRequiredTempMax() == null) {
+                rowResult.addError("Maximum storage temperature is required");
+            }
+
+            if (sample.getRequiredTempMin() != null && sample.getRequiredTempMax() != null
+                    && sample.getRequiredTempMin().compareTo(sample.getRequiredTempMax()) > 0) {
+                rowResult.addError("Maximum storage temperature must be greater than or equal to minimum storage temperature");
             }
 
             // Validate collection date format (if provided)
@@ -1220,19 +1264,33 @@ public class BioSampleRestController extends BaseRestController {
             return ResponseEntity.badRequest().body(response);
         }
 
-        Shipment shipment = null;
-        if (request.getShipmentId() != null) {
-            shipment = shipmentService.get(request.getShipmentId());
+        TransactionTemplate rowTransaction = new TransactionTemplate(transactionManager);
+        rowTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        for (SampleRegistrationDTO dto : samples) {
+            try {
+                BulkRegistrationResponse.RegisteredSample registered = rowTransaction
+                        .execute(status -> registerSingleSample(dto, request.getShipmentId(), sysUserId));
+
+                if (registered != null) {
+                    response.addSample(registered);
+                } else {
+                    response.addRowError("Sample registration returned no result");
+                }
+            } catch (Exception e) {
+                String sampleRef = firstNonBlank(dto.getBarcode(), dto.getExternalId());
+                String prefix = (sampleRef == null || sampleRef.isBlank()) ? "Sample" : "Sample '" + sampleRef + "'";
+                String detailedError = getRootCauseMessage(e);
+                logger.error("Bulk manifest import failed for {}", prefix, e);
+                response.addRowError(prefix + ": " + detailedError);
+            }
         }
 
-        try {
-            for (SampleRegistrationDTO dto : samples) {
-                BulkRegistrationResponse.RegisteredSample registered = registerSingleSample(dto, shipment, sysUserId);
-                response.addSample(registered);
-            }
-        } catch (Exception e) {
+        if (response.getRegisteredCount() == 0) {
             response.setSuccess(false);
-            response.setError("Failed to register samples: " + e.getMessage());
+            String errorSummary = response.getRowErrors().isEmpty() ? "Failed to register samples"
+                    : response.getRowErrors().stream().limit(3).collect(Collectors.joining("; "));
+            response.setError("Failed to register samples: " + errorSummary);
             return ResponseEntity.internalServerError().body(response);
         }
 
@@ -1242,11 +1300,13 @@ public class BioSampleRestController extends BaseRestController {
     /**
      * Register a single sample from the manifest DTO.
      */
-    private BulkRegistrationResponse.RegisteredSample registerSingleSample(SampleRegistrationDTO dto, Shipment shipment,
+    private BulkRegistrationResponse.RegisteredSample registerSingleSample(SampleRegistrationDTO dto,
+            Integer shipmentId,
             String sysUserId) {
-        // Get barcode from externalId
-        String barcode = dto.getExternalId() != null ? dto.getExternalId().trim()
-                : generateBarcode().getBody().get("barcode");
+        String barcode = firstNonBlank(dto.getBarcode(), dto.getExternalId());
+        if (barcode == null || barcode.isBlank()) {
+            barcode = generateBarcode().getBody().get("barcode");
+        }
 
         // Find or create sample type by name or ID for biorepository intake.
         TypeOfSample sampleType = resolveManifestSampleType(dto.getSampleTypeId(), sysUserId, true);
@@ -1255,13 +1315,13 @@ public class BioSampleRestController extends BaseRestController {
         }
 
         // Create Sample (accession-level record)
-        Sample sample = new Sample();
-        sample.setAccessionNumber(generateAccessionNumber());
-        sample.setReceivedTimestamp(new Timestamp(System.currentTimeMillis()));
-        sample.setEnteredDate(new java.sql.Date(System.currentTimeMillis()));
-        sample.setDomain("H"); // Human domain
-        sample.setSysUserId(sysUserId);
-        Sample savedSample = sampleService.save(sample);
+        Timestamp receiptTimestamp = dto.getReceiptDate() != null && !dto.getReceiptDate().trim().isEmpty()
+                ? parseDate(dto.getReceiptDate().trim())
+                : null;
+        if (receiptTimestamp == null) {
+            receiptTimestamp = new Timestamp(System.currentTimeMillis());
+        }
+        Sample savedSample = createSampleWithGeneratedAccession(receiptTimestamp, sysUserId);
 
         // Create SampleItem (aliquot-level record)
         SampleItem sampleItem = new SampleItem();
@@ -1289,7 +1349,8 @@ public class BioSampleRestController extends BaseRestController {
         bioSample.setPrincipalInvestigator(dto.getPrincipalInvestigator());
         bioSample.setPreservationMedium(dto.getPreservationMedium());
         bioSample.setArrivalCondition(dto.getArrivalCondition());
-        bioSample.setSpecialHandling(dto.getSpecialHandling());
+        bioSample.setSpecialHandling(
+                mergeExternalIdIntoSpecialHandling(dto.getSpecialHandling(), dto.getExternalId(), barcode));
         bioSample.setOriginLab(dto.getOriginLab());
         bioSample.setProjectId(dto.getProjectId());
         if (dto.getRequiredTempMin() != null) {
@@ -1298,11 +1359,17 @@ public class BioSampleRestController extends BaseRestController {
         if (dto.getRequiredTempMax() != null) {
             bioSample.setRequiredTempMax(dto.getRequiredTempMax());
         }
-        if (shipment != null) {
-            bioSample.setShipment(shipment);
+        if (shipmentId != null) {
+            Shipment shipment = shipmentService.get(shipmentId);
+            if (shipment != null) {
+                bioSample.setShipment(shipment);
+            }
         }
         bioSample.setSysUserId(sysUserId);
         BioSample savedBioSample = bioSampleService.createForSampleItem(savedSampleItem, bioSample);
+
+        // Force SQL execution in this row transaction so DB constraint failures surface with a specific cause.
+        entityManager.flush();
 
         // Build response
         BulkRegistrationResponse.RegisteredSample registered = new BulkRegistrationResponse.RegisteredSample();
@@ -1311,6 +1378,24 @@ public class BioSampleRestController extends BaseRestController {
         registered.setSampleItemId(Integer.valueOf(savedSampleItem.getId()));
         registered.setSampleId(Integer.valueOf(savedSample.getId()));
         return registered;
+    }
+
+    private String getRootCauseMessage(Throwable throwable) {
+        if (throwable == null) {
+            return "Unknown error";
+        }
+
+        Throwable current = throwable;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+
+        String message = current.getMessage();
+        if (message == null || message.isBlank()) {
+            message = throwable.getMessage();
+        }
+
+        return (message == null || message.isBlank()) ? "Unknown error" : message;
     }
 
     /**
@@ -1323,14 +1408,13 @@ public class BioSampleRestController extends BaseRestController {
         nameOrId = nameOrId.trim();
         String normalizedInput = normalizeSampleTypeLabel(nameOrId);
 
-        // Try to find by ID first
-        try {
+        // Try ID lookup only for numeric identifiers to avoid rollback-only side effects
+        // from invalid numeric conversions in legacy ID handling.
+        if (isNumericIdentifier(nameOrId)) {
             TypeOfSample byId = typeOfSampleService.get(nameOrId);
             if (byId != null) {
                 return byId;
             }
-        } catch (Exception e) {
-            // Not a valid ID, try by name
         }
 
         // Try to find by description (name)
@@ -1342,6 +1426,10 @@ public class BioSampleRestController extends BaseRestController {
         }
 
         return null;
+    }
+
+    private boolean isNumericIdentifier(String value) {
+        return value != null && value.matches("\\d+");
     }
 
     private TypeOfSample resolveManifestSampleType(String nameOrId, String sysUserId, boolean createIfMissing) {
@@ -1613,40 +1701,77 @@ public class BioSampleRestController extends BaseRestController {
      * Check if date string is in valid format.
      */
     private boolean isValidDateFormat(String dateStr) {
-        // Support multiple formats: yyyy-MM-dd, dd/MM/yyyy, dd-MM-yyyy
-        String[] patterns = { "\\d{4}-\\d{2}-\\d{2}", "\\d{2}/\\d{2}/\\d{4}", "\\d{2}-\\d{2}-\\d{4}" };
-        for (String pattern : patterns) {
-            if (dateStr.matches(pattern)) {
-                return true;
-            }
-        }
-        return false;
+        return parseDate(dateStr) != null;
     }
 
     /**
      * Parse date string to Timestamp.
      */
     private Timestamp parseDate(String dateStr) {
-        try {
-            // Try yyyy-MM-dd format (ISO)
-            if (dateStr.matches("\\d{4}-\\d{2}-\\d{2}")) {
-                return Timestamp.valueOf(dateStr + " 00:00:00");
-            }
-            // Try dd/MM/yyyy format
-            if (dateStr.matches("\\d{2}/\\d{2}/\\d{4}")) {
-                String[] parts = dateStr.split("/");
-                String iso = parts[2] + "-" + parts[1] + "-" + parts[0];
-                return Timestamp.valueOf(iso + " 00:00:00");
-            }
-            // Try dd-MM-yyyy format
-            if (dateStr.matches("\\d{2}-\\d{2}-\\d{4}")) {
-                String[] parts = dateStr.split("-");
-                String iso = parts[2] + "-" + parts[1] + "-" + parts[0];
-                return Timestamp.valueOf(iso + " 00:00:00");
-            }
-        } catch (Exception e) {
-            // Return null on parse error
+        if (dateStr == null || dateStr.trim().isEmpty()) {
+            return null;
         }
+
+        String normalizedDate = dateStr.trim().replace("T", " ");
+        String[] dateTimePatterns = {
+                "yyyy-MM-dd HH:mm:ss",
+                "yyyy-MM-dd HH:mm",
+                "dd/MM/yyyy HH:mm:ss",
+                "dd/MM/yyyy HH:mm",
+                "dd-MM-yyyy HH:mm:ss",
+                "dd-MM-yyyy HH:mm" };
+
+        for (String pattern : dateTimePatterns) {
+            try {
+                LocalDateTime parsedDate = LocalDateTime.parse(normalizedDate, DateTimeFormatter.ofPattern(pattern));
+                return Timestamp.valueOf(parsedDate);
+            } catch (DateTimeParseException e) {
+                // Try the next pattern
+            }
+        }
+
+        String[] datePatterns = { "yyyy-MM-dd", "dd/MM/yyyy", "dd-MM-yyyy" };
+        for (String pattern : datePatterns) {
+            try {
+                LocalDate parsedDate = LocalDate.parse(normalizedDate, DateTimeFormatter.ofPattern(pattern));
+                return Timestamp.valueOf(parsedDate.atStartOfDay());
+            } catch (DateTimeParseException e) {
+                // Try the next pattern
+            }
+        }
+
         return null;
+    }
+
+    private String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+
+        for (String value : values) {
+            if (value != null && !value.trim().isEmpty()) {
+                return value.trim();
+            }
+        }
+
+        return null;
+    }
+
+    private String mergeExternalIdIntoSpecialHandling(String specialHandling, String externalId, String barcode) {
+        String normalizedExternalId = firstNonBlank(externalId);
+        if (normalizedExternalId == null || normalizedExternalId.equals(firstNonBlank(barcode))) {
+            return specialHandling;
+        }
+
+        String externalIdNote = "External ID: " + normalizedExternalId;
+        if (specialHandling == null || specialHandling.trim().isEmpty()) {
+            return externalIdNote;
+        }
+
+        if (specialHandling.contains(externalIdNote)) {
+            return specialHandling;
+        }
+
+        return specialHandling + " | " + externalIdNote;
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/dto/BulkRegistrationResponse.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/dto/BulkRegistrationResponse.java
@@ -11,7 +11,9 @@ public class BulkRegistrationResponse {
     private boolean success;
     private String error;
     private int registeredCount;
+    private int failedCount;
     private List<RegisteredSample> samples = new ArrayList<>();
+    private List<String> rowErrors = new ArrayList<>();
 
     public boolean isSuccess() {
         return success;
@@ -37,6 +39,14 @@ public class BulkRegistrationResponse {
         this.registeredCount = registeredCount;
     }
 
+    public int getFailedCount() {
+        return failedCount;
+    }
+
+    public void setFailedCount(int failedCount) {
+        this.failedCount = failedCount;
+    }
+
     public List<RegisteredSample> getSamples() {
         return samples;
     }
@@ -45,9 +55,22 @@ public class BulkRegistrationResponse {
         this.samples = samples;
     }
 
+    public List<String> getRowErrors() {
+        return rowErrors;
+    }
+
+    public void setRowErrors(List<String> rowErrors) {
+        this.rowErrors = rowErrors;
+    }
+
     public void addSample(RegisteredSample sample) {
         this.samples.add(sample);
         this.registeredCount++;
+    }
+
+    public void addRowError(String rowError) {
+        this.rowErrors.add(rowError);
+        this.failedCount++;
     }
 
     /**

--- a/src/test/java/org/openelisglobal/biorepository/BioSampleRestControllerManifestImportTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/BioSampleRestControllerManifestImportTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -153,12 +154,12 @@ public class BioSampleRestControllerManifestImportTest extends BaseWebContextSen
     }
 
     @Test
-    public void testValidateManifestImport_MissingExternalId_ReturnsError() throws Exception {
+    public void testValidateManifestImport_MissingBarcode_ReturnsError() throws Exception {
         // Arrange
         ManifestImportRequest request = new ManifestImportRequest();
         List<SampleRegistrationDTO> samples = new ArrayList<>();
 
-        SampleRegistrationDTO sample = createValidSampleDTO(null); // Missing external ID
+        SampleRegistrationDTO sample = createValidSampleDTO(null); // Missing barcode/sample ID
         samples.add(sample);
         request.setSamples(samples);
 
@@ -178,8 +179,14 @@ public class BioSampleRestControllerManifestImportTest extends BaseWebContextSen
         assertFalse("Row should be invalid", firstRow.get("valid").asBoolean());
         assertTrue("Row should have errors", firstRow.get("errors").size() > 0);
 
-        String errorMessage = firstRow.get("errors").get(0).asText();
-        assertTrue("Error should mention external ID", errorMessage.toLowerCase().contains("external id"));
+        boolean foundBarcodeError = false;
+        for (JsonNode error : firstRow.get("errors")) {
+            if (error.asText().toLowerCase().contains("barcode")) {
+                foundBarcodeError = true;
+                break;
+            }
+        }
+        assertTrue("Error should mention barcode", foundBarcodeError);
     }
 
     @Test
@@ -487,6 +494,34 @@ public class BioSampleRestControllerManifestImportTest extends BaseWebContextSen
     }
 
     @Test
+    public void testRegisterBulk_DistinctExternalId_PreservesValueInSpecialHandling() throws Exception {
+        ManifestImportRequest request = new ManifestImportRequest();
+        List<SampleRegistrationDTO> samples = new ArrayList<>();
+
+        SampleRegistrationDTO sample = createValidSampleDTO("BIO-BARCODE-" + System.currentTimeMillis());
+        sample.setExternalId("PARTICIPANT-12345");
+        sample.setSpecialHandling("Handle with care");
+        samples.add(sample);
+        request.setSamples(samples);
+
+        MvcResult result = mockMvc.perform(post("/rest/biorepository/sample/register-bulk")
+                .contentType(MediaType.APPLICATION_JSON).sessionAttr("userSessionData", userSessionData)
+                .content(objectMapper.writeValueAsString(request))).andExpect(status().isOk()).andReturn();
+
+        JsonNode response = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        assertTrue("Registration should succeed", response.get("success").asBoolean());
+        Integer bioSampleId = response.get("samples").get(0).get("id").asInt();
+
+        var bioSample = bioSampleService.get(bioSampleId);
+        assertNotNull("BioSample should exist in database", bioSample);
+        assertTrue("Special handling should preserve original text",
+                bioSample.getSpecialHandling().contains("Handle with care"));
+        assertTrue("Special handling should preserve the distinct external ID",
+                bioSample.getSpecialHandling().contains("External ID: PARTICIPANT-12345"));
+    }
+
+    @Test
     public void testRegisterBulk_EmptySamplesList_ReturnsBadRequest() throws Exception {
         // Arrange
         ManifestImportRequest request = new ManifestImportRequest();
@@ -512,11 +547,8 @@ public class BioSampleRestControllerManifestImportTest extends BaseWebContextSen
         ManifestImportRequest request = new ManifestImportRequest();
         List<SampleRegistrationDTO> samples = new ArrayList<>();
 
-        SampleRegistrationDTO sample = new SampleRegistrationDTO();
-        sample.setExternalId("INVALID-TYPE-" + System.currentTimeMillis());
+        SampleRegistrationDTO sample = createValidSampleDTO("INVALID-TYPE-" + System.currentTimeMillis());
         sample.setSampleType("NonExistentSampleType12345");
-        sample.setBiosafetyLevel("BSL_1");
-        sample.setOriginLab("Test Lab");
 
         samples.add(sample);
         request.setSamples(samples);
@@ -537,14 +569,46 @@ public class BioSampleRestControllerManifestImportTest extends BaseWebContextSen
                 response.get("error").asText().toLowerCase().contains("sample type"));
     }
 
+    @Test
+    public void testRegisterBulk_PartialFailure_ReturnsRowErrorsAndKeepsSuccesses() throws Exception {
+        ManifestImportRequest request = new ManifestImportRequest();
+        List<SampleRegistrationDTO> samples = new ArrayList<>();
+
+        String duplicateBarcode = "PARTIAL-DUP-" + System.currentTimeMillis();
+        createExistingSampleItem(duplicateBarcode);
+
+        samples.add(createValidSampleDTO("PARTIAL-VALID-" + System.currentTimeMillis()));
+        samples.add(createValidSampleDTO(duplicateBarcode));
+        request.setSamples(samples);
+
+        MvcResult result = mockMvc
+                .perform(post("/rest/biorepository/sample/register-bulk").contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttr("userSessionData", userSessionData)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk()).andReturn();
+
+        JsonNode response = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        assertTrue("Response should keep successful imports", response.get("success").asBoolean());
+        assertEquals("Should register exactly one sample", 1, response.get("registeredCount").asInt());
+        assertEquals("Should report one failed sample", 1, response.get("failedCount").asInt());
+        assertEquals("Should include one row error", 1, response.get("rowErrors").size());
+        assertTrue("Row error should mention the duplicate barcode",
+                response.get("rowErrors").get(0).asText().contains(duplicateBarcode));
+    }
+
     // ========== HELPER METHODS ==========
 
     private SampleRegistrationDTO createValidSampleDTO(String externalId) {
         SampleRegistrationDTO dto = new SampleRegistrationDTO();
+        dto.setBarcode(externalId);
         dto.setExternalId(externalId);
         dto.setSampleType(testSampleType.getId());
         dto.setBiosafetyLevel("BSL_2");
         dto.setOriginLab("Test Integration Lab");
+        dto.setReceiptDate("2026-01-15 09:00:00");
+        dto.setRequiredTempMin(new BigDecimal("2"));
+        dto.setRequiredTempMax(new BigDecimal("8"));
         dto.setCollectionDate("2026-01-15");
         return dto;
     }

--- a/test-data/biorepository_manifest_sample.csv
+++ b/test-data/biorepository_manifest_sample.csv
@@ -1,16 +1,16 @@
-externalId,sampleType,projectId,collectionDate,biosafetyLevel,originLab,principalInvestigator,consentId,ethicsApprovalRef,mtaReference,preservationMedium,arrivalCondition,notes
-BIO-2026-001,Serum,PROJ-MALARIA-001,2026-01-15,BSL_2,AHRI Clinical Lab,Dr. Sarah Johnson,CONSENT-2026-001,ETH-2025-042,MTA-EXT-001,EDTA,Good,Blood sample from malaria study participant
-BIO-2026-002,Plasma,PROJ-MALARIA-001,2026-01-15,BSL_2,AHRI Clinical Lab,Dr. Sarah Johnson,CONSENT-2026-002,ETH-2025-042,,Heparin,Good,
-BIO-2026-003,Whole Blood,PROJ-MALARIA-001,2026-01-15,BSL_2,AHRI Clinical Lab,Dr. Sarah Johnson,CONSENT-2026-003,ETH-2025-042,,EDTA,Good,
-BIO-2026-004,DNA,PROJ-GENOMICS-001,2026-01-14,BSL_1,Molecular Biology Lab,Dr. Michael Chen,,ETH-2024-108,,Cryoprotectant,Good,Extracted from PBMCs
-BIO-2026-005,RNA,PROJ-GENOMICS-001,2026-01-14,BSL_1,Molecular Biology Lab,Dr. Michael Chen,,ETH-2024-108,,RNAlater,Good,RNA extraction from tissue biopsy
-BIO-2026-006,Bacterial Isolate,PROJ-AMR-001,2026-01-13,BSL_2,Microbiology Reference Lab,Dr. Amina Bekele,,ETH-2025-015,,Glycerol Stock,Good,E. coli isolate - AMR surveillance
-BIO-2026-007,Bacterial Isolate,PROJ-AMR-001,2026-01-13,BSL_2,Microbiology Reference Lab,Dr. Amina Bekele,,ETH-2025-015,,Glycerol Stock,Good,K. pneumoniae isolate - MDR
-BIO-2026-008,Viral Culture,PROJ-RESP-001,2026-01-12,BSL_3,Virology Lab,Dr. James Oduya,,ETH-2025-033,MTA-CDC-2025,VTM,Good,Influenza A isolate - requires BSL-3
-BIO-2026-009,FFPE Block,PROJ-PATHOLOGY-001,2026-01-10,BSL_1,Pathology Department,Dr. Grace Mwangi,CONSENT-2026-009,ETH-2023-077,,Formalin Fixed,Good,Tissue block for histopathology
-BIO-2026-010,Fresh Frozen,PROJ-PATHOLOGY-001,2026-01-10,BSL_1,Pathology Department,Dr. Grace Mwangi,CONSENT-2026-010,ETH-2023-077,,Snap Frozen,Good,Tumor tissue - needs -80C storage
-BIO-2026-011,PBMCs,PROJ-IMMUNO-001,2026-01-09,BSL_2,Immunology Lab,Dr. Peter Kimani,CONSENT-2026-011,ETH-2025-055,,DMSO/FBS,Good,PBMCs for T-cell studies
-BIO-2026-012,Cell Line,PROJ-CELLBANK-001,2026-01-08,BSL_1,Cell Culture Facility,Dr. Rebecca Wanjiru,,,MTA-ATCC-2024,DMSO/FBS,Good,HeLa cell line passage 15
-BIO-2026-013,Urine,PROJ-KIDNEY-001,2026-01-16,BSL_1,Nephrology Clinic,Dr. David Otieno,CONSENT-2026-013,ETH-2025-061,,None,Good,24hr urine collection
-BIO-2026-014,CSF,PROJ-NEURO-001,2026-01-16,BSL_2,Neurology Ward,Dr. Elizabeth Njeri,CONSENT-2026-014,ETH-2025-070,,None,Good,CSF sample - meningitis investigation
-BIO-2026-015,Respiratory Swab,PROJ-RESP-001,2026-01-16,BSL_2,Respiratory Clinic,Dr. James Oduya,CONSENT-2026-015,ETH-2025-033,,VTM,Good,Nasopharyngeal swab
+barcode,externalId,sampleType,projectId,originLab,receiptDate,requiredTempMin,requiredTempMax,biosafetyLevel,collectionDate,principalInvestigator,consentId,ethicsApprovalRef,mtaReference,preservationMedium,arrivalCondition,specialHandling
+BIO-2026-001,PART-001,Serum,PROJ-MALARIA-001,AHRI Clinical Lab,2026-01-15 09:00:00,2,8,BSL_2,2026-01-15,Dr. Sarah Johnson,CONSENT-2026-001,ETH-2025-042,MTA-EXT-001,EDTA,Good,Blood sample from malaria study participant
+BIO-2026-002,PART-002,Plasma,PROJ-MALARIA-001,AHRI Clinical Lab,2026-01-15 09:10:00,2,8,BSL_2,2026-01-15,Dr. Sarah Johnson,CONSENT-2026-002,ETH-2025-042,,Heparin,Good,
+BIO-2026-003,PART-003,Whole Blood,PROJ-MALARIA-001,AHRI Clinical Lab,2026-01-15 09:20:00,2,8,BSL_2,2026-01-15,Dr. Sarah Johnson,CONSENT-2026-003,ETH-2025-042,,EDTA,Good,
+BIO-2026-004,PART-004,DNA,PROJ-GENOMICS-001,Molecular Biology Lab,2026-01-14 10:00:00,-20,-20,BSL_1,2026-01-14,Dr. Michael Chen,,ETH-2024-108,,Cryoprotectant,Good,Extracted from PBMCs
+BIO-2026-005,PART-005,RNA,PROJ-GENOMICS-001,Molecular Biology Lab,2026-01-14 10:15:00,-80,-80,BSL_1,2026-01-14,Dr. Michael Chen,,ETH-2024-108,,RNAlater,Good,RNA extraction from tissue biopsy
+BIO-2026-006,PART-006,Bacterial Isolate,PROJ-AMR-001,Microbiology Reference Lab,2026-01-13 08:45:00,-80,-20,BSL_2,2026-01-13,Dr. Amina Bekele,,ETH-2025-015,,Glycerol Stock,Good,E. coli isolate for AMR surveillance
+BIO-2026-007,PART-007,Bacterial Isolate,PROJ-AMR-001,Microbiology Reference Lab,2026-01-13 08:50:00,-80,-20,BSL_2,2026-01-13,Dr. Amina Bekele,,ETH-2025-015,,Glycerol Stock,Good,K. pneumoniae isolate MDR
+BIO-2026-008,PART-008,Viral Culture,PROJ-RESP-001,Virology Lab,2026-01-12 11:30:00,-80,-20,BSL_3,2026-01-12,Dr. James Oduya,,ETH-2025-033,MTA-CDC-2025,VTM,Good,Influenza A isolate requires BSL-3
+BIO-2026-009,PART-009,FFPE Block,PROJ-PATHOLOGY-001,Pathology Department,2026-01-10 14:00:00,20,25,BSL_1,2026-01-10,Dr. Grace Mwangi,CONSENT-2026-009,ETH-2023-077,,Formalin Fixed,Good,Tissue block for histopathology
+BIO-2026-010,PART-010,Fresh Frozen,PROJ-PATHOLOGY-001,Pathology Department,2026-01-10 14:20:00,-80,-80,BSL_1,2026-01-10,Dr. Grace Mwangi,CONSENT-2026-010,ETH-2023-077,,Snap Frozen,Good,Tumor tissue needs -80C storage
+BIO-2026-011,PART-011,PBMCs,PROJ-IMMUNO-001,Immunology Lab,2026-01-09 15:00:00,-196,-150,BSL_2,2026-01-09,Dr. Peter Kimani,CONSENT-2026-011,ETH-2025-055,,DMSO/FBS,Good,PBMCs for T-cell studies
+BIO-2026-012,PART-012,Cell Line,PROJ-CELLBANK-001,Cell Culture Facility,2026-01-08 16:10:00,-196,-80,BSL_1,2026-01-08,Dr. Rebecca Wanjiru,,,MTA-ATCC-2024,DMSO/FBS,Good,HeLa cell line passage 15
+BIO-2026-013,PART-013,Urine,PROJ-KIDNEY-001,Nephrology Clinic,2026-01-16 08:15:00,2,8,BSL_1,2026-01-16,Dr. David Otieno,CONSENT-2026-013,ETH-2025-061,,None,Good,24 hour urine collection
+BIO-2026-014,PART-014,CSF,PROJ-NEURO-001,Neurology Ward,2026-01-16 09:05:00,2,8,BSL_2,2026-01-16,Dr. Elizabeth Njeri,CONSENT-2026-014,ETH-2025-070,,None,Good,CSF sample meningitis investigation
+BIO-2026-015,PART-015,Respiratory Swab,PROJ-RESP-001,Respiratory Clinic,2026-01-16 09:25:00,2,8,BSL_2,2026-01-16,Dr. James Oduya,CONSENT-2026-015,ETH-2025-033,,VTM,Good,Nasopharyngeal swab

--- a/test-data/demo-biorepository-manifest.csv
+++ b/test-data/demo-biorepository-manifest.csv
@@ -1,21 +1,21 @@
-externalId,sampleType,projectId,collectionDate,biosafetyLevel,originLab,principalInvestigator,consentId,ethicsApprovalRef,mtaReference,preservationMedium,arrivalCondition,notes
-BIO-2026-001,Serum,PROJ-TB-2026,2026-01-05,BSL_2,AHRI Main Lab,Dr. Sarah Alemayehu,CONS-2026-001,ETH-AHRI-2026-001,,EDTA,Good,Baseline sample from TB study cohort
-BIO-2026-002,Plasma,PROJ-TB-2026,2026-01-05,BSL_2,AHRI Main Lab,Dr. Sarah Alemayehu,CONS-2026-002,ETH-AHRI-2026-001,,Heparin,Good,Follow-up sample week 4
-BIO-2026-003,Whole Blood,PROJ-TB-2026,2026-01-06,BSL_2,AHRI Main Lab,Dr. Sarah Alemayehu,CONS-2026-003,ETH-AHRI-2026-001,,EDTA,Good,Paired sample for genomic analysis
-BIO-2026-004,DNA,PROJ-GEN-2026,2026-01-04,BSL_1,AHRI Molecular Lab,Dr. Kidist Bobosha,CONS-2026-004,ETH-AHRI-2026-002,,TE Buffer,Good,Extracted from whole blood sample
-BIO-2026-005,RNA,PROJ-GEN-2026,2026-01-04,BSL_1,AHRI Molecular Lab,Dr. Kidist Bobosha,CONS-2026-005,ETH-AHRI-2026-002,,RNAlater,Good,Gene expression study
-BIO-2026-006,PBMCs,PROJ-IMM-2026,2026-01-03,BSL_2,AHRI Immunology Lab,Dr. Rawleigh Howe,CONS-2026-006,ETH-AHRI-2026-003,,DMSO/FBS,Good,Cryopreserved for T-cell assays
-BIO-2026-007,Cell Line,PROJ-IMM-2026,2026-01-02,BSL_2,AHRI Immunology Lab,Dr. Rawleigh Howe,,,MTA-EMORY-2026-001,DMSO/FBS,Good,Immortalized B-cell line from collaborator
-BIO-2026-008,Bacterial Isolate,PROJ-MDR-2026,2026-01-07,BSL_3,AHRI BSL-3 Lab,Dr. Alemseged Abdissa,,,MTA-CDC-2026-001,Glycerol Stock,Good,MDR-TB isolate for susceptibility testing
-BIO-2026-009,Biopsy,PROJ-PATH-2026,2026-01-06,BSL_2,AHRI Pathology Lab,Dr. Taye Tolera,CONS-2026-009,ETH-AHRI-2026-004,,Formalin,Good,Lymph node biopsy
-BIO-2026-010,FFPE Block,PROJ-PATH-2026,2026-01-01,BSL_2,AHRI Pathology Lab,Dr. Taye Tolera,CONS-2026-010,ETH-AHRI-2026-004,,Paraffin,Good,Archived tissue block from 2025
-BIO-2026-011,Respiratory Swab,PROJ-RESP-2026,2026-01-08,BSL_2,AHRI Clinical Lab,Dr. Nega Berhe,CONS-2026-011,ETH-AHRI-2026-005,,VTM,Good,Nasopharyngeal swab for respiratory panel
-BIO-2026-012,Urine,PROJ-TB-2026,2026-01-08,BSL_2,AHRI Main Lab,Dr. Sarah Alemayehu,CONS-2026-012,ETH-AHRI-2026-001,,None,Good,Morning void for LAM testing
-BIO-2026-013,CSF,PROJ-NEURO-2026,2026-01-07,BSL_2,Black Lion Hospital,Dr. Yohannes Mengistu,CONS-2026-013,ETH-BLH-2026-001,,None,Good,Lumbar puncture sample
-BIO-2026-014,Stool,PROJ-GI-2026,2026-01-09,BSL_2,AHRI Clinical Lab,Dr. Nega Berhe,CONS-2026-014,ETH-AHRI-2026-006,,Cary-Blair,Good,Enteric pathogen study
-BIO-2026-015,Saliva,PROJ-ORAL-2026,2026-01-09,BSL_1,AHRI Dental Clinic,Dr. Fasil Kenea,CONS-2026-015,ETH-AHRI-2026-007,,DNA Shield,Good,Oral microbiome study
-BIO-2026-016,Buffy Coat,PROJ-TB-2026,2026-01-05,BSL_2,AHRI Main Lab,Dr. Sarah Alemayehu,CONS-2026-016,ETH-AHRI-2026-001,,None,Good,Isolated from whole blood for DNA extraction
-BIO-2026-017,Fresh Frozen,PROJ-PATH-2026,2026-01-08,BSL_2,AHRI Pathology Lab,Dr. Taye Tolera,CONS-2026-017,ETH-AHRI-2026-004,,OCT Medium,Good,Snap frozen tissue for protein analysis
-BIO-2026-018,Viral Culture,PROJ-VIR-2026,2026-01-02,BSL_3,AHRI BSL-3 Lab,Dr. Alemseged Abdissa,,,MTA-NIH-2026-001,Cell Culture Medium,Good,Influenza isolate for sequencing
-BIO-2026-019,Fluid,PROJ-PATH-2026,2026-01-06,BSL_2,AHRI Pathology Lab,Dr. Taye Tolera,CONS-2026-019,ETH-AHRI-2026-004,,None,Good,Pleural fluid aspiration
-BIO-2026-020,Environmental,PROJ-ENV-2026,2026-01-09,BSL_1,AHRI Environmental Lab,Dr. Girmay Medhin,,ETH-AHRI-2026-008,,Sterile Container,Good,Soil sample from leprosy endemic area
+barcode,externalId,sampleType,projectId,originLab,receiptDate,requiredTempMin,requiredTempMax,biosafetyLevel,collectionDate,principalInvestigator,consentId,ethicsApprovalRef,mtaReference,preservationMedium,arrivalCondition,specialHandling
+BIO-2026-001,CONS-001,Serum,PROJ-TB-2026,AHRI Main Lab,2026-01-05 09:00:00,2,8,BSL_2,2026-01-05,Dr. Sarah Alemayehu,CONS-2026-001,ETH-AHRI-2026-001,,EDTA,Good,Baseline sample from TB study cohort
+BIO-2026-002,CONS-002,Plasma,PROJ-TB-2026,AHRI Main Lab,2026-01-05 09:15:00,2,8,BSL_2,2026-01-05,Dr. Sarah Alemayehu,CONS-2026-002,ETH-AHRI-2026-001,,Heparin,Good,Follow-up sample week 4
+BIO-2026-003,CONS-003,Whole Blood,PROJ-TB-2026,AHRI Main Lab,2026-01-06 10:00:00,2,8,BSL_2,2026-01-06,Dr. Sarah Alemayehu,CONS-2026-003,ETH-AHRI-2026-001,,EDTA,Good,Paired sample for genomic analysis
+BIO-2026-004,CONS-004,DNA,PROJ-GEN-2026,AHRI Molecular Lab,2026-01-04 11:00:00,-20,-20,BSL_1,2026-01-04,Dr. Kidist Bobosha,CONS-2026-004,ETH-AHRI-2026-002,,TE Buffer,Good,Extracted from whole blood sample
+BIO-2026-005,CONS-005,RNA,PROJ-GEN-2026,AHRI Molecular Lab,2026-01-04 11:15:00,-80,-80,BSL_1,2026-01-04,Dr. Kidist Bobosha,CONS-2026-005,ETH-AHRI-2026-002,,RNAlater,Good,Gene expression study
+BIO-2026-006,CONS-006,PBMCs,PROJ-IMM-2026,AHRI Immunology Lab,2026-01-03 08:30:00,-196,-150,BSL_2,2026-01-03,Dr. Rawleigh Howe,CONS-2026-006,ETH-AHRI-2026-003,,DMSO/FBS,Good,Cryopreserved for T-cell assays
+BIO-2026-007,COLLAB-007,Cell Line,PROJ-IMM-2026,AHRI Immunology Lab,2026-01-02 08:45:00,-196,-80,BSL_2,2026-01-02,Dr. Rawleigh Howe,,,MTA-EMORY-2026-001,DMSO/FBS,Good,Immortalized B-cell line from collaborator
+BIO-2026-008,COLLAB-008,Bacterial Isolate,PROJ-MDR-2026,AHRI BSL-3 Lab,2026-01-07 09:10:00,-80,-20,BSL_3,2026-01-07,Dr. Alemseged Abdissa,,,MTA-CDC-2026-001,Glycerol Stock,Good,MDR-TB isolate for susceptibility testing
+BIO-2026-009,CONS-009,Biopsy,PROJ-PATH-2026,AHRI Pathology Lab,2026-01-06 13:00:00,2,8,BSL_2,2026-01-06,Dr. Taye Tolera,CONS-2026-009,ETH-AHRI-2026-004,,Formalin,Good,Lymph node biopsy
+BIO-2026-010,CONS-010,FFPE Block,PROJ-PATH-2026,AHRI Pathology Lab,2026-01-01 13:20:00,20,25,BSL_2,2026-01-01,Dr. Taye Tolera,CONS-2026-010,ETH-AHRI-2026-004,,Paraffin,Good,Archived tissue block from 2025
+BIO-2026-011,CONS-011,Respiratory Swab,PROJ-RESP-2026,AHRI Clinical Lab,2026-01-08 10:10:00,2,8,BSL_2,2026-01-08,Dr. Nega Berhe,CONS-2026-011,ETH-AHRI-2026-005,,VTM,Good,Nasopharyngeal swab for respiratory panel
+BIO-2026-012,CONS-012,Urine,PROJ-TB-2026,AHRI Main Lab,2026-01-08 10:30:00,2,8,BSL_2,2026-01-08,Dr. Sarah Alemayehu,CONS-2026-012,ETH-AHRI-2026-001,,None,Good,Morning void for LAM testing
+BIO-2026-013,CONS-013,CSF,PROJ-NEURO-2026,Black Lion Hospital,2026-01-07 15:00:00,2,8,BSL_2,2026-01-07,Dr. Yohannes Mengistu,CONS-2026-013,ETH-BLH-2026-001,,None,Good,Lumbar puncture sample
+BIO-2026-014,CONS-014,Stool,PROJ-GI-2026,AHRI Clinical Lab,2026-01-09 11:00:00,2,8,BSL_2,2026-01-09,Dr. Nega Berhe,CONS-2026-014,ETH-AHRI-2026-006,,Cary-Blair,Good,Enteric pathogen study
+BIO-2026-015,CONS-015,Saliva,PROJ-ORAL-2026,AHRI Dental Clinic,2026-01-09 11:20:00,2,8,BSL_1,2026-01-09,Dr. Fasil Kenea,CONS-2026-015,ETH-AHRI-2026-007,,DNA Shield,Good,Oral microbiome study
+BIO-2026-016,CONS-016,Buffy Coat,PROJ-TB-2026,AHRI Main Lab,2026-01-05 09:40:00,-20,-20,BSL_2,2026-01-05,Dr. Sarah Alemayehu,CONS-2026-016,ETH-AHRI-2026-001,,None,Good,Isolated from whole blood for DNA extraction
+BIO-2026-017,CONS-017,Fresh Frozen,PROJ-PATH-2026,AHRI Pathology Lab,2026-01-08 13:45:00,-80,-80,BSL_2,2026-01-08,Dr. Taye Tolera,CONS-2026-017,ETH-AHRI-2026-004,,OCT Medium,Good,Snap frozen tissue for protein analysis
+BIO-2026-018,COLLAB-018,Viral Culture,PROJ-VIR-2026,AHRI BSL-3 Lab,2026-01-02 14:10:00,-80,-20,BSL_3,2026-01-02,Dr. Alemseged Abdissa,,,MTA-NIH-2026-001,Cell Culture Medium,Good,Influenza isolate for sequencing
+BIO-2026-019,CONS-019,Fluid,PROJ-PATH-2026,AHRI Pathology Lab,2026-01-06 15:30:00,2,8,BSL_2,2026-01-06,Dr. Taye Tolera,CONS-2026-019,ETH-AHRI-2026-004,,None,Good,Pleural fluid aspiration
+BIO-2026-020,ENV-020,Environmental,PROJ-ENV-2026,AHRI Environmental Lab,2026-01-09 16:00:00,20,25,BSL_1,2026-01-09,Dr. Girmay Medhin,,ETH-AHRI-2026-008,,Sterile Container,Good,Soil sample from leprosy endemic area


### PR DESCRIPTION
## Summary
- support AHRI legacy workbook-style manifest intake in the biorepository upload flow
- keep manifest imports scoped to Sample Intake & Registration and skip rows without a sample ID/barcode
- harden bulk registration by using safe accession generation and stricter intake manifest validation
- raise intake sample fetch limits so large manifest imports remain visible after registration
- refresh the sample manifest test-data files to match the current intake manifest structure

## Testing
- locally tested 