### PR TITLE
Bugfix/lazy initialization exception csv export

### DIFF
--- a/src/main/java/org/openelisglobal/testresult/daoimpl/TestResultDAOImpl.java
+++ b/src/main/java/org/openelisglobal/testresult/daoimpl/TestResultDAOImpl.java
@@ -66,7 +66,7 @@ public class TestResultDAOImpl extends BaseDAOImpl<TestResult, String> implement
     public List<TestResult> getAllTestResults() throws LIMSRuntimeException {
         List<TestResult> list;
         try {
-            String sql = "from TestResult";
+            String sql = "from TestResult tr JOIN FETCH tr.test";
             Query<TestResult> query = entityManager.unwrap(Session.class).createQuery(sql, TestResult.class);
             list = query.list();
         } catch (RuntimeException e) {

--- a/src/test/java/org/openelisglobal/testResult/TestResultServiceTest.java
+++ b/src/test/java/org/openelisglobal/testResult/TestResultServiceTest.java
@@ -78,16 +78,12 @@ public class TestResultServiceTest extends BaseWebContextSensitiveTest {
     public void getAllTestResults_shouldEagerlyLoadTestEntities() {
         List<TestResult> testResults = testResultService.getAllTestResults();
 
-        // Verify that Test entities are eagerly loaded (not lazy proxies)
         for (TestResult testResult : testResults) {
-            // This should NOT throw LazyInitializationException
             org.openelisglobal.test.valueholder.Test test = testResult.getTest();
 
-            // Verify we can access Test properties without session
             assertNotNull("Test should be loaded", test);
             assertNotNull("Test ID should be accessible", test.getId());
 
-            // Verify Test entity is not a Hibernate proxy
             assertFalse("Test should not be a proxy", test.getClass().getName().contains("$HibernateProxy$"));
         }
     }

--- a/src/test/java/org/openelisglobal/testResult/TestResultServiceTest.java
+++ b/src/test/java/org/openelisglobal/testResult/TestResultServiceTest.java
@@ -1,6 +1,8 @@
 package org.openelisglobal.testResult;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -70,6 +72,24 @@ public class TestResultServiceTest extends BaseWebContextSensitiveTest {
         assertEquals(2, testResults.size());
         assertEquals("1", testResults.get(0).getId());
         assertEquals("2", testResults.get(1).getId());
+    }
+
+    @Test
+    public void getAllTestResults_shouldEagerlyLoadTestEntities() {
+        List<TestResult> testResults = testResultService.getAllTestResults();
+
+        // Verify that Test entities are eagerly loaded (not lazy proxies)
+        for (TestResult testResult : testResults) {
+            // This should NOT throw LazyInitializationException
+            org.openelisglobal.test.valueholder.Test test = testResult.getTest();
+
+            // Verify we can access Test properties without session
+            assertNotNull("Test should be loaded", test);
+            assertNotNull("Test ID should be accessible", test.getId());
+
+            // Verify Test entity is not a Hibernate proxy
+            assertFalse("Test should not be a proxy", test.getClass().getName().contains("$HibernateProxy$"));
+        }
     }
 
     @Test


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Fixes LazyInitializationException that occurs when exporting Routine CSV files. The error "could not initialize proxy [org.openelisglobal.test.valueholder.Test#11] - no Session" happened because the legacy ValueHolder pattern was trying to access Test entities after the Hibernate session closed.

  **Changes**
  - Modified TestResultDAOImpl.getAllTestResults() to use JOIN FETCH tr.test for eager loading
  - Added test to verify Test entities are properly loaded without lazy proxy errors

  **Root Cause**: The DAO query "from TestResult" left Test entities as lazy proxies, which failed when accessed during CSV generation outside the transaction scope.

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
