### PR TITLE
feat(storage): add minimal shelf/compartment chooser

### DIFF
--- a/frontend/src/components/storage/StorageLocationModal.jsx
+++ b/frontend/src/components/storage/StorageLocationModal.jsx
@@ -782,12 +782,12 @@ const StorageLocationModal = ({
                   id="shelf-storage-type"
                   data-testid="shelf-storage-type-dropdown"
                   titleText={intl.formatMessage({
-                    id: "storage.location.type",
-                    defaultMessage: "Location Type",
+                    id: "storage.shelf.label.type",
+                    defaultMessage: "Label Type (labeling only)",
                   })}
                   label={intl.formatMessage({
-                    id: "storage.location.type.select",
-                    defaultMessage: "Select type",
+                    id: "storage.shelf.label.type.select",
+                    defaultMessage: "Select label type",
                   })}
                   items={storageLevel3TypeOptions}
                   selectedItem={selectedStorageLevel3Option || null}

--- a/frontend/src/components/storage/StorageLocationModal.jsx
+++ b/frontend/src/components/storage/StorageLocationModal.jsx
@@ -72,6 +72,8 @@ const StorageLocationModal = ({
   const [selectedParentRoomId, setSelectedParentRoomId] = useState(null);
   const [selectedParentDeviceId, setSelectedParentDeviceId] = useState(null);
   const [selectedParentShelfId, setSelectedParentShelfId] = useState(null);
+  const [selectedStorageLevel3Type, setSelectedStorageLevel3Type] =
+    useState("shelf");
 
   // Helper to get plural form for API endpoints
   const getPluralType = (type) => {
@@ -229,6 +231,7 @@ const StorageLocationModal = ({
       setSelectedParentRoomId(null);
       setSelectedParentDeviceId(null);
       setSelectedParentShelfId(null);
+      setSelectedStorageLevel3Type("shelf");
     }
   }, [open]);
 
@@ -475,7 +478,45 @@ const StorageLocationModal = ({
     { id: "other", label: "Other" },
   ];
 
+  const storageLevel3TypeOptions = [
+    {
+      id: "shelf",
+      label: intl.formatMessage({
+        id: "storage.type.shelf",
+        defaultMessage: "Shelf",
+      }),
+    },
+    {
+      id: "compartment",
+      label: intl.formatMessage({
+        id: "storage.type.compartment",
+        defaultMessage: "Compartment",
+      }),
+    },
+  ];
+
+  const selectedStorageLevel3Option = storageLevel3TypeOptions.find(
+    (option) => option.id === selectedStorageLevel3Type,
+  );
+
+  const storageLevel3Label =
+    selectedStorageLevel3Option?.label ||
+    intl.formatMessage({
+      id: "storage.type.shelf",
+      defaultMessage: "Shelf",
+    });
+
   const getModalTitle = () => {
+    if (locationType === "shelf" && mode === "create") {
+      return intl.formatMessage(
+        {
+          id: "storage.add.level3.dynamic",
+          defaultMessage: "Add {locationLabel}",
+        },
+        { locationLabel: storageLevel3Label },
+      );
+    }
+
     const action = mode === "create" ? "add" : "edit";
     const typeKey = `storage.${action}.${locationType}`;
     return intl.formatMessage(
@@ -736,12 +777,44 @@ const StorageLocationModal = ({
           {/* Shelf fields */}
           {locationType === "shelf" && (
             <>
+              {mode === "create" && (
+                <Dropdown
+                  id="shelf-storage-type"
+                  data-testid="shelf-storage-type-dropdown"
+                  titleText={intl.formatMessage({
+                    id: "storage.location.type",
+                    defaultMessage: "Location Type",
+                  })}
+                  label={intl.formatMessage({
+                    id: "storage.location.type.select",
+                    defaultMessage: "Select type",
+                  })}
+                  items={storageLevel3TypeOptions}
+                  selectedItem={selectedStorageLevel3Option || null}
+                  onChange={({ selectedItem }) => {
+                    if (selectedItem?.id) {
+                      setSelectedStorageLevel3Type(selectedItem.id);
+                    }
+                  }}
+                  itemToString={(item) => (item ? item.label : "")}
+                />
+              )}
               <TextInput
                 id="shelf-label"
-                labelText={intl.formatMessage({
-                  id: "storage.shelf.label",
-                  defaultMessage: "Label",
-                })}
+                labelText={
+                  mode === "create"
+                    ? intl.formatMessage(
+                        {
+                          id: "storage.level3.label.dynamic",
+                          defaultMessage: "{locationLabel} Label",
+                        },
+                        { locationLabel: storageLevel3Label },
+                      )
+                    : intl.formatMessage({
+                        id: "storage.shelf.label",
+                        defaultMessage: "Label",
+                      })
+                }
                 value={formData.label || ""}
                 onChange={(e) => handleFieldChange("label", e.target.value)}
                 invalid={!!errors.label}

--- a/frontend/src/components/storage/StorageLocationModal.test.jsx
+++ b/frontend/src/components/storage/StorageLocationModal.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
@@ -91,7 +91,7 @@ describe("StorageLocationModal", () => {
     await screen.findByLabelText(/communication protocol/i);
   });
 
-  test("testStorageLocationModal_ShelfCreateMode_AllowsSelectingStorageType", async () => {
+  test("testStorageLocationModal_ShelfCreateMode_CompartmentSelectionUpdatesTitleAndLabel", async () => {
     Utils.getFromOpenElisServerV2.mockResolvedValue([
       {
         id: "11",
@@ -111,8 +111,20 @@ describe("StorageLocationModal", () => {
     );
 
     await screen.findByTestId("storage-location-modal");
-    await screen.findByTestId("shelf-storage-type-dropdown");
+
+    await screen.findByText(/add shelf/i);
     await screen.findByLabelText(/shelf label/i);
+
+    const storageTypeDropdown = await screen.findByTestId(
+      "shelf-storage-type-dropdown",
+    );
+    const dropdownButton = within(storageTypeDropdown).getByRole("button");
+
+    await userEvent.click(dropdownButton);
+    await userEvent.click(await screen.findByText(/^compartment$/i));
+
+    await screen.findByText(/add compartment/i);
+    await screen.findByLabelText(/compartment label/i);
   });
 
   /**

--- a/frontend/src/components/storage/StorageLocationModal.test.jsx
+++ b/frontend/src/components/storage/StorageLocationModal.test.jsx
@@ -85,10 +85,34 @@ describe("StorageLocationModal", () => {
     );
 
     await screen.findByTestId("storage-location-modal");
-    await screen.findByLabelText(/location name/i);
+    await screen.findByLabelText(/^name$/i);
     await screen.findByLabelText(/ip address/i);
     await screen.findByLabelText(/^port$/i);
     await screen.findByLabelText(/communication protocol/i);
+  });
+
+  test("testStorageLocationModal_ShelfCreateMode_AllowsSelectingStorageType", async () => {
+    Utils.getFromOpenElisServerV2.mockResolvedValue([
+      {
+        id: "11",
+        name: "Ultra-Low Freezer 1",
+        active: true,
+      },
+    ]);
+
+    renderWithIntl(
+      <StorageLocationModal
+        open={true}
+        locationType="shelf"
+        mode="create"
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await screen.findByTestId("storage-location-modal");
+    await screen.findByTestId("shelf-storage-type-dropdown");
+    await screen.findByLabelText(/shelf label/i);
   });
 
   /**
@@ -213,7 +237,7 @@ describe("StorageLocationModal", () => {
     );
 
     // Assert: Verify fields are pre-filled
-    const nameInput = await screen.findByLabelText(/location name/i);
+    const nameInput = await screen.findByLabelText(/^name$/i);
     expect(nameInput.value).toBe("Freezer Unit 1");
 
     const ipInput = await screen.findByLabelText(/ip address/i);


### PR DESCRIPTION
Adds a small chooser in the storage location modal so level-3 storage can be created as either a shelf or a compartment.

Testing:tested locally 