### PR TITLE
feat(biorepository): clean up QC and storage scope behavior

### DIFF
--- a/frontend/src/components/notebook/NoteBookInstanceEntryForm.js
+++ b/frontend/src/components/notebook/NoteBookInstanceEntryForm.js
@@ -126,8 +126,40 @@ const NoteBookInstanceEntryForm = () => {
   const [projectTags, setProjectTags] = useState([]); // Template tags (for display only)
   const [projectFiles, setProjectFiles] = useState([]); // Template files (for display only)
 
+  const isBiorepositoryNotebook = (notebook) => {
+    const workflowType = notebook?.workflowType;
+    if (
+      typeof workflowType === "string" &&
+      workflowType.toLowerCase() === "biorepository"
+    ) {
+      return true;
+    }
+
+    const typeName = notebook?.typeName;
+    if (
+      typeof typeName === "string" &&
+      typeName.toLowerCase().includes("biorepository")
+    ) {
+      return true;
+    }
+
+    return false;
+  };
+
   const handleSubmit = () => {
     if (isSubmitting) {
+      return;
+    }
+    if (isBiorepositoryNotebook(noteBookData) && ["FINALIZED", "ARCHIVED"].includes(noteBookData.status)) {
+      addNotification({
+        kind: NotificationKinds.error,
+        title: intl.formatMessage({ id: "notification.title" }),
+        message: intl.formatMessage({
+          id: "biorepository.notebook.status.restricted",
+          defaultMessage:
+            "Biorepository entries stay operational and cannot be finalized or archived.",
+        }),
+      });
       return;
     }
     setIsSubmitting(true);
@@ -518,6 +550,8 @@ const NoteBookInstanceEntryForm = () => {
                 // Override with latest template properties (for display)
                 title: templateData.title,
                 type: templateData.type,
+                typeName: templateData.typeName || data.typeName,
+                workflowType: templateData.workflowType || data.workflowType,
                 objective: templateData.objective,
                 protocol: templateData.protocol,
                 content: templateData.content,
@@ -597,6 +631,14 @@ const NoteBookInstanceEntryForm = () => {
   const getStatusColor = (status) => {
     return statusColors[status] || "gray";
   };
+
+  const isOperationalBiorepositoryNotebook = isBiorepositoryNotebook(noteBookData);
+
+  const editableStatuses = isOperationalBiorepositoryNotebook
+    ? statuses.filter(
+        (status) => !["FINALIZED", "ARCHIVED"].includes(status.id),
+      )
+    : statuses;
 
   return (
     <>
@@ -1163,7 +1205,7 @@ const NoteBookInstanceEntryForm = () => {
               )}
             {noteBookData?.isTemplate !== true &&
               noteBookData?.id &&
-              noteBookData?.title?.toLowerCase().includes("biorepository") && (
+              isBiorepositoryNotebook(noteBookData) && (
                 <BiorepositoryWorkflowTab notebookId={noteBookData.id} />
               )}
             {noteBookData?.isTemplate !== true &&
@@ -1197,7 +1239,7 @@ const NoteBookInstanceEntryForm = () => {
               !noteBookData?.title
                 ?.toLowerCase()
                 .includes("medical laboratory") &&
-              !noteBookData?.title?.toLowerCase().includes("biorepository") &&
+              !isBiorepositoryNotebook(noteBookData) &&
               !noteBookData?.title
                 ?.toLowerCase()
                 .includes("genomics & bioinformatics laboratory") &&
@@ -1577,9 +1619,9 @@ const NoteBookInstanceEntryForm = () => {
         <Column lg={16} md={8} sm={4}>
           <Grid fullWidth={true} className="gridBoundary">
             <Column lg={8} md={8} sm={4}>
-              <Select
-                id="status"
-                name="status"
+                <Select
+                  id="status"
+                  name="status"
                 labelText={intl.formatMessage({ id: "notebook.label.status" })}
                 value={noteBookData.status || ""}
                 onChange={(event) => {
@@ -1591,7 +1633,7 @@ const NoteBookInstanceEntryForm = () => {
                 disabled={isViewMode}
               >
                 <SelectItem />
-                {statuses.map((status, index) => {
+                {editableStatuses.map((status, index) => {
                   return (
                     <SelectItem
                       key={index}

--- a/frontend/src/components/notebook/pages/biorepository/BiorepositoryEnvironmentalMonitoringPage.js
+++ b/frontend/src/components/notebook/pages/biorepository/BiorepositoryEnvironmentalMonitoringPage.js
@@ -174,7 +174,9 @@ function BiorepositoryEnvironmentalMonitoringPage({
   // Load storage devices
   const loadDevices = useCallback(() => {
     setLoadingDevices(true);
-    getFromOpenElisServer(`/rest/storage/devices`, (response) => {
+    getFromOpenElisServer(
+      `/rest/storage/devices?status=active&biorepositoryOnly=true`,
+      (response) => {
       if (componentMounted.current) {
         if (response && Array.isArray(response)) {
           setDevices(response);
@@ -183,13 +185,14 @@ function BiorepositoryEnvironmentalMonitoringPage({
         }
         setLoadingDevices(false);
       }
-    });
+      },
+    );
   }, []);
 
   // Load storage rooms
   const loadRooms = useCallback(() => {
     setLoadingRooms(true);
-    getFromOpenElisServer(`/rest/storage/rooms`, (response) => {
+    getFromOpenElisServer(`/rest/storage/rooms?status=active&biorepositoryOnly=true`, (response) => {
       if (componentMounted.current) {
         if (response && Array.isArray(response)) {
           // Response is already room objects from /rest/storage/rooms

--- a/frontend/src/components/notebook/pages/biorepository/BiorepositoryQCInspectionPage.js
+++ b/frontend/src/components/notebook/pages/biorepository/BiorepositoryQCInspectionPage.js
@@ -3,6 +3,7 @@ import {
   Grid,
   Column,
   Button,
+  ButtonSet,
   Tile,
   InlineNotification,
   Modal,
@@ -11,6 +12,7 @@ import {
   TextInput,
   Checkbox,
   Dropdown,
+  Toggle,
   DataTable,
   TableContainer,
   Table,
@@ -35,10 +37,6 @@ import {
   postToOpenElisServerJsonResponse,
 } from "../../../utils/Utils";
 
-/**
- * QC Checklist items for Biorepository sample inspection
- * Based on ISO 20387:2018 quality control requirements
- */
 const QC_CHECKLIST = [
   {
     id: "samplePresent",
@@ -67,39 +65,183 @@ const QC_CHECKLIST = [
   },
 ];
 
-/**
- * Discrepancy types for failed QC
- */
 const DISCREPANCY_TYPES = [
   { id: "MISSING_SAMPLE", label: "Missing Sample" },
+  { id: "WRONG_SAMPLE_IN_POSITION", label: "Wrong Sample In Position" },
   { id: "DAMAGED_LABEL", label: "Damaged/Illegible Label" },
   { id: "MISPLACED_ITEM", label: "Misplaced Item (Wrong Position)" },
+  {
+    id: "EMPTY_POSITION_REGISTERED_OCCUPIED",
+    label: "Empty Position But Registered Occupied",
+  },
+  { id: "LABELING_ERROR", label: "Labeling Error" },
+  { id: "BOX_RACK_MISPLACEMENT", label: "Box/Rack Misplacement" },
   { id: "CONTAINER_DAMAGE", label: "Container Damage" },
   { id: "VOLUME_DISCREPANCY", label: "Volume Discrepancy" },
   { id: "OTHER", label: "Other" },
 ];
 
-/**
- * BiorepositoryQCInspectionPage - QC Inspection workflow for stored samples
- *
- * Allows technicians to perform visual inspection and verification of samples
- * in storage against their expected location and condition.
- *
- * Features:
- * - Load samples with workflowStatus = STORED
- * - Display storage coordinates (freezer/shelf/rack/box/position)
- * - 5-point QC checklist (presence, label, container, volume, position)
- * - Auto-calculate QC result (all pass = VERIFIED, any fail = DISCREPANCY_FOUND)
- * - Record discrepancy details (type + corrective action)
- * - Bulk apply QC to multiple samples
- *
- * @param {Object} props
- * @param {number} props.entryId - The notebook entry ID
- * @param {Object} props.pageData - The notebook page data
- * @param {Object} props.progress - Page progress
- * @param {function} props.onProgressUpdate - Callback when progress changes
- * @param {number} props.notebookId - The notebook ID
- */
+const ALL_FREEZERS = "All freezers";
+const ALL_SHELVES = "All shelves";
+const ALL_RACKS = "All racks";
+
+const createBlankChecklist = () =>
+  QC_CHECKLIST.reduce((acc, item) => {
+    acc[item.id] = false;
+    return acc;
+  }, {});
+
+const createInitialInspectionForm = () => ({
+  inspectorName: "",
+  inspectionDate: new Date().toISOString().slice(0, 16),
+  qcChecklist: createBlankChecklist(),
+  qcResult: "",
+  discrepancyType: "",
+  correctiveAction: "",
+  remarks: "",
+});
+
+const toSafeString = (value, fallback = "") => {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+  const asString = String(value).trim();
+  return asString || fallback;
+};
+
+const parseLocationPath = (
+  locationPath,
+  positionCoordinate,
+  locationDetails = {},
+) => {
+  const path = toSafeString(locationPath);
+  const coordinate = toSafeString(positionCoordinate);
+  const explicitFreezer = toSafeString(locationDetails.deviceName);
+  const explicitShelf = toSafeString(locationDetails.shelfLabel);
+  const explicitRack = toSafeString(locationDetails.rackLabel);
+  const explicitBox = toSafeString(locationDetails.boxLabel);
+
+  const segments = path
+    .split(/\s*>\s*/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  let freezer;
+  let shelf;
+  let rack;
+  let box;
+
+  segments.forEach((segment) => {
+    const lower = segment.toLowerCase();
+    if (!freezer && lower.includes("freezer")) {
+      freezer = segment;
+    } else if (!shelf && lower.includes("shelf")) {
+      shelf = segment;
+    } else if (!rack && lower.includes("rack")) {
+      rack = segment;
+    } else if (!box && (lower.includes("box") || lower.startsWith("bx"))) {
+      box = segment;
+    }
+  });
+
+  if (!freezer && segments[0]) {
+    freezer = segments[0];
+  }
+  if (!shelf && segments[1]) {
+    shelf = segments[1];
+  }
+  if (!rack && segments[2]) {
+    rack = segments[2];
+  }
+  if (!box && segments[3]) {
+    box = segments[3];
+  }
+  if (!box && segments.length > 0) {
+    box = segments[segments.length - 1];
+  }
+
+  const normalizedFreezer = explicitFreezer || freezer || "Unknown Freezer";
+  const normalizedShelf = explicitShelf || shelf || "Unknown Shelf";
+  const normalizedRack = explicitRack || rack || "Unknown Rack";
+  const normalizedBox = explicitBox || box || "Unknown Box";
+
+  return {
+    freezer: normalizedFreezer,
+    shelf: normalizedShelf,
+    rack: normalizedRack,
+    box: normalizedBox,
+    positionCoordinate: coordinate || "-",
+    shelfKey: `${normalizedFreezer} > ${normalizedShelf}`,
+    rackKey: `${normalizedFreezer} > ${normalizedShelf} > ${normalizedRack}`,
+    boxKey: `${normalizedFreezer} > ${normalizedShelf} > ${normalizedRack} > ${normalizedBox}`,
+  };
+};
+
+const computeOverview = (samples) => {
+  const freezers = new Set();
+  const shelves = new Set();
+  const racks = new Set();
+  const boxes = new Set();
+  const freezerSummaryMap = new Map();
+
+  samples.forEach((sample) => {
+    freezers.add(sample.freezer);
+    shelves.add(sample.shelfKey);
+    racks.add(sample.rackKey);
+    boxes.add(sample.boxKey);
+
+    if (!freezerSummaryMap.has(sample.freezer)) {
+      freezerSummaryMap.set(sample.freezer, {
+        freezer: sample.freezer,
+        sampleCount: 0,
+        shelfSet: new Set(),
+        rackSet: new Set(),
+        boxSet: new Set(),
+      });
+    }
+
+    const row = freezerSummaryMap.get(sample.freezer);
+    row.sampleCount += 1;
+    row.shelfSet.add(sample.shelfKey);
+    row.rackSet.add(sample.rackKey);
+    row.boxSet.add(sample.boxKey);
+  });
+
+  const freezerSummary = Array.from(freezerSummaryMap.values())
+    .map((row) => ({
+      freezer: row.freezer,
+      sampleCount: row.sampleCount,
+      shelfCount: row.shelfSet.size,
+      rackCount: row.rackSet.size,
+      boxCount: row.boxSet.size,
+    }))
+    .sort((a, b) => a.freezer.localeCompare(b.freezer));
+
+  return {
+    totalStoredSamples: samples.length,
+    freezerCount: freezers.size,
+    shelfCount: shelves.size,
+    rackCount: racks.size,
+    boxCount: boxes.size,
+    freezerSummary,
+  };
+};
+
+const buildSnapshotText = (sample) => {
+  if (!sample) {
+    return null;
+  }
+  if (!sample.locationPath || sample.locationPath === "Not Assigned") {
+    return sample.positionCoordinate && sample.positionCoordinate !== "-"
+      ? sample.positionCoordinate
+      : null;
+  }
+  if (!sample.positionCoordinate || sample.positionCoordinate === "-") {
+    return sample.locationPath;
+  }
+  return `${sample.locationPath} @ ${sample.positionCoordinate}`;
+};
+
 function BiorepositoryQCInspectionPage({
   entryId,
   pageData,
@@ -109,440 +251,1173 @@ function BiorepositoryQCInspectionPage({
 }) {
   const intl = useIntl();
 
-  // State for samples
   const [samples, setSamples] = useState([]);
+  const [overview, setOverview] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [overviewLoading, setOverviewLoading] = useState(false);
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
 
-  // Bulk apply modal state
-  const [bulkApplyModalOpen, setBulkApplyModalOpen] = useState(false);
-  const [isBulkApplying, setIsBulkApplying] = useState(false);
-  const [selectedForBulkApply, setSelectedForBulkApply] = useState([]); // Capture selection when modal opens
-
-  // Bulk apply form values
-  const [bulkApplyValues, setBulkApplyValues] = useState({
-    inspectorName: "",
-    inspectionDate: new Date().toISOString().slice(0, 16),
-    // QC Checklist - 5 boolean criteria
-    qcChecklist: QC_CHECKLIST.reduce((acc, item) => {
-      acc[item.id] = false;
-      return acc;
-    }, {}),
-    // Auto-calculated QC result
-    qcResult: "",
-    // Discrepancy details (only for failed QC)
-    discrepancyType: "",
-    correctiveAction: "",
-    remarks: "",
+  const [filters, setFilters] = useState({
+    freezer: "",
+    shelf: "",
+    rack: "",
+    box: "",
   });
 
-  // Load stored samples for QC
+  const [roundSettings, setRoundSettings] = useState({
+    boxesPerRound: "12",
+    samplesPerBox: "4",
+    seed: "",
+  });
+
+  const [qcRoundInfo, setQcRoundInfo] = useState(null);
+  const [showSelectedOnly, setShowSelectedOnly] = useState(false);
+
+  const [inspectionModalOpen, setInspectionModalOpen] = useState(false);
+  const [isSubmittingInspection, setIsSubmittingInspection] = useState(false);
+  const [inspectionContext, setInspectionContext] = useState({
+    mode: "bulk",
+    sampleIds: [],
+    samplePreview: [],
+  });
+  const [inspectionValues, setInspectionValues] = useState(
+    createInitialInspectionForm(),
+  );
+
+  const resetInspectionForm = useCallback(() => {
+    setInspectionValues(createInitialInspectionForm());
+  }, []);
+
+  const calculateQCResult = useCallback((checklist) => {
+    const allPassed = Object.values(checklist).every((value) => value === true);
+    return allPassed ? "VERIFIED" : "DISCREPANCY_FOUND";
+  }, []);
+
   const loadStoredSamples = useCallback(() => {
     setLoading(true);
     setError(null);
 
-    getFromOpenElisServer(
-      `/rest/biorepository/qc-inspection/samples`,
-      (response) => {
-        setLoading(false);
-        if (response && Array.isArray(response)) {
-          // Transform API response to component state
-          const transformedSamples = response.map((sample) => ({
+    getFromOpenElisServer(`/rest/biorepository/qc-inspection/samples`, (response) => {
+      setLoading(false);
+      if (Array.isArray(response)) {
+        const transformed = response.map((sample) => {
+          const storageLocation = sample.storageLocation || {};
+          const rawCoordinate = toSafeString(
+            storageLocation.positionCoordinate,
+            "-",
+          );
+
+          return {
             id: sample.bioSampleId,
             sampleItemId: sample.sampleItemId,
             externalId: sample.externalId || "-",
             accessionNumber: sample.accessionNumber || "-",
             sampleType: sample.sampleType || "-",
-            locationPath: sample.locationPath || "Not Assigned",
-            storageLocation: sample.storageLocation, // Full location object
+            locationPath:
+              sample.locationPath ||
+              storageLocation.hierarchicalPath ||
+              "Not Assigned",
+            positionCoordinate: rawCoordinate,
+            storageDetails: storageLocation,
             biosafetyLevel: sample.biosafetyLevel || "-",
             workflowStatus: sample.workflowStatus,
-            lastQCInspection: sample.lastQCInspection, // Most recent inspection record
-          }));
-          setSamples(transformedSamples);
+            lastQCInspection: sample.lastQCInspection,
+          };
+        });
+
+        setSamples(transformed);
+      } else {
+        setSamples([]);
+      }
+    });
+  }, []);
+
+  const loadLocationOverview = useCallback(() => {
+    setOverviewLoading(true);
+    getFromOpenElisServer(
+      `/rest/biorepository/qc-inspection/location-overview`,
+      (response) => {
+        setOverviewLoading(false);
+        if (response && typeof response === "object" && !response.error) {
+          setOverview(response);
         } else {
-          setSamples([]);
+          setOverview(null);
         }
       },
     );
   }, []);
 
-  // Load samples on mount
   useEffect(() => {
     loadStoredSamples();
-  }, [loadStoredSamples]);
+    loadLocationOverview();
+  }, [loadStoredSamples, loadLocationOverview]);
 
-  // Reset bulk apply values
-  const resetBulkApplyValues = () => {
-    setBulkApplyValues({
-      inspectorName: "",
-      inspectionDate: new Date().toISOString().slice(0, 16),
-      qcChecklist: QC_CHECKLIST.reduce((acc, item) => {
-        acc[item.id] = false;
+  const enrichedSamples = useMemo(
+    () =>
+      samples.map((sample) => ({
+        ...sample,
+        ...parseLocationPath(
+          sample.locationPath,
+          sample.positionCoordinate,
+          sample.storageDetails,
+        ),
+      })),
+    [samples],
+  );
+
+  const fullOverviewFallback = useMemo(
+    () => computeOverview(enrichedSamples),
+    [enrichedSamples],
+  );
+
+  const freezerScopeOptions = useMemo(() => {
+    if (Array.isArray(overview?.freezerOptions) && overview.freezerOptions.length) {
+      return overview.freezerOptions;
+    }
+    return Array.from(
+      new Set(enrichedSamples.map((sample) => sample.freezer)),
+    )
+      .sort((a, b) => a.localeCompare(b))
+      .map((value) => ({ value, label: value }));
+  }, [overview, enrichedSamples]);
+
+  const availableFreezers = useMemo(
+    () =>
+      freezerScopeOptions
+        .map((option) => option?.value || option?.label)
+        .filter(Boolean),
+    [freezerScopeOptions],
+  );
+
+  const availableShelves = useMemo(
+    () => {
+      if (Array.isArray(overview?.shelfOptions) && overview.shelfOptions.length) {
+        return Array.from(
+          new Set(
+            overview.shelfOptions
+              .filter(
+                (option) =>
+                  !filters.freezer || option.freezer === filters.freezer,
+              )
+              .map((option) => option?.value || option?.label)
+              .filter(Boolean),
+          ),
+        ).sort((a, b) => a.localeCompare(b));
+      }
+
+      return Array.from(
+        new Set(
+          enrichedSamples
+            .filter(
+              (sample) => !filters.freezer || sample.freezer === filters.freezer,
+            )
+            .map((sample) => sample.shelf),
+        ),
+      ).sort((a, b) => a.localeCompare(b));
+    },
+    [overview, enrichedSamples, filters.freezer],
+  );
+
+  const availableRacks = useMemo(
+    () => {
+      if (Array.isArray(overview?.rackOptions) && overview.rackOptions.length) {
+        return Array.from(
+          new Set(
+            overview.rackOptions
+              .filter(
+                (option) =>
+                  (!filters.freezer || option.freezer === filters.freezer) &&
+                  (!filters.shelf || option.shelf === filters.shelf),
+              )
+              .map((option) => option?.value || option?.label)
+              .filter(Boolean),
+          ),
+        ).sort((a, b) => a.localeCompare(b));
+      }
+
+      return Array.from(
+        new Set(
+          enrichedSamples
+            .filter(
+              (sample) =>
+                (!filters.freezer || sample.freezer === filters.freezer) &&
+                (!filters.shelf || sample.shelf === filters.shelf),
+            )
+            .map((sample) => sample.rack),
+        ),
+      ).sort((a, b) => a.localeCompare(b));
+    },
+    [overview, enrichedSamples, filters.freezer, filters.shelf],
+  );
+
+  const roundSelectedIds = useMemo(
+    () =>
+      new Set(
+        (qcRoundInfo?.samples || [])
+          .map((sample) => String(sample.bioSampleId))
+          .filter(Boolean),
+      ),
+    [qcRoundInfo],
+  );
+
+  const displayedSamples = useMemo(
+    () =>
+      enrichedSamples.filter((sample) => {
+        if (filters.freezer && sample.freezer !== filters.freezer) {
+          return false;
+        }
+        if (filters.shelf && sample.shelf !== filters.shelf) {
+          return false;
+        }
+        if (filters.rack && sample.rack !== filters.rack) {
+          return false;
+        }
+        if (
+          filters.box &&
+          !sample.box.toLowerCase().includes(filters.box.trim().toLowerCase())
+        ) {
+          return false;
+        }
+        if (showSelectedOnly && qcRoundInfo) {
+          return roundSelectedIds.has(String(sample.id));
+        }
+        return true;
+      }),
+    [enrichedSamples, filters, showSelectedOnly, qcRoundInfo, roundSelectedIds],
+  );
+
+  const filteredOverview = useMemo(
+    () => computeOverview(displayedSamples),
+    [displayedSamples],
+  );
+
+  const activeOverview = useMemo(() => {
+    if (overview && !filters.freezer && !filters.shelf && !filters.rack && !filters.box) {
+      return overview;
+    }
+    return filteredOverview;
+  }, [overview, filters, filteredOverview]);
+
+  const verifiedCount = useMemo(
+    () =>
+      displayedSamples.filter(
+        (sample) => sample.lastQCInspection?.qcResult === "VERIFIED",
+      ).length,
+    [displayedSamples],
+  );
+
+  const discrepancyCount = useMemo(
+    () =>
+      displayedSamples.filter(
+        (sample) => sample.lastQCInspection?.qcResult === "DISCREPANCY_FOUND",
+      ).length,
+    [displayedSamples],
+  );
+
+  const pendingCount = useMemo(
+    () => displayedSamples.filter((sample) => !sample.lastQCInspection).length,
+    [displayedSamples],
+  );
+
+  const checkedCount = useMemo(
+    () =>
+      Object.values(inspectionValues.qcChecklist).filter((checked) => checked)
+        .length,
+    [inspectionValues.qcChecklist],
+  );
+
+  const openInspectionModal = useCallback(
+    (mode, sampleIds, samplePreview = []) => {
+      setInspectionContext({
+        mode,
+        sampleIds,
+        samplePreview,
+      });
+      resetInspectionForm();
+      setInspectionModalOpen(true);
+      setError(null);
+    },
+    [resetInspectionForm],
+  );
+
+  const closeInspectionModal = useCallback(() => {
+    setInspectionModalOpen(false);
+    setInspectionContext({ mode: "bulk", sampleIds: [], samplePreview: [] });
+    resetInspectionForm();
+  }, [resetInspectionForm]);
+
+  const handleChecklistChange = useCallback(
+    (criteriaId, checked) => {
+      setInspectionValues((previous) => {
+        const qcChecklist = {
+          ...previous.qcChecklist,
+          [criteriaId]: checked,
+        };
+        const qcResult = calculateQCResult(qcChecklist);
+        return {
+          ...previous,
+          qcChecklist,
+          qcResult,
+          discrepancyType: qcResult === "VERIFIED" ? "" : previous.discrepancyType,
+          correctiveAction:
+            qcResult === "VERIFIED" ? "" : previous.correctiveAction,
+        };
+      });
+    },
+    [calculateQCResult],
+  );
+
+  const handleSetAllChecklist = useCallback(
+    (isChecked) => {
+      const checklist = QC_CHECKLIST.reduce((acc, item) => {
+        acc[item.id] = isChecked;
         return acc;
-      }, {}),
-      qcResult: "",
-      discrepancyType: "",
-      correctiveAction: "",
-      remarks: "",
-    });
-  };
+      }, {});
 
-  // Calculate QC result based on checklist
-  const calculateQCResult = (checklist) => {
-    const allPassed = Object.values(checklist).every((v) => v === true);
-    return allPassed ? "VERIFIED" : "DISCREPANCY_FOUND";
-  };
+      setInspectionValues((previous) => ({
+        ...previous,
+        qcChecklist: checklist,
+        qcResult: calculateQCResult(checklist),
+        discrepancyType: isChecked ? "" : previous.discrepancyType,
+        correctiveAction: isChecked ? "" : previous.correctiveAction,
+      }));
+    },
+    [calculateQCResult],
+  );
 
-  // Handle checklist change
-  const handleChecklistChange = (criteriaId, checked) => {
-    setBulkApplyValues((prev) => {
-      const newChecklist = { ...prev.qcChecklist, [criteriaId]: checked };
-      const autoResult = calculateQCResult(newChecklist);
-      return {
-        ...prev,
-        qcChecklist: newChecklist,
-        qcResult: autoResult,
-        // Clear fail-related fields if now passing
-        discrepancyType: autoResult === "VERIFIED" ? "" : prev.discrepancyType,
-        correctiveAction:
-          autoResult === "VERIFIED" ? "" : prev.correctiveAction,
-      };
-    });
-  };
+  const handleGenerateQCRound = useCallback(() => {
+    setError(null);
 
-  // Handle "Check All" for QC criteria
-  const handleCheckAll = () => {
-    setBulkApplyValues((prev) => ({
-      ...prev,
-      qcChecklist: QC_CHECKLIST.reduce((acc, item) => {
-        acc[item.id] = true;
-        return acc;
-      }, {}),
-      qcResult: "VERIFIED",
-      discrepancyType: "",
-      correctiveAction: "",
-    }));
-  };
+    const boxesPerRound = Math.max(
+      1,
+      Number.parseInt(roundSettings.boxesPerRound || "10", 10) || 10,
+    );
+    const samplesPerBox = Math.max(
+      1,
+      Number.parseInt(roundSettings.samplesPerBox || "3", 10) || 3,
+    );
 
-  // Handle "Clear All" for QC criteria
-  const handleClearAll = () => {
-    setBulkApplyValues((prev) => ({
-      ...prev,
-      qcChecklist: QC_CHECKLIST.reduce((acc, item) => {
-        acc[item.id] = false;
-        return acc;
-      }, {}),
-      qcResult: "DISCREPANCY_FOUND",
-    }));
-  };
+    const seedValue = roundSettings.seed.trim();
+    const parsedSeed = seedValue ? Number.parseInt(seedValue, 10) : null;
 
-  // Handle bulk apply
-  const handleBulkApply = useCallback(() => {
-    if (selectedForBulkApply.length === 0) {
+    if (seedValue && Number.isNaN(parsedSeed)) {
+      setError(
+        intl.formatMessage({
+          id: "biorepository.qc.error.invalidSeed",
+          defaultMessage: "Seed must be a valid whole number.",
+        }),
+      );
+      return;
+    }
+
+    const payload = {
+      boxesPerRound,
+      samplesPerBox,
+      seed: parsedSeed,
+      freezer: filters.freezer || null,
+      shelf: filters.shelf || null,
+      rack: filters.rack || null,
+      box: filters.box || null,
+    };
+
+    postToOpenElisServerJsonResponse(
+      `/rest/biorepository/qc-inspection/generate-round`,
+      JSON.stringify(payload),
+      (response) => {
+        if (response?.error) {
+          setError(response.error);
+          return;
+        }
+
+        const selectedIds = (response?.samples || [])
+          .map((sample) => String(sample.bioSampleId))
+          .filter(Boolean);
+
+        if (selectedIds.length === 0) {
+          setError(
+            intl.formatMessage({
+              id: "biorepository.qc.error.emptyRound",
+              defaultMessage:
+                "No eligible samples were found for the selected location and round settings.",
+            }),
+          );
+          return;
+        }
+
+        setQcRoundInfo(response);
+        setShowSelectedOnly(true);
+
+        setSuccessMessage(
+          intl.formatMessage(
+            {
+              id: "biorepository.qc.round.success",
+              defaultMessage:
+                "QC round generated successfully: {boxes} box(es), {samples} sample(s).",
+            },
+            {
+              boxes: response.boxesSelected || 0,
+              samples: response.samplesSelected || 0,
+            },
+          ),
+        );
+      },
+    );
+  }, [filters, intl, roundSettings]);
+
+  const handleSubmitInspection = useCallback(() => {
+    if (!inspectionContext.sampleIds.length) {
       setError(
         intl.formatMessage({
           id: "biorepository.qc.error.noSelection",
-          defaultMessage: "Please select samples to apply QC to.",
+          defaultMessage: "Please choose at least one sample.",
         }),
       );
       return;
     }
 
-    // Validate: Inspector name required
-    if (!bulkApplyValues.inspectorName.trim()) {
+    if (!inspectionValues.inspectorName.trim()) {
       setError(
         intl.formatMessage({
           id: "biorepository.qc.error.noInspector",
-          defaultMessage: "Please enter inspector name.",
+          defaultMessage: "Inspector name is required.",
         }),
       );
       return;
     }
 
-    // Validate: QC result must be set
-    if (!bulkApplyValues.qcResult) {
+    if (!inspectionValues.qcResult) {
       setError(
         intl.formatMessage({
           id: "biorepository.qc.error.noResult",
           defaultMessage:
-            "Please complete the QC checklist to determine pass/fail status.",
+            "Complete the checklist first so the system can determine pass/fail.",
         }),
       );
       return;
     }
 
-    // Validate: If discrepancy found, must have discrepancy type and corrective action
-    if (bulkApplyValues.qcResult === "DISCREPANCY_FOUND") {
-      if (!bulkApplyValues.discrepancyType) {
+    if (inspectionValues.qcResult === "DISCREPANCY_FOUND") {
+      if (!inspectionValues.discrepancyType) {
         setError(
           intl.formatMessage({
             id: "biorepository.qc.error.noDiscrepancyType",
-            defaultMessage: "Please select a discrepancy type.",
+            defaultMessage: "Discrepancy type is required for failed QC.",
           }),
         );
         return;
       }
-      if (!bulkApplyValues.correctiveAction.trim()) {
+      if (!inspectionValues.correctiveAction.trim()) {
         setError(
           intl.formatMessage({
             id: "biorepository.qc.error.noCorrectiveAction",
-            defaultMessage: "Please describe the corrective action taken.",
+            defaultMessage: "Corrective action details are required for failed QC.",
+          }),
+        );
+        return;
+      }
+      if (!inspectionValues.remarks.trim()) {
+        setError(
+          intl.formatMessage({
+            id: "biorepository.qc.error.noRemarks",
+            defaultMessage: "Comment/remarks are required for failed QC.",
           }),
         );
         return;
       }
     }
 
-    setIsBulkApplying(true);
+    setIsSubmittingInspection(true);
     setError(null);
 
-    // Prepare request payload
+    const singleSampleSnapshot =
+      inspectionContext.mode === "single" && inspectionContext.samplePreview.length
+        ? buildSnapshotText(inspectionContext.samplePreview[0])
+        : null;
+
     const payload = {
-      bioSampleIds: selectedForBulkApply.map((id) => parseInt(id, 10)),
-      inspectorName: bulkApplyValues.inspectorName.trim(),
-      inspectionDate: bulkApplyValues.inspectionDate
-        ? new Date(bulkApplyValues.inspectionDate).toISOString()
+      bioSampleIds: inspectionContext.sampleIds.map((id) => Number(id)),
+      inspectorName: inspectionValues.inspectorName.trim(),
+      inspectionDate: inspectionValues.inspectionDate
+        ? new Date(inspectionValues.inspectionDate).toISOString()
         : null,
-      samplePresent: bulkApplyValues.qcChecklist.samplePresent,
-      labelIntegrity: bulkApplyValues.qcChecklist.labelIntegrity,
-      containerIntegrity: bulkApplyValues.qcChecklist.containerIntegrity,
+      samplePresent: inspectionValues.qcChecklist.samplePresent,
+      labelIntegrity: inspectionValues.qcChecklist.labelIntegrity,
+      containerIntegrity: inspectionValues.qcChecklist.containerIntegrity,
       volumeAppearanceAcceptable:
-        bulkApplyValues.qcChecklist.volumeAppearanceAcceptable,
-      correctPosition: bulkApplyValues.qcChecklist.correctPosition,
+        inspectionValues.qcChecklist.volumeAppearanceAcceptable,
+      correctPosition: inspectionValues.qcChecklist.correctPosition,
       discrepancyType:
-        bulkApplyValues.qcResult === "DISCREPANCY_FOUND"
-          ? bulkApplyValues.discrepancyType
+        inspectionValues.qcResult === "DISCREPANCY_FOUND"
+          ? inspectionValues.discrepancyType
           : null,
       correctiveAction:
-        bulkApplyValues.qcResult === "DISCREPANCY_FOUND"
-          ? bulkApplyValues.correctiveAction
+        inspectionValues.qcResult === "DISCREPANCY_FOUND"
+          ? inspectionValues.correctiveAction.trim()
           : null,
-      remarks: bulkApplyValues.remarks || null,
+      remarks: inspectionValues.remarks.trim() || null,
+      qcBatchId: qcRoundInfo?.qcBatchId || null,
+      expectedCoordinateSnapshot: singleSampleSnapshot,
     };
 
     postToOpenElisServerJsonResponse(
       `/rest/biorepository/qc-inspection/bulk-apply`,
       JSON.stringify(payload),
       (response) => {
-        setIsBulkApplying(false);
-        if (response && !response.error) {
-          const count = response.count || selectedForBulkApply.length;
-          setSuccessMessage(
-            intl.formatMessage(
-              {
-                id: "biorepository.qc.success.applied",
-                defaultMessage: "QC inspection applied to {count} sample(s).",
-              },
-              { count },
-            ),
-          );
-          setBulkApplyModalOpen(false);
-          resetBulkApplyValues();
-          setSelectedForBulkApply([]); // Clear captured selection
-          loadStoredSamples();
-          if (onProgressUpdate) {
-            onProgressUpdate();
-          }
-        } else {
-          setError(
-            response?.error ||
-              intl.formatMessage({
-                id: "biorepository.qc.error.apply",
-                defaultMessage:
-                  "Failed to apply QC inspection. Please try again.",
-              }),
-          );
+        setIsSubmittingInspection(false);
+        if (response?.error) {
+          setError(response.error);
+          return;
+        }
+
+        const count = response?.count || inspectionContext.sampleIds.length;
+        setSuccessMessage(
+          intl.formatMessage(
+            {
+              id: "biorepository.qc.success.applied",
+              defaultMessage: "QC inspection recorded for {count} sample(s).",
+            },
+            { count },
+          ),
+        );
+
+        closeInspectionModal();
+        loadStoredSamples();
+        loadLocationOverview();
+
+        if (onProgressUpdate) {
+          onProgressUpdate();
         }
       },
     );
   }, [
-    selectedForBulkApply,
-    bulkApplyValues,
+    closeInspectionModal,
+    inspectionContext,
+    inspectionValues,
     intl,
+    loadLocationOverview,
     loadStoredSamples,
     onProgressUpdate,
+    qcRoundInfo?.qcBatchId,
   ]);
 
-  // Calculate stats
-  const totalSamples = samples.length;
-  const verifiedCount = samples.filter(
-    (s) => s.lastQCInspection && s.lastQCInspection.qcResult === "VERIFIED",
-  ).length;
-  const discrepanciesCount = samples.filter(
-    (s) =>
-      s.lastQCInspection && s.lastQCInspection.qcResult === "DISCREPANCY_FOUND",
-  ).length;
-  const pendingCount = samples.filter((s) => !s.lastQCInspection).length;
+  const handleDownloadRoundCSV = useCallback(() => {
+    if (!qcRoundInfo?.samples?.length) {
+      return;
+    }
 
-  // Count checked criteria
-  const checkedCount = useMemo(() => {
-    return Object.values(bulkApplyValues.qcChecklist).filter((v) => v).length;
-  }, [bulkApplyValues.qcChecklist]);
+    const headers = [
+      "qcBatchId",
+      "freezer",
+      "shelf",
+      "rack",
+      "box",
+      "position",
+      "locationPath",
+      "sampleNumber",
+      "sampleId",
+    ];
 
-  // Get QC result tag
-  const getQCTag = (qcResult) => {
-    if (!qcResult) return <Tag type="gray">Pending</Tag>;
-    if (qcResult === "VERIFIED") return <Tag type="green">Verified</Tag>;
-    if (qcResult === "DISCREPANCY_FOUND")
+    const escapeCSV = (value) => {
+      const text = value === null || value === undefined ? "" : String(value);
+      if (text.includes(",") || text.includes('"') || text.includes("\n")) {
+        return `"${text.replace(/"/g, '""')}"`;
+      }
+      return text;
+    };
+
+    const rows = qcRoundInfo.samples.map((sample) => {
+      const parsed = parseLocationPath(
+        sample.locationPath,
+        sample.expectedCoordinate || sample.positionCoordinate,
+      );
+      return [
+        qcRoundInfo.qcBatchId || "",
+        sample.freezer || parsed.freezer,
+        sample.shelf || parsed.shelf,
+        sample.rack || parsed.rack,
+        sample.box || parsed.box,
+        sample.expectedCoordinate || sample.positionCoordinate || "",
+        sample.locationPath || "",
+        sample.accessionNumber || "",
+        sample.externalId || "",
+      ];
+    });
+
+    const csv = `${headers.join(",")}\n${rows
+      .map((row) => row.map(escapeCSV).join(","))
+      .join("\n")}\n`;
+
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `biorepository-qc-round-${qcRoundInfo.qcBatchId || "batch"}.csv`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }, [qcRoundInfo]);
+
+  const roundRows = useMemo(
+    () =>
+      (qcRoundInfo?.samples || []).map((sample, index) => {
+        const parsed = parseLocationPath(
+          sample.locationPath,
+          sample.expectedCoordinate || sample.positionCoordinate,
+        );
+
+        return {
+          id: `${sample.bioSampleId || "sample"}-${index}`,
+          freezer: sample.freezer || parsed.freezer,
+          shelf: sample.shelf || parsed.shelf,
+          rack: sample.rack || parsed.rack,
+          box: sample.box || parsed.box,
+          position:
+            sample.expectedCoordinate || sample.positionCoordinate || parsed.positionCoordinate,
+          accessionNumber: sample.accessionNumber || "-",
+          externalId: sample.externalId || "-",
+        };
+      }),
+    [qcRoundInfo],
+  );
+
+  const roundHeaders = useMemo(
+    () => [
+      { key: "freezer", header: "Freezer" },
+      { key: "shelf", header: "Shelf" },
+      { key: "rack", header: "Rack" },
+      { key: "box", header: "Box" },
+      { key: "position", header: "Position" },
+      { key: "accessionNumber", header: "Sample Number" },
+      { key: "externalId", header: "Sample ID" },
+    ],
+    [],
+  );
+
+  const tableHeaders = useMemo(
+    () => [
+      {
+        key: "accessionNumber",
+        header: intl.formatMessage({
+          id: "biorepository.sample.accessionNumber",
+          defaultMessage: "Sample Number",
+        }),
+      },
+      {
+        key: "sampleType",
+        header: intl.formatMessage({
+          id: "biorepository.sample.type",
+          defaultMessage: "Sample Type",
+        }),
+      },
+      { key: "freezer", header: "Freezer" },
+      { key: "shelf", header: "Shelf" },
+      { key: "rack", header: "Rack" },
+      { key: "box", header: "Box" },
+      { key: "positionCoordinate", header: "Position" },
+      {
+        key: "biosafetyLevel",
+        header: intl.formatMessage({
+          id: "biorepository.sample.bsl",
+          defaultMessage: "BSL",
+        }),
+      },
+      {
+        key: "lastQCInspection",
+        header: intl.formatMessage({
+          id: "biorepository.qc.lastInspection",
+          defaultMessage: "Last QC",
+        }),
+      },
+      { key: "actions", header: "Actions" },
+    ],
+    [intl],
+  );
+
+  const tableRows = useMemo(
+    () =>
+      displayedSamples.map((sample) => ({
+        id: String(sample.id),
+        accessionNumber: sample.accessionNumber,
+        sampleType: sample.sampleType,
+        freezer: sample.freezer,
+        shelf: sample.shelf,
+        rack: sample.rack,
+        box: sample.box,
+        positionCoordinate: sample.positionCoordinate,
+        biosafetyLevel: sample.biosafetyLevel,
+        lastQCInspection: sample.lastQCInspection,
+        actions: "inspect",
+        _raw: sample,
+      })),
+    [displayedSamples],
+  );
+
+  const freezerDropdownItems = useMemo(
+    () => [ALL_FREEZERS, ...availableFreezers],
+    [availableFreezers],
+  );
+
+  const shelfDropdownItems = useMemo(
+    () => [ALL_SHELVES, ...availableShelves],
+    [availableShelves],
+  );
+
+  const rackDropdownItems = useMemo(
+    () => [ALL_RACKS, ...availableRacks],
+    [availableRacks],
+  );
+
+  const getQCTag = useCallback((qcResult) => {
+    if (!qcResult) {
+      return <Tag type="gray">Pending</Tag>;
+    }
+    if (qcResult === "VERIFIED") {
+      return <Tag type="green">Verified</Tag>;
+    }
+    if (qcResult === "DISCREPANCY_FOUND") {
       return <Tag type="red">Discrepancy</Tag>;
+    }
     return <Tag type="gray">{qcResult}</Tag>;
-  };
-
-  // Table headers
-  const headers = [
-    {
-      key: "accessionNumber",
-      header: intl.formatMessage({
-        id: "biorepository.sample.accessionNumber",
-        defaultMessage: "Sample Number",
-      }),
-    },
-    {
-      key: "sampleType",
-      header: intl.formatMessage({
-        id: "biorepository.sample.type",
-        defaultMessage: "Sample Type",
-      }),
-    },
-    {
-      key: "locationPath",
-      header: intl.formatMessage({
-        id: "biorepository.sample.storageLocation",
-        defaultMessage: "Storage Location",
-      }),
-    },
-    {
-      key: "biosafetyLevel",
-      header: intl.formatMessage({
-        id: "biorepository.sample.bsl",
-        defaultMessage: "BSL",
-      }),
-    },
-    {
-      key: "lastQCInspection",
-      header: intl.formatMessage({
-        id: "biorepository.qc.lastInspection",
-        defaultMessage: "Last QC Inspection",
-      }),
-    },
-  ];
+  }, []);
 
   return (
     <div className="biorepository-qc-inspection-page">
-      {/* Page Header */}
       <div className="page-section-header">
         <h4>
           <FormattedMessage
             id="biorepository.qc.title"
-            defaultMessage="Quality Control Inspection"
+            defaultMessage="Biorepository Periodic QC"
           />
         </h4>
         <p className="page-description">
           <FormattedMessage
             id="biorepository.qc.description"
-            defaultMessage="Perform visual inspection and verification of stored samples. Use the QC checklist to assess physical presence, label integrity, container condition, volume/appearance, and storage position. Samples with discrepancies require corrective action documentation."
+            defaultMessage="Start with a room overview, scope the location to check, generate a randomized QC round, then record outcomes individually or in bulk with required failure documentation."
           />
         </p>
       </div>
 
-      {/* Progress Summary */}
-      <Grid fullWidth className="progress-section">
+      {error && (
+        <InlineNotification
+          kind="error"
+          title={error}
+          lowContrast
+          onClose={() => setError(null)}
+        />
+      )}
+
+      {successMessage && (
+        <InlineNotification
+          kind="success"
+          title={successMessage}
+          lowContrast
+          onClose={() => setSuccessMessage(null)}
+        />
+      )}
+
+      <Grid fullWidth style={{ marginTop: "1rem" }}>
         <Column lg={16} md={8} sm={4}>
-          <div className="progress-tiles">
-            <Tile className="progress-tile">
-              <span className="progress-label">
-                <FormattedMessage
-                  id="biorepository.qc.totalStored"
-                  defaultMessage="Total Stored"
+          <Tile>
+            <h5 style={{ marginTop: 0, marginBottom: "0.75rem" }}>
+              Room Overview
+            </h5>
+            <p style={{ marginTop: 0, marginBottom: "1rem", color: "#525252" }}>
+              Review storage scale before starting QC. Filters below let you plan a
+              focused QC round.
+            </p>
+
+            {overviewLoading && (
+              <div style={{ marginBottom: "1rem" }}>
+                <Loading small withOverlay={false} />
+              </div>
+            )}
+
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+                gap: "0.75rem",
+                marginBottom: "1rem",
+              }}
+            >
+              <Tile>
+                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                  Total Stored Samples
+                </div>
+                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+                  {fullOverviewFallback.totalStoredSamples}
+                </div>
+              </Tile>
+              <Tile>
+                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                  Matching Current Filters
+                </div>
+                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+                  {filteredOverview.totalStoredSamples}
+                </div>
+              </Tile>
+              <Tile>
+                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                  Freezers
+                </div>
+                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+                  {activeOverview.freezerCount || 0}
+                </div>
+              </Tile>
+              <Tile>
+                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                  Shelves
+                </div>
+                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+                  {activeOverview.shelfCount || 0}
+                </div>
+              </Tile>
+              <Tile>
+                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                  Racks
+                </div>
+                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+                  {activeOverview.rackCount || 0}
+                </div>
+              </Tile>
+              <Tile>
+                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                  Boxes
+                </div>
+                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+                  {activeOverview.boxCount || 0}
+                </div>
+              </Tile>
+            </div>
+
+            <Grid condensed fullWidth>
+              <Column lg={4} md={4} sm={4}>
+                <Dropdown
+                  id="qc-filter-freezer"
+                  titleText="Freezer"
+                  label={ALL_FREEZERS}
+                  items={freezerDropdownItems}
+                  selectedItem={filters.freezer || ALL_FREEZERS}
+                  itemToString={(item) => (item ? String(item) : "")}
+                  onChange={({ selectedItem }) => {
+                    const value = selectedItem === ALL_FREEZERS ? "" : selectedItem;
+                    setFilters((previous) => ({
+                      ...previous,
+                      freezer: value,
+                      shelf: "",
+                      rack: "",
+                    }));
+                  }}
                 />
-              </span>
-              <span className="progress-value">{totalSamples}</span>
+              </Column>
+              <Column lg={4} md={4} sm={4}>
+                <Dropdown
+                  id="qc-filter-shelf"
+                  titleText="Shelf"
+                  label={ALL_SHELVES}
+                  items={shelfDropdownItems}
+                  selectedItem={filters.shelf || ALL_SHELVES}
+                  itemToString={(item) => (item ? String(item) : "")}
+                  onChange={({ selectedItem }) => {
+                    const value = selectedItem === ALL_SHELVES ? "" : selectedItem;
+                    setFilters((previous) => ({
+                      ...previous,
+                      shelf: value,
+                      rack: "",
+                    }));
+                  }}
+                />
+              </Column>
+              <Column lg={4} md={4} sm={4}>
+                <Dropdown
+                  id="qc-filter-rack"
+                  titleText="Rack"
+                  label={ALL_RACKS}
+                  items={rackDropdownItems}
+                  selectedItem={filters.rack || ALL_RACKS}
+                  itemToString={(item) => (item ? String(item) : "")}
+                  onChange={({ selectedItem }) => {
+                    const value = selectedItem === ALL_RACKS ? "" : selectedItem;
+                    setFilters((previous) => ({
+                      ...previous,
+                      rack: value,
+                    }));
+                  }}
+                />
+              </Column>
+              <Column lg={4} md={4} sm={4}>
+                <TextInput
+                  id="qc-filter-box"
+                  labelText="Box (optional text filter)"
+                  placeholder="e.g. BX078"
+                  value={filters.box}
+                  onChange={(event) =>
+                    setFilters((previous) => ({
+                      ...previous,
+                      box: event.target.value,
+                    }))
+                  }
+                />
+              </Column>
+            </Grid>
+
+            <div style={{ marginTop: "0.75rem", display: "flex", gap: "0.5rem" }}>
+              <Button
+                kind="ghost"
+                size="sm"
+                onClick={() =>
+                  setFilters({ freezer: "", shelf: "", rack: "", box: "" })
+                }
+              >
+                Clear location filters
+              </Button>
+              <Button kind="ghost" size="sm" renderIcon={Renew} onClick={loadStoredSamples}>
+                Refresh samples
+              </Button>
+              <Button kind="ghost" size="sm" renderIcon={Renew} onClick={loadLocationOverview}>
+                Refresh overview
+              </Button>
+            </div>
+          </Tile>
+        </Column>
+      </Grid>
+
+      <Grid fullWidth style={{ marginTop: "1rem" }}>
+        <Column lg={16} md={8} sm={4}>
+          <Tile>
+            <h5 style={{ marginTop: 0, marginBottom: "0.75rem" }}>
+              QC Round Planning
+            </h5>
+            <p style={{ marginTop: 0, marginBottom: "1rem", color: "#525252" }}>
+              Choose how many boxes and positions to sample for this periodic QC
+              round. The system will generate a randomized list from the selected
+              location scope.
+            </p>
+
+            <Grid condensed fullWidth>
+              <Column lg={4} md={4} sm={4}>
+                <TextInput
+                  id="qc-round-boxes"
+                  type="number"
+                  min="1"
+                  max="200"
+                  labelText="Boxes per round"
+                  value={roundSettings.boxesPerRound}
+                  onChange={(event) =>
+                    setRoundSettings((previous) => ({
+                      ...previous,
+                      boxesPerRound: event.target.value,
+                    }))
+                  }
+                />
+              </Column>
+              <Column lg={4} md={4} sm={4}>
+                <TextInput
+                  id="qc-round-samples-per-box"
+                  type="number"
+                  min="1"
+                  max="50"
+                  labelText="Samples per box"
+                  value={roundSettings.samplesPerBox}
+                  onChange={(event) =>
+                    setRoundSettings((previous) => ({
+                      ...previous,
+                      samplesPerBox: event.target.value,
+                    }))
+                  }
+                />
+              </Column>
+              <Column lg={4} md={4} sm={4}>
+                <TextInput
+                  id="qc-round-seed"
+                  type="number"
+                  labelText="Random seed (optional)"
+                  placeholder="Leave empty for true random"
+                  value={roundSettings.seed}
+                  onChange={(event) =>
+                    setRoundSettings((previous) => ({
+                      ...previous,
+                      seed: event.target.value,
+                    }))
+                  }
+                />
+              </Column>
+              <Column lg={4} md={4} sm={4} style={{ display: "flex", alignItems: "end" }}>
+                <Button size="sm" onClick={handleGenerateQCRound}>
+                  Generate random QC round
+                </Button>
+              </Column>
+            </Grid>
+
+            {qcRoundInfo && (
+              <div style={{ marginTop: "1rem" }}>
+                <InlineNotification
+                  kind="info"
+                  lowContrast
+                  title={intl.formatMessage(
+                    {
+                      id: "biorepository.qc.round.generated",
+                      defaultMessage:
+                        "Round {batch}: {boxes} box(es), {samples} sample(s) selected.",
+                    },
+                    {
+                      batch: qcRoundInfo.qcBatchId,
+                      boxes: qcRoundInfo.boxesSelected || 0,
+                      samples: qcRoundInfo.samplesSelected || 0,
+                    },
+                  )}
+                />
+
+                <div style={{ marginTop: "0.75rem" }}>
+                  <ButtonSet>
+                    <Button
+                      kind="primary"
+                      size="sm"
+                      onClick={() => {
+                        const selectedIds = (qcRoundInfo.samples || [])
+                          .map((sample) => String(sample.bioSampleId))
+                          .filter(Boolean);
+                        const preview = displayedSamples
+                          .filter((sample) => selectedIds.includes(String(sample.id)))
+                          .slice(0, 6);
+                        openInspectionModal("bulk", selectedIds, preview);
+                      }}
+                    >
+                      Bulk inspect generated round
+                    </Button>
+                    <Button kind="tertiary" size="sm" onClick={handleDownloadRoundCSV}>
+                      Download round list (CSV)
+                    </Button>
+                    <Button
+                      kind="ghost"
+                      size="sm"
+                      onClick={() => {
+                        setQcRoundInfo(null);
+                        setShowSelectedOnly(false);
+                      }}
+                    >
+                      Clear round
+                    </Button>
+                  </ButtonSet>
+                </div>
+
+                <div style={{ marginTop: "0.75rem" }}>
+                  <Toggle
+                    id="show-selected-round-only"
+                    labelText="Show only generated round samples in main table"
+                    toggled={showSelectedOnly}
+                    onToggle={(nextValue) => setShowSelectedOnly(Boolean(nextValue))}
+                  />
+                </div>
+              </div>
+            )}
+          </Tile>
+        </Column>
+      </Grid>
+
+      {qcRoundInfo && roundRows.length > 0 && (
+        <Grid fullWidth style={{ marginTop: "1rem" }}>
+          <Column lg={16} md={8} sm={4}>
+            <DataTable rows={roundRows} headers={roundHeaders}>
+              {({
+                rows,
+                headers,
+                getTableProps,
+                getHeaderProps,
+                getRowProps,
+              }) => (
+                <TableContainer
+                  title="Generated QC Checklist"
+                  description="Technician path guidance: Freezer > Shelf > Rack > Box > Position"
+                >
+                  <Table {...getTableProps()}>
+                    <TableHead>
+                      <TableRow>
+                        {headers.map((header) => (
+                          <TableHeader key={header.key} {...getHeaderProps({ header })}>
+                            {header.header}
+                          </TableHeader>
+                        ))}
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {rows.map((row) => (
+                        <TableRow key={row.id} {...getRowProps({ row })}>
+                          {row.cells.map((cell) => (
+                            <TableCell key={cell.id}>{cell.value}</TableCell>
+                          ))}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              )}
+            </DataTable>
+          </Column>
+        </Grid>
+      )}
+
+      <Grid fullWidth style={{ marginTop: "1rem" }}>
+        <Column lg={16} md={8} sm={4}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+              gap: "0.75rem",
+              marginBottom: "1rem",
+            }}
+          >
+            <Tile>
+              <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                In View
+              </div>
+              <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+                {displayedSamples.length}
+              </div>
             </Tile>
-            <Tile className="progress-tile verified">
-              <span className="progress-label">
-                <FormattedMessage
-                  id="biorepository.qc.verified"
-                  defaultMessage="Verified"
-                />
-              </span>
-              <span className="progress-value">{verifiedCount}</span>
+            <Tile>
+              <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                Verified
+              </div>
+              <div style={{ fontSize: "1.5rem", fontWeight: 600, color: "#198038" }}>
+                {verifiedCount}
+              </div>
             </Tile>
-            <Tile className="progress-tile error">
-              <span className="progress-label">
-                <FormattedMessage
-                  id="biorepository.qc.discrepancies"
-                  defaultMessage="Discrepancies"
-                />
-              </span>
-              <span className="progress-value">{discrepanciesCount}</span>
+            <Tile>
+              <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                Discrepancies
+              </div>
+              <div style={{ fontSize: "1.5rem", fontWeight: 600, color: "#da1e28" }}>
+                {discrepancyCount}
+              </div>
             </Tile>
-            <Tile className="progress-tile pending">
-              <span className="progress-label">
-                <FormattedMessage
-                  id="biorepository.qc.pending"
-                  defaultMessage="Pending"
-                />
-              </span>
-              <span className="progress-value">{pendingCount}</span>
+            <Tile>
+              <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+                Pending
+              </div>
+              <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>{pendingCount}</div>
             </Tile>
           </div>
         </Column>
       </Grid>
 
-      {/* Messages */}
-      {error && (
-        <InlineNotification
-          kind="error"
-          title={error}
-          onClose={() => setError(null)}
-          lowContrast
-        />
-      )}
-      {successMessage && (
-        <InlineNotification
-          kind="success"
-          title={successMessage}
-          onClose={() => setSuccessMessage(null)}
-          lowContrast
-        />
-      )}
-
-      {/* Samples Table */}
-      <div className="sample-table-section" style={{ marginTop: "1rem" }}>
+      <div className="sample-table-section" style={{ marginTop: "0.5rem" }}>
         {loading ? (
           <div style={{ padding: "2rem", textAlign: "center" }}>
             <Loading withOverlay={false} />
           </div>
-        ) : samples.length === 0 ? (
+        ) : tableRows.length === 0 ? (
           <InlineNotification
             kind="info"
-            title={intl.formatMessage({
-              id: "biorepository.qc.noSamples",
-              defaultMessage: "No Stored Samples",
-            })}
-            subtitle={intl.formatMessage({
-              id: "biorepository.qc.noSamples.message",
-              defaultMessage:
-                "No samples with STORED status available for QC inspection.",
-            })}
             lowContrast
             hideCloseButton
+            title="No samples found for current view"
+            subtitle="Adjust location filters or generate a new QC round."
           />
         ) : (
-          <DataTable
-            rows={samples.map((sample) => ({
-              id: sample.id.toString(),
-              accessionNumber: sample.accessionNumber,
-              sampleType: sample.sampleType,
-              locationPath: sample.locationPath,
-              biosafetyLevel: sample.biosafetyLevel,
-              lastQCInspection: sample.lastQCInspection,
-              _raw: sample,
-            }))}
-            headers={headers}
-          >
+          <DataTable rows={tableRows} headers={tableHeaders}>
             {({
               rows,
               headers,
@@ -553,44 +1428,33 @@ function BiorepositoryQCInspectionPage({
               getBatchActionProps,
               selectedRows,
             }) => {
-              // Get selected IDs from Carbon's DataTable state (read-only, no setState in render)
-              const currentSelectedIds = selectedRows.map((r) => r.id);
+              const selectedIds = selectedRows.map((row) => row.id);
 
               return (
-                <TableContainer>
+                <TableContainer title="QC Execution Table">
                   <TableToolbar>
                     <TableBatchActions {...getBatchActionProps()}>
                       <TableBatchAction
                         renderIcon={Edit}
-                        iconDescription={intl.formatMessage({
-                          id: "biorepository.qc.bulkApply",
-                          defaultMessage: "Bulk Apply QC",
-                        })}
+                        iconDescription="Bulk inspect selected"
                         onClick={() => {
-                          // Capture selection when modal opens
-                          setSelectedForBulkApply(currentSelectedIds);
-                          resetBulkApplyValues();
-                          setBulkApplyModalOpen(true);
+                          const preview = displayedSamples
+                            .filter((sample) => selectedIds.includes(String(sample.id)))
+                            .slice(0, 6);
+                          openInspectionModal("bulk", selectedIds, preview);
                         }}
                       >
-                        <FormattedMessage
-                          id="biorepository.qc.bulkApply"
-                          defaultMessage="Bulk Apply QC"
-                        />
+                        Bulk inspect selected
                       </TableBatchAction>
                     </TableBatchActions>
                     <TableToolbarContent>
                       <Button
                         kind="ghost"
-                        size="sm"
-                        renderIcon={Renew}
-                        iconDescription={intl.formatMessage({
-                          id: "label.refresh",
-                          defaultMessage: "Refresh",
-                        })}
                         hasIconOnly
+                        size="sm"
+                        iconDescription="Refresh"
+                        renderIcon={Renew}
                         onClick={loadStoredSamples}
-                        disabled={loading}
                       />
                     </TableToolbarContent>
                   </TableToolbar>
@@ -599,10 +1463,7 @@ function BiorepositoryQCInspectionPage({
                       <TableRow>
                         <TableSelectAll {...getSelectionProps()} />
                         {headers.map((header) => (
-                          <TableHeader
-                            {...getHeaderProps({ header })}
-                            key={header.key}
-                          >
+                          <TableHeader key={header.key} {...getHeaderProps({ header })}>
                             {header.header}
                           </TableHeader>
                         ))}
@@ -610,66 +1471,72 @@ function BiorepositoryQCInspectionPage({
                     </TableHead>
                     <TableBody>
                       {rows.map((row) => {
-                        const sample = samples.find(
-                          (s) => s.id.toString() === row.id,
-                        );
+                        const raw = row.cells.find((cell) => cell.info.header === "actions")
+                          ? displayedSamples.find(
+                              (sample) => String(sample.id) === String(row.id),
+                            )
+                          : null;
+
                         return (
-                          <TableRow {...getRowProps({ row })} key={row.id}>
+                          <TableRow key={row.id} {...getRowProps({ row })}>
                             <TableSelectRow {...getSelectionProps({ row })} />
                             {row.cells.map((cell) => {
                               if (cell.info.header === "biosafetyLevel") {
                                 let bslColor = "gray";
-                                if (cell.value === "BSL_1") bslColor = "green";
-                                else if (cell.value === "BSL_2")
+                                if (cell.value === "BSL_1") {
+                                  bslColor = "green";
+                                } else if (cell.value === "BSL_2") {
                                   bslColor = "teal";
-                                else if (cell.value === "BSL_3")
+                                } else if (cell.value === "BSL_3") {
                                   bslColor = "purple";
-                                else if (cell.value === "BSL_4")
+                                } else if (cell.value === "BSL_4") {
                                   bslColor = "red";
+                                }
                                 return (
                                   <TableCell key={cell.id}>
                                     <Tag type={bslColor}>{cell.value}</Tag>
                                   </TableCell>
                                 );
                               }
+
                               if (cell.info.header === "lastQCInspection") {
-                                if (!sample.lastQCInspection) {
+                                const inspection = raw?.lastQCInspection;
+                                if (!inspection) {
                                   return (
                                     <TableCell key={cell.id}>
-                                      <Tag type="gray">Never Inspected</Tag>
+                                      <Tag type="gray">Never inspected</Tag>
                                     </TableCell>
                                   );
                                 }
-                                const qc = sample.lastQCInspection;
                                 return (
                                   <TableCell key={cell.id}>
-                                    <div
-                                      style={{
-                                        display: "flex",
-                                        gap: "0.5rem",
-                                        alignItems: "center",
-                                      }}
-                                    >
-                                      {getQCTag(qc.qcResult)}
-                                      <span
-                                        style={{
-                                          fontSize: "0.75rem",
-                                          color: "#525252",
-                                        }}
-                                      >
-                                        {new Date(
-                                          qc.inspectionDate,
-                                        ).toLocaleDateString()}
+                                    <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                                      {getQCTag(inspection.qcResult)}
+                                      <span style={{ fontSize: "0.75rem", color: "#525252" }}>
+                                        {new Date(inspection.inspectionDate).toLocaleDateString()}
                                       </span>
                                     </div>
                                   </TableCell>
                                 );
                               }
-                              return (
-                                <TableCell key={cell.id}>
-                                  {cell.value}
-                                </TableCell>
-                              );
+
+                              if (cell.info.header === "actions") {
+                                return (
+                                  <TableCell key={cell.id}>
+                                    <Button
+                                      kind="ghost"
+                                      size="sm"
+                                      onClick={() =>
+                                        openInspectionModal("single", [row.id], [raw])
+                                      }
+                                    >
+                                      Inspect
+                                    </Button>
+                                  </TableCell>
+                                );
+                              }
+
+                              return <TableCell key={cell.id}>{cell.value}</TableCell>;
                             })}
                           </TableRow>
                         );
@@ -683,277 +1550,187 @@ function BiorepositoryQCInspectionPage({
         )}
       </div>
 
-      {/* Bulk Apply QC Modal */}
       <Modal
-        open={bulkApplyModalOpen}
-        onRequestClose={() => setBulkApplyModalOpen(false)}
-        modalHeading={intl.formatMessage({
-          id: "biorepository.qc.bulkApply.title",
-          defaultMessage: "Bulk QC Inspection",
-        })}
-        primaryButtonText={
-          isBulkApplying
-            ? intl.formatMessage({
-                id: "label.applying",
-                defaultMessage: "Applying...",
-              })
-            : bulkApplyValues.qcResult === "VERIFIED"
-              ? intl.formatMessage({
-                  id: "biorepository.qc.action.verify",
-                  defaultMessage: "Record Verification",
-                })
-              : bulkApplyValues.qcResult === "DISCREPANCY_FOUND"
-                ? intl.formatMessage({
-                    id: "biorepository.qc.action.recordDiscrepancy",
-                    defaultMessage: "Record Discrepancy",
-                  })
-                : intl.formatMessage({
-                    id: "label.apply",
-                    defaultMessage: "Apply",
-                  })
+        open={inspectionModalOpen}
+        onRequestClose={closeInspectionModal}
+        modalHeading={
+          inspectionContext.mode === "single"
+            ? "Individual QC Inspection"
+            : "Bulk QC Inspection"
         }
-        secondaryButtonText={intl.formatMessage({
-          id: "label.cancel",
-          defaultMessage: "Cancel",
-        })}
-        onRequestSubmit={handleBulkApply}
-        onSecondarySubmit={() => setBulkApplyModalOpen(false)}
+        primaryButtonText={
+          isSubmittingInspection
+            ? "Saving..."
+            : inspectionValues.qcResult === "DISCREPANCY_FOUND"
+              ? "Record Failed QC"
+              : "Record QC"
+        }
+        secondaryButtonText="Cancel"
+        onRequestSubmit={handleSubmitInspection}
+        onSecondarySubmit={closeInspectionModal}
+        primaryButtonDisabled={isSubmittingInspection || !inspectionValues.qcResult}
+        danger={inspectionValues.qcResult === "DISCREPANCY_FOUND"}
         size="md"
-        primaryButtonDisabled={isBulkApplying || !bulkApplyValues.qcResult}
-        danger={bulkApplyValues.qcResult === "DISCREPANCY_FOUND"}
       >
-        <div className="qc-bulk-apply-modal">
-          <p className="modal-description">
-            <FormattedMessage
-              id="biorepository.qc.bulkApply.description"
-              defaultMessage="Apply QC inspection to {count} selected sample(s)."
-              values={{ count: selectedForBulkApply.length }}
+        <p style={{ marginTop: 0 }}>
+          {inspectionContext.mode === "single"
+            ? "Record QC for one selected sample."
+            : `Record QC for ${inspectionContext.sampleIds.length} selected sample(s).`}
+        </p>
+
+        {inspectionContext.samplePreview.length > 0 && (
+          <Tile style={{ marginBottom: "1rem" }}>
+            <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
+              Selected preview
+            </div>
+            {inspectionContext.samplePreview.slice(0, 4).map((sample) => (
+              <div key={`preview-${sample.id}`} style={{ marginTop: "0.35rem" }}>
+                {sample.accessionNumber} - {sample.freezer} / {sample.shelf} / {sample.rack} / {sample.box} / {sample.positionCoordinate}
+              </div>
+            ))}
+            {inspectionContext.samplePreview.length > 4 && (
+              <div style={{ marginTop: "0.35rem", color: "#6f6f6f" }}>
+                +{inspectionContext.samplePreview.length - 4} more sample(s)
+              </div>
+            )}
+          </Tile>
+        )}
+
+        <Grid fullWidth>
+          <Column lg={8} md={4} sm={4}>
+            <TextInput
+              id="qc-inspector-name"
+              labelText="Inspector name (required)"
+              value={inspectionValues.inspectorName}
+              onChange={(event) =>
+                setInspectionValues((previous) => ({
+                  ...previous,
+                  inspectorName: event.target.value,
+                }))
+              }
             />
-          </p>
-
-          {/* Inspector Information */}
-          <div className="qc-section">
-            <h5 className="qc-section-header">
-              <FormattedMessage
-                id="biorepository.qc.section.inspector"
-                defaultMessage="Inspector Information"
+          </Column>
+          <Column lg={8} md={4} sm={4}>
+            <div className="cds--form-item">
+              <label className="cds--label">Inspection date and time</label>
+              <input
+                type="datetime-local"
+                className="cds--text-input"
+                value={inspectionValues.inspectionDate}
+                onChange={(event) =>
+                  setInspectionValues((previous) => ({
+                    ...previous,
+                    inspectionDate: event.target.value,
+                  }))
+                }
               />
-            </h5>
-            <Grid fullWidth>
-              <Column lg={8} md={4} sm={4}>
-                <TextInput
-                  id="inspectorName"
-                  labelText={intl.formatMessage({
-                    id: "biorepository.qc.inspectorName",
-                    defaultMessage: "Inspector Name (Required)",
-                  })}
-                  value={bulkApplyValues.inspectorName}
-                  onChange={(e) =>
-                    setBulkApplyValues((prev) => ({
-                      ...prev,
-                      inspectorName: e.target.value,
-                    }))
-                  }
-                  placeholder={intl.formatMessage({
-                    id: "biorepository.qc.inspectorName.placeholder",
-                    defaultMessage: "Enter inspector name",
-                  })}
-                />
-              </Column>
-              <Column lg={8} md={4} sm={4}>
-                <div className="cds--form-item">
-                  <label className="cds--label">
-                    <FormattedMessage
-                      id="biorepository.qc.inspectionDate"
-                      defaultMessage="Inspection Date & Time"
-                    />
-                  </label>
-                  <input
-                    type="datetime-local"
-                    className="cds--text-input"
-                    value={bulkApplyValues.inspectionDate}
-                    onChange={(e) =>
-                      setBulkApplyValues((prev) => ({
-                        ...prev,
-                        inspectionDate: e.target.value,
-                      }))
-                    }
-                  />
-                </div>
-              </Column>
-            </Grid>
-          </div>
+            </div>
+          </Column>
+        </Grid>
 
-          {/* QC Checklist Section */}
-          <div className="qc-section">
-            <h5 className="qc-section-header">
-              <FormattedMessage
-                id="biorepository.qc.section.checklist"
-                defaultMessage="QC Checklist"
-              />
-              <span className="qc-checklist-count">
-                ({checkedCount}/{QC_CHECKLIST.length})
-              </span>
-            </h5>
-            <div className="qc-checklist-actions">
-              <Button kind="ghost" size="sm" onClick={handleCheckAll}>
-                <FormattedMessage
-                  id="biorepository.qc.checkAll"
-                  defaultMessage="Check All (Verify)"
-                />
+        <div style={{ marginTop: "1rem" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: "0.5rem",
+            }}
+          >
+            <strong>
+              QC Checklist ({checkedCount}/{QC_CHECKLIST.length})
+            </strong>
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <Button kind="ghost" size="sm" onClick={() => handleSetAllChecklist(true)}>
+                Check all
               </Button>
-              <Button kind="ghost" size="sm" onClick={handleClearAll}>
-                <FormattedMessage
-                  id="biorepository.qc.clearAll"
-                  defaultMessage="Clear All"
-                />
+              <Button kind="ghost" size="sm" onClick={() => handleSetAllChecklist(false)}>
+                Clear all
               </Button>
             </div>
-            <div className="qc-checklist-items">
-              {QC_CHECKLIST.map((criteria) => (
-                <Checkbox
-                  key={criteria.id}
-                  id={`qc-${criteria.id}`}
-                  labelText={intl.formatMessage({
-                    id: criteria.labelId,
-                    defaultMessage: criteria.defaultLabel,
-                  })}
-                  checked={bulkApplyValues.qcChecklist[criteria.id]}
-                  onChange={(_, { checked }) =>
-                    handleChecklistChange(criteria.id, checked)
-                  }
-                />
-              ))}
-            </div>
           </div>
 
-          {/* QC Result Indicator */}
-          <div className="qc-section qc-decision-section">
-            <h5 className="qc-section-header">
-              <FormattedMessage
-                id="biorepository.qc.section.result"
-                defaultMessage="QC Result"
-              />
-            </h5>
-            <div
-              className={`qc-result-indicator ${bulkApplyValues.qcResult === "VERIFIED" ? "pass" : bulkApplyValues.qcResult === "DISCREPANCY_FOUND" ? "fail" : ""}`}
-            >
-              {bulkApplyValues.qcResult === "VERIFIED" && (
-                <Tag type="green" size="md">
-                  <Checkmark size={16} style={{ marginRight: "0.5rem" }} />
-                  <FormattedMessage
-                    id="biorepository.qc.result.verified"
-                    defaultMessage="QC VERIFIED - All checks passed"
-                  />
-                </Tag>
-              )}
-              {bulkApplyValues.qcResult === "DISCREPANCY_FOUND" && (
-                <Tag type="red" size="md">
-                  <WarningAlt size={16} style={{ marginRight: "0.5rem" }} />
-                  <FormattedMessage
-                    id="biorepository.qc.result.discrepancy"
-                    defaultMessage="DISCREPANCY FOUND - Corrective action required"
-                  />
-                </Tag>
-              )}
-              {!bulkApplyValues.qcResult && (
-                <Tag type="gray" size="md">
-                  <FormattedMessage
-                    id="biorepository.qc.result.pending"
-                    defaultMessage="Complete checklist to determine result"
-                  />
-                </Tag>
-              )}
-            </div>
-          </div>
+          {QC_CHECKLIST.map((item) => (
+            <Checkbox
+              key={item.id}
+              id={`qc-check-${item.id}`}
+              labelText={intl.formatMessage({
+                id: item.labelId,
+                defaultMessage: item.defaultLabel,
+              })}
+              checked={inspectionValues.qcChecklist[item.id]}
+              onChange={(_, { checked }) => handleChecklistChange(item.id, checked)}
+            />
+          ))}
+        </div>
 
-          {/* Discrepancy Details - Only show if QC result is DISCREPANCY_FOUND */}
-          {bulkApplyValues.qcResult === "DISCREPANCY_FOUND" && (
-            <div className="qc-section">
-              <h5 className="qc-section-header">
-                <WarningAlt size={16} style={{ marginRight: "0.5rem" }} />
-                <FormattedMessage
-                  id="biorepository.qc.section.discrepancy"
-                  defaultMessage="Discrepancy Details"
-                />
-              </h5>
-              <Grid fullWidth>
-                <Column lg={16} md={8} sm={4}>
-                  <Dropdown
-                    id="discrepancyType"
-                    titleText={intl.formatMessage({
-                      id: "biorepository.qc.discrepancyType",
-                      defaultMessage: "Discrepancy Type (Required)",
-                    })}
-                    label={intl.formatMessage({
-                      id: "biorepository.qc.discrepancyType.placeholder",
-                      defaultMessage: "Select discrepancy type",
-                    })}
-                    items={DISCREPANCY_TYPES}
-                    itemToString={(item) => (item ? item.label : "")}
-                    selectedItem={DISCREPANCY_TYPES.find(
-                      (d) => d.id === bulkApplyValues.discrepancyType,
-                    )}
-                    onChange={({ selectedItem }) =>
-                      setBulkApplyValues((prev) => ({
-                        ...prev,
-                        discrepancyType: selectedItem?.id || "",
-                      }))
-                    }
-                  />
-                </Column>
-                <Column lg={16} md={8} sm={4}>
-                  <TextArea
-                    id="correctiveAction"
-                    labelText={intl.formatMessage({
-                      id: "biorepository.qc.correctiveAction",
-                      defaultMessage: "Corrective Action Taken (Required)",
-                    })}
-                    value={bulkApplyValues.correctiveAction}
-                    onChange={(e) =>
-                      setBulkApplyValues((prev) => ({
-                        ...prev,
-                        correctiveAction: e.target.value,
-                      }))
-                    }
-                    placeholder={intl.formatMessage({
-                      id: "biorepository.qc.correctiveAction.placeholder",
-                      defaultMessage:
-                        "Describe the corrective action taken to resolve the discrepancy...",
-                    })}
-                    rows={3}
-                  />
-                </Column>
-              </Grid>
-            </div>
+        <div style={{ marginTop: "1rem" }}>
+          {inspectionValues.qcResult === "VERIFIED" && (
+            <Tag type="green">
+              <Checkmark size={16} style={{ marginRight: "0.25rem" }} />
+              QC VERIFIED
+            </Tag>
           )}
+          {inspectionValues.qcResult === "DISCREPANCY_FOUND" && (
+            <Tag type="red">
+              <WarningAlt size={16} style={{ marginRight: "0.25rem" }} />
+              DISCREPANCY FOUND
+            </Tag>
+          )}
+          {!inspectionValues.qcResult && <Tag type="gray">Complete checklist</Tag>}
+        </div>
 
-          {/* Remarks (Optional) */}
-          <div className="qc-section">
-            <Grid fullWidth>
-              <Column lg={16} md={8} sm={4}>
-                <TextArea
-                  id="remarks"
-                  labelText={intl.formatMessage({
-                    id: "biorepository.qc.remarks",
-                    defaultMessage: "Remarks (Optional)",
-                  })}
-                  value={bulkApplyValues.remarks}
-                  onChange={(e) =>
-                    setBulkApplyValues((prev) => ({
-                      ...prev,
-                      remarks: e.target.value,
-                    }))
-                  }
-                  placeholder={intl.formatMessage({
-                    id: "biorepository.qc.remarks.placeholder",
-                    defaultMessage: "Additional observations or notes...",
-                  })}
-                  rows={2}
-                />
-              </Column>
-            </Grid>
+        {inspectionValues.qcResult === "DISCREPANCY_FOUND" && (
+          <div style={{ marginTop: "1rem" }}>
+            <Dropdown
+              id="qc-discrepancy-type"
+              titleText="Discrepancy type (required)"
+              label="Choose discrepancy"
+              items={DISCREPANCY_TYPES}
+              itemToString={(item) => (item ? item.label : "")}
+              selectedItem={DISCREPANCY_TYPES.find(
+                (item) => item.id === inspectionValues.discrepancyType,
+              )}
+              onChange={({ selectedItem }) =>
+                setInspectionValues((previous) => ({
+                  ...previous,
+                  discrepancyType: selectedItem?.id || "",
+                }))
+              }
+            />
+
+            <TextArea
+              id="qc-corrective-action"
+              labelText="Corrective action (required)"
+              rows={3}
+              value={inspectionValues.correctiveAction}
+              onChange={(event) =>
+                setInspectionValues((previous) => ({
+                  ...previous,
+                  correctiveAction: event.target.value,
+                }))
+              }
+            />
           </div>
+        )}
+
+        <div style={{ marginTop: "1rem" }}>
+          <TextArea
+            id="qc-remarks"
+            labelText={
+              inspectionValues.qcResult === "DISCREPANCY_FOUND"
+                ? "Comment/remarks (required for failed QC)"
+                : "Comment/remarks (optional)"
+            }
+            rows={2}
+            value={inspectionValues.remarks}
+            onChange={(event) =>
+              setInspectionValues((previous) => ({
+                ...previous,
+                remarks: event.target.value,
+              }))
+            }
+          />
         </div>
       </Modal>
     </div>

--- a/frontend/src/components/notebook/pages/biorepository/BiorepositoryStorageAssignmentPage.js
+++ b/frontend/src/components/notebook/pages/biorepository/BiorepositoryStorageAssignmentPage.js
@@ -86,6 +86,31 @@ const STORAGE_CONDITIONS = [
   },
 ];
 
+const deriveStoragePageStatus = (sample) => {
+  const rawStatus = sample.pageStatus || sample.status || "PENDING";
+  const hasStorageAssignment =
+    sample.data?.storageWell ||
+    sample.data?.storagePath ||
+    sample.data?.storageRoom ||
+    sample.data?.storageFreezer ||
+    sample.data?.storageShelf ||
+    sample.data?.storageRack ||
+    sample.data?.storageBox ||
+    sample.storageWell ||
+    sample.storagePath ||
+    sample.storageRoom ||
+    sample.storageFreezer ||
+    sample.storageShelf ||
+    sample.storageRack ||
+    sample.storageBox;
+
+  if (rawStatus === "COMPLETED" || rawStatus === "SKIPPED") {
+    return rawStatus;
+  }
+
+  return hasStorageAssignment ? "IN_PROGRESS" : rawStatus;
+};
+
 /**
  * BiorepositoryStorageAssignmentPage - Storage Assignment workflow page
  * Stage 2 of the Biorepository workflow
@@ -98,16 +123,12 @@ const STORAGE_CONDITIONS = [
  * @param {Object} props
  * @param {number} props.entryId - The notebook entry ID
  * @param {Object} props.pageData - Page configuration from notebook
- * @param {Object} props.progress - Progress tracking data
  * @param {Function} props.onProgressUpdate - Callback when progress changes
- * @param {number} props.notebookId - The notebook ID
  */
 function BiorepositoryStorageAssignmentPage({
   entryId,
   pageData,
-  progress: _progress,
   onProgressUpdate,
-  notebookId,
 }) {
   const intl = useIntl();
   const componentMounted = useRef(false);
@@ -115,7 +136,7 @@ function BiorepositoryStorageAssignmentPage({
   // State for samples
   const [samples, setSamples] = useState([]);
   const [selectedSampleIds, setSelectedSampleIds] = useState([]);
-  const [statusFilter, setStatusFilter] = useState("ALL");
+  const [statusFilter, setStatusFilter] = useState("PENDING");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
@@ -132,7 +153,6 @@ function BiorepositoryStorageAssignmentPage({
 
   // Storage assignment modal state
   const [storageModalOpen, setStorageModalOpen] = useState(false);
-  const [selectedWell, setSelectedWell] = useState(null);
   const [isAssigning, setIsAssigning] = useState(false);
   const [wellAssignments, setWellAssignments] = useState({});
   const [isReassignment, setIsReassignment] = useState(false);
@@ -319,35 +339,47 @@ function BiorepositoryStorageAssignmentPage({
       (response) => {
         if (componentMounted.current) {
           if (response && Array.isArray(response)) {
-            const transformedSamples = response.map((sample) => ({
-              id: String(sample.id || sample.sampleItemId),
-              sampleItemId: sample.sampleItemId,
-              externalId: sample.externalId || "-",
-              accessionNumber: sample.accessionNumber || "-",
-              sampleType:
-                sample.sampleType || sample.typeOfSample?.description || "-",
-              collectionDate: sample.collectionDate,
-              status: sample.pageStatus || sample.status || "PENDING",
-              // Biorepository specific fields
-              biosafetyLevel: sample.data?.biosafetyLevel,
-              projectName: sample.data?.projectName,
-              originLab: sample.data?.originLab,
-              // Storage assignment fields from data
-              storageRoom: sample.data?.storageRoom,
-              storageFreezer: sample.data?.storageFreezer,
-              storageRack: sample.data?.storageRack,
-              storageBox: sample.data?.storageBox,
-              storageWell: sample.data?.storageWell,
-              storagePath: sample.data?.storagePath,
-              storageCondition: sample.data?.storageCondition,
-              assignedBy: sample.data?.assignedBy,
-              assignedDateTime: sample.data?.assignedDateTime,
-              // Retention policy fields (initial values, will be enriched by biorepository API)
-              retentionPolicyName:
-                sample.retentionPolicyName || sample.data?.retentionPolicyName,
-              retentionExpiryDate:
-                sample.retentionExpiryDate || sample.data?.retentionExpiryDate,
-            }));
+            const transformedSamples = response.map((sample) => {
+              const normalizedStatus = deriveStoragePageStatus(sample);
+              return {
+                id: String(sample.id || sample.sampleItemId),
+                sampleItemId: sample.sampleItemId,
+                externalId: sample.externalId || "-",
+                accessionNumber: sample.accessionNumber || "-",
+                sampleType:
+                  sample.sampleType || sample.typeOfSample?.description || "-",
+                collectionDate: sample.collectionDate,
+                status: normalizedStatus,
+                pageStatus: normalizedStatus,
+                // Biorepository specific fields
+                biosafetyLevel:
+                  sample.data?.biosafetyLevel || sample.biosafetyLevel,
+                projectName: sample.data?.projectName || sample.projectName,
+                originLab: sample.data?.originLab || sample.originLab,
+                // Storage assignment fields from data or legacy root fields
+                storageRoom: sample.data?.storageRoom || sample.storageRoom,
+                storageFreezer:
+                  sample.data?.storageFreezer || sample.storageFreezer,
+                storageShelf:
+                  sample.data?.storageShelf || sample.storageShelf,
+                storageRack: sample.data?.storageRack || sample.storageRack,
+                storageBox: sample.data?.storageBox || sample.storageBox,
+                storageWell: sample.data?.storageWell || sample.storageWell,
+                storagePath: sample.data?.storagePath || sample.storagePath,
+                storageCondition:
+                  sample.data?.storageCondition || sample.storageCondition,
+                assignedBy: sample.data?.assignedBy || sample.assignedBy,
+                assignedDateTime:
+                  sample.data?.assignedDateTime || sample.assignedDateTime,
+                // Retention policy fields (initial values, will be enriched by biorepository API)
+                retentionPolicyName:
+                  sample.retentionPolicyName ||
+                  sample.data?.retentionPolicyName,
+                retentionExpiryDate:
+                  sample.retentionExpiryDate ||
+                  sample.data?.retentionExpiryDate,
+              };
+            });
             setSamples(transformedSamples);
 
             // Fetch retention policy data from biorepository API
@@ -444,7 +476,6 @@ function BiorepositoryStorageAssignmentPage({
           return;
         }
 
-        setSelectedWell(wellCoord);
         setStorageModalOpen(true);
       }
     },
@@ -1197,6 +1228,7 @@ function BiorepositoryStorageAssignmentPage({
                 entryId={entryId}
                 onBoxLayoutLoaded={handleBoxLayoutLoaded}
                 boxRequired={true}
+                biorepositoryOnly
                 showPath={true}
               />
             </div>

--- a/frontend/src/components/notebook/workflow/StorageHierarchySelector.js
+++ b/frontend/src/components/notebook/workflow/StorageHierarchySelector.js
@@ -1,7 +1,92 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { Grid, Column, Dropdown, Loading } from "@carbon/react";
+import {
+  Grid,
+  Column,
+  Dropdown,
+  Loading,
+  InlineNotification,
+} from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../../utils/Utils";
+
+const normalizeResponseList = (response) => {
+  if (Array.isArray(response)) {
+    return response;
+  }
+  if (Array.isArray(response?.items)) {
+    return response.items;
+  }
+  return [];
+};
+
+const resolveEntityId = (item) => {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const candidate =
+    item.id ??
+    item.roomId ??
+    item.deviceId ??
+    item.shelfId ??
+    item.rackId ??
+    item.boxId;
+
+  if (candidate === null || candidate === undefined || candidate === "") {
+    return null;
+  }
+
+  return candidate;
+};
+
+const resolveEntityLabel = (item, preferredKeys = []) => {
+  const keys = [
+    ...preferredKeys,
+    "label",
+    "name",
+    "roomName",
+    "deviceName",
+    "shelfLabel",
+    "rackLabel",
+    "code",
+  ];
+
+  for (const key of keys) {
+    const value = item?.[key];
+    if (value !== null && value !== undefined && String(value).trim() !== "") {
+      return String(value).trim();
+    }
+  }
+
+  return "";
+};
+
+const toOption = (item, preferredLabelKeys = []) => {
+  const id = resolveEntityId(item);
+  const label = resolveEntityLabel(item, preferredLabelKeys);
+
+  return {
+    ...item,
+    id,
+    label,
+  };
+};
+
+const resolveErrorDetail = (error) => {
+  if (!error) {
+    return "";
+  }
+
+  if (typeof error === "string" && error.trim() !== "") {
+    return error.trim();
+  }
+
+  if (error?.message && String(error.message).trim() !== "") {
+    return String(error.message).trim();
+  }
+
+  return "";
+};
 
 /**
  * StorageHierarchySelector - Reusable component for hierarchical storage location selection.
@@ -17,22 +102,20 @@ import { getFromOpenElisServer } from "../../utils/Utils";
  *
  * @param {Object} props
  * @param {function} props.onSelectionChange - Callback when selection changes, receives { room, device, shelf, rack, box }
- * @param {Object} props.initialSelection - Initial selection state (optional)
- * @param {boolean} props.boxRequired - Whether box selection is required (default: true)
  * @param {boolean} props.showPath - Whether to show the hierarchical path (default: true)
  * @param {number} props.entryId - Notebook entry ID for box layout loading (optional)
  * @param {function} props.onBoxLayoutLoaded - Callback when box layout is loaded (optional)
  */
 function StorageHierarchySelector({
   onSelectionChange,
-  initialSelection,
-  boxRequired = true,
   showPath = true,
   entryId,
   onBoxLayoutLoaded,
+  biorepositoryOnly = false,
 }) {
   const intl = useIntl();
   const componentMounted = useRef(false);
+  const requestCountRef = useRef(0);
 
   // Hierarchical storage selection state
   const [rooms, setRooms] = useState([]);
@@ -48,6 +131,182 @@ function StorageHierarchySelector({
   const [selectedBox, setSelectedBox] = useState(null);
 
   const [loadingHierarchy, setLoadingHierarchy] = useState(false);
+  const [hierarchyNotice, setHierarchyNotice] = useState(null);
+
+  const beginHierarchyLoad = useCallback(() => {
+    requestCountRef.current += 1;
+    setLoadingHierarchy(true);
+  }, []);
+
+  const endHierarchyLoad = useCallback(() => {
+    requestCountRef.current = Math.max(0, requestCountRef.current - 1);
+    if (componentMounted.current && requestCountRef.current === 0) {
+      setLoadingHierarchy(false);
+    }
+  }, []);
+
+  const logHierarchyError = useCallback((level, endpoint, error) => {
+    const errorDetail = resolveErrorDetail(error);
+    if (errorDetail) {
+      console.warn(
+        `[StorageHierarchySelector:${level}]`,
+        endpoint,
+        errorDetail,
+      );
+    }
+  }, []);
+
+  const clearHierarchyNotice = useCallback(() => {
+    setHierarchyNotice(null);
+  }, []);
+
+  const setHierarchyErrorNotice = useCallback(
+    (levelLabel, error) => {
+      const errorDetail = resolveErrorDetail(error);
+      const detailSuffix = errorDetail ? ` (${errorDetail})` : "";
+
+      setHierarchyNotice({
+        kind: "error",
+        title: intl.formatMessage({
+          id: "notebook.storage.hierarchy.error.title",
+          defaultMessage: "Unable to load storage hierarchy",
+        }),
+        subtitle: intl.formatMessage(
+          {
+            id: "notebook.storage.hierarchy.error.subtitle",
+            defaultMessage:
+              "Could not load {levelLabel} from the server. Refresh and try again, then confirm storage setup exists.{detailSuffix}",
+          },
+          { levelLabel, detailSuffix },
+        ),
+      });
+    },
+    [intl],
+  );
+
+  const setHierarchyEmptyNotice = useCallback(
+    (level, context = {}) => {
+      if (level === "rooms") {
+        setHierarchyNotice({
+          kind: "warning",
+          title: intl.formatMessage({
+            id: "notebook.storage.hierarchy.empty.rooms.title",
+            defaultMessage: "No active storage rooms found",
+          }),
+          subtitle: intl.formatMessage({
+            id: "notebook.storage.hierarchy.empty.rooms.subtitle",
+            defaultMessage:
+              "Set up and activate at least one storage room and freezer/device in Storage Management before assigning samples.",
+          }),
+        });
+        return;
+      }
+
+      if (level === "devices") {
+        setHierarchyNotice({
+          kind: "warning",
+          title: intl.formatMessage(
+            {
+              id: "notebook.storage.hierarchy.empty.devices.title",
+              defaultMessage: "No active devices in {roomLabel}",
+            },
+            {
+              roomLabel:
+                context.roomLabel ||
+                intl.formatMessage({
+                  id: "notebook.storage.hierarchy.unknownRoom",
+                  defaultMessage: "the selected room",
+                }),
+            },
+          ),
+          subtitle: intl.formatMessage({
+            id: "notebook.storage.hierarchy.empty.devices.subtitle",
+            defaultMessage:
+              "Add or activate a freezer/device for this room in Storage Management.",
+          }),
+        });
+        return;
+      }
+
+      if (level === "shelves") {
+        setHierarchyNotice({
+          kind: "info",
+          title: intl.formatMessage(
+            {
+              id: "notebook.storage.hierarchy.empty.shelves.title",
+              defaultMessage: "No shelves found in {deviceLabel}",
+            },
+            {
+              deviceLabel:
+                context.deviceLabel ||
+                intl.formatMessage({
+                  id: "notebook.storage.hierarchy.unknownDevice",
+                  defaultMessage: "the selected device",
+                }),
+            },
+          ),
+          subtitle: intl.formatMessage({
+            id: "notebook.storage.hierarchy.empty.shelves.subtitle",
+            defaultMessage:
+              "You can assign at room/device level, or configure shelves for finer location tracking.",
+          }),
+        });
+        return;
+      }
+
+      if (level === "shelfTargets") {
+        setHierarchyNotice({
+          kind: "info",
+          title: intl.formatMessage(
+            {
+              id: "notebook.storage.hierarchy.empty.shelfTargets.title",
+              defaultMessage: "No racks or boxes found under {shelfLabel}",
+            },
+            {
+              shelfLabel:
+                context.shelfLabel ||
+                intl.formatMessage({
+                  id: "notebook.storage.hierarchy.unknownShelf",
+                  defaultMessage: "the selected shelf",
+                }),
+            },
+          ),
+          subtitle: intl.formatMessage({
+            id: "notebook.storage.hierarchy.empty.shelfTargets.subtitle",
+            defaultMessage:
+              "Assign at shelf level or configure racks/boxes for position-level storage.",
+          }),
+        });
+        return;
+      }
+
+      if (level === "rackBoxes") {
+        setHierarchyNotice({
+          kind: "info",
+          title: intl.formatMessage(
+            {
+              id: "notebook.storage.hierarchy.empty.rackBoxes.title",
+              defaultMessage: "No boxes found in {rackLabel}",
+            },
+            {
+              rackLabel:
+                context.rackLabel ||
+                intl.formatMessage({
+                  id: "notebook.storage.hierarchy.unknownRack",
+                  defaultMessage: "the selected rack",
+                }),
+            },
+          ),
+          subtitle: intl.formatMessage({
+            id: "notebook.storage.hierarchy.empty.rackBoxes.subtitle",
+            defaultMessage:
+              "Assign at rack/shelf level or create boxes to enable well-level placement.",
+          }),
+        });
+      }
+    },
+    [intl],
+  );
 
   // Load rooms on mount
   useEffect(() => {
@@ -57,7 +316,8 @@ function StorageHierarchySelector({
     return () => {
       componentMounted.current = false;
     };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [biorepositoryOnly]);
 
   // Notify parent of selection changes
   useEffect(() => {
@@ -75,36 +335,46 @@ function StorageHierarchySelector({
   }, [selectedRoom, selectedDevice, selectedShelf, selectedRack, selectedBox]);
 
   const loadRooms = () => {
-    getFromOpenElisServer("/rest/storage/rooms?status=active", (response) => {
-      if (componentMounted.current && response && Array.isArray(response)) {
-        const mappedRooms = response.map((r) => ({
-          id: r.id,
-          label: r.name,
-          ...r,
-        }));
-        // Debug logging to verify rooms have id property
-        const roomsWithoutId = mappedRooms.filter((room) => !room.id);
-        if (roomsWithoutId.length > 0) {
-          console.warn(
-            "StorageHierarchySelector: Rooms loaded without id:",
-            roomsWithoutId,
-          );
-        }
-        setRooms(mappedRooms);
+    clearHierarchyNotice();
+    const endpoint = `/rest/storage/rooms?status=active${
+      biorepositoryOnly ? "&biorepositoryOnly=true" : ""
+    }`;
+    beginHierarchyLoad();
+    getFromOpenElisServer(endpoint, (response, error) => {
+      endHierarchyLoad();
+      if (!componentMounted.current) {
+        return;
+      }
+
+      if (error) {
+        setRooms([]);
+        logHierarchyError("rooms", endpoint, error);
+        setHierarchyErrorNotice(
+          intl.formatMessage({
+            id: "notebook.storage.hierarchy.level.rooms",
+            defaultMessage: "rooms",
+          }),
+          error,
+        );
+        return;
+      }
+
+      const mappedRooms = normalizeResponseList(response)
+        .map((room) => toOption(room, ["name", "label"]))
+        .filter((room) => room.id);
+
+      setRooms(mappedRooms);
+      if (mappedRooms.length === 0) {
+        setHierarchyEmptyNotice("rooms");
       }
     });
   };
 
   // Load devices when room changes
   const handleRoomChange = ({ selectedItem }) => {
-    // Debug logging to trace room selection issues
-    if (selectedItem && !selectedItem.id) {
-      console.warn(
-        "StorageHierarchySelector: Room selected without id property:",
-        JSON.stringify(selectedItem),
-      );
-    }
-    setSelectedRoom(selectedItem);
+    const selectedRoomOption = selectedItem ? toOption(selectedItem) : null;
+    clearHierarchyNotice();
+    setSelectedRoom(selectedRoomOption);
     setSelectedDevice(null);
     setSelectedShelf(null);
     setSelectedRack(null);
@@ -114,29 +384,49 @@ function StorageHierarchySelector({
     setRacks([]);
     setBoxes([]);
 
-    if (selectedItem) {
-      setLoadingHierarchy(true);
-      getFromOpenElisServer(
-        `/rest/storage/devices?roomId=${selectedItem.id}&active=true`,
-        (response) => {
-          setLoadingHierarchy(false);
-          if (componentMounted.current && response && Array.isArray(response)) {
-            setDevices(
-              response.map((d) => ({
-                id: d.id,
-                label: d.name,
-                ...d,
-              })),
-            );
-          }
-        },
-      );
+    if (selectedRoomOption?.id) {
+      const endpoint = `/rest/storage/devices?roomId=${encodeURIComponent(selectedRoomOption.id)}&status=active${
+        biorepositoryOnly ? "&biorepositoryOnly=true" : ""
+      }`;
+      beginHierarchyLoad();
+      getFromOpenElisServer(endpoint, (response, error) => {
+        endHierarchyLoad();
+        if (!componentMounted.current) {
+          return;
+        }
+
+        if (error) {
+          setDevices([]);
+          logHierarchyError("devices", endpoint, error);
+          setHierarchyErrorNotice(
+            intl.formatMessage({
+              id: "notebook.storage.hierarchy.level.devices",
+              defaultMessage: "devices",
+            }),
+            error,
+          );
+          return;
+        }
+
+        const mappedDevices = normalizeResponseList(response)
+          .map((device) => toOption(device, ["name", "label", "deviceName"]))
+          .filter((device) => device.id);
+
+        setDevices(mappedDevices);
+        if (mappedDevices.length === 0) {
+          setHierarchyEmptyNotice("devices", {
+            roomLabel: selectedRoomOption.label,
+          });
+        }
+      });
     }
   };
 
   // Load shelves when device changes
   const handleDeviceChange = ({ selectedItem }) => {
-    setSelectedDevice(selectedItem);
+    const selectedDeviceOption = selectedItem ? toOption(selectedItem) : null;
+    clearHierarchyNotice();
+    setSelectedDevice(selectedDeviceOption);
     setSelectedShelf(null);
     setSelectedRack(null);
     setSelectedBox(null);
@@ -144,115 +434,231 @@ function StorageHierarchySelector({
     setRacks([]);
     setBoxes([]);
 
-    if (selectedItem) {
-      setLoadingHierarchy(true);
-      getFromOpenElisServer(
-        `/rest/storage/shelves?deviceId=${selectedItem.id}&active=true`,
-        (response) => {
-          setLoadingHierarchy(false);
-          if (componentMounted.current && response && Array.isArray(response)) {
-            setShelves(
-              response.map((s) => ({
-                id: s.id,
-                label: s.label || s.name,
-                ...s,
-              })),
-            );
-          }
-        },
-      );
+    if (selectedDeviceOption?.id) {
+      const endpoint = `/rest/storage/shelves?deviceId=${encodeURIComponent(selectedDeviceOption.id)}&status=active${
+        biorepositoryOnly ? "&biorepositoryOnly=true" : ""
+      }`;
+      beginHierarchyLoad();
+      getFromOpenElisServer(endpoint, (response, error) => {
+        endHierarchyLoad();
+        if (!componentMounted.current) {
+          return;
+        }
+
+        if (error) {
+          setShelves([]);
+          logHierarchyError("shelves", endpoint, error);
+          setHierarchyErrorNotice(
+            intl.formatMessage({
+              id: "notebook.storage.hierarchy.level.shelves",
+              defaultMessage: "shelves",
+            }),
+            error,
+          );
+          return;
+        }
+
+        const mappedShelves = normalizeResponseList(response)
+          .map((shelf) => toOption(shelf, ["label", "name", "shelfLabel"]))
+          .filter((shelf) => shelf.id);
+
+        setShelves(mappedShelves);
+        if (mappedShelves.length === 0) {
+          setHierarchyEmptyNotice("shelves", {
+            deviceLabel: selectedDeviceOption.label,
+          });
+        }
+      });
     }
   };
 
   // Load racks and boxes when shelf changes
   const handleShelfChange = ({ selectedItem }) => {
-    setSelectedShelf(selectedItem);
+    const selectedShelfOption = selectedItem ? toOption(selectedItem) : null;
+    clearHierarchyNotice();
+    setSelectedShelf(selectedShelfOption);
     setSelectedRack(null);
     setSelectedBox(null);
     setRacks([]);
     setBoxes([]);
 
-    if (selectedItem) {
-      setLoadingHierarchy(true);
-      // Load racks for this shelf
-      getFromOpenElisServer(
-        `/rest/storage/racks?shelfId=${selectedItem.id}&active=true`,
-        (response) => {
-          if (componentMounted.current && response && Array.isArray(response)) {
-            setRacks(
-              response.map((r) => ({
-                id: r.id,
-                label: r.label || r.name,
-                ...r,
-              })),
-            );
-          }
-        },
-      );
-      // Also load boxes directly on this shelf (boxes without a rack)
-      getFromOpenElisServer(
-        `/rest/storage/boxes?shelfId=${selectedItem.id}&active=true`,
-        (response) => {
-          setLoadingHierarchy(false);
-          if (componentMounted.current && response && Array.isArray(response)) {
-            setBoxes(
-              response.map((b) => ({
-                id: b.id,
-                label: b.label || b.name,
-                rows: b.rows || 8,
-                columns: b.columns || 12,
-                ...b,
-              })),
-            );
-          }
-        },
-      );
+    if (selectedShelfOption?.id) {
+      const racksEndpoint = `/rest/storage/racks?shelfId=${encodeURIComponent(selectedShelfOption.id)}&status=active${
+        biorepositoryOnly ? "&biorepositoryOnly=true" : ""
+      }`;
+      const boxesEndpoint = `/rest/storage/boxes?shelfId=${encodeURIComponent(selectedShelfOption.id)}&active=true${
+        biorepositoryOnly ? "&biorepositoryOnly=true" : ""
+      }`;
+      let rackRequestDone = false;
+      let boxRequestDone = false;
+      let rackRequestError = null;
+      let boxRequestError = null;
+      let rackCount = 0;
+      let boxCount = 0;
+
+      const finalizeShelfLoad = () => {
+        if (!componentMounted.current || !rackRequestDone || !boxRequestDone) {
+          return;
+        }
+
+        if (rackRequestError || boxRequestError) {
+          setHierarchyErrorNotice(
+            intl.formatMessage({
+              id: "notebook.storage.hierarchy.level.shelfChildren",
+              defaultMessage: "racks and boxes",
+            }),
+            rackRequestError || boxRequestError,
+          );
+          return;
+        }
+
+        if (rackCount === 0 && boxCount === 0) {
+          setHierarchyEmptyNotice("shelfTargets", {
+            shelfLabel: selectedShelfOption.label,
+          });
+        }
+      };
+
+      beginHierarchyLoad();
+      getFromOpenElisServer(racksEndpoint, (response, error) => {
+        endHierarchyLoad();
+        rackRequestDone = true;
+
+        if (!componentMounted.current) {
+          return;
+        }
+
+        if (error) {
+          rackRequestError = error;
+          setRacks([]);
+          logHierarchyError("racks", racksEndpoint, error);
+          finalizeShelfLoad();
+          return;
+        }
+
+        const mappedRacks = normalizeResponseList(response)
+          .map((rack) => toOption(rack, ["label", "name", "rackLabel"]))
+          .filter((rack) => rack.id);
+        rackCount = mappedRacks.length;
+        setRacks(mappedRacks);
+        finalizeShelfLoad();
+      });
+
+      beginHierarchyLoad();
+      getFromOpenElisServer(boxesEndpoint, (response, error) => {
+        endHierarchyLoad();
+        boxRequestDone = true;
+
+        if (!componentMounted.current) {
+          return;
+        }
+
+        if (error) {
+          boxRequestError = error;
+          setBoxes([]);
+          logHierarchyError("boxesByShelf", boxesEndpoint, error);
+          finalizeShelfLoad();
+          return;
+        }
+
+        const mappedBoxes = normalizeResponseList(response)
+          .map((box) => toOption(box, ["label", "name"]))
+          .filter((box) => box.id)
+          .map((box) => ({
+            ...box,
+            rows: box.rows || 8,
+            columns: box.columns || 12,
+          }));
+
+        boxCount = mappedBoxes.length;
+        setBoxes(mappedBoxes);
+        finalizeShelfLoad();
+      });
     }
   };
 
   // Load boxes when rack changes
   const handleRackChange = ({ selectedItem }) => {
-    setSelectedRack(selectedItem);
+    const selectedRackOption = selectedItem ? toOption(selectedItem) : null;
+    clearHierarchyNotice();
+    setSelectedRack(selectedRackOption);
     setSelectedBox(null);
     setBoxes([]);
 
-    if (selectedItem) {
-      setLoadingHierarchy(true);
-      getFromOpenElisServer(
-        `/rest/storage/boxes?rackId=${selectedItem.id}&active=true`,
-        (response) => {
-          setLoadingHierarchy(false);
-          if (componentMounted.current && response && Array.isArray(response)) {
-            setBoxes(
-              response.map((b) => ({
-                id: b.id,
-                label: b.label || b.name,
-                rows: b.rows || 8,
-                columns: b.columns || 12,
-                ...b,
-              })),
-            );
-          }
-        },
-      );
+    if (selectedRackOption?.id) {
+      const endpoint = `/rest/storage/boxes?rackId=${encodeURIComponent(selectedRackOption.id)}&active=true${
+        biorepositoryOnly ? "&biorepositoryOnly=true" : ""
+      }`;
+      beginHierarchyLoad();
+      getFromOpenElisServer(endpoint, (response, error) => {
+        endHierarchyLoad();
+        if (!componentMounted.current) {
+          return;
+        }
+
+        if (error) {
+          setBoxes([]);
+          logHierarchyError("boxesByRack", endpoint, error);
+          setHierarchyErrorNotice(
+            intl.formatMessage({
+              id: "notebook.storage.hierarchy.level.boxes",
+              defaultMessage: "boxes",
+            }),
+            error,
+          );
+          return;
+        }
+
+        const mappedBoxes = normalizeResponseList(response)
+          .map((box) => toOption(box, ["label", "name"]))
+          .filter((box) => box.id)
+          .map((box) => ({
+            ...box,
+            rows: box.rows || 8,
+            columns: box.columns || 12,
+          }));
+
+        setBoxes(mappedBoxes);
+        if (mappedBoxes.length === 0) {
+          setHierarchyEmptyNotice("rackBoxes", {
+            rackLabel: selectedRackOption.label,
+          });
+        }
+      });
     }
   };
 
   // Load box layout when box changes
   const handleBoxChange = ({ selectedItem }) => {
-    setSelectedBox(selectedItem);
+    const selectedBoxOption = selectedItem ? toOption(selectedItem) : null;
+    clearHierarchyNotice();
+    setSelectedBox(selectedBoxOption);
 
-    if (selectedItem && entryId && onBoxLayoutLoaded) {
-      setLoadingHierarchy(true);
-      getFromOpenElisServer(
-        `/rest/notebook/${entryId}/box/${selectedItem.id}/layout`,
-        (response) => {
-          setLoadingHierarchy(false);
-          if (componentMounted.current && response) {
-            onBoxLayoutLoaded(response.wells || {});
-          }
-        },
-      );
+    if (selectedBoxOption?.id && entryId && onBoxLayoutLoaded) {
+      const endpoint = `/rest/notebook/${entryId}/box/${selectedBoxOption.id}/layout`;
+      beginHierarchyLoad();
+      getFromOpenElisServer(endpoint, (response, error) => {
+        endHierarchyLoad();
+        if (!componentMounted.current) {
+          return;
+        }
+
+        if (error) {
+          logHierarchyError("boxLayout", endpoint, error);
+          setHierarchyErrorNotice(
+            intl.formatMessage({
+              id: "notebook.storage.hierarchy.level.boxLayout",
+              defaultMessage: "box layout",
+            }),
+            error,
+          );
+          return;
+        }
+
+        if (response) {
+          onBoxLayoutLoaded(response.wells || {});
+        }
+      });
     }
   };
 
@@ -283,7 +689,13 @@ function StorageHierarchySelector({
             })}
             items={rooms}
             itemToString={(item) => (item ? item.label : "")}
-            selectedItem={selectedRoom}
+            selectedItem={
+              selectedRoom
+                ? rooms.find(
+                    (room) => String(room.id) === String(selectedRoom.id),
+                  ) || selectedRoom
+                : null
+            }
             onChange={handleRoomChange}
           />
         </Column>
@@ -300,7 +712,13 @@ function StorageHierarchySelector({
             })}
             items={devices}
             itemToString={(item) => (item ? item.label : "")}
-            selectedItem={selectedDevice}
+            selectedItem={
+              selectedDevice
+                ? devices.find(
+                    (device) => String(device.id) === String(selectedDevice.id),
+                  ) || selectedDevice
+                : null
+            }
             onChange={handleDeviceChange}
             disabled={!selectedRoom}
             helperText={intl.formatMessage({
@@ -325,7 +743,13 @@ function StorageHierarchySelector({
             })}
             items={shelves}
             itemToString={(item) => (item ? item.label : "")}
-            selectedItem={selectedShelf}
+            selectedItem={
+              selectedShelf
+                ? shelves.find(
+                    (shelf) => String(shelf.id) === String(selectedShelf.id),
+                  ) || selectedShelf
+                : null
+            }
             onChange={handleShelfChange}
             disabled={!selectedDevice}
             helperText={intl.formatMessage({
@@ -347,7 +771,13 @@ function StorageHierarchySelector({
             })}
             items={racks}
             itemToString={(item) => (item ? item.label : "")}
-            selectedItem={selectedRack}
+            selectedItem={
+              selectedRack
+                ? racks.find(
+                    (rack) => String(rack.id) === String(selectedRack.id),
+                  ) || selectedRack
+                : null
+            }
             onChange={handleRackChange}
             disabled={!selectedShelf}
             helperText={intl.formatMessage({
@@ -369,7 +799,13 @@ function StorageHierarchySelector({
             })}
             items={boxes}
             itemToString={(item) => (item ? item.label : "")}
-            selectedItem={selectedBox}
+            selectedItem={
+              selectedBox
+                ? boxes.find(
+                    (box) => String(box.id) === String(selectedBox.id),
+                  ) || selectedBox
+                : null
+            }
             onChange={handleBoxChange}
             disabled={!selectedShelf && !selectedRack}
             helperText={intl.formatMessage({
@@ -399,6 +835,18 @@ function StorageHierarchySelector({
             />
           </strong>{" "}
           {getHierarchicalPath()}
+        </div>
+      )}
+
+      {hierarchyNotice && (
+        <div style={{ marginTop: "0.5rem" }}>
+          <InlineNotification
+            lowContrast
+            hideCloseButton
+            kind={hierarchyNotice.kind}
+            title={hierarchyNotice.title}
+            subtitle={hierarchyNotice.subtitle}
+          />
         </div>
       )}
 

--- a/frontend/src/components/storage/LocationManagement/EditLocationModal.jsx
+++ b/frontend/src/components/storage/LocationManagement/EditLocationModal.jsx
@@ -51,6 +51,7 @@ const EditLocationModal = ({
     rows: "",
     columns: "",
     positionSchemaHint: "",
+    biorepositoryStorage: false,
   });
   const [error, setError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -118,6 +119,7 @@ const EditLocationModal = ({
       rows: loc.rows || "",
       columns: loc.columns || "",
       positionSchemaHint: loc.positionSchemaHint || "",
+      biorepositoryStorage: loc.biorepositoryStorage === true,
       // Support multiple field names from API for parent data
       parentRoomName:
         loc.parentRoomName || loc.parentRoom?.name || loc.roomName || "",
@@ -162,6 +164,7 @@ const EditLocationModal = ({
               rows: fullLocation.rows || "",
               columns: fullLocation.columns || "",
               positionSchemaHint: fullLocation.positionSchemaHint || "",
+              biorepositoryStorage: fullLocation.biorepositoryStorage === true,
               // Support multiple field names from API for parent data
               parentRoomName:
                 fullLocation.parentRoomName ||
@@ -264,6 +267,7 @@ const EditLocationModal = ({
         rows: "",
         columns: "",
         positionSchemaHint: "",
+        biorepositoryStorage: false,
       };
       formDataRef.current = empty;
       setFormData(empty);
@@ -490,6 +494,7 @@ const EditLocationModal = ({
           ? parseInt(latest.capacityLimit, 10)
           : null;
         payload.active = latest.active;
+        payload.biorepositoryStorage = latest.biorepositoryStorage === true;
         // Always include parent room ID if selected (backend will handle if unchanged)
         if (selectedParentRoomId) {
           payload.parentRoomId = selectedParentRoomId;
@@ -902,6 +907,18 @@ const EditLocationModal = ({
                     handleFieldChange("capacityLimit", e.target.value)
                   }
                   type="number"
+                />
+                <Toggle
+                  id="device-biorepository-storage"
+                  data-testid="edit-location-device-biorepository-storage"
+                  labelText={intl.formatMessage({
+                    id: "storage.device.biorepositoryStorage",
+                    defaultMessage: "Biorepository storage",
+                  })}
+                  toggled={formData.biorepositoryStorage === true}
+                  onToggle={(checked) =>
+                    handleFieldChange("biorepositoryStorage", checked)
+                  }
                 />
                 <Toggle
                   id="device-active"

--- a/frontend/src/components/storage/StorageLocationModal.jsx
+++ b/frontend/src/components/storage/StorageLocationModal.jsx
@@ -62,6 +62,7 @@ const StorageLocationModal = ({
     ipAddress: "",
     port: "",
     communicationProtocol: "BACnet",
+    biorepositoryStorage: false,
   });
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -104,6 +105,7 @@ const StorageLocationModal = ({
           ipAddress: location.ipAddress || "",
           port: location.port || "",
           communicationProtocol: location.communicationProtocol || "BACnet",
+          biorepositoryStorage: location.biorepositoryStorage === true,
         });
       } else {
         // Create mode: initialize with defaults
@@ -122,6 +124,7 @@ const StorageLocationModal = ({
           ipAddress: "",
           port: "",
           communicationProtocol: "BACnet",
+          biorepositoryStorage: false,
         });
       }
       setErrors({});
@@ -338,6 +341,7 @@ const StorageLocationModal = ({
         payload.port = formData.port ? parseInt(formData.port, 10) : null;
         payload.communicationProtocol =
           formData.communicationProtocol?.trim() || "BACnet";
+        payload.biorepositoryStorage = formData.biorepositoryStorage === true;
         if (mode === "create" && selectedParentRoomId) {
           payload.parentRoomId = selectedParentRoomId;
         }
@@ -720,6 +724,17 @@ const StorageLocationModal = ({
                   defaultMessage:
                     "Protocol used for device communication (e.g., BACnet)",
                 })}
+              />
+              <Toggle
+                id="device-biorepository-storage"
+                labelText={intl.formatMessage({
+                  id: "storage.device.biorepositoryStorage",
+                  defaultMessage: "Biorepository storage",
+                })}
+                toggled={formData.biorepositoryStorage === true}
+                onToggle={(checked) =>
+                  handleFieldChange("biorepositoryStorage", checked)
+                }
               />
               <Toggle
                 id="device-active"

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestController.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestController.java
@@ -4,8 +4,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.openelisglobal.biorepository.service.BioSampleService;
 import org.openelisglobal.biorepository.service.BiorepositoryQCInspectionService;
 import org.openelisglobal.biorepository.valueholder.BioSample;
@@ -36,6 +39,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/rest/biorepository/qc-inspection")
 public class BiorepositoryQCInspectionRestController extends BaseRestController {
 
+    private static final int MAX_BOXES_PER_ROUND = 200;
+    private static final int MAX_SAMPLES_PER_BOX = 50;
+
     @Autowired
     private BiorepositoryQCInspectionService qcInspectionService;
 
@@ -52,18 +58,43 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
     @GetMapping(value = "/samples", produces = MediaType.APPLICATION_JSON_VALUE)
     @Transactional(readOnly = true)
     public ResponseEntity<List<Map<String, Object>>> getStoredSamplesForQC() {
-        List<BioSample> storedSamples = bioSampleService.getAll().stream()
-                .filter(bs -> WorkflowStatus.STORED.equals(bs.getWorkflowStatus())).toList();
+        List<BioSample> storedSamples = bioSampleService.getAllWithRelationships(50000).stream()
+                .filter(sample -> sample != null && sample.getWorkflowStatus() == WorkflowStatus.STORED)
+                .collect(Collectors.toList());
+
+        List<Integer> bioSampleIds = new ArrayList<>();
+        List<String> sampleItemIds = new ArrayList<>();
+        for (BioSample bioSample : storedSamples) {
+            if (bioSample == null || bioSample.getId() == null) {
+                continue;
+            }
+            bioSampleIds.add(bioSample.getId());
+
+            SampleItem sampleItem = bioSample.getSampleItem();
+            if (sampleItem != null && sampleItem.getId() != null && !sampleItem.getId().trim().isEmpty()) {
+                sampleItemIds.add(sampleItem.getId().trim());
+            }
+        }
+
+        Map<String, Map<String, Object>> locationsBySampleItemId = storageService.getSampleItemLocations(sampleItemIds);
+        Map<Integer, BiorepositoryQCInspection> latestInspectionByBioSampleId = qcInspectionService
+                .getMostRecentByBioSampleIds(bioSampleIds);
 
         List<Map<String, Object>> result = new ArrayList<>();
 
         for (BioSample bioSample : storedSamples) {
+            if (bioSample == null || bioSample.getId() == null) {
+                continue;
+            }
+
             Map<String, Object> sampleData = new HashMap<>();
 
             // BioSample basic info
             sampleData.put("bioSampleId", bioSample.getId());
-            sampleData.put("workflowStatus", bioSample.getWorkflowStatus().name());
-            sampleData.put("biosafetyLevel", bioSample.getBiosafetyLevel().name());
+            sampleData.put("workflowStatus",
+                    bioSample.getWorkflowStatus() != null ? bioSample.getWorkflowStatus().name() : null);
+            sampleData.put("biosafetyLevel",
+                    bioSample.getBiosafetyLevel() != null ? bioSample.getBiosafetyLevel().name() : null);
 
             if (bioSample.getProjectId() != null) {
                 sampleData.put("projectId", bioSample.getProjectId());
@@ -71,32 +102,39 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
 
             // SampleItem info
             SampleItem sampleItem = bioSample.getSampleItem();
-            if (sampleItem != null) {
-                sampleData.put("sampleItemId", sampleItem.getId());
-                sampleData.put("externalId", sampleItem.getExternalId());
-
-                if (sampleItem.getTypeOfSample() != null) {
-                    sampleData.put("sampleType", sampleItem.getTypeOfSample().getDescription());
-                    sampleData.put("sampleTypeId", sampleItem.getTypeOfSample().getId());
-                }
-
-                if (sampleItem.getSample() != null) {
-                    sampleData.put("accessionNumber", sampleItem.getSample().getAccessionNumber());
-                }
-
-                // Get storage location
-                Map<String, Object> location = storageService.getSampleItemLocation(sampleItem.getId().toString());
-                if (location != null && !location.isEmpty()) {
-                    sampleData.put("storageLocation", location);
-                    // Extract hierarchical path for display
-                    if (location.containsKey("hierarchicalPath")) {
-                        sampleData.put("locationPath", location.get("hierarchicalPath"));
-                    }
-                }
+            if (sampleItem == null || sampleItem.getId() == null || sampleItem.getId().trim().isEmpty()) {
+                continue;
             }
 
-            // Check if sample has existing QC inspection
-            BiorepositoryQCInspection mostRecent = qcInspectionService.getMostRecentByBioSampleId(bioSample.getId());
+            sampleData.put("sampleItemId", sampleItem.getId());
+            sampleData.put("externalId", sampleItem.getExternalId());
+
+            if (sampleItem.getTypeOfSample() != null) {
+                sampleData.put("sampleType", sampleItem.getTypeOfSample().getDescription());
+                sampleData.put("sampleTypeId", sampleItem.getTypeOfSample().getId());
+            }
+
+            if (sampleItem.getSample() != null) {
+                sampleData.put("accessionNumber", sampleItem.getSample().getAccessionNumber());
+            }
+
+            // Use pre-fetched storage location map to avoid per-sample query
+            String sampleItemId = sampleItem.getId().trim();
+            Map<String, Object> location = locationsBySampleItemId.get(sampleItemId);
+            if (location == null || location.isEmpty()
+                    || !Boolean.TRUE.equals(location.get("deviceBiorepositoryStorage"))
+                    || !"freezer".equalsIgnoreCase(String.valueOf(location.get("deviceType")))) {
+                continue;
+            }
+
+            sampleData.put("storageLocation", location);
+            // Extract hierarchical path for display
+            if (location.containsKey("hierarchicalPath")) {
+                sampleData.put("locationPath", location.get("hierarchicalPath"));
+            }
+
+            // Use pre-fetched latest QC map to avoid per-sample query
+            BiorepositoryQCInspection mostRecent = latestInspectionByBioSampleId.get(bioSample.getId());
             if (mostRecent != null) {
                 sampleData.put("lastQCInspection", mapQCInspection(mostRecent));
             }
@@ -120,9 +158,22 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
 
         try {
             // Validate required fields
+            if (request == null) {
+                return ResponseEntity.badRequest().body(Map.of("error", "Request payload is required"));
+            }
             if (request.getBioSampleIds() == null || request.getBioSampleIds().isEmpty()) {
                 return ResponseEntity.badRequest().body(Map.of("error", "At least one biosample ID is required"));
             }
+            if (request.getBioSampleIds().stream().anyMatch(id -> id == null || id <= 0)) {
+                return ResponseEntity.badRequest().body(Map.of("error", "BioSample IDs must be positive integers"));
+            }
+
+            Set<Integer> uniqueBioSampleIds = new LinkedHashSet<>(request.getBioSampleIds());
+            if (uniqueBioSampleIds.size() != request.getBioSampleIds().size()) {
+                return ResponseEntity.badRequest()
+                        .body(Map.of("error", "Duplicate biosample IDs are not allowed in bulk QC request"));
+            }
+
             if (request.getInspectorName() == null || request.getInspectorName().trim().isEmpty()) {
                 return ResponseEntity.badRequest().body(Map.of("error", "Inspector name is required"));
             }
@@ -132,10 +183,11 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
                     : new Timestamp(System.currentTimeMillis());
 
             List<BiorepositoryQCInspection> inspections = qcInspectionService.createBulkInspections(
-                    request.getBioSampleIds(), request.getInspectorName(), inspectionDate, request.isSamplePresent(),
+                    new ArrayList<>(uniqueBioSampleIds), request.getInspectorName(), inspectionDate,
+                    request.isSamplePresent(),
                     request.isLabelIntegrity(), request.isContainerIntegrity(), request.isVolumeAppearanceAcceptable(),
                     request.isCorrectPosition(), request.getDiscrepancyType(), request.getCorrectiveAction(),
-                    request.getRemarks(), sysUserId);
+                    request.getRemarks(), request.getQcBatchId(), request.getExpectedCoordinateSnapshot(), sysUserId);
 
             List<Map<String, Object>> result = new ArrayList<>();
             for (BiorepositoryQCInspection inspection : inspections) {
@@ -149,6 +201,89 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "Failed to create QC inspections: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Generate a random QC round (N boxes x M samples per box) from current stored
+     * inventory.
+     */
+    @PostMapping(value = "/generate-round", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> generateQCRound(@RequestBody(required = false) GenerateQCRoundRequest request,
+            HttpServletRequest httpRequest) {
+        String sysUserId = getSysUserId(httpRequest);
+        if (sysUserId == null) {
+            return ResponseEntity.status(401).body(Map.of("error", "User session not found. Please log in again."));
+        }
+
+        if (request != null && (request.getBoxesPerRound() < 1 || request.getBoxesPerRound() > MAX_BOXES_PER_ROUND)) {
+            return ResponseEntity.badRequest().body(Map.of("error", "boxesPerRound must be between 1 and "
+                    + MAX_BOXES_PER_ROUND));
+        }
+        if (request != null
+                && (request.getSamplesPerBox() < 1 || request.getSamplesPerBox() > MAX_SAMPLES_PER_BOX)) {
+            return ResponseEntity.badRequest().body(Map.of("error", "samplesPerBox must be between 1 and "
+                    + MAX_SAMPLES_PER_BOX));
+        }
+
+        int boxesPerRound = request != null ? request.getBoxesPerRound() : 10;
+        int samplesPerBox = request != null ? request.getSamplesPerBox() : 3;
+        Long seed = request != null ? request.getSeed() : null;
+
+        Map<String, String> locationFilters = new HashMap<>();
+        if (request != null) {
+            putIfNotBlank(locationFilters, "freezer", request.getFreezer());
+            putIfNotBlank(locationFilters, "shelf", request.getShelf());
+            putIfNotBlank(locationFilters, "rack", request.getRack());
+            putIfNotBlank(locationFilters, "box", request.getBox());
+        }
+
+        try {
+            Map<String, Object> generated = qcInspectionService.generateRandomQCRound(boxesPerRound, samplesPerBox,
+                    seed, sysUserId, locationFilters);
+            return ResponseEntity.ok(generated);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError()
+                    .body(Map.of("error", "Failed to generate QC round: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Get storage location overview for QC planning (room-level summary).
+     */
+    @GetMapping(value = "/location-overview", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Transactional(readOnly = true)
+    public ResponseEntity<Map<String, Object>> getLocationOverview() {
+        return ResponseEntity.ok(qcInspectionService.getLocationOverview());
+    }
+
+    /**
+     * Apply corrective action for a failed QC inspection and capture coordinate
+     * audit details.
+     */
+    @PostMapping(value = "/{inspectionId}/corrective-action", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> applyCorrectiveAction(@PathVariable("inspectionId") Integer inspectionId,
+            @RequestBody CorrectiveActionRequest request, HttpServletRequest httpRequest) {
+        String sysUserId = getSysUserId(httpRequest);
+        if (sysUserId == null) {
+            return ResponseEntity.status(401).body(Map.of("error", "User session not found. Please log in again."));
+        }
+
+        if (request == null || request.getReason() == null || request.getReason().trim().isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Corrective reason is required"));
+        }
+
+        try {
+            Map<String, Object> result = qcInspectionService.applyCorrectiveAction(inspectionId,
+                    request.getObservedCoordinate(), request.getCorrectedCoordinate(), request.getReason(), sysUserId);
+            return ResponseEntity.ok(result);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError()
+                    .body(Map.of("error", "Failed to apply corrective action: " + e.getMessage()));
         }
     }
 
@@ -192,10 +327,10 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
     private Map<String, Object> mapQCInspection(BiorepositoryQCInspection inspection) {
         Map<String, Object> map = new HashMap<>();
         map.put("id", inspection.getId());
-        map.put("bioSampleId", inspection.getBioSample().getId());
+        map.put("bioSampleId", inspection.getBioSample() != null ? inspection.getBioSample().getId() : null);
         map.put("inspectorName", inspection.getInspectorName());
-        map.put("inspectionDate", inspection.getInspectionDate().toString());
-        map.put("qcResult", inspection.getQcResult().name());
+        map.put("inspectionDate", inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
+        map.put("qcResult", inspection.getQcResult() != null ? inspection.getQcResult().name() : null);
 
         // Checklist items
         map.put("samplePresent", inspection.isSamplePresent());
@@ -214,8 +349,20 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         if (inspection.getRemarks() != null) {
             map.put("remarks", inspection.getRemarks());
         }
+        if (inspection.getQcBatchId() != null) {
+            map.put("qcBatchId", inspection.getQcBatchId());
+        }
+        if (inspection.getExpectedCoordinateSnapshot() != null) {
+            map.put("expectedCoordinateSnapshot", inspection.getExpectedCoordinateSnapshot());
+        }
 
         return map;
+    }
+
+    private void putIfNotBlank(Map<String, String> target, String key, String value) {
+        if (value != null && !value.trim().isEmpty()) {
+            target.put(key, value.trim());
+        }
     }
 
     // ========== Request DTOs ==========
@@ -232,6 +379,8 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         private String discrepancyType;
         private String correctiveAction;
         private String remarks;
+        private String qcBatchId;
+        private String expectedCoordinateSnapshot;
 
         // Getters and setters
         public List<Integer> getBioSampleIds() {
@@ -320,6 +469,118 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
 
         public void setRemarks(String remarks) {
             this.remarks = remarks;
+        }
+
+        public String getQcBatchId() {
+            return qcBatchId;
+        }
+
+        public void setQcBatchId(String qcBatchId) {
+            this.qcBatchId = qcBatchId;
+        }
+
+        public String getExpectedCoordinateSnapshot() {
+            return expectedCoordinateSnapshot;
+        }
+
+        public void setExpectedCoordinateSnapshot(String expectedCoordinateSnapshot) {
+            this.expectedCoordinateSnapshot = expectedCoordinateSnapshot;
+        }
+    }
+
+    public static class GenerateQCRoundRequest {
+        private int boxesPerRound = 10;
+        private int samplesPerBox = 3;
+        private Long seed;
+        private String freezer;
+        private String shelf;
+        private String rack;
+        private String box;
+
+        public int getBoxesPerRound() {
+            return boxesPerRound;
+        }
+
+        public void setBoxesPerRound(int boxesPerRound) {
+            this.boxesPerRound = boxesPerRound;
+        }
+
+        public int getSamplesPerBox() {
+            return samplesPerBox;
+        }
+
+        public void setSamplesPerBox(int samplesPerBox) {
+            this.samplesPerBox = samplesPerBox;
+        }
+
+        public Long getSeed() {
+            return seed;
+        }
+
+        public void setSeed(Long seed) {
+            this.seed = seed;
+        }
+
+        public String getFreezer() {
+            return freezer;
+        }
+
+        public void setFreezer(String freezer) {
+            this.freezer = freezer;
+        }
+
+        public String getShelf() {
+            return shelf;
+        }
+
+        public void setShelf(String shelf) {
+            this.shelf = shelf;
+        }
+
+        public String getRack() {
+            return rack;
+        }
+
+        public void setRack(String rack) {
+            this.rack = rack;
+        }
+
+        public String getBox() {
+            return box;
+        }
+
+        public void setBox(String box) {
+            this.box = box;
+        }
+    }
+
+    public static class CorrectiveActionRequest {
+        private String observedCoordinate;
+        private String correctedCoordinate;
+        private String reason;
+
+        public String getObservedCoordinate() {
+            return observedCoordinate;
+        }
+
+        public void setObservedCoordinate(String observedCoordinate) {
+            this.observedCoordinate = observedCoordinate;
+        }
+
+        public String getCorrectedCoordinate() {
+            return correctedCoordinate;
+        }
+
+        public void setCorrectedCoordinate(String correctedCoordinate) {
+            this.correctedCoordinate = correctedCoordinate;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+
+        public void setReason(String reason) {
+            this.reason = reason;
         }
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/dao/BiorepositoryQCInspectionDAO.java
+++ b/src/main/java/org/openelisglobal/biorepository/dao/BiorepositoryQCInspectionDAO.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.biorepository.dao;
 
 import java.util.List;
+import java.util.Map;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection.QCResult;
 import org.openelisglobal.common.dao.BaseDAO;
@@ -26,6 +27,15 @@ public interface BiorepositoryQCInspectionDAO extends BaseDAO<BiorepositoryQCIns
      * @return the most recent inspection or null if none found
      */
     BiorepositoryQCInspection getMostRecentByBioSampleId(Integer bioSampleId);
+
+    /**
+     * Find the most recent QC inspections for multiple biosamples in a single
+     * query.
+     *
+     * @param bioSampleIds list of biosample IDs
+     * @return map keyed by biosample ID containing the latest inspection
+     */
+    Map<Integer, BiorepositoryQCInspection> getMostRecentByBioSampleIds(List<Integer> bioSampleIds);
 
     /**
      * Find all inspections by QC result.

--- a/src/main/java/org/openelisglobal/biorepository/daoimpl/BiorepositoryQCInspectionDAOImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/daoimpl/BiorepositoryQCInspectionDAOImpl.java
@@ -1,7 +1,9 @@
 package org.openelisglobal.biorepository.daoimpl;
 
 import java.sql.Timestamp;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.hibernate.Session;
 import org.openelisglobal.biorepository.dao.BiorepositoryQCInspectionDAO;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
@@ -38,6 +40,32 @@ public class BiorepositoryQCInspectionDAOImpl extends BaseDAOImpl<BiorepositoryQ
                 .setParameter("bioSampleId", bioSampleId).setMaxResults(1).getResultList();
         return results.isEmpty() ? null : results.get(0);
     }
+
+        @Override
+        public Map<Integer, BiorepositoryQCInspection> getMostRecentByBioSampleIds(List<Integer> bioSampleIds) {
+                if (bioSampleIds == null || bioSampleIds.isEmpty()) {
+                        return Map.of();
+                }
+
+                Session session = entityManager.unwrap(Session.class);
+                String hql = "SELECT qc FROM BiorepositoryQCInspection qc "
+                                + "JOIN FETCH qc.bioSample bs "
+                                + "WHERE bs.id IN :bioSampleIds "
+                                + "ORDER BY bs.id ASC, qc.inspectionDate DESC, qc.id DESC";
+
+                List<BiorepositoryQCInspection> inspections = session.createQuery(hql, BiorepositoryQCInspection.class)
+                                .setParameter("bioSampleIds", bioSampleIds)
+                                .getResultList();
+
+                Map<Integer, BiorepositoryQCInspection> mostRecentBySampleId = new HashMap<>();
+                for (BiorepositoryQCInspection inspection : inspections) {
+                        Integer sampleId = inspection.getBioSample() != null ? inspection.getBioSample().getId() : null;
+                        if (sampleId != null && !mostRecentBySampleId.containsKey(sampleId)) {
+                                mostRecentBySampleId.put(sampleId, inspection);
+                        }
+                }
+                return mostRecentBySampleId;
+        }
 
     @Override
     public List<BiorepositoryQCInspection> getByQCResult(QCResult qcResult) {

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionService.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionService.java
@@ -2,6 +2,7 @@ package org.openelisglobal.biorepository.service;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection.QCResult;
 import org.openelisglobal.common.service.BaseObjectService;
@@ -27,6 +28,15 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
      * @return the most recent inspection or null if none found
      */
     BiorepositoryQCInspection getMostRecentByBioSampleId(Integer bioSampleId);
+
+        /**
+         * Find the most recent QC inspections for multiple biosamples in a single
+         * call.
+         *
+         * @param bioSampleIds list of biosample IDs
+         * @return map keyed by biosample ID containing the latest inspection
+         */
+        Map<Integer, BiorepositoryQCInspection> getMostRecentByBioSampleIds(List<Integer> bioSampleIds);
 
     /**
      * Find all inspections by QC result.
@@ -89,7 +99,17 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
     BiorepositoryQCInspection createInspection(Integer bioSampleId, String inspectorName, Timestamp inspectionDate,
             boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String sysUserId);
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId);
+
+    default BiorepositoryQCInspection createInspection(Integer bioSampleId, String inspectorName,
+            Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
+            boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
+            String correctiveAction, String remarks, String sysUserId) {
+        return createInspection(bioSampleId, inspectorName, inspectionDate, samplePresent, labelIntegrity,
+                containerIntegrity, volumeAppearanceAcceptable, correctPosition, discrepancyType, correctiveAction,
+                remarks, null, null, sysUserId);
+    }
 
     /**
      * Bulk create QC inspections for multiple biosamples.
@@ -111,5 +131,57 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
     List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String sysUserId);
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId);
+
+    default List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
+            Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
+            boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
+            String correctiveAction, String remarks, String sysUserId) {
+        return createBulkInspections(bioSampleIds, inspectorName, inspectionDate, samplePresent, labelIntegrity,
+                containerIntegrity, volumeAppearanceAcceptable, correctPosition, discrepancyType, correctiveAction,
+                remarks, null, null, sysUserId);
+    }
+
+    /**
+     * Generate a randomized QC round from currently stored samples.
+     *
+     * @param boxesPerRound number of boxes to sample
+     * @param samplesPerBox number of samples to sample per selected box
+     * @param randomSeed    optional seed for deterministic generation
+     * @param sysUserId     request user ID
+     * @return round metadata and selected samples
+     */
+    Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed, String sysUserId);
+
+        /**
+         * Generate a randomized QC round scoped by optional location filters.
+         *
+         * Supported filter keys: freezer, shelf, rack, box
+         */
+        default Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed,
+                        String sysUserId, Map<String, String> locationFilters) {
+                return generateRandomQCRound(boxesPerRound, samplesPerBox, randomSeed, sysUserId);
+        }
+
+        /**
+         * Build a storage location overview for QC planning UI.
+         *
+         * @return summary counts and location breakdowns by freezer/shelf/rack/box
+         */
+        Map<String, Object> getLocationOverview();
+
+    /**
+     * Record a corrective action for a failed QC inspection and keep an auditable
+     * trace of coordinate changes.
+     *
+     * @param inspectionId        target QC inspection ID
+     * @param observedCoordinate  observed coordinate during QC
+     * @param correctedCoordinate corrected coordinate saved in system
+     * @param correctiveReason    reason for correction
+     * @param sysUserId           user making the change
+     * @return operation summary
+     */
+    Map<String, Object> applyCorrectiveAction(Integer inspectionId, String observedCoordinate,
+            String correctedCoordinate, String correctiveReason, String sysUserId);
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionServiceImpl.java
@@ -2,13 +2,26 @@ package org.openelisglobal.biorepository.service;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
 import org.openelisglobal.biorepository.dao.BiorepositoryQCInspectionDAO;
 import org.openelisglobal.biorepository.valueholder.BioSample;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection.DiscrepancyType;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection.QCResult;
+import org.openelisglobal.biorepository.valueholder.ChainOfCustodyLog.CustodyAction;
 import org.openelisglobal.common.service.AuditableBaseObjectServiceImpl;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.storage.service.SampleStorageService;
+import org.openelisglobal.storage.service.StorageLocationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +38,15 @@ public class BiorepositoryQCInspectionServiceImpl extends
 
     @Autowired
     private BioSampleService bioSampleService;
+
+    @Autowired
+    private SampleStorageService sampleStorageService;
+
+    @Autowired
+    private StorageLocationService storageLocationService;
+
+    @Autowired
+    private ChainOfCustodyService chainOfCustodyService;
 
     BiorepositoryQCInspectionServiceImpl() {
         super(BiorepositoryQCInspection.class);
@@ -45,6 +67,12 @@ public class BiorepositoryQCInspectionServiceImpl extends
     @Transactional(readOnly = true)
     public BiorepositoryQCInspection getMostRecentByBioSampleId(Integer bioSampleId) {
         return baseObjectDAO.getMostRecentByBioSampleId(bioSampleId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<Integer, BiorepositoryQCInspection> getMostRecentByBioSampleIds(List<Integer> bioSampleIds) {
+        return baseObjectDAO.getMostRecentByBioSampleIds(bioSampleIds);
     }
 
     @Override
@@ -82,22 +110,34 @@ public class BiorepositoryQCInspectionServiceImpl extends
     public BiorepositoryQCInspection createInspection(Integer bioSampleId, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String sysUserId) {
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId) {
 
         BioSample bioSample = bioSampleService.get(bioSampleId);
         if (bioSample == null) {
             throw new IllegalArgumentException("BioSample not found: " + bioSampleId);
         }
+        if (!BioSample.WorkflowStatus.STORED.equals(bioSample.getWorkflowStatus())) {
+            throw new IllegalArgumentException("QC inspection can only be recorded for STORED samples. Current "
+                    + "status: " + bioSample.getWorkflowStatus());
+        }
+        if (inspectorName == null || inspectorName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Inspector name is required");
+        }
 
         BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
         inspection.setBioSample(bioSample);
-        inspection.setInspectorName(inspectorName);
-        inspection.setInspectionDate(inspectionDate);
+        inspection.setInspectorName(inspectorName.trim());
+        inspection
+                .setInspectionDate(inspectionDate != null ? inspectionDate : new Timestamp(System.currentTimeMillis()));
         inspection.setSamplePresent(samplePresent);
         inspection.setLabelIntegrity(labelIntegrity);
         inspection.setContainerIntegrity(containerIntegrity);
         inspection.setVolumeAppearanceAcceptable(volumeAppearanceAcceptable);
         inspection.setCorrectPosition(correctPosition);
+        inspection.setQcBatchId(qcBatchId);
+        inspection.setExpectedCoordinateSnapshot(
+                resolveExpectedCoordinateSnapshot(bioSample, expectedCoordinateSnapshot));
 
         // Auto-calculate QC result based on checklist
         inspection.updateQcResult();
@@ -105,8 +145,20 @@ public class BiorepositoryQCInspectionServiceImpl extends
         // Set discrepancy details if QC failed
         if (inspection.getQcResult() == QCResult.DISCREPANCY_FOUND) {
             DiscrepancyType type = DiscrepancyType.fromString(discrepancyType);
+            if (type == null) {
+                throw new IllegalArgumentException("Discrepancy type is required when QC fails");
+            }
+            if (correctiveAction == null || correctiveAction.trim().isEmpty()) {
+                throw new IllegalArgumentException("Corrective action is required when QC fails");
+            }
+            if (remarks == null || remarks.trim().isEmpty()) {
+                throw new IllegalArgumentException("Comment/remarks are required when QC fails");
+            }
             inspection.setDiscrepancyType(type);
-            inspection.setCorrectiveAction(correctiveAction);
+            inspection.setCorrectiveAction(correctiveAction.trim());
+        } else {
+            inspection.setDiscrepancyType(null);
+            inspection.setCorrectiveAction(null);
         }
 
         inspection.setRemarks(remarks);
@@ -120,17 +172,660 @@ public class BiorepositoryQCInspectionServiceImpl extends
     public List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String sysUserId) {
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId) {
 
         List<BiorepositoryQCInspection> inspections = new ArrayList<>();
 
         for (Integer bioSampleId : bioSampleIds) {
             BiorepositoryQCInspection inspection = createInspection(bioSampleId, inspectorName, inspectionDate,
                     samplePresent, labelIntegrity, containerIntegrity, volumeAppearanceAcceptable, correctPosition,
-                    discrepancyType, correctiveAction, remarks, sysUserId);
+                    discrepancyType, correctiveAction, remarks, qcBatchId, expectedCoordinateSnapshot, sysUserId);
             inspections.add(inspection);
         }
 
         return inspections;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed,
+            String sysUserId) {
+        return generateRandomQCRound(boxesPerRound, samplesPerBox, randomSeed, sysUserId, null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed,
+            String sysUserId, Map<String, String> locationFilters) {
+        int effectiveBoxes = boxesPerRound > 0 ? boxesPerRound : 10;
+        int effectiveSamplesPerBox = samplesPerBox > 0 ? samplesPerBox : 3;
+        Random random = randomSeed != null ? new Random(randomSeed) : new Random();
+        String qcBatchId = "QCBATCH-" + System.currentTimeMillis() + "-"
+                + UUID.randomUUID().toString().substring(0, 8);
+
+        List<Map<String, Object>> candidates = collectStoredSampleCandidates(locationFilters);
+
+        Map<String, List<Map<String, Object>>> candidatesByBox = new HashMap<>();
+        for (Map<String, Object> candidate : candidates) {
+            String boxKey = asString(candidate.get("boxKey"));
+            if (boxKey == null) {
+                continue;
+            }
+            candidatesByBox.computeIfAbsent(boxKey, k -> new ArrayList<>()).add(candidate);
+        }
+
+        List<String> selectedBoxes = selectDistributedBoxesByShelf(candidatesByBox, effectiveBoxes, random);
+
+        List<Map<String, Object>> selectedSamples = new ArrayList<>();
+        for (String boxKey : selectedBoxes) {
+            List<Map<String, Object>> boxCandidates = new ArrayList<>(candidatesByBox.get(boxKey));
+            Collections.shuffle(boxCandidates, random);
+            int limit = Math.min(effectiveSamplesPerBox, boxCandidates.size());
+            for (int i = 0; i < limit; i++) {
+                Map<String, Object> selected = new HashMap<>(boxCandidates.get(i));
+                selected.put("qcBatchId", qcBatchId);
+                selectedSamples.add(selected);
+            }
+        }
+
+        selectedSamples.sort(
+                Comparator.comparing(m -> asString(m.get("boxKey")) + ":" + asString(m.get("expectedCoordinate"))));
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("qcBatchId", qcBatchId);
+        result.put("boxesSelected", selectedBoxes.size());
+        result.put("samplesSelected", selectedSamples.size());
+        result.put("boxesPerRound", effectiveBoxes);
+        result.put("samplesPerBox", effectiveSamplesPerBox);
+        result.put("seed", randomSeed);
+        result.put("filters", locationFilters != null ? locationFilters : Collections.emptyMap());
+        result.put("generatedBy", sysUserId);
+        result.put("samples", selectedSamples);
+        return result;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> getLocationOverview() {
+        List<Map<String, Object>> candidates = collectStoredSampleCandidates(null);
+        List<Map<String, Object>> freezerDevices = new ArrayList<>();
+        for (Map<String, Object> device : storageLocationService.getDevicesForAPI(null)) {
+            if (isBiorepositoryFreezer(device)) {
+                freezerDevices.add(device);
+            }
+        }
+
+        Set<String> freezerNames = new HashSet<>();
+        Set<String> configuredShelfKeys = new HashSet<>();
+        Set<String> configuredRackKeys = new HashSet<>();
+        Set<String> configuredBoxKeys = new HashSet<>();
+        List<Map<String, Object>> freezerOptions = new ArrayList<>();
+        List<Map<String, Object>> shelfOptions = new ArrayList<>();
+        List<Map<String, Object>> rackOptions = new ArrayList<>();
+        List<Map<String, Object>> boxOptions = new ArrayList<>();
+
+        for (Map<String, Object> device : freezerDevices) {
+            String freezerName = asString(device.get("name"));
+            Integer deviceId = asInteger(device.get("id"));
+            if (freezerName == null || deviceId == null) {
+                continue;
+            }
+
+            freezerNames.add(freezerName);
+            freezerOptions.add(optionRow(freezerName, freezerName, null, null, null));
+
+            for (Map<String, Object> shelf : storageLocationService.getShelvesForAPI(deviceId)) {
+                if (!Boolean.TRUE.equals(shelf.get("biorepositoryStorage")) || !Boolean.TRUE.equals(shelf.get("active"))) {
+                    continue;
+                }
+                String shelfLabel = asString(shelf.get("label"));
+                if (shelfLabel == null) {
+                    continue;
+                }
+                String shelfKey = freezerName + " > " + shelfLabel;
+                configuredShelfKeys.add(shelfKey);
+                shelfOptions.add(optionRow(shelfLabel, shelfLabel, freezerName, null, null));
+
+                Integer shelfId = asInteger(shelf.get("id"));
+                if (shelfId == null) {
+                    continue;
+                }
+
+                for (Map<String, Object> rack : storageLocationService.getRacksForAPI(shelfId)) {
+                    if (!Boolean.TRUE.equals(rack.get("biorepositoryStorage")) || !Boolean.TRUE.equals(rack.get("active"))) {
+                        continue;
+                    }
+                    String rackLabel = asString(rack.get("rackLabel"));
+                    if (rackLabel == null) {
+                        rackLabel = asString(rack.get("label"));
+                    }
+                    if (rackLabel == null) {
+                        continue;
+                    }
+                    String rackKey = shelfKey + " > " + rackLabel;
+                    configuredRackKeys.add(rackKey);
+                    rackOptions.add(optionRow(rackLabel, rackLabel, freezerName, shelfLabel, null));
+                }
+            }
+        }
+
+        for (Map<String, Object> box : storageLocationService.getBoxesForAPI(null)) {
+            if (!Boolean.TRUE.equals(box.get("biorepositoryStorage")) || !Boolean.TRUE.equals(box.get("active"))) {
+                continue;
+            }
+            String deviceName = asString(box.get("deviceName"));
+            String shelfLabel = asString(box.get("shelfLabel"));
+            String rackLabel = asString(box.get("rackLabel"));
+            String boxLabel = asString(box.get("label"));
+            if (deviceName == null || shelfLabel == null || rackLabel == null || boxLabel == null) {
+                continue;
+            }
+            if (!freezerNames.contains(deviceName)) {
+                continue;
+            }
+            configuredBoxKeys.add(deviceName + " > " + shelfLabel + " > " + rackLabel + " > " + boxLabel);
+            boxOptions.add(optionRow(boxLabel, boxLabel, deviceName, shelfLabel, rackLabel));
+        }
+
+        Map<String, Integer> freezerSampleCount = new HashMap<>();
+        Map<String, Set<String>> freezerShelfSet = new HashMap<>();
+        Map<String, Set<String>> freezerRackSet = new HashMap<>();
+        Map<String, Set<String>> freezerBoxSet = new HashMap<>();
+        Map<String, Integer> shelfSampleCount = new HashMap<>();
+        Map<String, Set<String>> shelfRackSet = new HashMap<>();
+        Map<String, Set<String>> shelfBoxSet = new HashMap<>();
+        Map<String, String> shelfToFreezer = new HashMap<>();
+        Map<String, String> shelfLabelMap = new HashMap<>();
+
+        for (Map<String, Object> candidate : candidates) {
+            String freezer = asString(candidate.get("freezer"));
+            String shelf = asString(candidate.get("shelf"));
+            String shelfKey = asString(candidate.get("shelfKey"));
+            String rackKey = asString(candidate.get("rackKey"));
+            String boxKey = asString(candidate.get("boxKey"));
+            if (freezer == null) {
+                continue;
+            }
+
+            freezerSampleCount.merge(freezer, 1, Integer::sum);
+            freezerShelfSet.computeIfAbsent(freezer, key -> new HashSet<>());
+            freezerRackSet.computeIfAbsent(freezer, key -> new HashSet<>());
+            freezerBoxSet.computeIfAbsent(freezer, key -> new HashSet<>());
+
+            if (shelfKey != null) {
+                freezerShelfSet.get(freezer).add(shelfKey);
+            }
+            if (rackKey != null) {
+                freezerRackSet.get(freezer).add(rackKey);
+            }
+            if (boxKey != null) {
+                freezerBoxSet.get(freezer).add(boxKey);
+            }
+
+            if (shelfKey != null) {
+                shelfToFreezer.putIfAbsent(shelfKey, freezer);
+                shelfLabelMap.putIfAbsent(shelfKey, shelf != null ? shelf : "Unknown Shelf");
+                shelfSampleCount.merge(shelfKey, 1, Integer::sum);
+                shelfRackSet.computeIfAbsent(shelfKey, key -> new HashSet<>());
+                shelfBoxSet.computeIfAbsent(shelfKey, key -> new HashSet<>());
+                if (rackKey != null) {
+                    shelfRackSet.get(shelfKey).add(rackKey);
+                }
+                if (boxKey != null) {
+                    shelfBoxSet.get(shelfKey).add(boxKey);
+                }
+            }
+        }
+
+        List<Map<String, Object>> freezerSummary = new ArrayList<>();
+        for (String freezerName : freezerNames) {
+            Map<String, Object> summaryRow = new HashMap<>();
+            summaryRow.put("freezer", freezerName);
+            summaryRow.put("sampleCount", freezerSampleCount.getOrDefault(freezerName, 0));
+            summaryRow.put("shelfCount", countMatchingPrefix(configuredShelfKeys, freezerName + " > "));
+            summaryRow.put("rackCount", countMatchingPrefix(configuredRackKeys, freezerName + " > "));
+            summaryRow.put("boxCount", countMatchingPrefix(configuredBoxKeys, freezerName + " > "));
+            freezerSummary.add(summaryRow);
+        }
+
+        List<Map<String, Object>> shelfSummary = new ArrayList<>();
+        for (String shelfKey : configuredShelfKeys) {
+            Map<String, Object> summaryRow = new HashMap<>();
+            summaryRow.put("freezer", shelfToFreezer.getOrDefault(shelfKey, prefixBeforeLastSeparator(shelfKey)));
+            summaryRow.put("shelf", shelfLabelMap.getOrDefault(shelfKey, suffixAfterLastSeparator(shelfKey)));
+            summaryRow.put("shelfKey", shelfKey);
+            summaryRow.put("sampleCount", shelfSampleCount.getOrDefault(shelfKey, 0));
+            summaryRow.put("rackCount", countMatchingPrefix(configuredRackKeys, shelfKey + " > "));
+            summaryRow.put("boxCount", countMatchingPrefix(configuredBoxKeys, shelfKey + " > "));
+            shelfSummary.add(summaryRow);
+        }
+
+        freezerSummary.sort(Comparator.comparing(row -> asString(row.get("freezer"))));
+        shelfSummary.sort(Comparator.comparing(row -> asString(row.get("shelfKey"))));
+        freezerOptions.sort(Comparator.comparing(row -> asString(row.get("label"))));
+        shelfOptions.sort(Comparator.comparing(row -> asString(row.get("freezer")) + ":" + asString(row.get("label"))));
+        rackOptions.sort(Comparator.comparing(
+                row -> asString(row.get("freezer")) + ":" + asString(row.get("shelf")) + ":" + asString(row.get("label"))));
+        boxOptions.sort(Comparator.comparing(row -> asString(row.get("freezer")) + ":" + asString(row.get("shelf"))
+                + ":" + asString(row.get("rack")) + ":" + asString(row.get("label"))));
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("totalStoredSamples", candidates.size());
+        result.put("freezerCount", freezerNames.size());
+        result.put("shelfCount", configuredShelfKeys.size());
+        result.put("rackCount", configuredRackKeys.size());
+        result.put("boxCount", configuredBoxKeys.size());
+        result.put("freezerSummary", freezerSummary);
+        result.put("shelfSummary", shelfSummary);
+        result.put("freezerOptions", freezerOptions);
+        result.put("shelfOptions", shelfOptions);
+        result.put("rackOptions", rackOptions);
+        result.put("boxOptions", boxOptions);
+        result.put("generatedAt", System.currentTimeMillis());
+        return result;
+    }
+
+    @Override
+    @Transactional
+    public Map<String, Object> applyCorrectiveAction(Integer inspectionId, String observedCoordinate,
+            String correctedCoordinate, String correctiveReason, String sysUserId) {
+        BiorepositoryQCInspection inspection = get(inspectionId);
+        if (inspection == null) {
+            throw new IllegalArgumentException("QC inspection not found: " + inspectionId);
+        }
+        if (!QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+            throw new IllegalStateException("Corrective action is only allowed for failed QC inspections");
+        }
+        if (correctiveReason == null || correctiveReason.trim().isEmpty()) {
+            throw new IllegalArgumentException("Corrective reason is required");
+        }
+        if (correctedCoordinate == null || correctedCoordinate.trim().isEmpty()) {
+            throw new IllegalArgumentException("Corrected coordinate is required");
+        }
+
+        SampleItem sampleItem = inspection.getBioSample() != null ? inspection.getBioSample().getSampleItem() : null;
+        if (sampleItem == null || sampleItem.getId() == null) {
+            throw new IllegalStateException("QC inspection sample is missing sample item linkage");
+        }
+
+        Map<String, Object> before = sampleStorageService.getSampleItemLocation(sampleItem.getId());
+        String previousCoordinate = before != null ? asString(before.get("positionCoordinate")) : null;
+        String previousPath = before != null ? asString(before.get("hierarchicalPath")) : null;
+
+        sampleStorageService.updateAssignmentMetadata(sampleItem.getId(), correctedCoordinate, correctiveReason);
+
+        Map<String, Object> after = sampleStorageService.getSampleItemLocation(sampleItem.getId());
+        String newCoordinate = after != null ? asString(after.get("positionCoordinate")) : null;
+        String newPath = after != null ? asString(after.get("hierarchicalPath")) : null;
+
+        String note = "QC corrective action. InspectionId=" + inspectionId + ", batchId="
+                + asString(inspection.getQcBatchId()) + ", observed=" + asString(observedCoordinate) + ", old="
+                + asString(previousCoordinate) + ", new=" + asString(newCoordinate) + ", reason="
+                + correctiveReason.trim();
+
+        chainOfCustodyService.logCustodyAction(sampleItem, CustodyAction.RETURN_INSPECTED, null, null, newCoordinate,
+                null, previousPath, newPath, null, note, sysUserId);
+
+        inspection.setCorrectiveAction(correctiveReason.trim());
+        inspection.setRemarks((inspection.getRemarks() == null ? "" : inspection.getRemarks() + " | ")
+                + "Corrected coordinate from " + asString(previousCoordinate) + " to " + asString(newCoordinate));
+        inspection.setSysUserId(sysUserId);
+        update(inspection);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("inspectionId", inspectionId);
+        result.put("sampleItemId", sampleItem.getId());
+        result.put("oldCoordinate", previousCoordinate);
+        result.put("newCoordinate", newCoordinate);
+        result.put("oldPath", previousPath);
+        result.put("newPath", newPath);
+        result.put("reason", correctiveReason.trim());
+        return result;
+    }
+
+    private List<String> selectDistributedBoxesByShelf(Map<String, List<Map<String, Object>>> candidatesByBox,
+            int boxesToSelect, Random random) {
+        Map<String, List<String>> boxesByShelf = new HashMap<>();
+        for (Map.Entry<String, List<Map<String, Object>>> entry : candidatesByBox.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
+
+            String shelfKey = asString(entry.getValue().get(0).get("shelfKey"));
+            String bucket = shelfKey != null ? shelfKey : "Unknown Shelf";
+            boxesByShelf.computeIfAbsent(bucket, key -> new ArrayList<>()).add(entry.getKey());
+        }
+
+        for (List<String> boxList : boxesByShelf.values()) {
+            Collections.shuffle(boxList, random);
+        }
+
+        List<String> shelfKeys = new ArrayList<>(boxesByShelf.keySet());
+        Collections.shuffle(shelfKeys, random);
+
+        List<String> selected = new ArrayList<>();
+        while (selected.size() < boxesToSelect) {
+            boolean addedInCycle = false;
+            for (String shelfKey : shelfKeys) {
+                List<String> boxes = boxesByShelf.get(shelfKey);
+                if (boxes == null || boxes.isEmpty()) {
+                    continue;
+                }
+                selected.add(boxes.remove(0));
+                addedInCycle = true;
+                if (selected.size() >= boxesToSelect) {
+                    break;
+                }
+            }
+            if (!addedInCycle) {
+                break;
+            }
+        }
+
+        return selected;
+    }
+
+    private List<Map<String, Object>> collectStoredSampleCandidates(Map<String, String> locationFilters) {
+        List<Map<String, Object>> candidates = new ArrayList<>();
+        List<BioSample> storedSamples = bioSampleService.getAllWithRelationships(50000);
+        List<String> sampleItemIds = new ArrayList<>();
+
+        for (BioSample bioSample : storedSamples) {
+            if (!BioSample.WorkflowStatus.STORED.equals(bioSample.getWorkflowStatus())) {
+                continue;
+            }
+            SampleItem sampleItem = bioSample.getSampleItem();
+            if (sampleItem == null || sampleItem.getId() == null || sampleItem.getId().trim().isEmpty()) {
+                continue;
+            }
+            sampleItemIds.add(sampleItem.getId().trim());
+        }
+
+        Map<String, Map<String, Object>> locationsBySampleItemId = sampleStorageService.getSampleItemLocations(sampleItemIds);
+
+        for (BioSample bioSample : storedSamples) {
+            if (!BioSample.WorkflowStatus.STORED.equals(bioSample.getWorkflowStatus())) {
+                continue;
+            }
+            SampleItem sampleItem = bioSample.getSampleItem();
+            if (sampleItem == null || sampleItem.getId() == null || sampleItem.getId().trim().isEmpty()) {
+                continue;
+            }
+
+            Map<String, Object> location = locationsBySampleItemId.get(sampleItem.getId().trim());
+            if (!isBiorepositoryFreezerLocation(location)) {
+                continue;
+            }
+
+            Map<String, String> parsedLocation = normalizeFreezerLocation(location);
+
+            Map<String, Object> candidate = new HashMap<>();
+            candidate.put("bioSampleId", bioSample.getId());
+            candidate.put("sampleItemId", sampleItem.getId());
+            candidate.put("externalId", sampleItem.getExternalId());
+            candidate.put("accessionNumber",
+                    sampleItem.getSample() != null ? sampleItem.getSample().getAccessionNumber() : null);
+            candidate.put("locationPath", asString(location.get("hierarchicalPath")));
+            candidate.put("expectedCoordinate", asString(location.get("positionCoordinate")));
+            candidate.put("freezer", parsedLocation.get("freezer"));
+            candidate.put("shelf", parsedLocation.get("shelf"));
+            candidate.put("rack", parsedLocation.get("rack"));
+            candidate.put("box", parsedLocation.get("box"));
+            candidate.put("shelfKey", parsedLocation.get("shelfKey"));
+            candidate.put("rackKey", parsedLocation.get("rackKey"));
+            candidate.put("boxKey", parsedLocation.get("boxKey"));
+
+            if (matchesLocationFilters(candidate, locationFilters)) {
+                candidates.add(candidate);
+            }
+        }
+
+        return candidates;
+    }
+
+    private boolean isBiorepositoryFreezer(Map<String, Object> device) {
+        return device != null
+                && Boolean.TRUE.equals(device.get("active"))
+                && Boolean.TRUE.equals(device.get("biorepositoryStorage"))
+                && "freezer".equalsIgnoreCase(asString(device.get("deviceType")));
+    }
+
+    private boolean isBiorepositoryFreezerLocation(Map<String, Object> location) {
+        return location != null
+                && !location.isEmpty()
+                && Boolean.TRUE.equals(location.get("deviceBiorepositoryStorage"))
+                && "freezer".equalsIgnoreCase(asString(location.get("deviceType")));
+    }
+
+    private Map<String, String> normalizeFreezerLocation(Map<String, Object> location) {
+        String freezer = asString(location.get("deviceName"));
+        String shelf = asString(location.get("shelfLabel"));
+        String rack = asString(location.get("rackLabel"));
+        String box = asString(location.get("boxLabel"));
+
+        if (freezer != null && shelf != null && rack != null && box != null) {
+            Map<String, String> parsed = new HashMap<>();
+            parsed.put("freezer", freezer);
+            parsed.put("shelf", shelf);
+            parsed.put("rack", rack);
+            parsed.put("box", box);
+            parsed.put("shelfKey", freezer + " > " + shelf);
+            parsed.put("rackKey", freezer + " > " + shelf + " > " + rack);
+            parsed.put("boxKey", freezer + " > " + shelf + " > " + rack + " > " + box);
+            return parsed;
+        }
+
+        return parseLocationParts(asString(location.get("hierarchicalPath")), asString(location.get("positionCoordinate")));
+    }
+
+    private Map<String, String> parseLocationParts(String locationPath, String coordinate) {
+        String freezer = null;
+        String shelf = null;
+        String rack = null;
+        String box = null;
+
+        String[] segments = locationPath != null ? locationPath.split("\\s*>\\s*") : new String[0];
+        List<String> normalizedSegments = new ArrayList<>();
+        for (String segment : segments) {
+            if (segment == null) {
+                continue;
+            }
+            String trimmed = segment.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            normalizedSegments.add(trimmed);
+
+            String lower = trimmed.toLowerCase();
+            if (freezer == null && lower.contains("freezer")) {
+                freezer = trimmed;
+                continue;
+            }
+            if (shelf == null && lower.contains("shelf")) {
+                shelf = trimmed;
+                continue;
+            }
+            if (rack == null && lower.contains("rack")) {
+                rack = trimmed;
+                continue;
+            }
+            if (box == null && (lower.contains("box") || lower.startsWith("bx"))) {
+                box = trimmed;
+            }
+        }
+
+        if (freezer == null && !normalizedSegments.isEmpty()) {
+            freezer = normalizedSegments.get(0);
+        }
+        if (shelf == null && normalizedSegments.size() > 1) {
+            shelf = normalizedSegments.get(1);
+        }
+        if (rack == null && normalizedSegments.size() > 2) {
+            rack = normalizedSegments.get(2);
+        }
+        if (box == null) {
+            if (normalizedSegments.size() > 3) {
+                box = normalizedSegments.get(3);
+            } else if (!normalizedSegments.isEmpty()) {
+                box = normalizedSegments.get(normalizedSegments.size() - 1);
+            }
+        }
+
+        String normalizedFreezer = freezer != null ? freezer : "Unknown Freezer";
+        String normalizedShelf = shelf != null ? shelf : "Unknown Shelf";
+        String normalizedRack = rack != null ? rack : "Unknown Rack";
+        String normalizedBox = box != null ? box : "Unknown Box";
+
+        Map<String, String> parsed = new HashMap<>();
+        parsed.put("freezer", normalizedFreezer);
+        parsed.put("shelf", normalizedShelf);
+        parsed.put("rack", normalizedRack);
+        parsed.put("box", normalizedBox);
+        parsed.put("shelfKey", normalizedFreezer + " > " + normalizedShelf);
+        parsed.put("rackKey", normalizedFreezer + " > " + normalizedShelf + " > " + normalizedRack);
+        parsed.put("boxKey", normalizedFreezer + " > " + normalizedShelf + " > " + normalizedRack + " > "
+                + normalizedBox);
+        parsed.put("position", coordinate != null ? coordinate : "");
+        return parsed;
+    }
+
+    private boolean matchesLocationFilters(Map<String, Object> candidate, Map<String, String> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return true;
+        }
+
+        String freezerFilter = normalizeFilter(filters.get("freezer"));
+        String shelfFilter = normalizeFilter(filters.get("shelf"));
+        String rackFilter = normalizeFilter(filters.get("rack"));
+        String boxFilter = normalizeFilter(filters.get("box"));
+
+        if (!matchesSingleFilter(asString(candidate.get("freezer")), freezerFilter)) {
+            return false;
+        }
+        if (!matchesSingleFilter(asString(candidate.get("shelf")), shelfFilter)) {
+            return false;
+        }
+        if (!matchesSingleFilter(asString(candidate.get("rack")), rackFilter)) {
+            return false;
+        }
+
+        if (boxFilter != null) {
+            String box = asString(candidate.get("box"));
+            String boxKey = asString(candidate.get("boxKey"));
+            boolean boxMatches = matchesSingleFilter(box, boxFilter) || matchesSingleFilter(boxKey, boxFilter);
+            if (!boxMatches) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean matchesSingleFilter(String actual, String normalizedFilter) {
+        if (normalizedFilter == null) {
+            return true;
+        }
+        if (actual == null) {
+            return false;
+        }
+        return actual.toLowerCase().contains(normalizedFilter);
+    }
+
+    private String normalizeFilter(String filterValue) {
+        if (filterValue == null || filterValue.trim().isEmpty()) {
+            return null;
+        }
+        return filterValue.trim().toLowerCase();
+    }
+
+    private Map<String, Object> optionRow(String value, String label, String freezer, String shelf, String rack) {
+        Map<String, Object> row = new HashMap<>();
+        row.put("value", value);
+        row.put("label", label);
+        if (freezer != null) {
+            row.put("freezer", freezer);
+        }
+        if (shelf != null) {
+            row.put("shelf", shelf);
+        }
+        if (rack != null) {
+            row.put("rack", rack);
+        }
+        return row;
+    }
+
+    private int countMatchingPrefix(Set<String> values, String prefix) {
+        int count = 0;
+        for (String value : values) {
+            if (value != null && value.startsWith(prefix)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private String prefixBeforeLastSeparator(String value) {
+        if (value == null || !value.contains(" > ")) {
+            return value;
+        }
+        return value.substring(0, value.lastIndexOf(" > "));
+    }
+
+    private String suffixAfterLastSeparator(String value) {
+        if (value == null || !value.contains(" > ")) {
+            return value;
+        }
+        return value.substring(value.lastIndexOf(" > ") + 3);
+    }
+
+    private Integer asInteger(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Integer) {
+            return (Integer) value;
+        }
+        try {
+            return Integer.valueOf(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private String asString(Object value) {
+        if (Objects.isNull(value)) {
+            return null;
+        }
+        String str = String.valueOf(value);
+        return str.isBlank() ? null : str;
+    }
+
+    private String resolveExpectedCoordinateSnapshot(BioSample bioSample, String providedSnapshot) {
+        if (providedSnapshot != null && !providedSnapshot.trim().isEmpty()) {
+            return providedSnapshot.trim();
+        }
+        if (bioSample == null || bioSample.getSampleItem() == null || bioSample.getSampleItem().getId() == null) {
+            return null;
+        }
+
+        Map<String, Object> location = sampleStorageService.getSampleItemLocation(bioSample.getSampleItem().getId());
+        if (location == null || location.isEmpty()) {
+            return null;
+        }
+
+        String path = asString(location.get("hierarchicalPath"));
+        String coordinate = asString(location.get("positionCoordinate"));
+
+        if (path == null && coordinate == null) {
+            return null;
+        }
+        if (path == null) {
+            return coordinate;
+        }
+        if (coordinate == null) {
+            return path;
+        }
+        return path + " @ " + coordinate;
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryApprovedSampleType.java
+++ b/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryApprovedSampleType.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.biorepository.valueholder;
 
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -27,6 +28,7 @@ import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
  */
 @Entity
 @Table(name = "biorepository_approved_sample_type", schema = "clinlims")
+@AttributeOverride(name = "lastupdated", column = @Column(name = "last_updated"))
 public class BiorepositoryApprovedSampleType extends BaseObject<Integer> {
 
     /**

--- a/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryQCInspection.java
+++ b/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryQCInspection.java
@@ -49,9 +49,11 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
      * Types of discrepancies that can be found during QC inspection.
      */
     public enum DiscrepancyType {
-        MISSING_SAMPLE("Missing Sample"), DAMAGED_LABEL("Damaged/Illegible Label"),
-        MISPLACED_ITEM("Misplaced Item (wrong position)"), CONTAINER_DAMAGE("Container Damage"),
-        VOLUME_DISCREPANCY("Volume Discrepancy"), OTHER("Other");
+        MISSING_SAMPLE("Missing Sample"), WRONG_SAMPLE_IN_POSITION("Wrong Sample In Position"),
+        MISPLACED_ITEM("Misplaced Item (Found Elsewhere)"),
+        EMPTY_POSITION_REGISTERED_OCCUPIED("Empty Position But Registered Occupied"), LABELING_ERROR("Labeling Error"),
+        BOX_RACK_MISPLACEMENT("Box/Rack Misplacement"), DAMAGED_LABEL("Damaged/Illegible Label"),
+        CONTAINER_DAMAGE("Container Damage"), VOLUME_DISCREPANCY("Volume Discrepancy"), OTHER("Other");
 
         private final String displayValue;
 
@@ -132,6 +134,16 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
 
     @Column(name = "remarks", columnDefinition = "TEXT")
     private String remarks;
+
+    // ========================================
+    // QC Round / Coordinate Snapshot
+    // ========================================
+
+    @Column(name = "qc_batch_id", length = 80)
+    private String qcBatchId;
+
+    @Column(name = "expected_coordinate_snapshot", length = 512)
+    private String expectedCoordinateSnapshot;
 
     // ========================================
     // Inspection Metadata
@@ -263,6 +275,22 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
 
     public void setRemarks(String remarks) {
         this.remarks = remarks;
+    }
+
+    public String getQcBatchId() {
+        return qcBatchId;
+    }
+
+    public void setQcBatchId(String qcBatchId) {
+        this.qcBatchId = qcBatchId;
+    }
+
+    public String getExpectedCoordinateSnapshot() {
+        return expectedCoordinateSnapshot;
+    }
+
+    public void setExpectedCoordinateSnapshot(String expectedCoordinateSnapshot) {
+        this.expectedCoordinateSnapshot = expectedCoordinateSnapshot;
     }
 
     public String getInspectorName() {

--- a/src/main/java/org/openelisglobal/notebook/controller/rest/NoteBookRestController.java
+++ b/src/main/java/org/openelisglobal/notebook/controller/rest/NoteBookRestController.java
@@ -294,7 +294,11 @@ public class NoteBookRestController extends BaseRestController {
         }
 
         form.setSystemUserId(Integer.valueOf(sysUserId));
-        noteBookService.updateWithFormValues(noteBookId, form);
+        try {
+            noteBookService.updateWithFormValues(noteBookId, form);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
 
         return ResponseEntity.ok(Map.of("id", noteBookId));
     }
@@ -310,7 +314,11 @@ public class NoteBookRestController extends BaseRestController {
             return ResponseEntity.status(403).body(Map.of("error", "Admin access required to update template status"));
         }
 
-        noteBookService.updateWithStatus(noteBookId, status, sysUserId);
+        try {
+            noteBookService.updateWithStatus(noteBookId, status, sysUserId);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
         return ResponseEntity.ok(Map.of("id", noteBookId, "status", status.name()));
     }
 
@@ -372,7 +380,12 @@ public class NoteBookRestController extends BaseRestController {
         }
 
         form.setSystemUserId(Integer.valueOf(sysUserId));
-        NoteBook noteBook = noteBookService.createWithFormValues(form);
+        NoteBook noteBook;
+        try {
+            noteBook = noteBookService.createWithFormValues(form);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
         org.openelisglobal.common.log.LogEvent.logInfo(this.getClass().getSimpleName(), "createNoteBookEntry",
                 "Successfully created notebook entry with id=" + noteBook.getId());
         return ResponseEntity.ok(Map.of("id", noteBook.getId()));

--- a/src/main/java/org/openelisglobal/notebook/controller/rest/NotebookSampleEntryController.java
+++ b/src/main/java/org/openelisglobal/notebook/controller/rest/NotebookSampleEntryController.java
@@ -276,6 +276,7 @@ public class NotebookSampleEntryController extends BaseRestController {
         if (page != null && page.getNotebook() != null) {
             notebookId = page.getNotebook().getId();
         }
+        boolean biorepositoryContext = isBiorepositoryContext(page);
 
         // Track which sample IDs are already in the list
         java.util.Set<String> includedSampleIds = new java.util.HashSet<>();
@@ -483,6 +484,11 @@ public class NotebookSampleEntryController extends BaseRestController {
             }
         }
 
+        // Sixth pass: overlay authoritative storage assignment data from the storage
+        // subsystem. This keeps UI status filters aligned with real assignment state even
+        // when page-sample data is stale or incomplete.
+        enrichSampleMapsWithStorageAssignments(sampleMaps, biorepositoryContext);
+
         // Sort to show parents before their children (by external ID, then nesting
         // level)
         sampleMaps.sort((a, b) -> {
@@ -508,6 +514,150 @@ public class NotebookSampleEntryController extends BaseRestController {
         });
 
         return ResponseEntity.ok(sampleMaps);
+    }
+
+    private void enrichSampleMapsWithStorageAssignments(List<Map<String, Object>> sampleMaps,
+            boolean biorepositoryContext) {
+        if (!biorepositoryContext || sampleMaps == null || sampleMaps.isEmpty()) {
+            return;
+        }
+
+        List<String> sampleItemIds = sampleMaps.stream().map(sampleMap -> {
+            Object sampleItemIdObj = sampleMap.get("sampleItemId");
+            return sampleItemIdObj != null ? String.valueOf(sampleItemIdObj).trim() : null;
+        }).filter(sampleItemId -> sampleItemId != null && !sampleItemId.isBlank()).distinct()
+                .collect(Collectors.toList());
+
+        if (sampleItemIds.isEmpty()) {
+            return;
+        }
+
+        Map<String, Map<String, Object>> locationsBySampleId = sampleStorageService.getSampleItemLocations(sampleItemIds);
+        if (locationsBySampleId == null || locationsBySampleId.isEmpty()) {
+            return;
+        }
+
+        for (Map<String, Object> sampleMap : sampleMaps) {
+            Object sampleItemIdObj = sampleMap.get("sampleItemId");
+            if (sampleItemIdObj == null) {
+                continue;
+            }
+
+            String sampleItemId = String.valueOf(sampleItemIdObj).trim();
+            if (sampleItemId.isBlank()) {
+                continue;
+            }
+
+            Map<String, Object> location = locationsBySampleId.get(sampleItemId);
+            if (location == null || location.isEmpty()) {
+                continue;
+            }
+
+            String hierarchicalPath = asTrimmedString(location.get("hierarchicalPath"));
+            String coordinate = asTrimmedString(location.get("positionCoordinate"));
+            String roomName = asTrimmedString(location.get("roomName"));
+            String deviceName = asTrimmedString(location.get("deviceName"));
+            String shelfLabel = asTrimmedString(location.get("shelfLabel"));
+            String rackLabel = asTrimmedString(location.get("rackLabel"));
+            String boxLabel = asTrimmedString(location.get("boxLabel"));
+
+            Map<String, Object> data = new HashMap<>();
+            Object existingDataObj = sampleMap.get("data");
+            if (existingDataObj instanceof Map<?, ?> existingData) {
+                for (Map.Entry<?, ?> entry : existingData.entrySet()) {
+                    if (entry.getKey() != null) {
+                        data.put(String.valueOf(entry.getKey()), entry.getValue());
+                    }
+                }
+            }
+
+            if (!hierarchicalPath.isBlank()) {
+                sampleMap.put("storagePath", hierarchicalPath);
+                data.put("storagePath", hierarchicalPath);
+            }
+            if (!coordinate.isBlank()) {
+                sampleMap.put("storageWell", coordinate);
+                data.put("storageWell", coordinate);
+            }
+            if (!roomName.isBlank()) {
+                sampleMap.put("storageRoom", roomName);
+                data.put("storageRoom", roomName);
+            }
+            if (!deviceName.isBlank()) {
+                sampleMap.put("storageFreezer", deviceName);
+                data.put("storageFreezer", deviceName);
+            }
+            if (!shelfLabel.isBlank()) {
+                sampleMap.put("storageShelf", shelfLabel);
+                data.put("storageShelf", shelfLabel);
+            }
+            if (!rackLabel.isBlank()) {
+                sampleMap.put("storageRack", rackLabel);
+                data.put("storageRack", rackLabel);
+            }
+            if (!boxLabel.isBlank()) {
+                sampleMap.put("storageBox", boxLabel);
+                data.put("storageBox", boxLabel);
+            }
+
+            sampleMap.put("data", data);
+
+            // If a sample has a real storage assignment but still appears as PENDING on the
+            // page, expose it as IN_PROGRESS for filtering and display consistency.
+            String currentStatus = asTrimmedString(sampleMap.get("status"));
+            boolean hasStorageAssignment = !hierarchicalPath.isBlank() || !coordinate.isBlank();
+            if (hasStorageAssignment && "PENDING".equalsIgnoreCase(currentStatus)) {
+                sampleMap.put("status", "IN_PROGRESS");
+                sampleMap.put("pageStatus", "IN_PROGRESS");
+            }
+        }
+    }
+
+    private String asTrimmedString(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
+    }
+
+    private boolean isBiorepositoryContext(NoteBookPage page) {
+        if (page == null) {
+            return false;
+        }
+
+        return isBiorepositoryWorkflowContext(page.getNotebook());
+    }
+
+    private boolean isBiorepositoryWorkflowContext(NoteBook notebook) {
+        if (notebook == null) {
+            return false;
+        }
+
+        if (isBiorepositoryWorkflowType(notebook.getWorkflowType())) {
+            return true;
+        }
+
+        if (notebook.isChildInstance() && notebook.getParentNotebook() != null
+                && isBiorepositoryWorkflowType(notebook.getParentNotebook().getWorkflowType())) {
+            return true;
+        }
+
+        if (notebook.getId() != null) {
+            NoteBook parentTemplate = noteBookService.getParentTemplate(notebook.getId());
+            if (parentTemplate != null) {
+                if (isBiorepositoryWorkflowType(parentTemplate.getWorkflowType())) {
+                    return true;
+                }
+
+                if (parentTemplate.isChildInstance() && parentTemplate.getParentNotebook() != null
+                        && isBiorepositoryWorkflowType(parentTemplate.getParentNotebook().getWorkflowType())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isBiorepositoryWorkflowType(String workflowType) {
+        return workflowType != null && "biorepository".equalsIgnoreCase(workflowType.trim());
     }
 
     /**

--- a/src/main/java/org/openelisglobal/notebook/service/ArchivingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/ArchivingServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.notebook.valueholder.NoteBook;
 import org.openelisglobal.notebook.valueholder.NoteBook.NoteBookStatus;
@@ -324,6 +325,10 @@ public class ArchivingServiceImpl implements ArchivingService {
             throw new IllegalArgumentException("Notebook not found: " + notebookId);
         }
 
+        if (isOperationalBiorepositoryNotebook(notebook)) {
+            throw new IllegalStateException("Biorepository notebook remains active and cannot be finalized");
+        }
+
         if (notebook.getStatus() == NoteBookStatus.FINALIZED) {
             throw new IllegalStateException("Notebook is already finalized");
         }
@@ -351,6 +356,16 @@ public class ArchivingServiceImpl implements ArchivingService {
     @Override
     @Transactional(readOnly = true)
     public boolean canFinalize(Integer notebookId) {
+        NoteBook notebook;
+        try {
+            notebook = noteBookService.get(notebookId);
+        } catch (org.hibernate.ObjectNotFoundException e) {
+            return false;
+        }
+        if (notebook == null || isOperationalBiorepositoryNotebook(notebook)) {
+            return false;
+        }
+
         TraceabilityResult traceability = verifyTraceability(notebookId);
         return !ArchivingService.hasCriticalFailures(traceability);
     }
@@ -599,5 +614,40 @@ public class ArchivingServiceImpl implements ArchivingService {
         }
 
         return records;
+    }
+
+    private boolean isOperationalBiorepositoryNotebook(NoteBook notebook) {
+        if (notebook == null) {
+            return false;
+        }
+
+        if (isBiorepositoryWorkflowType(notebook.getWorkflowType())) {
+            return true;
+        }
+
+        if (notebook.isChildInstance() && notebook.getParentNotebook() != null
+                && isBiorepositoryWorkflowType(notebook.getParentNotebook().getWorkflowType())) {
+            return true;
+        }
+
+        if (notebook.getId() != null) {
+            NoteBook parentTemplate = noteBookService.getParentTemplate(notebook.getId());
+            if (parentTemplate != null) {
+                if (isBiorepositoryWorkflowType(parentTemplate.getWorkflowType())) {
+                    return true;
+                }
+
+                if (parentTemplate.isChildInstance() && parentTemplate.getParentNotebook() != null
+                        && isBiorepositoryWorkflowType(parentTemplate.getParentNotebook().getWorkflowType())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isBiorepositoryWorkflowType(String workflowType) {
+        return StringUtils.equalsIgnoreCase(StringUtils.trimToNull(workflowType), "biorepository");
     }
 }

--- a/src/main/java/org/openelisglobal/notebook/service/NoteBookServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NoteBookServiceImpl.java
@@ -148,6 +148,7 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
         Optional<NoteBook> optionalNoteBook = baseObjectDAO.get(notebookId);
         if (optionalNoteBook.isPresent()) {
             NoteBook noteBook = optionalNoteBook.get();
+            validateBiorepositoryStatusChange(noteBook, status);
             noteBook.setStatus(status);
             if (sysUserId != null) {
                 noteBook.setSysUserId(sysUserId);
@@ -655,6 +656,7 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
 
         noteBook.setIsTemplate(form.getIsTemplate());
         if (form.getStatus() != null) {
+            validateBiorepositoryStatusChange(noteBook, form.getStatus());
             noteBook.setStatus(form.getStatus());
         }
 
@@ -803,6 +805,32 @@ public class NoteBookServiceImpl extends AuditableBaseObjectServiceImpl<NoteBook
         }
 
         return noteBook;
+    }
+
+    private void validateBiorepositoryStatusChange(NoteBook noteBook, NoteBookStatus requestedStatus) {
+        if (requestedStatus == null) {
+            return;
+        }
+
+        if (!isBiorepositoryNotebook(noteBook)) {
+            return;
+        }
+
+        if (requestedStatus == NoteBookStatus.FINALIZED || requestedStatus == NoteBookStatus.ARCHIVED) {
+            throw new IllegalStateException("Biorepository entries stay operational and cannot be finalized or archived");
+        }
+    }
+
+    private boolean isBiorepositoryNotebook(NoteBook noteBook) {
+        if (noteBook == null) {
+            return false;
+        }
+
+        return isBiorepositoryWorkflowType(getEffectiveWorkflowType(noteBook));
+    }
+
+    private boolean isBiorepositoryWorkflowType(String workflowType) {
+        return StringUtils.equalsIgnoreCase(StringUtils.trimToNull(workflowType), "biorepository");
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/notebook/service/NotebookBulkOperationServiceImpl.java
+++ b/src/main/java/org/openelisglobal/notebook/service/NotebookBulkOperationServiceImpl.java
@@ -603,6 +603,7 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
                             existingData.put("storagePath", hierarchicalPath);
                         }
 
+                        advanceStorageSampleStatus(nps);
                         nps.setData(existingData);
                         nps.setLastupdated(new Timestamp(System.currentTimeMillis()));
                         notebookPageSampleService.update(nps);
@@ -735,6 +736,7 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
                         existingData.put("storageWell", wellCoordinate);
                         existingData.put("storageAssignmentId", assignmentResult.get("assignmentId"));
                         existingData.put("storagePath", assignmentResult.get("hierarchicalPath"));
+                        advanceStorageSampleStatus(nps);
                         nps.setData(existingData);
                         nps.setLastupdated(new Timestamp(System.currentTimeMillis()));
                         notebookPageSampleService.update(nps);
@@ -1040,6 +1042,7 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
                         existingData.put("storageWell", wellCoordinate);
                         existingData.put("storageAssignmentId", assignmentResult.get("assignmentId"));
                         existingData.put("storagePath", assignmentResult.get("hierarchicalPath"));
+                        advanceStorageSampleStatus(nps);
                         nps.setData(existingData);
                         nps.setLastupdated(new Timestamp(System.currentTimeMillis()));
                         notebookPageSampleService.update(nps);
@@ -1079,6 +1082,12 @@ public class NotebookBulkOperationServiceImpl implements NotebookBulkOperationSe
         }
 
         return result;
+    }
+
+    private void advanceStorageSampleStatus(NotebookPageSample nps) {
+        if (nps != null && nps.getStatus() == NotebookPageSample.Status.PENDING) {
+            nps.setStatus(NotebookPageSample.Status.IN_PROGRESS);
+        }
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/storage/controller/StorageLocationRestController.java
+++ b/src/main/java/org/openelisglobal/storage/controller/StorageLocationRestController.java
@@ -138,7 +138,8 @@ public class StorageLocationRestController extends BaseRestController {
      * Get rooms with optional status filter (FR-065: Rooms tab - filter by status)
      */
     @GetMapping("/rooms")
-    public ResponseEntity<List<Map<String, Object>>> getRooms(@RequestParam(required = false) String status) {
+    public ResponseEntity<List<Map<String, Object>>> getRooms(@RequestParam(required = false) String status,
+            @RequestParam(required = false) Boolean biorepositoryOnly) {
         try {
             List<Map<String, Object>> response;
             if (status != null && !status.isEmpty()) {
@@ -149,6 +150,9 @@ public class StorageLocationRestController extends BaseRestController {
             } else {
                 // No filter - return all rooms
                 response = storageLocationService.getRoomsForAPI();
+            }
+            if (Boolean.TRUE.equals(biorepositoryOnly)) {
+                response.removeIf(room -> !Boolean.TRUE.equals(room.get("hasBiorepositoryDevices")));
             }
             return ResponseEntity.ok(response);
         } catch (Exception e) {
@@ -352,6 +356,8 @@ public class StorageLocationRestController extends BaseRestController {
             device.setIpAddress(form.getIpAddress());
             device.setPort(form.getPort());
             device.setCommunicationProtocol(form.getCommunicationProtocol());
+            device.setBiorepositoryStorage(
+                    form.getBiorepositoryStorage() != null ? form.getBiorepositoryStorage() : Boolean.FALSE);
             device.setFhirUuid(UUID.randomUUID());
             device.setSysUserId("1"); // Default system user for REST API
             device.setParentRoom(parentRoom);
@@ -399,7 +405,8 @@ public class StorageLocationRestController extends BaseRestController {
     @GetMapping("/devices")
     public ResponseEntity<List<Map<String, Object>>> getDevices(@RequestParam(required = false) String roomId,
             @RequestParam(required = false) String type, @RequestParam(required = false) String status,
-            @RequestParam(required = false) String temperatureSetting) {
+            @RequestParam(required = false) String temperatureSetting,
+            @RequestParam(required = false) Boolean biorepositoryOnly) {
         try {
             List<Map<String, Object>> response;
             if (type != null || roomId != null || status != null || temperatureSetting != null) {
@@ -417,6 +424,9 @@ public class StorageLocationRestController extends BaseRestController {
                 // No filters - return all devices
                 Integer roomIdInt = roomId != null ? Integer.parseInt(roomId) : null;
                 response = storageLocationService.getDevicesForAPI(roomIdInt);
+            }
+            if (Boolean.TRUE.equals(biorepositoryOnly)) {
+                response.removeIf(device -> !Boolean.TRUE.equals(device.get("biorepositoryStorage")));
             }
             return ResponseEntity.ok(response);
         } catch (Exception e) {
@@ -453,11 +463,16 @@ public class StorageLocationRestController extends BaseRestController {
             deviceToUpdate.setCapacityLimit(form.getCapacityLimit());
             deviceToUpdate.setActive(form.getActive());
             deviceToUpdate.setCode(form.getCode());
+            deviceToUpdate.setBiorepositoryStorage(form.getBiorepositoryStorage());
 
             // Get existing device to preserve ID
             StorageDevice existingDevice = (StorageDevice) storageLocationService.get(idInt, StorageDevice.class);
             if (existingDevice == null) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            }
+
+            if (deviceToUpdate.getBiorepositoryStorage() == null) {
+                deviceToUpdate.setBiorepositoryStorage(existingDevice.getBiorepositoryStorage());
             }
 
             // Handle parent room change if provided
@@ -674,7 +689,8 @@ public class StorageLocationRestController extends BaseRestController {
      */
     @GetMapping("/shelves")
     public ResponseEntity<List<Map<String, Object>>> getShelves(@RequestParam(required = false) String deviceId,
-            @RequestParam(required = false) String roomId, @RequestParam(required = false) String status) {
+            @RequestParam(required = false) String roomId, @RequestParam(required = false) String status,
+            @RequestParam(required = false) Boolean biorepositoryOnly) {
         try {
             List<Map<String, Object>> response;
             if (deviceId != null || roomId != null || status != null) {
@@ -689,6 +705,9 @@ public class StorageLocationRestController extends BaseRestController {
                 // No filters - return all shelves
                 Integer deviceIdInt = deviceId != null ? Integer.parseInt(deviceId) : null;
                 response = storageLocationService.getShelvesForAPI(deviceIdInt);
+            }
+            if (Boolean.TRUE.equals(biorepositoryOnly)) {
+                response.removeIf(shelf -> !Boolean.TRUE.equals(shelf.get("biorepositoryStorage")));
             }
             return ResponseEntity.ok(response);
         } catch (Exception e) {
@@ -936,7 +955,8 @@ public class StorageLocationRestController extends BaseRestController {
     @GetMapping("/racks")
     public ResponseEntity<List<Map<String, Object>>> getRacks(@RequestParam(required = false) String shelfId,
             @RequestParam(required = false) String deviceId, @RequestParam(required = false) String roomId,
-            @RequestParam(required = false) String status) {
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) Boolean biorepositoryOnly) {
         try {
             List<Map<String, Object>> response;
             if (shelfId != null || deviceId != null || roomId != null || status != null) {
@@ -952,6 +972,9 @@ public class StorageLocationRestController extends BaseRestController {
                 // Service layer already includes roomId in getRacksForAPI response
                 Integer shelfIdInt = shelfId != null ? Integer.parseInt(shelfId) : null;
                 response = storageLocationService.getRacksForAPI(shelfIdInt);
+            }
+            if (Boolean.TRUE.equals(biorepositoryOnly)) {
+                response.removeIf(rack -> !Boolean.TRUE.equals(rack.get("biorepositoryStorage")));
             }
             return ResponseEntity.ok(response);
         } catch (Exception e) {
@@ -1208,7 +1231,9 @@ public class StorageLocationRestController extends BaseRestController {
 
     @GetMapping("/boxes")
     public ResponseEntity<List<StorageBoxResponse>> getBoxes(@RequestParam(required = false) String rackId,
-            @RequestParam(required = false) Boolean active, @RequestParam(required = false) Boolean occupied) {
+            @RequestParam(required = false) Integer shelfId, @RequestParam(required = false) Boolean active,
+            @RequestParam(required = false) Boolean occupied,
+            @RequestParam(required = false) Boolean biorepositoryOnly) {
         try {
             List<StorageBox> boxes;
             if (rackId != null) {
@@ -1216,6 +1241,20 @@ public class StorageLocationRestController extends BaseRestController {
                 boxes = storageLocationService.getBoxesByRack(rackIdInt);
             } else {
                 boxes = storageLocationService.getAllBoxes();
+            }
+
+            if (shelfId != null) {
+                boxes.removeIf(box -> box.getParentRack() == null || box.getParentRack().getParentShelf() == null
+                        || !shelfId.equals(box.getParentRack().getParentShelf().getId()));
+            }
+
+            if (Boolean.TRUE.equals(biorepositoryOnly)) {
+                boxes.removeIf(box -> {
+                    StorageRack parentRack = box.getParentRack();
+                    StorageShelf parentShelf = parentRack != null ? parentRack.getParentShelf() : null;
+                    StorageDevice parentDevice = parentShelf != null ? parentShelf.getParentDevice() : null;
+                    return parentDevice == null || !Boolean.TRUE.equals(parentDevice.getBiorepositoryStorage());
+                });
             }
 
             // Filter by active status if specified
@@ -1567,6 +1606,7 @@ public class StorageLocationRestController extends BaseRestController {
         response.setTemperatureSetting(device.getTemperatureSetting());
         response.setCapacityLimit(device.getCapacityLimit());
         response.setActive(device.getActive());
+        response.setBiorepositoryStorage(device.getBiorepositoryStorage());
         response.setFhirUuid(device.getFhirUuidAsString());
         response.setIpAddress(device.getIpAddress());
         response.setPort(device.getPort());

--- a/src/main/java/org/openelisglobal/storage/dao/SampleStorageAssignmentDAO.java
+++ b/src/main/java/org/openelisglobal/storage/dao/SampleStorageAssignmentDAO.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 public interface SampleStorageAssignmentDAO extends BaseDAO<SampleStorageAssignment, Integer> {
     SampleStorageAssignment findBySampleItemId(String sampleItemId);
 
+    List<SampleStorageAssignment> findBySampleItemIds(List<String> sampleItemIds);
+
     SampleStorageAssignment findByStorageBox(StorageBox box);
 
     boolean isBoxOccupied(StorageBox box);

--- a/src/main/java/org/openelisglobal/storage/dao/SampleStorageAssignmentDAOImpl.java
+++ b/src/main/java/org/openelisglobal/storage/dao/SampleStorageAssignmentDAOImpl.java
@@ -60,6 +60,44 @@ public class SampleStorageAssignmentDAOImpl extends BaseDAOImpl<SampleStorageAss
 
     @Override
     @Transactional(readOnly = true)
+    public List<SampleStorageAssignment> findBySampleItemIds(List<String> sampleItemIds) {
+        if (sampleItemIds == null || sampleItemIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Integer> numericIds = sampleItemIds.stream()
+                .filter(id -> id != null && !id.trim().isEmpty())
+                .map(String::trim)
+                .map(id -> {
+                    try {
+                        return Integer.parseInt(id);
+                    } catch (NumberFormatException e) {
+                        logger.warn("Skipping invalid SampleItem ID format in batch lookup: {}", id);
+                        return null;
+                    }
+                })
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (numericIds.isEmpty()) {
+            return List.of();
+        }
+
+        try {
+            String hql = "FROM SampleStorageAssignment ssa WHERE ssa.sampleItemId IN :sampleItemIds";
+            Query<SampleStorageAssignment> query = entityManager.unwrap(Session.class).createQuery(hql,
+                    SampleStorageAssignment.class);
+            query.setParameter("sampleItemIds", numericIds);
+            return query.list();
+        } catch (Exception e) {
+            logger.error("Error finding SampleStorageAssignments by SampleItem IDs", e);
+            throw new LIMSRuntimeException("Error finding SampleStorageAssignments by SampleItem IDs", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public SampleStorageAssignment findByStorageBox(StorageBox box) {
         try {
             if (box == null) {

--- a/src/main/java/org/openelisglobal/storage/form/StorageDeviceForm.java
+++ b/src/main/java/org/openelisglobal/storage/form/StorageDeviceForm.java
@@ -30,6 +30,8 @@ public class StorageDeviceForm {
 
     private Boolean active = true;
 
+    private Boolean biorepositoryStorage = false;
+
     // Note: parentRoomId is required for creation but optional for updates
     // (parent cannot be changed after creation, backend ignores this field on PUT)
     private String parentRoomId;
@@ -100,6 +102,14 @@ public class StorageDeviceForm {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    public Boolean getBiorepositoryStorage() {
+        return biorepositoryStorage;
+    }
+
+    public void setBiorepositoryStorage(Boolean biorepositoryStorage) {
+        this.biorepositoryStorage = biorepositoryStorage;
     }
 
     public String getParentRoomId() {

--- a/src/main/java/org/openelisglobal/storage/form/response/StorageDeviceResponse.java
+++ b/src/main/java/org/openelisglobal/storage/form/response/StorageDeviceResponse.java
@@ -10,6 +10,7 @@ public class StorageDeviceResponse {
     private BigDecimal temperatureSetting;
     private Integer capacityLimit;
     private Boolean active;
+    private Boolean biorepositoryStorage;
     private String fhirUuid;
     private String ipAddress;
     private Integer port;
@@ -73,6 +74,14 @@ public class StorageDeviceResponse {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    public Boolean getBiorepositoryStorage() {
+        return biorepositoryStorage;
+    }
+
+    public void setBiorepositoryStorage(Boolean biorepositoryStorage) {
+        this.biorepositoryStorage = biorepositoryStorage;
     }
 
     public String getFhirUuid() {

--- a/src/main/java/org/openelisglobal/storage/service/SampleStorageService.java
+++ b/src/main/java/org/openelisglobal/storage/service/SampleStorageService.java
@@ -70,6 +70,8 @@ public interface SampleStorageService {
      */
     java.util.Map<String, Object> getSampleItemLocation(String sampleItemId);
 
+    java.util.Map<String, java.util.Map<String, Object>> getSampleItemLocations(java.util.List<String> sampleItemIds);
+
     /**
      * Get paginated sample storage assignments for dashboard display (OGC-150).
      * 

--- a/src/main/java/org/openelisglobal/storage/service/SampleStorageServiceImpl.java
+++ b/src/main/java/org/openelisglobal/storage/service/SampleStorageServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.storage.service;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -208,17 +209,38 @@ public class SampleStorageServiceImpl implements SampleStorageService {
             return new HashMap<>();
         }
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("sampleItemId", sampleItemId);
+        return buildLocationDetailsFromAssignment(assignment, new HashMap<>(), new HashMap<>(), new HashMap<>(),
+                new HashMap<>(), new HashMap<>());
+    }
 
-        String hierarchicalPath = buildHierarchicalPathForAssignment(assignment);
-        result.put("location", hierarchicalPath != null ? hierarchicalPath : "");
-        result.put("hierarchicalPath", hierarchicalPath != null ? hierarchicalPath : "");
-        result.put("assignedBy", assignment.getAssignedByUserId());
-        result.put("assignedDate", assignment.getAssignedDate() != null ? assignment.getAssignedDate().toString() : "");
-        result.put("positionCoordinate",
-                assignment.getPositionCoordinate() != null ? assignment.getPositionCoordinate() : "");
-        result.put("notes", assignment.getNotes() != null ? assignment.getNotes() : "");
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Map<String, Object>> getSampleItemLocations(List<String> sampleItemIds) {
+        Map<String, Map<String, Object>> result = new HashMap<>();
+        if (sampleItemIds == null || sampleItemIds.isEmpty()) {
+            return result;
+        }
+
+        List<SampleStorageAssignment> assignments = sampleStorageAssignmentDAO.findBySampleItemIds(sampleItemIds);
+        if (assignments.isEmpty()) {
+            return result;
+        }
+
+        Map<Integer, StorageRoom> roomCache = new HashMap<>();
+        Map<Integer, StorageDevice> deviceCache = new HashMap<>();
+        Map<Integer, StorageShelf> shelfCache = new HashMap<>();
+        Map<Integer, StorageRack> rackCache = new HashMap<>();
+        Map<Integer, StorageBox> boxCache = new HashMap<>();
+
+        for (SampleStorageAssignment assignment : assignments) {
+            if (assignment == null || assignment.getSampleItemId() == null) {
+                continue;
+            }
+
+            result.put(assignment.getSampleItemId().toString(),
+                    buildLocationDetailsFromAssignment(assignment, roomCache, deviceCache, shelfCache, rackCache,
+                            boxCache));
+        }
 
         return result;
     }
@@ -534,6 +556,141 @@ public class SampleStorageServiceImpl implements SampleStorageService {
         } else {
             return rack.getLabel() + " > " + box.getLabel();
         }
+    }
+
+    private Map<String, Object> buildLocationDetailsFromAssignment(SampleStorageAssignment assignment,
+            Map<Integer, StorageRoom> roomCache, Map<Integer, StorageDevice> deviceCache,
+            Map<Integer, StorageShelf> shelfCache, Map<Integer, StorageRack> rackCache,
+            Map<Integer, StorageBox> boxCache) {
+        Map<String, Object> result = new HashMap<>();
+        if (assignment == null) {
+            return result;
+        }
+
+        String sampleItemId = assignment.getSampleItemId() != null ? assignment.getSampleItemId().toString() : null;
+        result.put("sampleItemId", sampleItemId);
+        result.put("locationType", assignment.getLocationType());
+        result.put("locationId", assignment.getLocationId());
+        result.put("assignedBy", assignment.getAssignedByUserId());
+        result.put("assignedDate", assignment.getAssignedDate() != null ? assignment.getAssignedDate().toString() : "");
+        result.put("positionCoordinate",
+                assignment.getPositionCoordinate() != null ? assignment.getPositionCoordinate() : "");
+        result.put("notes", assignment.getNotes() != null ? assignment.getNotes() : "");
+
+        StorageRoom room = null;
+        StorageDevice device = null;
+        StorageShelf shelf = null;
+        StorageRack rack = null;
+        StorageBox box = null;
+
+        Integer locationId = assignment.getLocationId();
+        String locationType = assignment.getLocationType();
+
+        if (locationId != null && locationType != null) {
+            switch (locationType) {
+            case "room":
+                room = getCachedLocation(locationId, StorageRoom.class, roomCache);
+                break;
+            case "device":
+                device = getCachedLocation(locationId, StorageDevice.class, deviceCache);
+                room = device != null ? device.getParentRoom() : null;
+                break;
+            case "shelf":
+                shelf = getCachedLocation(locationId, StorageShelf.class, shelfCache);
+                device = shelf != null ? shelf.getParentDevice() : null;
+                room = device != null ? device.getParentRoom() : null;
+                break;
+            case "rack":
+                rack = getCachedLocation(locationId, StorageRack.class, rackCache);
+                shelf = rack != null ? rack.getParentShelf() : null;
+                device = shelf != null ? shelf.getParentDevice() : null;
+                room = device != null ? device.getParentRoom() : null;
+                break;
+            case "box":
+                box = getCachedLocation(locationId, StorageBox.class, boxCache);
+                rack = box != null ? box.getParentRack() : null;
+                shelf = rack != null ? rack.getParentShelf() : null;
+                device = shelf != null ? shelf.getParentDevice() : null;
+                room = device != null ? device.getParentRoom() : null;
+                break;
+            default:
+                break;
+            }
+        }
+
+        String hierarchicalPath = buildHierarchicalPathForResolvedLocation(locationType, room, device, shelf, rack, box,
+                assignment.getPositionCoordinate());
+        result.put("location", hierarchicalPath != null ? hierarchicalPath : "");
+        result.put("hierarchicalPath", hierarchicalPath != null ? hierarchicalPath : "");
+
+        if (room != null) {
+            result.put("roomId", room.getId());
+            result.put("roomName", room.getName());
+        }
+        if (device != null) {
+            result.put("deviceId", device.getId());
+            result.put("deviceName", device.getName());
+            result.put("deviceType", device.getTypeAsString());
+            result.put("deviceBiorepositoryStorage", Boolean.TRUE.equals(device.getBiorepositoryStorage()));
+        }
+        if (shelf != null) {
+            result.put("shelfId", shelf.getId());
+            result.put("shelfLabel", shelf.getLabel());
+        }
+        if (rack != null) {
+            result.put("rackId", rack.getId());
+            result.put("rackLabel", rack.getLabel());
+        }
+        if (box != null) {
+            result.put("boxId", box.getId());
+            result.put("boxLabel", box.getLabel());
+        }
+
+        return result;
+    }
+
+    private <T> T getCachedLocation(Integer id, Class<T> entityClass, Map<Integer, T> cache) {
+        if (id == null) {
+            return null;
+        }
+        if (!cache.containsKey(id)) {
+            @SuppressWarnings("unchecked")
+            T entity = (T) storageLocationService.get(id, entityClass);
+            cache.put(id, entity);
+        }
+        return cache.get(id);
+    }
+
+    private String buildHierarchicalPathForResolvedLocation(String locationType, StorageRoom room, StorageDevice device,
+            StorageShelf shelf, StorageRack rack, StorageBox box, String positionCoordinate) {
+        List<String> parts = new ArrayList<>();
+
+        if (room != null && room.getName() != null && !room.getName().trim().isEmpty()) {
+            parts.add(room.getName().trim());
+        }
+        if (device != null && device.getName() != null && !device.getName().trim().isEmpty()) {
+            parts.add(device.getName().trim());
+        }
+        if (shelf != null && shelf.getLabel() != null && !shelf.getLabel().trim().isEmpty()) {
+            parts.add(shelf.getLabel().trim());
+        }
+        if (rack != null && rack.getLabel() != null && !rack.getLabel().trim().isEmpty()) {
+            parts.add(rack.getLabel().trim());
+        }
+        if (box != null && box.getLabel() != null && !box.getLabel().trim().isEmpty()) {
+            parts.add(box.getLabel().trim());
+        }
+
+        String path = String.join(" > ", parts);
+        if ((path == null || path.isEmpty()) && locationType != null) {
+            return locationType;
+        }
+        if (positionCoordinate != null && !positionCoordinate.trim().isEmpty()
+                && !"box".equals(locationType)
+                && (path == null || !path.endsWith(positionCoordinate.trim()))) {
+            return path;
+        }
+        return path;
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/storage/service/StorageLocationServiceImpl.java
+++ b/src/main/java/org/openelisglobal/storage/service/StorageLocationServiceImpl.java
@@ -393,6 +393,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
             existingDevice.setTemperatureSetting(device.getTemperatureSetting());
             existingDevice.setCapacityLimit(device.getCapacityLimit());
             existingDevice.setActive(device.getActive());
+            existingDevice.setBiorepositoryStorage(device.getBiorepositoryStorage());
 
             // Code is editable - validate if provided
             if (device.getCode() != null && !device.getCode().equals(existingDevice.getCode())) {
@@ -753,6 +754,11 @@ public class StorageLocationServiceImpl implements StorageLocationService {
             try {
                 List<StorageDevice> devices = storageDeviceDAO.findByParentRoomId(room.getId());
                 map.put("deviceCount", devices != null ? devices.size() : 0);
+                long biorepositoryDeviceCount = devices == null ? 0
+                        : devices.stream().filter(device -> Boolean.TRUE.equals(device.getBiorepositoryStorage()))
+                                .count();
+                map.put("biorepositoryDeviceCount", biorepositoryDeviceCount);
+                map.put("hasBiorepositoryDevices", biorepositoryDeviceCount > 0);
 
                 // Count unique sample items assigned to locations within this room
                 // This counts distinct sample items from sample_storage_assignment, not
@@ -763,6 +769,8 @@ public class StorageLocationServiceImpl implements StorageLocationService {
                 map.put("sampleCount", sampleCount);
             } catch (Exception e) {
                 map.put("deviceCount", 0);
+                map.put("biorepositoryDeviceCount", 0);
+                map.put("hasBiorepositoryDevices", false);
                 map.put("sampleCount", 0);
             }
 
@@ -800,6 +808,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
             map.put("temperatureSetting", device.getTemperatureSetting());
             map.put("capacityLimit", device.getCapacityLimit());
             map.put("active", device.getActive());
+            map.put("biorepositoryStorage", Boolean.TRUE.equals(device.getBiorepositoryStorage()));
             map.put("fhirUuid", device.getFhirUuidAsString());
 
             // Add capacity calculation (per FR-062a, FR-062b, FR-062c)
@@ -891,6 +900,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
                 map.put("parentDeviceId", parentDevice.getId());
                 map.put("deviceName", parentDevice.getName());
                 map.put("parentDeviceName", parentDevice.getName());
+                map.put("biorepositoryStorage", Boolean.TRUE.equals(parentDevice.getBiorepositoryStorage()));
             }
             if (parentRoom != null) {
                 map.put("parentRoomId", parentRoom.getId());
@@ -967,6 +977,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
                 map.put("parentDeviceId", parentDevice.getId());
                 map.put("deviceName", parentDevice.getName());
                 map.put("parentDeviceName", parentDevice.getName());
+                map.put("biorepositoryStorage", Boolean.TRUE.equals(parentDevice.getBiorepositoryStorage()));
             }
             // FR-065a: Include parentRoomId and room name
             if (parentRoom != null) {
@@ -1065,6 +1076,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
             if (parentDevice != null) {
                 map.put("parentDeviceId", parentDevice.getId());
                 map.put("deviceName", parentDevice.getName());
+                map.put("biorepositoryStorage", Boolean.TRUE.equals(parentDevice.getBiorepositoryStorage()));
             }
             if (parentRoom != null) {
                 map.put("parentRoomId", parentRoom.getId());

--- a/src/main/java/org/openelisglobal/storage/valueholder/StorageDevice.java
+++ b/src/main/java/org/openelisglobal/storage/valueholder/StorageDevice.java
@@ -80,6 +80,9 @@ public class StorageDevice extends BaseObject<Integer> {
     @Column(name = "ACTIVE", nullable = false)
     private Boolean active;
 
+    @Column(name = "BIOREPOSITORY_STORAGE", nullable = false)
+    private Boolean biorepositoryStorage;
+
     @ManyToOne(fetch = jakarta.persistence.FetchType.EAGER)
     @JoinColumn(name = "PARENT_ROOM_ID", nullable = false)
     private StorageRoom parentRoom;
@@ -170,6 +173,14 @@ public class StorageDevice extends BaseObject<Integer> {
         this.active = active;
     }
 
+    public Boolean getBiorepositoryStorage() {
+        return biorepositoryStorage;
+    }
+
+    public void setBiorepositoryStorage(Boolean biorepositoryStorage) {
+        this.biorepositoryStorage = biorepositoryStorage;
+    }
+
     public StorageRoom getParentRoom() {
         return parentRoom;
     }
@@ -216,6 +227,9 @@ public class StorageDevice extends BaseObject<Integer> {
     protected void onCreate() {
         if (fhirUuid == null) {
             fhirUuid = UUID.randomUUID();
+        }
+        if (biorepositoryStorage == null) {
+            biorepositoryStorage = Boolean.FALSE;
         }
     }
 

--- a/src/main/resources/liquibase/3.5.x.x/031-biorepository-qc-round-hardening.xml
+++ b/src/main/resources/liquibase/3.5.x.x/031-biorepository-qc-round-hardening.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="add-qc-inspection-batch-and-coordinate-snapshot" author="openelis-biorepository">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="biorepository_qc_inspection" schemaName="clinlims"/>
+            <not>
+                <columnExists tableName="biorepository_qc_inspection" schemaName="clinlims" columnName="qc_batch_id"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="qc_batch_id" type="VARCHAR(80)"/>
+            <column name="expected_coordinate_snapshot" type="VARCHAR(512)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="replace-qc-inspection-discrepancy-constraint" author="openelis-biorepository">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="biorepository_qc_inspection" schemaName="clinlims"/>
+        </preConditions>
+
+        <sql>
+            ALTER TABLE clinlims.biorepository_qc_inspection
+            DROP CONSTRAINT IF EXISTS check_discrepancy_type;
+        </sql>
+
+        <sql>
+            ALTER TABLE clinlims.biorepository_qc_inspection
+            ADD CONSTRAINT check_discrepancy_type
+            CHECK (
+                discrepancy_type IS NULL OR discrepancy_type IN (
+                    'MISSING_SAMPLE',
+                    'WRONG_SAMPLE_IN_POSITION',
+                    'MISPLACED_ITEM',
+                    'EMPTY_POSITION_REGISTERED_OCCUPIED',
+                    'LABELING_ERROR',
+                    'BOX_RACK_MISPLACEMENT',
+                    'DAMAGED_LABEL',
+                    'CONTAINER_DAMAGE',
+                    'VOLUME_DISCREPANCY',
+                    'OTHER'
+                )
+            );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/034-add-biorepository-storage-flag.xml
+++ b/src/main/resources/liquibase/3.5.x.x/034-add-biorepository-storage-flag.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="034-add-biorepository-storage-flag" author="codex">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="storage_device" schemaName="clinlims"/>
+            <not>
+                <columnExists tableName="storage_device" columnName="biorepository_storage" schemaName="clinlims"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="storage_device" schemaName="clinlims">
+            <column name="biorepository_storage" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="storage_device" schemaName="clinlims" columnName="biorepository_storage"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -96,4 +96,12 @@
 
     <include file="liquibase/3.5.x.x/033-add-retrieval-notebook-link.xml"/>
 
+    <!-- ======================================================== -->
+    <!-- Biorepository QC Round hardening                        -->
+    <!-- Add qc_batch_id + expected snapshot + discrepancy check -->
+    <!-- ======================================================== -->
+
+    <include file="liquibase/3.5.x.x/031-biorepository-qc-round-hardening.xml"/>
+    <include file="liquibase/3.5.x.x/034-add-biorepository-storage-flag.xml"/>
+
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/biorepository/BiorepositoryQCInspectionServiceIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/BiorepositoryQCInspectionServiceIntegrationTest.java
@@ -184,6 +184,24 @@ public class BiorepositoryQCInspectionServiceIntegrationTest extends BaseWebCont
                 testUser.getId().toString());
     }
 
+        @Test
+        public void testCreateInspection_NonStoredSample_ThrowsIllegalArgumentException() {
+                // Arrange
+                BioSample nonStoredSample = createTestBioSample("QC-NON-STORED-" + System.currentTimeMillis(),
+                                WorkflowStatus.PENDING_STORAGE);
+
+                // Act
+                try {
+                        qcInspectionService.createInspection(nonStoredSample.getId(), "Inspector",
+                                        new Timestamp(System.currentTimeMillis()), true, true, true, true, true, null, null, null,
+                                        testUser.getId().toString());
+                        fail("Expected IllegalArgumentException for non-stored sample");
+                } catch (IllegalArgumentException expected) {
+                        // Assert
+                        assertTrue(expected.getMessage().contains("STORED"));
+                }
+        }
+
     // ========== BULK CREATE INSPECTIONS TESTS ==========
 
     @Test
@@ -467,6 +485,13 @@ public class BiorepositoryQCInspectionServiceIntegrationTest extends BaseWebCont
      * Create a test BioSample with STORED workflow status.
      */
     private BioSample createTestBioSample(String externalId) {
+                return createTestBioSample(externalId, WorkflowStatus.STORED);
+        }
+
+        /**
+         * Create a test BioSample with the given workflow status.
+         */
+        private BioSample createTestBioSample(String externalId, WorkflowStatus workflowStatus) {
         // Create Sample
         Sample sample = new Sample();
         // Use shorter accession number to fit VARCHAR(20) constraint
@@ -493,7 +518,7 @@ public class BiorepositoryQCInspectionServiceIntegrationTest extends BaseWebCont
         BioSample bioSample = new BioSample();
         bioSample.setSampleItem(sampleItem);
         bioSample.setBiosafetyLevel(BiosafetyLevel.BSL_1);
-        bioSample.setWorkflowStatus(WorkflowStatus.STORED); // IMPORTANT: Set to STORED for QC inspection
+                bioSample.setWorkflowStatus(workflowStatus);
         bioSample.setPreservationMedium("EDTA");
         bioSample.setSysUserId(testUser.getId().toString());
 

--- a/src/test/java/org/openelisglobal/notebook/controller/rest/NotebookSampleEntryControllerTest.java
+++ b/src/test/java/org/openelisglobal/notebook/controller/rest/NotebookSampleEntryControllerTest.java
@@ -1,0 +1,95 @@
+package org.openelisglobal.notebook.controller.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.storage.service.SampleStorageService;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotebookSampleEntryControllerTest {
+
+    @Mock
+    private SampleStorageService sampleStorageService;
+
+    @InjectMocks
+    private NotebookSampleEntryController controller;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void enrichSampleMapsWithStorageAssignments_pendingSampleWithStorage_becomesInProgress() {
+        // Arrange
+        Map<String, Object> sampleMap = new HashMap<>();
+        sampleMap.put("sampleItemId", "1001");
+        sampleMap.put("status", "PENDING");
+        sampleMap.put("pageStatus", "PENDING");
+
+        Map<String, Object> existingData = new HashMap<>();
+        existingData.put("existingKey", "existingValue");
+        sampleMap.put("data", existingData);
+
+        List<Map<String, Object>> sampleMaps = new ArrayList<>();
+        sampleMaps.add(sampleMap);
+
+        Map<String, Object> locationMap = new HashMap<>();
+        locationMap.put("hierarchicalPath", "Room A > Freezer 1 > Shelf B > Rack C > Box D");
+        locationMap.put("positionCoordinate", "A1");
+        locationMap.put("roomName", "Room A");
+        locationMap.put("deviceName", "Freezer 1");
+        locationMap.put("shelfLabel", "Shelf B");
+        locationMap.put("rackLabel", "Rack C");
+        locationMap.put("boxLabel", "Box D");
+
+        Map<String, Map<String, Object>> locationsBySampleId = new HashMap<>();
+        locationsBySampleId.put("1001", locationMap);
+
+        when(sampleStorageService.getSampleItemLocations(List.of("1001"))).thenReturn(locationsBySampleId);
+
+        // Act
+        ReflectionTestUtils.invokeMethod(controller, "enrichSampleMapsWithStorageAssignments", sampleMaps, true);
+
+        // Assert
+        assertEquals("IN_PROGRESS", sampleMap.get("status"));
+        assertEquals("IN_PROGRESS", sampleMap.get("pageStatus"));
+        assertEquals("Room A > Freezer 1 > Shelf B > Rack C > Box D", sampleMap.get("storagePath"));
+        assertEquals("A1", sampleMap.get("storageWell"));
+
+        Map<String, Object> mergedData = (Map<String, Object>) sampleMap.get("data");
+        assertEquals("existingValue", mergedData.get("existingKey"));
+        assertEquals("A1", mergedData.get("storageWell"));
+        assertEquals("Room A > Freezer 1 > Shelf B > Rack C > Box D", mergedData.get("storagePath"));
+
+        verify(sampleStorageService).getSampleItemLocations(List.of("1001"));
+    }
+
+    @Test
+    public void enrichSampleMapsWithStorageAssignments_nonBiorepositoryContext_skipsOverlay() {
+        // Arrange
+        Map<String, Object> sampleMap = new HashMap<>();
+        sampleMap.put("sampleItemId", "1001");
+        sampleMap.put("status", "PENDING");
+        sampleMap.put("pageStatus", "PENDING");
+
+        List<Map<String, Object>> sampleMaps = new ArrayList<>();
+        sampleMaps.add(sampleMap);
+
+        // Act
+        ReflectionTestUtils.invokeMethod(controller, "enrichSampleMapsWithStorageAssignments", sampleMaps, false);
+
+        // Assert
+        assertEquals("PENDING", sampleMap.get("status"));
+        assertEquals("PENDING", sampleMap.get("pageStatus"));
+        verifyZeroInteractions(sampleStorageService);
+    }
+}

--- a/src/test/java/org/openelisglobal/notebook/service/ArchivingServiceTest.java
+++ b/src/test/java/org/openelisglobal/notebook/service/ArchivingServiceTest.java
@@ -518,6 +518,35 @@ public class ArchivingServiceTest {
     }
 
     /**
+     * Biorepository notebooks remain operational and cannot be finalized.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testFinalizeNotebook_BiorepositoryWorkflow_ThrowsException() {
+        // Arrange
+        testNotebook.setWorkflowType("biorepository");
+        when(noteBookService.get(1)).thenReturn(testNotebook);
+
+        // Act - should throw
+        archivingService.finalizeNotebook(1, "1");
+    }
+
+    /**
+     * canFinalize should return false for operational biorepository notebooks.
+     */
+    @Test
+    public void testCanFinalize_BiorepositoryWorkflow_ReturnsFalse() {
+        // Arrange
+        testNotebook.setWorkflowType("biorepository");
+        when(noteBookService.get(1)).thenReturn(testNotebook);
+
+        // Act
+        boolean canFinalize = archivingService.canFinalize(1);
+
+        // Assert
+        assertFalse("Biorepository notebook should not be finalizable", canFinalize);
+    }
+
+    /**
      * canFinalize returns false when critical failures exist.
      */
     @Test

--- a/src/test/java/org/openelisglobal/notebook/service/NoteBookServiceTest.java
+++ b/src/test/java/org/openelisglobal/notebook/service/NoteBookServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -152,6 +153,46 @@ public class NoteBookServiceTest extends BaseWebContextSensitiveTest {
         NoteBook updated = noteBookService.get(4);
         assertNotNull(updated);
         assertEquals(NoteBookStatus.LOCKED, updated.getStatus());
+    }
+
+    @Test
+    public void updateWithStatus_biorepositoryCannotBeFinalized() {
+        NoteBook notebook = noteBookService.get(3);
+        assertNotNull(notebook);
+        assertEquals(NoteBookStatus.SUBMITTED, notebook.getStatus());
+
+        notebook.setWorkflowType("biorepository");
+        noteBookService.update(notebook);
+
+        try {
+            noteBookService.updateWithStatus(3, NoteBookStatus.FINALIZED, "1");
+            fail("Expected IllegalStateException when finalizing a biorepository notebook");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().toLowerCase().contains("biorepository"));
+        }
+
+        NoteBook reloaded = noteBookService.get(3);
+        assertEquals("Status should remain unchanged", NoteBookStatus.SUBMITTED, reloaded.getStatus());
+    }
+
+    @Test
+    public void updateWithStatus_biorepositoryCannotBeArchived() {
+        NoteBook notebook = noteBookService.get(3);
+        assertNotNull(notebook);
+        assertEquals(NoteBookStatus.SUBMITTED, notebook.getStatus());
+
+        notebook.setWorkflowType("biorepository");
+        noteBookService.update(notebook);
+
+        try {
+            noteBookService.updateWithStatus(3, NoteBookStatus.ARCHIVED, "1");
+            fail("Expected IllegalStateException when archiving a biorepository notebook");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().toLowerCase().contains("biorepository"));
+        }
+
+        NoteBook reloaded = noteBookService.get(3);
+        assertEquals("Status should remain unchanged", NoteBookStatus.SUBMITTED, reloaded.getStatus());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/notebook/service/NotebookBulkOperationServiceTest.java
+++ b/src/test/java/org/openelisglobal/notebook/service/NotebookBulkOperationServiceTest.java
@@ -15,12 +15,14 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openelisglobal.notebook.valueholder.NotebookPageSample;
 import org.openelisglobal.notebook.valueholder.NotebookPageSample.Status;
+import org.openelisglobal.storage.service.SampleStorageService;
 
 /**
  * Unit tests for NotebookBulkOperationService. Tests bulk apply operations,
@@ -31,6 +33,9 @@ public class NotebookBulkOperationServiceTest {
 
     @Mock
     private NotebookPageSampleService notebookPageSampleService;
+
+    @Mock
+    private SampleStorageService sampleStorageService;
 
     @InjectMocks
     private NotebookBulkOperationServiceImpl bulkOperationService;
@@ -117,6 +122,40 @@ public class NotebookBulkOperationServiceTest {
         // Assert
         assertEquals("Should update all 10 samples", 10, updatedCount);
         verify(notebookPageSampleService).bulkUpdateStatus(testPageId, testSampleIds, Status.COMPLETED, testUserId);
+    }
+
+    /**
+     * Test that storage assignment advances PENDING samples to IN_PROGRESS.
+     */
+    @Test
+    public void testAssignSamplesToStorage_pendingStatus_advancesToInProgress() {
+        // Arrange
+        NotebookPageSample pendingSample = new NotebookPageSample();
+        pendingSample.setId(101);
+        pendingSample.setSampleItemId("1");
+        pendingSample.setStatus(Status.PENDING);
+        pendingSample.setData(new HashMap<>());
+
+        when(notebookPageSampleService.getByPageIdAndSampleItemId(testPageId, 1)).thenReturn(pendingSample);
+        when(sampleStorageService.assignSampleItemWithLocation("1", "200", "box", "A1", null)).thenReturn(
+            Map.of("assignmentId", "9001", "hierarchicalPath", "Room A > Freezer 1 > Shelf B > Rack C > Box"));
+
+        // Act
+        Map<String, Object> result = bulkOperationService.assignSamplesToStorage(testPageId, Arrays.asList(1), 200,
+            "A1", new HashMap<>(), testUserId);
+
+        // Assert
+        assertEquals("Assignment should succeed", true, result.get("success"));
+        assertEquals("Should assign exactly one sample", 1, result.get("assignedCount"));
+
+        ArgumentCaptor<NotebookPageSample> updatedSampleCaptor = ArgumentCaptor.forClass(NotebookPageSample.class);
+        verify(notebookPageSampleService).update(updatedSampleCaptor.capture());
+        NotebookPageSample updatedSample = updatedSampleCaptor.getValue();
+
+        assertEquals("Status should advance to IN_PROGRESS", Status.IN_PROGRESS, updatedSample.getStatus());
+        assertEquals("Storage assignment ID should be tracked", "9001",
+            String.valueOf(updatedSample.getData().get("storageAssignmentId")));
+        assertEquals("Well coordinate should be tracked", "A1", updatedSample.getData().get("storageWell"));
     }
 
     /**

--- a/src/test/java/org/openelisglobal/storage/controller/StorageLocationRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/storage/controller/StorageLocationRestControllerTest.java
@@ -1,5 +1,8 @@
 package org.openelisglobal.storage.controller;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -9,7 +12,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
 
 /**
  * Controller integration tests for Storage Location CRUD endpoints.
@@ -145,6 +152,107 @@ public class StorageLocationRestControllerTest extends BaseWebContextSensitiveTe
                 .andExpect(status().isCreated()).andExpect(jsonPath("$.ipAddress").value("192.168.1.100"))
                 .andExpect(jsonPath("$.port").value(502))
                 .andExpect(jsonPath("$.communicationProtocol").value("BACnet"));
+    }
+
+    @Test
+    public void testCreateDevice_WithBiorepositoryStorageFlag_Returns201WithFlag() throws Exception {
+        String deviceJson = "{" + "\"name\":\"Bio Freezer\"," + "\"code\":\"BIO-FRZ-01\"," + "\"type\":\"freezer\","
+                + "\"parentRoomId\":20005," + "\"biorepositoryStorage\":true" + "}";
+
+        this.mockMvc
+                .perform(post("/rest/storage/devices").contentType(MediaType.APPLICATION_JSON).content(deviceJson)
+                        .sessionAttr("userSessionData", usd))
+                .andExpect(status().isCreated()).andExpect(jsonPath("$.biorepositoryStorage").value(true));
+    }
+
+    @Test
+    public void testGetRooms_WithBiorepositoryOnly_ReturnsOnlyBiorepositoryRooms() throws Exception {
+        // Mark one room as biorepository-enabled by flagging one of its devices
+        jdbcTemplate.execute("UPDATE clinlims.storage_device SET biorepository_storage = true WHERE id = 20001");
+
+        MvcResult mvcResult = this.mockMvc
+                .perform(get("/rest/storage/rooms?biorepositoryOnly=true").contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttr("userSessionData", usd))
+                .andExpect(status().isOk()).andReturn();
+
+        List<Map<String, Object>> rooms = readMapList(mvcResult.getResponse().getContentAsString());
+        assertFalse("Expected at least one biorepository room", rooms.isEmpty());
+        assertTrue("All returned rooms must have biorepository devices",
+                rooms.stream().allMatch(room -> Boolean.TRUE.equals(room.get("hasBiorepositoryDevices"))));
+    }
+
+    @Test
+    public void testGetDevices_WithBiorepositoryOnly_ReturnsOnlyBiorepositoryDevices() throws Exception {
+        jdbcTemplate.execute("UPDATE clinlims.storage_device SET biorepository_storage = true WHERE id = 20001");
+
+        MvcResult mvcResult = this.mockMvc
+                .perform(get("/rest/storage/devices?biorepositoryOnly=true").contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttr("userSessionData", usd))
+                .andExpect(status().isOk()).andReturn();
+
+        List<Map<String, Object>> devices = readMapList(mvcResult.getResponse().getContentAsString());
+        assertFalse("Expected at least one biorepository device", devices.isEmpty());
+        assertTrue("All returned devices must be biorepository storage",
+                devices.stream().allMatch(device -> Boolean.TRUE.equals(device.get("biorepositoryStorage"))));
+    }
+
+    @Test
+    public void testGetShelvesAndRacks_WithBiorepositoryOnly_ReturnsOnlyBiorepositoryHierarchy() throws Exception {
+        // Shelf 20001 and rack 20000 belong to device 20003
+        jdbcTemplate.execute("UPDATE clinlims.storage_device SET biorepository_storage = true WHERE id = 20003");
+
+        MvcResult shelvesResult = this.mockMvc
+                .perform(get("/rest/storage/shelves?biorepositoryOnly=true").contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttr("userSessionData", usd))
+                .andExpect(status().isOk()).andReturn();
+
+        List<Map<String, Object>> shelves = readMapList(shelvesResult.getResponse().getContentAsString());
+        assertFalse("Expected at least one biorepository shelf", shelves.isEmpty());
+        assertTrue("All returned shelves must inherit biorepository storage flag",
+                shelves.stream().allMatch(shelf -> Boolean.TRUE.equals(shelf.get("biorepositoryStorage"))));
+
+        MvcResult racksResult = this.mockMvc
+                .perform(get("/rest/storage/racks?biorepositoryOnly=true").contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttr("userSessionData", usd))
+                .andExpect(status().isOk()).andReturn();
+
+        List<Map<String, Object>> racks = readMapList(racksResult.getResponse().getContentAsString());
+        assertFalse("Expected at least one biorepository rack", racks.isEmpty());
+        assertTrue("All returned racks must inherit biorepository storage flag",
+                racks.stream().allMatch(rack -> Boolean.TRUE.equals(rack.get("biorepositoryStorage"))));
+    }
+
+    @Test
+    public void testGetBoxes_WithBiorepositoryOnly_ReturnsOnlyBoxesUnderBiorepositoryDevices() throws Exception {
+        // Rack 20000 -> Shelf 20001 -> Device 20003
+        jdbcTemplate.execute("UPDATE clinlims.storage_device SET biorepository_storage = true WHERE id = 20003");
+        jdbcTemplate.execute("INSERT INTO clinlims.storage_box (id, label, code, type, rows, columns, parent_rack_id, active, fhir_uuid, sys_user_id, last_updated) "
+                + "VALUES (20999, 'Bio Box', 'BIO-BOX-1', 'plate', 8, 12, 20000, true, '40000000-0000-0000-0000-000000020999', '1', CURRENT_TIMESTAMP)");
+
+        MvcResult mvcResult = this.mockMvc
+                .perform(get("/rest/storage/boxes?biorepositoryOnly=true").contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttr("userSessionData", usd))
+                .andExpect(status().isOk()).andReturn();
+
+        List<Map<String, Object>> boxes = readMapList(mvcResult.getResponse().getContentAsString());
+        assertFalse("Expected at least one biorepository box", boxes.isEmpty());
+        assertTrue("All returned boxes must belong to the flagged biorepository device",
+                boxes.stream().allMatch(box -> Integer.valueOf(20003).equals(asInteger(box.get("parentDeviceId")))));
+    }
+
+    private List<Map<String, Object>> readMapList(String json) throws Exception {
+        return objectMapper.readValue(json, new TypeReference<List<Map<String, Object>>>() {
+        });
+    }
+
+    private Integer asInteger(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return Integer.valueOf(String.valueOf(value));
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR is  to biorepository QC/storage behavior and page-2 storage-assignment correctness. It does not claim to complete all remaining biorepository work.

### Included
- align storage assignment so already-assigned samples do not remain in pending-only behavior
- improve single-sample storage assignment visibility alongside bulk cases
- tighten biorepository QC freezer/shelf/rack/box hierarchy behavior
- align QC round generation with hierarchy and samples-per-box limits
- restrict biorepository notebook finalize/archive behavior
- use biorepository workflow/device metadata for storage scope behavior
- default new storage devices to non-biorepository unless explicitly flagged


## Validation
- local QC/storage flows reviewed on localhost

## Screenshots
- Local QC and storage flows were reviewed on localhost.
<img width="1919" height="1004" alt="Screenshot from 2026-04-19 17-44-33" src="https://github.com/user-attachments/assets/9871518f-2bc3-4654-a699-03a15a67596c" />


## Related Issue
- N/A

## Other
Freezer visibility currently depends on `biorepositoryStorage` device classification data. In environments that are not fully classified yet, some visibility differences may still be configuration-related.
