### PR TITLE
issue-3469: fix(inventory): resolve Hibernate 6 enum/bytea type mismatch in InventoryItemDAOImpl.getByItemType()

### DIFF
--- a/src/main/java/org/openelisglobal/inventory/daoimpl/InventoryItemDAOImpl.java
+++ b/src/main/java/org/openelisglobal/inventory/daoimpl/InventoryItemDAOImpl.java
@@ -46,14 +46,12 @@ public class InventoryItemDAOImpl extends BaseDAOImpl<InventoryItem, Long> imple
     @Transactional(readOnly = true)
     public List<InventoryItem> getByItemType(ItemType itemType) throws LIMSRuntimeException {
         try {
-            CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-            CriteriaQuery<InventoryItem> cq = cb.createQuery(InventoryItem.class);
-            Root<InventoryItem> root = cq.from(InventoryItem.class);
+            String jpql = "SELECT i FROM InventoryItem i " + "WHERE i.itemType = :itemType AND i.isActive = 'Y' "
+                    + "ORDER BY i.name";
 
-            cq.select(root).where(cb.and(cb.equal(root.get("itemType"), itemType), cb.equal(root.get("isActive"), "Y")))
-                    .orderBy(cb.asc(root.get("name")));
-
-            return entityManager.createQuery(cq).getResultList();
+            return entityManager.createQuery(jpql, InventoryItem.class)
+                    // use .name() to avoid PostgreSQL varchar/bytea type mismatch
+                    .setParameter("itemType", itemType.name()).getResultList();
         } catch (Exception e) {
             throw new LIMSRuntimeException("Error getting inventory items by type", e);
         }

--- a/src/main/java/org/openelisglobal/inventory/daoimpl/InventoryItemDAOImpl.java
+++ b/src/main/java/org/openelisglobal/inventory/daoimpl/InventoryItemDAOImpl.java
@@ -46,11 +46,11 @@ public class InventoryItemDAOImpl extends BaseDAOImpl<InventoryItem, Long> imple
     @Transactional(readOnly = true)
     public List<InventoryItem> getByItemType(ItemType itemType) throws LIMSRuntimeException {
         try {
-            String jpql = "SELECT i FROM InventoryItem i " + "WHERE i.itemType = :itemType AND i.isActive = 'Y' "
+            String jpql = "SELECT i FROM InventoryItem i "
+                    + "WHERE i.itemType = :itemType AND i.isActive = 'Y' "
                     + "ORDER BY i.name";
 
             return entityManager.createQuery(jpql, InventoryItem.class)
-                    // use .name() to avoid PostgreSQL varchar/bytea type mismatch
                     .setParameter("itemType", itemType.name()).getResultList();
         } catch (Exception e) {
             throw new LIMSRuntimeException("Error getting inventory items by type", e);

--- a/src/test/java/org/openelisglobal/inventory/service/InventoryItemServiceTest.java
+++ b/src/test/java/org/openelisglobal/inventory/service/InventoryItemServiceTest.java
@@ -87,4 +87,15 @@ public class InventoryItemServiceTest extends BaseWebContextSensitiveTest {
         assertNotNull("Saved item should be retrievable", savedItem);
         assertEquals("Test Item Created", savedItem.getName());
     }
+
+    @Test
+    public void getByItemType_shouldReturnItemsOfSpecifiedType() {
+        List<InventoryItem> reagents = inventoryItemService.getByItemType(ItemType.REAGENT);
+
+        assertNotNull("Result should not be null", reagents);
+        assertFalse("Should return at least one REAGENT item from dataset", reagents.isEmpty());
+        for (InventoryItem item : reagents) {
+            assertEquals("All returned items should be of type REAGENT", ItemType.REAGENT, item.getItemType());
+        }
+    }
 }


### PR DESCRIPTION
## Issue Number

Closes #3469

## Objective

Fix a production bug where `InventoryItemDAOImpl.getByItemType()` throws a PostgreSQL type mismatch error due to a Hibernate 6 behavioral change introduced with the Java 21 / Spring Boot upgrade. Also adds integration tests for this method, which had zero test coverage.

## What Changed

### 1. `InventoryItemDAOImpl.java` — bug fix

Replaced the JPA Criteria API query in `getByItemType()` with a JPQL query and added the `.name()` method for the `ItemType` enum.

**Why:** In Hibernate 6, the Criteria API no longer automatically resolves `@Enumerated(EnumType.STRING)` annotated fields when a raw Java enum is passed as a parameter to `cb.equal()`. Instead, it serializes the enum as binary data (`bytea`). PostgreSQL cannot compare a `VARCHAR` column with `bytea`

### 2. `InventoryItemServiceTest.java` — new integration tests

Added an integration tests for the updated `getByItemType()` method:
- `getByItemType_shouldReturnItemsOfSpecifiedType()` — verifies correct type filtering and verifies items are returned successfully

## How to Test

```bash
mvn test "-Dtest=org.openelisglobal.inventory.service.InventoryItemServiceTest"
```

**Before this fix:** `getByItemType_shouldReturnItemsOfSpecifiedType` fails with `LIMSRuntimeException: Error getting inventory items by type` caused by `PSQLException: operator does not exist: character varying = bytea`.

**After this fix:** All 8 tests in `InventoryItemServiceTest` pass with no errors whatsoever

## Test Results

<img width="893" height="168" alt="image" src="https://github.com/user-attachments/assets/aeed84bd-a5b1-4856-a7d5-c933e420b3a8" />


Only one test is skipped, this was done by the original contributor and it is intentional, so everything works as planned.
<br>
**This is part of my ongoing GSoc contributions to the project of increasing overall integraion tests coverage**  