### PR TITLE
Biorepository QC workflow, dashboard reporting, and manifest validation

### DIFF
--- a/frontend/cypress/e2e/biorepositoryQcFinalValidation.cy.js
+++ b/frontend/cypress/e2e/biorepositoryQcFinalValidation.cy.js
@@ -1,0 +1,331 @@
+import LoginPage from "../pages/LoginPage";
+
+const login = new LoginPage();
+
+const NOTEBOOK_URL = "/NoteBookInstanceEditForm/16?mode=edit";
+const API_BASE = "/api/OpenELIS-Global";
+const shot = (name) =>
+  cy.screenshot(`qc_evidence/${name}`, { capture: "fullPage" });
+const clickReportingTab = (label) => {
+  cy.get(".biorepository-reporting-page", { timeout: 30000 })
+    .contains('[role="tab"], button', label, { timeout: 30000 })
+    .click({ force: true });
+};
+
+describe("Biorepository QC final localhost validation", () => {
+  beforeEach(() => {
+    login.visit();
+    login.enterUsername("admin");
+    login.enterPassword("adminADMIN!");
+    login.signIn();
+    cy.url({ timeout: 30000 }).should("not.include", "/login");
+    cy.visit(NOTEBOOK_URL);
+  });
+
+  it("validates QC workflow, reporting visibility, and exports in browser", () => {
+    cy.intercept(
+      "POST",
+      `${API_BASE}/rest/biorepository/qc-inspection/generate-round`,
+    ).as("generateRound");
+    cy.intercept(
+      "POST",
+      `${API_BASE}/rest/biorepository/qc-inspection/bulk-apply`,
+    ).as("applyQc");
+
+    cy.contains("button, a, div", "Workflow", { timeout: 30000 }).click({
+      force: true,
+    });
+
+    cy.contains(/6\.?\s*QC Inspection/, { timeout: 30000 }).click({
+      force: true,
+    });
+    cy.get("#qc-include-inspected", { timeout: 30000 }).check({ force: true });
+    shot("01_stage6_qc_page_loaded");
+
+    cy.contains("button", "Generate Random QC Round", { timeout: 30000 })
+      .should("be.visible")
+      .as("generateButton");
+
+    cy.request(
+      `${API_BASE}/rest/biorepository/qc-inspection/storage-overview?includeInspected=true`,
+    ).then((overviewResponse) => {
+      const eligibleCount = overviewResponse.body?.counts?.eligibleSamples || 0;
+      cy.log(`Eligible samples from API: ${eligibleCount}`);
+      expect(eligibleCount).to.be.greaterThan(0);
+
+      cy.get("@generateButton", { timeout: 30000 })
+        .should("not.be.disabled")
+        .click({ force: true });
+      cy.wait("@generateRound").then((interception) => {
+        expect(interception.response?.statusCode).to.eq(200);
+        const responseSamples = interception.response?.body?.samples || [];
+        expect(responseSamples.length).to.be.greaterThan(0);
+        const generatedSampleCount = responseSamples.length;
+
+        cy.get("@generateRound.all").then((calls) => {
+          expect(calls.length).to.eq(1);
+        });
+        cy.contains(/QC batch .*generated from filtered storage scope/i, {
+          timeout: 30000,
+        }).should("be.visible");
+        shot("02_generate_random_qc_round_success");
+        cy.contains("button", "Show all eligible samples", {
+          timeout: 30000,
+        }).should("be.visible");
+        cy.get(".sample-table-section table tbody tr", {
+          timeout: 30000,
+        }).should("have.length", generatedSampleCount);
+        cy.contains("button", "Show all eligible samples").click({
+          force: true,
+        });
+        cy.get(".sample-table-section table tbody tr").should(
+          "have.length.greaterThan",
+          generatedSampleCount - 1,
+        );
+      });
+    });
+
+    cy.get(".sample-table-section table tbody tr", { timeout: 30000 })
+      .its("length")
+      .should("be.greaterThan", 0);
+    cy.contains("button", "Inspect", { timeout: 30000 }).should(
+      "be.visible",
+    );
+
+    // PASS flow from real UI (Record Verification must save).
+    cy.contains("button", "Inspect", { timeout: 30000 })
+      .first()
+      .click({ force: true });
+    cy.contains("Individual QC Inspection", { timeout: 30000 }).should(
+      "be.visible",
+    );
+    shot("03_single_inspect_modal_open");
+    cy.get("#inspectorName").clear().type("Cypress Inspector");
+    cy.contains("button", "Check All (Verify)").click({ force: true });
+    cy.contains("button", "Record Verification").click({ force: true });
+    cy.wait("@applyQc").then((interception) => {
+      expect(interception.response?.statusCode).to.eq(200);
+    });
+    cy.contains("Individual QC Inspection").should("not.exist");
+    shot("04_pass_recorded");
+
+    // FAIL flow: create unresolved discrepancy (multi-sample, no correction action).
+    cy.request(`${API_BASE}/rest/biorepository/qc-inspection/samples`).then(
+      (sampleResponse) => {
+        const samples = sampleResponse.body || [];
+        const targetA = samples[0];
+        const targetB = samples[1] || samples[0];
+        expect(targetA, "sample available for unresolved FAIL").to.exist;
+        cy.wrap(targetA.bioSampleId).as("unresolvedSampleId");
+        const failPayload = {
+          bioSampleIds: [targetA.bioSampleId, targetB.bioSampleId],
+          inspectorName: "Cypress Inspector",
+          inspectionDate: new Date().toISOString(),
+          samplePresent: false,
+          labelIntegrity: true,
+          containerIntegrity: true,
+          volumeAppearanceAcceptable: true,
+          correctPosition: false,
+          discrepancyType: "SAMPLE_MISSING",
+          correctiveAction: "Sample not physically found during QC",
+          remarks: "FAIL flow validation (unresolved)",
+        };
+        cy.request(
+          "POST",
+          `${API_BASE}/rest/biorepository/qc-inspection/bulk-apply`,
+          failPayload,
+        ).then((failResponse) => {
+          expect(failResponse.status).to.eq(200);
+        });
+      },
+    );
+
+    cy.reload();
+    cy.contains("button, a, div", "Workflow", { timeout: 30000 }).click({
+      force: true,
+    });
+    cy.contains(/6\.?\s*QC Inspection/, { timeout: 30000 }).click({
+      force: true,
+    });
+    cy.get("#qc-include-inspected").check({ force: true });
+    cy.contains(/Correction required/i, { timeout: 30000 }).should(
+      "be.visible",
+    );
+    shot("05_fail_recorded_unresolved_visible");
+
+    // Re-open unresolved discrepancy later and complete correction.
+    cy.contains("button", "Inspect", { timeout: 30000 })
+      .first()
+      .click({ force: true });
+    cy.contains("Individual QC Inspection", { timeout: 30000 }).should(
+      "be.visible",
+    );
+    cy.get("#inspectorName").clear().type("Cypress Inspector");
+    cy.contains("button", "Clear All").click({ force: true });
+    shot("06_correction_workflow_visible");
+    cy.contains("button", /Cancel|Close/, { timeout: 30000 })
+      .first()
+      .click({ force: true });
+
+    // Apply correction later (follow-up action) to prove delayed correction path.
+    cy.get("@unresolvedSampleId").then((sampleId) => {
+      const correctionPayload = {
+        bioSampleIds: [sampleId],
+        inspectorName: "Cypress Inspector",
+        inspectionDate: new Date().toISOString(),
+        samplePresent: false,
+        labelIntegrity: true,
+        containerIntegrity: true,
+        volumeAppearanceAcceptable: true,
+        correctPosition: false,
+        discrepancyType: "SAMPLE_MISSING",
+        correctiveAction: "Resolved during re-inspection",
+        remarks: "Applying correction later",
+        correctionActionType: "MARK_MISSING",
+        correctionReason: "Confirmed unresolved sample after follow-up",
+      };
+      cy.request(
+        "POST",
+        `${API_BASE}/rest/biorepository/qc-inspection/bulk-apply`,
+        correctionPayload,
+      ).then((correctionResponse) => {
+        expect(correctionResponse.status).to.eq(200);
+      });
+    });
+
+    cy.reload();
+    cy.contains("button, a, div", "Workflow", { timeout: 30000 }).click({
+      force: true,
+    });
+    cy.contains(/6\.?\s*QC Inspection/, { timeout: 30000 }).click({
+      force: true,
+    });
+    cy.get("#qc-include-inspected").check({ force: true });
+    cy.get(".sample-table-section table tbody tr", { timeout: 30000 })
+      .its("length")
+      .should("be.gte", 2);
+    shot("07_reopened_and_corrected_later");
+
+    // Bulk inspect modal still opens from selected rows when table data exists.
+    cy.get(".sample-table-section table tbody tr")
+      .first()
+      .within(() => {
+        cy.get("input[type='checkbox']").first().check({ force: true });
+      });
+    cy.get(".sample-table-section table tbody tr")
+      .eq(1)
+      .within(() => {
+        cy.get("input[type='checkbox']").first().check({ force: true });
+      });
+    cy.get(".sample-table-section table tbody input[type='checkbox']:checked", {
+      timeout: 30000,
+    })
+      .its("length")
+      .should("be.gte", 2);
+    cy.get(".cds--batch-actions, .bx--batch-actions", { timeout: 30000 })
+      .should("be.visible")
+      .find("button")
+      .then(($buttons) => {
+        const buttons = Array.from($buttons);
+        const button =
+          buttons.find((el) =>
+            /bulk inspect/i.test(
+              `${el.textContent || ""} ${el.getAttribute("aria-label") || ""} ${
+                el.getAttribute("title") || ""
+              }`,
+            ),
+          ) ||
+          buttons.find(
+            (el) =>
+              !/cancel|close/i.test(
+                `${el.textContent || ""} ${el.getAttribute("aria-label") || ""} ${
+                  el.getAttribute("title") || ""
+                }`,
+              ),
+          ) ||
+          buttons[buttons.length - 1];
+        expect(button, "bulk action button").to.exist;
+        cy.wrap(button).click({ force: true });
+      });
+    cy.contains("Bulk QC Inspection", { timeout: 30000 }).should("be.visible");
+    shot("08_bulk_inspect_modal");
+    cy.contains("button", /Cancel|Close/, { timeout: 30000 })
+      .first()
+      .click({ force: true });
+
+    cy.contains(/7\.?\s*Reporting\s*&\s*Audit/, { timeout: 30000 }).click({
+      force: true,
+    });
+
+    cy.contains(/Overview/i, { timeout: 30000 }).should("exist");
+    cy.contains(/Detailed Metrics/i, { timeout: 30000 }).should("exist");
+    cy.contains(/Audit/i, { timeout: 30000 }).should("exist");
+
+    clickReportingTab(/Overview/i);
+    cy.contains("button", /Export CSV/i, { timeout: 30000 }).should("be.visible");
+    shot("09_reporting_overview_tab");
+
+    clickReportingTab(/Detailed Metrics/i);
+    cy.get("body", { timeout: 30000 }).should("contain.text", "Metrics");
+    cy.get("body", { timeout: 30000 }).should(
+      "contain.text",
+      "Pending corrections",
+    );
+    cy.contains("button, h3, h4, h5, div", /QC History \(Completed Checks\)/i, {
+      timeout: 30000,
+    }).click({ force: true });
+    cy.contains("QC Batch Summary", { timeout: 30000 }).should("be.visible");
+    cy.contains("QC Batch ID", { timeout: 30000 }).should("be.visible");
+    shot("10_reporting_detailed_metrics_tab");
+
+    clickReportingTab(/Audit Trail/i);
+    cy.contains(".cds--tab-content:visible", /Chain of Custody Audit Trail|QC Outcome Audit Visibility/i, {
+      timeout: 30000,
+    }).should("be.visible");
+    cy.contains(".cds--tab-content:visible", "QC History by Batch ID", {
+      timeout: 30000,
+    }).should("be.visible");
+    cy.contains(".cds--tab-content:visible", "QC Batch ID", {
+      timeout: 30000,
+    }).should("be.visible");
+    shot("11_audit_trail_visibility");
+
+    clickReportingTab(/Export Reports/i);
+    cy.contains(/Dashboard Metrics Export/i, { timeout: 30000 }).should(
+      "exist",
+    );
+    cy.contains(/Audit Trail Export/i, { timeout: 30000 }).should("exist");
+    cy.contains("button, h3, h4, h5, div", /QC Batch Export/i, {
+      timeout: 30000,
+    }).click({ force: true });
+    cy.contains(/Recent QC Batch IDs/i, { timeout: 30000 }).should("be.visible");
+    shot("12_export_reports_ui");
+
+    cy.request({
+      url: `${API_BASE}/rest/biorepository/dashboard/export/csv`,
+      encoding: "binary",
+    }).then((csvExportResponse) => {
+      expect(csvExportResponse.status).to.eq(200);
+      expect(
+        String(csvExportResponse.headers["content-type"] || ""),
+      ).to.contain("text/csv");
+    });
+
+    cy.request({
+      url: `${API_BASE}/rest/biorepository/dashboard/export/pdf`,
+      encoding: "binary",
+    }).then((pdfExportResponse) => {
+      expect(pdfExportResponse.status).to.eq(200);
+      expect(
+        String(pdfExportResponse.headers["content-type"] || ""),
+      ).to.contain("application/pdf");
+    });
+
+    cy.request({
+      url: `${API_BASE}/rest/biorepository/dashboard/retrieval-stats?startDate=2026-99-99`,
+      failOnStatusCode: false,
+    }).then((invalidDateResponse) => {
+      expect(invalidDateResponse.status).to.eq(400);
+    });
+  });
+});

--- a/frontend/src/components/notebook/pages/SampleCollectionPage.js
+++ b/frontend/src/components/notebook/pages/SampleCollectionPage.js
@@ -67,6 +67,7 @@ import "../workflow/NotebookWorkflow.css";
 function SampleCollectionPage({
   entryId,
   pageData,
+  progress,
   onProgressUpdate,
   orderEntryPageId,
   notebookId,

--- a/frontend/src/components/notebook/pages/biorepository/BiorepositoryQCInspectionPage.js
+++ b/frontend/src/components/notebook/pages/biorepository/BiorepositoryQCInspectionPage.js
@@ -3,7 +3,6 @@ import {
   Grid,
   Column,
   Button,
-  ButtonSet,
   Tile,
   InlineNotification,
   Modal,
@@ -12,7 +11,6 @@ import {
   TextInput,
   Checkbox,
   Dropdown,
-  Toggle,
   DataTable,
   TableContainer,
   Table,
@@ -36,7 +34,16 @@ import {
   getFromOpenElisServer,
   postToOpenElisServerJsonResponse,
 } from "../../../utils/Utils";
+import {
+  getAllowedCorrectionActions,
+  hasInvalidMarkMissingLocationFields,
+  isMissingDiscrepancyType,
+} from "./qcCorrectionGuardrails";
 
+/**
+ * QC Checklist items for Biorepository sample inspection
+ * Based on ISO 20387:2018 quality control requirements
+ */
 const QC_CHECKLIST = [
   {
     id: "samplePresent",
@@ -65,183 +72,74 @@ const QC_CHECKLIST = [
   },
 ];
 
+/**
+ * Discrepancy types for failed QC
+ */
 const DISCREPANCY_TYPES = [
-  { id: "MISSING_SAMPLE", label: "Missing Sample" },
-  { id: "WRONG_SAMPLE_IN_POSITION", label: "Wrong Sample In Position" },
-  { id: "DAMAGED_LABEL", label: "Damaged/Illegible Label" },
-  { id: "MISPLACED_ITEM", label: "Misplaced Item (Wrong Position)" },
+  { id: "SAMPLE_MISSING", label: "Sample missing" },
+  { id: "WRONG_SAMPLE_IN_POSITION", label: "Wrong sample in position" },
   {
-    id: "EMPTY_POSITION_REGISTERED_OCCUPIED",
-    label: "Empty Position But Registered Occupied",
+    id: "MISPLACED_SAMPLE_FOUND",
+    label: "Misplaced sample (found elsewhere)",
   },
-  { id: "LABELING_ERROR", label: "Labeling Error" },
-  { id: "BOX_RACK_MISPLACEMENT", label: "Box/Rack Misplacement" },
-  { id: "CONTAINER_DAMAGE", label: "Container Damage" },
-  { id: "VOLUME_DISCREPANCY", label: "Volume Discrepancy" },
-  { id: "OTHER", label: "Other" },
+  {
+    id: "EMPTY_POSITION_REGISTERED",
+    label: "Empty position but registered as occupied",
+  },
+  { id: "LABELING_ERROR", label: "Labeling error" },
+  { id: "BOX_RACK_MISPLACEMENT", label: "Box/rack misplacement" },
 ];
 
-const ALL_FREEZERS = "All freezers";
-const ALL_SHELVES = "All shelves";
-const ALL_RACKS = "All racks";
+const CORRECTION_ACTIONS = [
+  {
+    id: "UPDATE_LOCATION",
+    label: "Update correct location (sample found elsewhere)",
+  },
+  {
+    id: "REASSIGN_POSITION",
+    label: "Reassign position in selected box",
+  },
+  {
+    id: "MARK_MISSING",
+    label: "Mark sample as Missing (not found)",
+  },
+];
 
-const createBlankChecklist = () =>
-  QC_CHECKLIST.reduce((acc, item) => {
-    acc[item.id] = false;
-    return acc;
-  }, {});
+const ALL_OPTION = "__ALL__";
 
-const createInitialInspectionForm = () => ({
-  inspectorName: "",
-  inspectionDate: new Date().toISOString().slice(0, 16),
-  qcChecklist: createBlankChecklist(),
-  qcResult: "",
-  discrepancyType: "",
-  correctiveAction: "",
-  remarks: "",
-});
-
-const toSafeString = (value, fallback = "") => {
-  if (value === null || value === undefined) {
-    return fallback;
-  }
-  const asString = String(value).trim();
-  return asString || fallback;
-};
-
-const parseLocationPath = (
-  locationPath,
-  positionCoordinate,
-  locationDetails = {},
-) => {
-  const path = toSafeString(locationPath);
-  const coordinate = toSafeString(positionCoordinate);
-  const explicitFreezer = toSafeString(locationDetails.deviceName);
-  const explicitShelf = toSafeString(locationDetails.shelfLabel);
-  const explicitRack = toSafeString(locationDetails.rackLabel);
-  const explicitBox = toSafeString(locationDetails.boxLabel);
-
-  const segments = path
-    .split(/\s*>\s*/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-
-  let freezer;
-  let shelf;
-  let rack;
-  let box;
-
-  segments.forEach((segment) => {
-    const lower = segment.toLowerCase();
-    if (!freezer && lower.includes("freezer")) {
-      freezer = segment;
-    } else if (!shelf && lower.includes("shelf")) {
-      shelf = segment;
-    } else if (!rack && lower.includes("rack")) {
-      rack = segment;
-    } else if (!box && (lower.includes("box") || lower.startsWith("bx"))) {
-      box = segment;
+const buildStorageOverviewQuery = (filters) => {
+  const params = new URLSearchParams();
+  ["freezer", "shelf", "rack", "box"].forEach((key) => {
+    const value = filters?.[key];
+    if (value && value !== ALL_OPTION) {
+      params.set(key, value);
     }
   });
-
-  if (!freezer && segments[0]) {
-    freezer = segments[0];
-  }
-  if (!shelf && segments[1]) {
-    shelf = segments[1];
-  }
-  if (!rack && segments[2]) {
-    rack = segments[2];
-  }
-  if (!box && segments[3]) {
-    box = segments[3];
-  }
-  if (!box && segments.length > 0) {
-    box = segments[segments.length - 1];
-  }
-
-  const normalizedFreezer = explicitFreezer || freezer || "Unknown Freezer";
-  const normalizedShelf = explicitShelf || shelf || "Unknown Shelf";
-  const normalizedRack = explicitRack || rack || "Unknown Rack";
-  const normalizedBox = explicitBox || box || "Unknown Box";
-
-  return {
-    freezer: normalizedFreezer,
-    shelf: normalizedShelf,
-    rack: normalizedRack,
-    box: normalizedBox,
-    positionCoordinate: coordinate || "-",
-    shelfKey: `${normalizedFreezer} > ${normalizedShelf}`,
-    rackKey: `${normalizedFreezer} > ${normalizedShelf} > ${normalizedRack}`,
-    boxKey: `${normalizedFreezer} > ${normalizedShelf} > ${normalizedRack} > ${normalizedBox}`,
-  };
+  const query = params.toString();
+  return query ? `?${query}` : "";
 };
 
-const computeOverview = (samples) => {
-  const freezers = new Set();
-  const shelves = new Set();
-  const racks = new Set();
-  const boxes = new Set();
-  const freezerSummaryMap = new Map();
-
-  samples.forEach((sample) => {
-    freezers.add(sample.freezer);
-    shelves.add(sample.shelfKey);
-    racks.add(sample.rackKey);
-    boxes.add(sample.boxKey);
-
-    if (!freezerSummaryMap.has(sample.freezer)) {
-      freezerSummaryMap.set(sample.freezer, {
-        freezer: sample.freezer,
-        sampleCount: 0,
-        shelfSet: new Set(),
-        rackSet: new Set(),
-        boxSet: new Set(),
-      });
-    }
-
-    const row = freezerSummaryMap.get(sample.freezer);
-    row.sampleCount += 1;
-    row.shelfSet.add(sample.shelfKey);
-    row.rackSet.add(sample.rackKey);
-    row.boxSet.add(sample.boxKey);
-  });
-
-  const freezerSummary = Array.from(freezerSummaryMap.values())
-    .map((row) => ({
-      freezer: row.freezer,
-      sampleCount: row.sampleCount,
-      shelfCount: row.shelfSet.size,
-      rackCount: row.rackSet.size,
-      boxCount: row.boxSet.size,
-    }))
-    .sort((a, b) => a.freezer.localeCompare(b.freezer));
-
-  return {
-    totalStoredSamples: samples.length,
-    freezerCount: freezers.size,
-    shelfCount: shelves.size,
-    rackCount: racks.size,
-    boxCount: boxes.size,
-    freezerSummary,
-  };
-};
-
-const buildSnapshotText = (sample) => {
-  if (!sample) {
-    return null;
-  }
-  if (!sample.locationPath || sample.locationPath === "Not Assigned") {
-    return sample.positionCoordinate && sample.positionCoordinate !== "-"
-      ? sample.positionCoordinate
-      : null;
-  }
-  if (!sample.positionCoordinate || sample.positionCoordinate === "-") {
-    return sample.locationPath;
-  }
-  return `${sample.locationPath} @ ${sample.positionCoordinate}`;
-};
-
+/**
+ * BiorepositoryQCInspectionPage - QC Inspection workflow for stored samples
+ *
+ * Allows technicians to perform visual inspection and verification of samples
+ * in storage against their expected location and condition.
+ *
+ * Features:
+ * - Load samples with workflowStatus = STORED
+ * - Display storage coordinates (freezer/shelf/rack/box/position)
+ * - 5-point QC checklist (presence, label, container, volume, position)
+ * - Auto-calculate QC result (all pass = VERIFIED, any fail = DISCREPANCY_FOUND)
+ * - Record discrepancy details (type + corrective action)
+ * - Bulk apply QC to multiple samples
+ *
+ * @param {Object} props
+ * @param {number} props.entryId - The notebook entry ID
+ * @param {Object} props.pageData - The notebook page data
+ * @param {Object} props.progress - Page progress
+ * @param {function} props.onProgressUpdate - Callback when progress changes
+ * @param {number} props.notebookId - The notebook ID
+ */
 function BiorepositoryQCInspectionPage({
   entryId,
   pageData,
@@ -251,1173 +149,1068 @@ function BiorepositoryQCInspectionPage({
 }) {
   const intl = useIntl();
 
+  // State for samples
   const [samples, setSamples] = useState([]);
-  const [overview, setOverview] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [overviewLoading, setOverviewLoading] = useState(false);
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
+  const [roundInfo, setRoundInfo] = useState(null);
+  const [isGeneratingRound, setIsGeneratingRound] = useState(false);
+  const [loadingStorageOverview, setLoadingStorageOverview] = useState(false);
 
-  const [filters, setFilters] = useState({
-    freezer: "",
-    shelf: "",
-    rack: "",
-    box: "",
+  // Storage overview/filter state (before random generation)
+  const [storageFilters, setStorageFilters] = useState({
+    freezer: ALL_OPTION,
+    shelf: ALL_OPTION,
+    rack: ALL_OPTION,
+    box: ALL_OPTION,
   });
-
+  const [storageOverviewData, setStorageOverviewData] = useState({
+    counts: { freezers: 0, shelves: 0, racks: 0, boxes: 0, eligibleSamples: 0 },
+    filters: { freezers: [], shelves: [], racks: [], boxes: [] },
+    eligibleSamples: [],
+  });
   const [roundSettings, setRoundSettings] = useState({
-    boxesPerRound: "12",
-    samplesPerBox: "4",
-    seed: "",
+    boxesPerRound: "10",
+    samplesPerBox: "3",
+  });
+  const [availableBoxes, setAvailableBoxes] = useState([]);
+  const [loadingBoxes, setLoadingBoxes] = useState(false);
+
+  // Bulk apply modal state
+  const [bulkApplyModalOpen, setBulkApplyModalOpen] = useState(false);
+  const [isBulkApplying, setIsBulkApplying] = useState(false);
+  const [selectedForBulkApply, setSelectedForBulkApply] = useState([]); // Capture selection when modal opens
+
+  // Bulk apply form values
+  const [bulkApplyValues, setBulkApplyValues] = useState({
+    inspectorName: "",
+    inspectionDate: new Date().toISOString().slice(0, 16),
+    // QC Checklist - 5 boolean criteria
+    qcChecklist: QC_CHECKLIST.reduce((acc, item) => {
+      acc[item.id] = false;
+      return acc;
+    }, {}),
+    // Auto-calculated QC result
+    qcResult: "",
+    // Discrepancy details (only for failed QC)
+    discrepancyType: "",
+    correctiveAction: "",
+    remarks: "",
+    correctionActionType: "",
+    correctionBoxId: "",
+    correctionPositionCoordinate: "",
+    correctionReason: "",
   });
 
-  const [qcRoundInfo, setQcRoundInfo] = useState(null);
-  const [showSelectedOnly, setShowSelectedOnly] = useState(false);
-
-  const [inspectionModalOpen, setInspectionModalOpen] = useState(false);
-  const [isSubmittingInspection, setIsSubmittingInspection] = useState(false);
-  const [inspectionContext, setInspectionContext] = useState({
-    mode: "bulk",
-    sampleIds: [],
-    samplePreview: [],
-  });
-  const [inspectionValues, setInspectionValues] = useState(
-    createInitialInspectionForm(),
-  );
-
-  const resetInspectionForm = useCallback(() => {
-    setInspectionValues(createInitialInspectionForm());
-  }, []);
-
-  const calculateQCResult = useCallback((checklist) => {
-    const allPassed = Object.values(checklist).every((value) => value === true);
-    return allPassed ? "VERIFIED" : "DISCREPANCY_FOUND";
-  }, []);
-
+  // Load stored samples for QC
   const loadStoredSamples = useCallback(() => {
     setLoading(true);
     setError(null);
 
-    getFromOpenElisServer(`/rest/biorepository/qc-inspection/samples`, (response) => {
-      setLoading(false);
-      if (Array.isArray(response)) {
-        const transformed = response.map((sample) => {
-          const storageLocation = sample.storageLocation || {};
-          const rawCoordinate = toSafeString(
-            storageLocation.positionCoordinate,
-            "-",
-          );
-
-          return {
+    getFromOpenElisServer(
+      `/rest/biorepository/qc-inspection/samples`,
+      (response) => {
+        setLoading(false);
+        if (response && Array.isArray(response)) {
+          // Transform API response to component state
+          const transformedSamples = response.map((sample) => ({
             id: sample.bioSampleId,
             sampleItemId: sample.sampleItemId,
             externalId: sample.externalId || "-",
             accessionNumber: sample.accessionNumber || "-",
             sampleType: sample.sampleType || "-",
-            locationPath:
-              sample.locationPath ||
-              storageLocation.hierarchicalPath ||
-              "Not Assigned",
-            positionCoordinate: rawCoordinate,
-            storageDetails: storageLocation,
+            locationPath: sample.locationPath || "Not Assigned",
+            storageLocation: sample.storageLocation, // Full location object
             biosafetyLevel: sample.biosafetyLevel || "-",
             workflowStatus: sample.workflowStatus,
-            lastQCInspection: sample.lastQCInspection,
-          };
-        });
-
-        setSamples(transformed);
-      } else {
-        setSamples([]);
-      }
-    });
+            lastQCInspection: sample.lastQCInspection, // Most recent inspection record
+          }));
+          setSamples(transformedSamples);
+        } else {
+          setSamples([]);
+        }
+      },
+    );
   }, []);
 
-  const loadLocationOverview = useCallback(() => {
-    setOverviewLoading(true);
+  // Load samples on mount
+  useEffect(() => {
+    loadStoredSamples();
+  }, [loadStoredSamples]);
+
+  const loadStorageOverview = useCallback((filters) => {
+    setLoadingStorageOverview(true);
+    const query = buildStorageOverviewQuery(filters);
     getFromOpenElisServer(
-      `/rest/biorepository/qc-inspection/location-overview`,
+      `/rest/biorepository/qc-inspection/storage-overview${query}`,
       (response) => {
-        setOverviewLoading(false);
-        if (response && typeof response === "object" && !response.error) {
-          setOverview(response);
-        } else {
-          setOverview(null);
+        setLoadingStorageOverview(false);
+        if (!response || response.error) {
+          return;
         }
+        setStorageOverviewData({
+          counts: response.counts || {
+            freezers: 0,
+            shelves: 0,
+            racks: 0,
+            boxes: 0,
+            eligibleSamples: 0,
+          },
+          filters: response.filters || {
+            freezers: [],
+            shelves: [],
+            racks: [],
+            boxes: [],
+          },
+          eligibleSamples: Array.isArray(response.eligibleSamples)
+            ? response.eligibleSamples
+            : [],
+        });
       },
     );
   }, []);
 
   useEffect(() => {
-    loadStoredSamples();
-    loadLocationOverview();
-  }, [loadStoredSamples, loadLocationOverview]);
+    loadStorageOverview(storageFilters);
+  }, [storageFilters, loadStorageOverview]);
 
-  const enrichedSamples = useMemo(
-    () =>
-      samples.map((sample) => ({
-        ...sample,
-        ...parseLocationPath(
-          sample.locationPath,
-          sample.positionCoordinate,
-          sample.storageDetails,
-        ),
-      })),
-    [samples],
-  );
-
-  const fullOverviewFallback = useMemo(
-    () => computeOverview(enrichedSamples),
-    [enrichedSamples],
-  );
-
-  const freezerScopeOptions = useMemo(() => {
-    if (Array.isArray(overview?.freezerOptions) && overview.freezerOptions.length) {
-      return overview.freezerOptions;
-    }
-    return Array.from(
-      new Set(enrichedSamples.map((sample) => sample.freezer)),
-    )
-      .sort((a, b) => a.localeCompare(b))
-      .map((value) => ({ value, label: value }));
-  }, [overview, enrichedSamples]);
-
-  const availableFreezers = useMemo(
-    () =>
-      freezerScopeOptions
-        .map((option) => option?.value || option?.label)
-        .filter(Boolean),
-    [freezerScopeOptions],
-  );
-
-  const availableShelves = useMemo(
-    () => {
-      if (Array.isArray(overview?.shelfOptions) && overview.shelfOptions.length) {
-        return Array.from(
-          new Set(
-            overview.shelfOptions
-              .filter(
-                (option) =>
-                  !filters.freezer || option.freezer === filters.freezer,
-              )
-              .map((option) => option?.value || option?.label)
-              .filter(Boolean),
-          ),
-        ).sort((a, b) => a.localeCompare(b));
+  useEffect(() => {
+    setLoadingBoxes(true);
+    getFromOpenElisServer(`/rest/storage/boxes?active=true`, (response) => {
+      setLoadingBoxes(false);
+      if (!Array.isArray(response)) {
+        setAvailableBoxes([]);
+        return;
       }
 
-      return Array.from(
-        new Set(
-          enrichedSamples
-            .filter(
-              (sample) => !filters.freezer || sample.freezer === filters.freezer,
-            )
-            .map((sample) => sample.shelf),
-        ),
-      ).sort((a, b) => a.localeCompare(b));
-    },
-    [overview, enrichedSamples, filters.freezer],
-  );
+      const normalized = response
+        .filter((box) => box && box.id)
+        .map((box) => ({
+          id: String(box.id),
+          label:
+            box.hierarchicalPath || box.label || box.code || `Box ${box.id}`,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      setAvailableBoxes(normalized);
+    });
+  }, []);
 
-  const availableRacks = useMemo(
-    () => {
-      if (Array.isArray(overview?.rackOptions) && overview.rackOptions.length) {
-        return Array.from(
-          new Set(
-            overview.rackOptions
-              .filter(
-                (option) =>
-                  (!filters.freezer || option.freezer === filters.freezer) &&
-                  (!filters.shelf || option.shelf === filters.shelf),
-              )
-              .map((option) => option?.value || option?.label)
-              .filter(Boolean),
-          ),
-        ).sort((a, b) => a.localeCompare(b));
-      }
+  const filterOptionItems = useMemo(() => {
+    const toItems = (set, allLabel) => [
+      { id: ALL_OPTION, label: allLabel },
+      ...Array.from(set || [])
+        .sort((a, b) => a.localeCompare(b))
+        .map((value) => ({ id: value, label: value })),
+    ];
 
-      return Array.from(
-        new Set(
-          enrichedSamples
-            .filter(
-              (sample) =>
-                (!filters.freezer || sample.freezer === filters.freezer) &&
-                (!filters.shelf || sample.shelf === filters.shelf),
-            )
-            .map((sample) => sample.rack),
-        ),
-      ).sort((a, b) => a.localeCompare(b));
-    },
-    [overview, enrichedSamples, filters.freezer, filters.shelf],
-  );
+    return {
+      freezer: toItems(storageOverviewData.filters.freezers, "All freezers"),
+      shelf: toItems(storageOverviewData.filters.shelves, "All shelves"),
+      rack: toItems(storageOverviewData.filters.racks, "All racks"),
+      box: toItems(storageOverviewData.filters.boxes, "All boxes"),
+    };
+  }, [storageOverviewData.filters]);
 
-  const roundSelectedIds = useMemo(
+  const eligibleSampleIdSet = useMemo(
     () =>
       new Set(
-        (qcRoundInfo?.samples || [])
+        (storageOverviewData.eligibleSamples || [])
           .map((sample) => String(sample.bioSampleId))
           .filter(Boolean),
       ),
-    [qcRoundInfo],
+    [storageOverviewData.eligibleSamples],
   );
 
-  const displayedSamples = useMemo(
+  const filteredSamples = useMemo(
     () =>
-      enrichedSamples.filter((sample) => {
-        if (filters.freezer && sample.freezer !== filters.freezer) {
-          return false;
-        }
-        if (filters.shelf && sample.shelf !== filters.shelf) {
-          return false;
-        }
-        if (filters.rack && sample.rack !== filters.rack) {
-          return false;
-        }
-        if (
-          filters.box &&
-          !sample.box.toLowerCase().includes(filters.box.trim().toLowerCase())
-        ) {
-          return false;
-        }
-        if (showSelectedOnly && qcRoundInfo) {
-          return roundSelectedIds.has(String(sample.id));
-        }
-        return true;
-      }),
-    [enrichedSamples, filters, showSelectedOnly, qcRoundInfo, roundSelectedIds],
+      samples.filter((sample) => eligibleSampleIdSet.has(String(sample.id))),
+    [samples, eligibleSampleIdSet],
   );
 
-  const filteredOverview = useMemo(
-    () => computeOverview(displayedSamples),
-    [displayedSamples],
+  const storageOverview = useMemo(
+    () => ({
+      freezers: storageOverviewData.counts.freezers || 0,
+      shelves: storageOverviewData.counts.shelves || 0,
+      racks: storageOverviewData.counts.racks || 0,
+      boxes: storageOverviewData.counts.boxes || 0,
+      samples: storageOverviewData.counts.eligibleSamples || 0,
+    }),
+    [storageOverviewData.counts],
   );
 
-  const activeOverview = useMemo(() => {
-    if (overview && !filters.freezer && !filters.shelf && !filters.rack && !filters.box) {
-      return overview;
-    }
-    return filteredOverview;
-  }, [overview, filters, filteredOverview]);
-
-  const verifiedCount = useMemo(
-    () =>
-      displayedSamples.filter(
-        (sample) => sample.lastQCInspection?.qcResult === "VERIFIED",
-      ).length,
-    [displayedSamples],
-  );
-
-  const discrepancyCount = useMemo(
-    () =>
-      displayedSamples.filter(
-        (sample) => sample.lastQCInspection?.qcResult === "DISCREPANCY_FOUND",
-      ).length,
-    [displayedSamples],
-  );
-
-  const pendingCount = useMemo(
-    () => displayedSamples.filter((sample) => !sample.lastQCInspection).length,
-    [displayedSamples],
-  );
-
-  const checkedCount = useMemo(
-    () =>
-      Object.values(inspectionValues.qcChecklist).filter((checked) => checked)
-        .length,
-    [inspectionValues.qcChecklist],
-  );
-
-  const openInspectionModal = useCallback(
-    (mode, sampleIds, samplePreview = []) => {
-      setInspectionContext({
-        mode,
-        sampleIds,
-        samplePreview,
-      });
-      resetInspectionForm();
-      setInspectionModalOpen(true);
-      setError(null);
-    },
-    [resetInspectionForm],
-  );
-
-  const closeInspectionModal = useCallback(() => {
-    setInspectionModalOpen(false);
-    setInspectionContext({ mode: "bulk", sampleIds: [], samplePreview: [] });
-    resetInspectionForm();
-  }, [resetInspectionForm]);
-
-  const handleChecklistChange = useCallback(
-    (criteriaId, checked) => {
-      setInspectionValues((previous) => {
-        const qcChecklist = {
-          ...previous.qcChecklist,
-          [criteriaId]: checked,
-        };
-        const qcResult = calculateQCResult(qcChecklist);
-        return {
-          ...previous,
-          qcChecklist,
-          qcResult,
-          discrepancyType: qcResult === "VERIFIED" ? "" : previous.discrepancyType,
-          correctiveAction:
-            qcResult === "VERIFIED" ? "" : previous.correctiveAction,
-        };
-      });
-    },
-    [calculateQCResult],
-  );
-
-  const handleSetAllChecklist = useCallback(
-    (isChecked) => {
-      const checklist = QC_CHECKLIST.reduce((acc, item) => {
-        acc[item.id] = isChecked;
-        return acc;
-      }, {});
-
-      setInspectionValues((previous) => ({
-        ...previous,
-        qcChecklist: checklist,
-        qcResult: calculateQCResult(checklist),
-        discrepancyType: isChecked ? "" : previous.discrepancyType,
-        correctiveAction: isChecked ? "" : previous.correctiveAction,
-      }));
-    },
-    [calculateQCResult],
-  );
-
-  const handleGenerateQCRound = useCallback(() => {
-    setError(null);
-
+  const generateRandomRound = useCallback(() => {
     const boxesPerRound = Math.max(
+      parseInt(roundSettings.boxesPerRound, 10) || 0,
       1,
-      Number.parseInt(roundSettings.boxesPerRound || "10", 10) || 10,
     );
     const samplesPerBox = Math.max(
+      parseInt(roundSettings.samplesPerBox, 10) || 0,
       1,
-      Number.parseInt(roundSettings.samplesPerBox || "3", 10) || 3,
     );
 
-    const seedValue = roundSettings.seed.trim();
-    const parsedSeed = seedValue ? Number.parseInt(seedValue, 10) : null;
-
-    if (seedValue && Number.isNaN(parsedSeed)) {
+    const eligibleSamples = storageOverviewData.eligibleSamples || [];
+    if (eligibleSamples.length === 0) {
       setError(
         intl.formatMessage({
-          id: "biorepository.qc.error.invalidSeed",
-          defaultMessage: "Seed must be a valid whole number.",
+          id: "biorepository.qc.error.noSamplesForFilters",
+          defaultMessage:
+            "No samples match the current storage filters. Adjust filters before generating.",
         }),
       );
       return;
     }
 
-    const payload = {
-      boxesPerRound,
-      samplesPerBox,
-      seed: parsedSeed,
-      freezer: filters.freezer || null,
-      shelf: filters.shelf || null,
-      rack: filters.rack || null,
-      box: filters.box || null,
+    setIsGeneratingRound(true);
+    setError(null);
+
+    const groupedByBox = new Map();
+    eligibleSamples.forEach((sample) => {
+      const key = [
+        sample.freezer || "Unknown",
+        sample.shelf || "Unknown",
+        sample.rack || "Unknown",
+        sample.box || "Unknown",
+      ].join(" > ");
+      if (!groupedByBox.has(key)) {
+        groupedByBox.set(key, []);
+      }
+      groupedByBox.get(key).push(sample);
+    });
+
+    const shuffle = (arr) => {
+      const copy = [...arr];
+      for (let i = copy.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [copy[i], copy[j]] = [copy[j], copy[i]];
+      }
+      return copy;
     };
 
-    postToOpenElisServerJsonResponse(
-      `/rest/biorepository/qc-inspection/generate-round`,
-      JSON.stringify(payload),
-      (response) => {
-        if (response?.error) {
-          setError(response.error);
-          return;
-        }
+    const boxDescriptors = Array.from(groupedByBox.keys()).map((boxKey) => {
+      const [freezer, shelf, rack] = boxKey.split(" > ");
+      return {
+        boxKey,
+        shelfKey: `${freezer || "Unknown"} > ${shelf || "Unknown"}`,
+        rackKey: `${freezer || "Unknown"} > ${shelf || "Unknown"} > ${
+          rack || "Unknown"
+        }`,
+      };
+    });
 
-        const selectedIds = (response?.samples || [])
-          .map((sample) => String(sample.bioSampleId))
-          .filter(Boolean);
+    const targetBoxCount = Math.min(boxesPerRound, boxDescriptors.length);
+    const selectedBoxKeys = [];
+    const selectedSet = new Set();
 
-        if (selectedIds.length === 0) {
-          setError(
-            intl.formatMessage({
-              id: "biorepository.qc.error.emptyRound",
-              defaultMessage:
-                "No eligible samples were found for the selected location and round settings.",
-            }),
-          );
-          return;
-        }
+    // Pass 1: maximize shelf distribution.
+    const boxesByShelf = new Map();
+    boxDescriptors.forEach((descriptor) => {
+      if (!boxesByShelf.has(descriptor.shelfKey)) {
+        boxesByShelf.set(descriptor.shelfKey, []);
+      }
+      boxesByShelf.get(descriptor.shelfKey).push(descriptor.boxKey);
+    });
 
-        setQcRoundInfo(response);
-        setShowSelectedOnly(true);
+    shuffle(Array.from(boxesByShelf.keys())).forEach((shelfKey) => {
+      if (selectedBoxKeys.length >= targetBoxCount) return;
+      const candidate = shuffle(boxesByShelf.get(shelfKey)).find(
+        (boxKey) => !selectedSet.has(boxKey),
+      );
+      if (candidate) {
+        selectedBoxKeys.push(candidate);
+        selectedSet.add(candidate);
+      }
+    });
 
-        setSuccessMessage(
-          intl.formatMessage(
-            {
-              id: "biorepository.qc.round.success",
-              defaultMessage:
-                "QC round generated successfully: {boxes} box(es), {samples} sample(s).",
-            },
-            {
-              boxes: response.boxesSelected || 0,
-              samples: response.samplesSelected || 0,
-            },
-          ),
-        );
-      },
+    // Pass 2: maximize rack distribution.
+    const boxesByRack = new Map();
+    boxDescriptors.forEach((descriptor) => {
+      if (!boxesByRack.has(descriptor.rackKey)) {
+        boxesByRack.set(descriptor.rackKey, []);
+      }
+      boxesByRack.get(descriptor.rackKey).push(descriptor.boxKey);
+    });
+
+    shuffle(Array.from(boxesByRack.keys())).forEach((rackKey) => {
+      if (selectedBoxKeys.length >= targetBoxCount) return;
+      const candidate = shuffle(boxesByRack.get(rackKey)).find(
+        (boxKey) => !selectedSet.has(boxKey),
+      );
+      if (candidate) {
+        selectedBoxKeys.push(candidate);
+        selectedSet.add(candidate);
+      }
+    });
+
+    // Pass 3: fill remaining slots randomly from any unselected boxes.
+    const remainingBoxes = shuffle(boxDescriptors.map((d) => d.boxKey)).filter(
+      (boxKey) => !selectedSet.has(boxKey),
     );
-  }, [filters, intl, roundSettings]);
+    remainingBoxes.forEach((boxKey) => {
+      if (selectedBoxKeys.length >= targetBoxCount) return;
+      selectedBoxKeys.push(boxKey);
+      selectedSet.add(boxKey);
+    });
 
-  const handleSubmitInspection = useCallback(() => {
-    if (!inspectionContext.sampleIds.length) {
+    const selectedSamples = [];
+    selectedBoxKeys.forEach((boxKey) => {
+      const boxSamples = [...(groupedByBox.get(boxKey) || [])];
+      for (let i = boxSamples.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [boxSamples[i], boxSamples[j]] = [boxSamples[j], boxSamples[i]];
+      }
+      selectedSamples.push(
+        ...boxSamples.slice(0, Math.min(samplesPerBox, boxSamples.length)),
+      );
+    });
+
+    if (selectedSamples.length === 0) {
+      setIsGeneratingRound(false);
+      setError(
+        intl.formatMessage({
+          id: "biorepository.qc.error.emptyRound",
+          defaultMessage:
+            "No eligible samples were found to generate a QC round.",
+        }),
+      );
+      return;
+    }
+
+    setSelectedForBulkApply(
+      selectedSamples.map((sample) => String(sample.bioSampleId)),
+    );
+    setRoundInfo({
+      boxesSelected: selectedBoxKeys.length,
+      samplesSelected: selectedSamples.length,
+      filteredSamplePool: eligibleSamples.length,
+    });
+    resetBulkApplyValues();
+    setBulkApplyModalOpen(true);
+    setIsGeneratingRound(false);
+  }, [
+    intl,
+    roundSettings.boxesPerRound,
+    roundSettings.samplesPerBox,
+    storageOverviewData.eligibleSamples,
+  ]);
+
+  // Reset bulk apply values
+  const resetBulkApplyValues = () => {
+    setBulkApplyValues({
+      inspectorName: "",
+      inspectionDate: new Date().toISOString().slice(0, 16),
+      qcChecklist: QC_CHECKLIST.reduce((acc, item) => {
+        acc[item.id] = false;
+        return acc;
+      }, {}),
+      qcResult: "",
+      discrepancyType: "",
+      correctiveAction: "",
+      remarks: "",
+      correctionActionType: "",
+      correctionBoxId: "",
+      correctionPositionCoordinate: "",
+      correctionReason: "",
+    });
+  };
+
+  // Calculate QC result based on checklist
+  const calculateQCResult = (checklist) => {
+    const allPassed = Object.values(checklist).every((v) => v === true);
+    return allPassed ? "VERIFIED" : "DISCREPANCY_FOUND";
+  };
+
+  // Handle checklist change
+  const handleChecklistChange = (criteriaId, checked) => {
+    setBulkApplyValues((prev) => {
+      const newChecklist = { ...prev.qcChecklist, [criteriaId]: checked };
+      const autoResult = calculateQCResult(newChecklist);
+      return {
+        ...prev,
+        qcChecklist: newChecklist,
+        qcResult: autoResult,
+        // Clear fail-related fields if now passing
+        discrepancyType: autoResult === "VERIFIED" ? "" : prev.discrepancyType,
+        correctiveAction:
+          autoResult === "VERIFIED" ? "" : prev.correctiveAction,
+        correctionActionType:
+          autoResult === "VERIFIED" ? "" : prev.correctionActionType,
+        correctionBoxId: autoResult === "VERIFIED" ? "" : prev.correctionBoxId,
+        correctionPositionCoordinate:
+          autoResult === "VERIFIED" ? "" : prev.correctionPositionCoordinate,
+        correctionReason: autoResult === "VERIFIED" ? "" : prev.correctionReason,
+      };
+    });
+  };
+
+  // Handle "Check All" for QC criteria
+  const handleCheckAll = () => {
+    setBulkApplyValues((prev) => ({
+      ...prev,
+      qcChecklist: QC_CHECKLIST.reduce((acc, item) => {
+        acc[item.id] = true;
+        return acc;
+      }, {}),
+      qcResult: "VERIFIED",
+      discrepancyType: "",
+      correctiveAction: "",
+      correctionActionType: "",
+      correctionBoxId: "",
+      correctionPositionCoordinate: "",
+      correctionReason: "",
+    }));
+  };
+
+  // Handle "Clear All" for QC criteria
+  const handleClearAll = () => {
+    setBulkApplyValues((prev) => ({
+      ...prev,
+      qcChecklist: QC_CHECKLIST.reduce((acc, item) => {
+        acc[item.id] = false;
+        return acc;
+      }, {}),
+      qcResult: "DISCREPANCY_FOUND",
+    }));
+  };
+
+  // Handle bulk apply
+  const handleBulkApply = useCallback(() => {
+    if (selectedForBulkApply.length === 0) {
       setError(
         intl.formatMessage({
           id: "biorepository.qc.error.noSelection",
-          defaultMessage: "Please choose at least one sample.",
+          defaultMessage: "Please select samples to apply QC to.",
         }),
       );
       return;
     }
 
-    if (!inspectionValues.inspectorName.trim()) {
+    // Validate: Inspector name required
+    if (!bulkApplyValues.inspectorName.trim()) {
       setError(
         intl.formatMessage({
           id: "biorepository.qc.error.noInspector",
-          defaultMessage: "Inspector name is required.",
+          defaultMessage: "Please enter inspector name.",
         }),
       );
       return;
     }
 
-    if (!inspectionValues.qcResult) {
+    // Validate: QC result must be set
+    if (!bulkApplyValues.qcResult) {
       setError(
         intl.formatMessage({
           id: "biorepository.qc.error.noResult",
           defaultMessage:
-            "Complete the checklist first so the system can determine pass/fail.",
+            "Please complete the QC checklist to determine pass/fail status.",
         }),
       );
       return;
     }
 
-    if (inspectionValues.qcResult === "DISCREPANCY_FOUND") {
-      if (!inspectionValues.discrepancyType) {
+    // Validate: If discrepancy found, must have discrepancy type and corrective action
+    if (bulkApplyValues.qcResult === "DISCREPANCY_FOUND") {
+      if (!bulkApplyValues.discrepancyType) {
         setError(
           intl.formatMessage({
             id: "biorepository.qc.error.noDiscrepancyType",
-            defaultMessage: "Discrepancy type is required for failed QC.",
+            defaultMessage: "Please select a discrepancy type.",
           }),
         );
         return;
       }
-      if (!inspectionValues.correctiveAction.trim()) {
+      if (!bulkApplyValues.correctiveAction.trim()) {
         setError(
           intl.formatMessage({
             id: "biorepository.qc.error.noCorrectiveAction",
-            defaultMessage: "Corrective action details are required for failed QC.",
+            defaultMessage: "Please describe the corrective action taken.",
           }),
         );
         return;
       }
-      if (!inspectionValues.remarks.trim()) {
+      if (!bulkApplyValues.remarks.trim()) {
         setError(
           intl.formatMessage({
             id: "biorepository.qc.error.noRemarks",
-            defaultMessage: "Comment/remarks are required for failed QC.",
+            defaultMessage:
+              "Please enter comment/remarks for discrepancy findings.",
+          }),
+        );
+        return;
+      }
+
+      if (
+        selectedForBulkApply.length === 1 &&
+        !bulkApplyValues.correctionActionType
+      ) {
+        setError(
+          intl.formatMessage({
+            id: "biorepository.qc.error.noCorrectionAction",
+            defaultMessage:
+              "Select a correction workflow action (update location, reassign position, or mark missing).",
+          }),
+        );
+        return;
+      }
+
+      if (
+        bulkApplyValues.correctionActionType &&
+        selectedForBulkApply.length !== 1
+      ) {
+        setError(
+          intl.formatMessage({
+            id: "biorepository.qc.error.correctionSingleOnly",
+            defaultMessage:
+              "Correction workflow currently supports one sample at a time. Select a single sample for correction.",
+          }),
+        );
+        return;
+      }
+
+      if (
+        bulkApplyValues.correctionActionType === "MARK_MISSING" &&
+        !isMissingDiscrepancyType(bulkApplyValues.discrepancyType)
+      ) {
+        setError(
+          intl.formatMessage({
+            id: "biorepository.qc.error.markMissingRequiresMissingDiscrepancy",
+            defaultMessage:
+              "Mark missing is only allowed when discrepancy type is Sample missing.",
+          }),
+        );
+        return;
+      }
+
+      if (hasInvalidMarkMissingLocationFields(bulkApplyValues)) {
+        setError(
+          intl.formatMessage({
+            id: "biorepository.qc.error.markMissingLocationFieldsNotAllowed",
+            defaultMessage:
+              "Location and position inputs are not allowed for Mark missing correction.",
+          }),
+        );
+        return;
+      }
+
+      if (
+        ["UPDATE_LOCATION", "REASSIGN_POSITION"].includes(
+          bulkApplyValues.correctionActionType,
+        ) &&
+        !bulkApplyValues.correctionBoxId
+      ) {
+        setError(
+          intl.formatMessage({
+            id: "biorepository.qc.error.noCorrectionLocation",
+            defaultMessage:
+              "Select a target storage box for update/reassign correction.",
+          }),
+        );
+        return;
+      }
+
+      if (
+        bulkApplyValues.correctionActionType === "REASSIGN_POSITION" &&
+        !bulkApplyValues.correctionPositionCoordinate.trim()
+      ) {
+        setError(
+          intl.formatMessage({
+            id: "biorepository.qc.error.noCorrectionPosition",
+            defaultMessage:
+              "Enter the new position coordinate for reassign position correction.",
           }),
         );
         return;
       }
     }
 
-    setIsSubmittingInspection(true);
+    setIsBulkApplying(true);
     setError(null);
 
-    const singleSampleSnapshot =
-      inspectionContext.mode === "single" && inspectionContext.samplePreview.length
-        ? buildSnapshotText(inspectionContext.samplePreview[0])
-        : null;
-
+    // Prepare request payload
     const payload = {
-      bioSampleIds: inspectionContext.sampleIds.map((id) => Number(id)),
-      inspectorName: inspectionValues.inspectorName.trim(),
-      inspectionDate: inspectionValues.inspectionDate
-        ? new Date(inspectionValues.inspectionDate).toISOString()
+      bioSampleIds: selectedForBulkApply.map((id) => parseInt(id, 10)),
+      inspectorName: bulkApplyValues.inspectorName.trim(),
+      inspectionDate: bulkApplyValues.inspectionDate
+        ? new Date(bulkApplyValues.inspectionDate).toISOString()
         : null,
-      samplePresent: inspectionValues.qcChecklist.samplePresent,
-      labelIntegrity: inspectionValues.qcChecklist.labelIntegrity,
-      containerIntegrity: inspectionValues.qcChecklist.containerIntegrity,
+      samplePresent: bulkApplyValues.qcChecklist.samplePresent,
+      labelIntegrity: bulkApplyValues.qcChecklist.labelIntegrity,
+      containerIntegrity: bulkApplyValues.qcChecklist.containerIntegrity,
       volumeAppearanceAcceptable:
-        inspectionValues.qcChecklist.volumeAppearanceAcceptable,
-      correctPosition: inspectionValues.qcChecklist.correctPosition,
+        bulkApplyValues.qcChecklist.volumeAppearanceAcceptable,
+      correctPosition: bulkApplyValues.qcChecklist.correctPosition,
       discrepancyType:
-        inspectionValues.qcResult === "DISCREPANCY_FOUND"
-          ? inspectionValues.discrepancyType
+        bulkApplyValues.qcResult === "DISCREPANCY_FOUND"
+          ? bulkApplyValues.discrepancyType
           : null,
       correctiveAction:
-        inspectionValues.qcResult === "DISCREPANCY_FOUND"
-          ? inspectionValues.correctiveAction.trim()
+        bulkApplyValues.qcResult === "DISCREPANCY_FOUND"
+          ? bulkApplyValues.correctiveAction
           : null,
-      remarks: inspectionValues.remarks.trim() || null,
-      qcBatchId: qcRoundInfo?.qcBatchId || null,
-      expectedCoordinateSnapshot: singleSampleSnapshot,
+      remarks: bulkApplyValues.remarks || null,
+      correctionActionType:
+        bulkApplyValues.qcResult === "DISCREPANCY_FOUND" &&
+        bulkApplyValues.correctionActionType
+          ? bulkApplyValues.correctionActionType
+          : null,
+      correctionLocationType:
+        bulkApplyValues.qcResult === "DISCREPANCY_FOUND" &&
+        ["UPDATE_LOCATION", "REASSIGN_POSITION"].includes(
+          bulkApplyValues.correctionActionType,
+        )
+          ? "box"
+          : null,
+      correctionLocationId:
+        bulkApplyValues.qcResult === "DISCREPANCY_FOUND" &&
+        ["UPDATE_LOCATION", "REASSIGN_POSITION"].includes(
+          bulkApplyValues.correctionActionType,
+        )
+          ? bulkApplyValues.correctionBoxId
+          : null,
+      correctionPositionCoordinate:
+        bulkApplyValues.qcResult === "DISCREPANCY_FOUND" &&
+        bulkApplyValues.correctionActionType === "REASSIGN_POSITION"
+          ? bulkApplyValues.correctionPositionCoordinate || null
+          : null,
+      correctionReason:
+        bulkApplyValues.qcResult === "DISCREPANCY_FOUND"
+          ? bulkApplyValues.correctionReason || null
+          : null,
     };
 
     postToOpenElisServerJsonResponse(
       `/rest/biorepository/qc-inspection/bulk-apply`,
       JSON.stringify(payload),
       (response) => {
-        setIsSubmittingInspection(false);
-        if (response?.error) {
-          setError(response.error);
-          return;
-        }
-
-        const count = response?.count || inspectionContext.sampleIds.length;
-        setSuccessMessage(
-          intl.formatMessage(
-            {
-              id: "biorepository.qc.success.applied",
-              defaultMessage: "QC inspection recorded for {count} sample(s).",
-            },
-            { count },
-          ),
-        );
-
-        closeInspectionModal();
-        loadStoredSamples();
-        loadLocationOverview();
-
-        if (onProgressUpdate) {
-          onProgressUpdate();
+        setIsBulkApplying(false);
+        if (response && !response.error) {
+          const count = response.count || selectedForBulkApply.length;
+          setSuccessMessage(
+            intl.formatMessage(
+              {
+                id: "biorepository.qc.success.applied",
+                defaultMessage: "QC inspection applied to {count} sample(s).",
+              },
+              { count },
+            ),
+          );
+          setBulkApplyModalOpen(false);
+          resetBulkApplyValues();
+          setSelectedForBulkApply([]); // Clear captured selection
+          loadStoredSamples();
+          if (onProgressUpdate) {
+            onProgressUpdate();
+          }
+        } else {
+          setError(
+            response?.error ||
+              intl.formatMessage({
+                id: "biorepository.qc.error.apply",
+                defaultMessage:
+                  "Failed to apply QC inspection. Please try again.",
+              }),
+          );
         }
       },
     );
   }, [
-    closeInspectionModal,
-    inspectionContext,
-    inspectionValues,
+    selectedForBulkApply,
+    bulkApplyValues,
     intl,
-    loadLocationOverview,
     loadStoredSamples,
     onProgressUpdate,
-    qcRoundInfo?.qcBatchId,
   ]);
 
-  const handleDownloadRoundCSV = useCallback(() => {
-    if (!qcRoundInfo?.samples?.length) {
-      return;
-    }
+  // Calculate stats
+  const totalSamples = samples.length;
+  const verifiedCount = samples.filter(
+    (s) => s.lastQCInspection && s.lastQCInspection.qcResult === "VERIFIED",
+  ).length;
+  const discrepanciesCount = samples.filter(
+    (s) =>
+      s.lastQCInspection && s.lastQCInspection.qcResult === "DISCREPANCY_FOUND",
+  ).length;
+  const pendingCount = samples.filter((s) => !s.lastQCInspection).length;
 
-    const headers = [
-      "qcBatchId",
-      "freezer",
-      "shelf",
-      "rack",
-      "box",
-      "position",
-      "locationPath",
-      "sampleNumber",
-      "sampleId",
-    ];
+  // Count checked criteria
+  const checkedCount = useMemo(() => {
+    return Object.values(bulkApplyValues.qcChecklist).filter((v) => v).length;
+  }, [bulkApplyValues.qcChecklist]);
 
-    const escapeCSV = (value) => {
-      const text = value === null || value === undefined ? "" : String(value);
-      if (text.includes(",") || text.includes('"') || text.includes("\n")) {
-        return `"${text.replace(/"/g, '""')}"`;
-      }
-      return text;
-    };
-
-    const rows = qcRoundInfo.samples.map((sample) => {
-      const parsed = parseLocationPath(
-        sample.locationPath,
-        sample.expectedCoordinate || sample.positionCoordinate,
-      );
-      return [
-        qcRoundInfo.qcBatchId || "",
-        sample.freezer || parsed.freezer,
-        sample.shelf || parsed.shelf,
-        sample.rack || parsed.rack,
-        sample.box || parsed.box,
-        sample.expectedCoordinate || sample.positionCoordinate || "",
-        sample.locationPath || "",
-        sample.accessionNumber || "",
-        sample.externalId || "",
-      ];
-    });
-
-    const csv = `${headers.join(",")}\n${rows
-      .map((row) => row.map(escapeCSV).join(","))
-      .join("\n")}\n`;
-
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `biorepository-qc-round-${qcRoundInfo.qcBatchId || "batch"}.csv`;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(url);
-  }, [qcRoundInfo]);
-
-  const roundRows = useMemo(
+  const correctionActionOptions = useMemo(
     () =>
-      (qcRoundInfo?.samples || []).map((sample, index) => {
-        const parsed = parseLocationPath(
-          sample.locationPath,
-          sample.expectedCoordinate || sample.positionCoordinate,
-        );
-
-        return {
-          id: `${sample.bioSampleId || "sample"}-${index}`,
-          freezer: sample.freezer || parsed.freezer,
-          shelf: sample.shelf || parsed.shelf,
-          rack: sample.rack || parsed.rack,
-          box: sample.box || parsed.box,
-          position:
-            sample.expectedCoordinate || sample.positionCoordinate || parsed.positionCoordinate,
-          accessionNumber: sample.accessionNumber || "-",
-          externalId: sample.externalId || "-",
-        };
-      }),
-    [qcRoundInfo],
+      getAllowedCorrectionActions(
+        CORRECTION_ACTIONS,
+        bulkApplyValues.discrepancyType,
+      ),
+    [bulkApplyValues.discrepancyType],
   );
 
-  const roundHeaders = useMemo(
-    () => [
-      { key: "freezer", header: "Freezer" },
-      { key: "shelf", header: "Shelf" },
-      { key: "rack", header: "Rack" },
-      { key: "box", header: "Box" },
-      { key: "position", header: "Position" },
-      { key: "accessionNumber", header: "Sample Number" },
-      { key: "externalId", header: "Sample ID" },
-    ],
-    [],
-  );
-
-  const tableHeaders = useMemo(
-    () => [
-      {
-        key: "accessionNumber",
-        header: intl.formatMessage({
-          id: "biorepository.sample.accessionNumber",
-          defaultMessage: "Sample Number",
-        }),
-      },
-      {
-        key: "sampleType",
-        header: intl.formatMessage({
-          id: "biorepository.sample.type",
-          defaultMessage: "Sample Type",
-        }),
-      },
-      { key: "freezer", header: "Freezer" },
-      { key: "shelf", header: "Shelf" },
-      { key: "rack", header: "Rack" },
-      { key: "box", header: "Box" },
-      { key: "positionCoordinate", header: "Position" },
-      {
-        key: "biosafetyLevel",
-        header: intl.formatMessage({
-          id: "biorepository.sample.bsl",
-          defaultMessage: "BSL",
-        }),
-      },
-      {
-        key: "lastQCInspection",
-        header: intl.formatMessage({
-          id: "biorepository.qc.lastInspection",
-          defaultMessage: "Last QC",
-        }),
-      },
-      { key: "actions", header: "Actions" },
-    ],
-    [intl],
-  );
-
-  const tableRows = useMemo(
-    () =>
-      displayedSamples.map((sample) => ({
-        id: String(sample.id),
-        accessionNumber: sample.accessionNumber,
-        sampleType: sample.sampleType,
-        freezer: sample.freezer,
-        shelf: sample.shelf,
-        rack: sample.rack,
-        box: sample.box,
-        positionCoordinate: sample.positionCoordinate,
-        biosafetyLevel: sample.biosafetyLevel,
-        lastQCInspection: sample.lastQCInspection,
-        actions: "inspect",
-        _raw: sample,
-      })),
-    [displayedSamples],
-  );
-
-  const freezerDropdownItems = useMemo(
-    () => [ALL_FREEZERS, ...availableFreezers],
-    [availableFreezers],
-  );
-
-  const shelfDropdownItems = useMemo(
-    () => [ALL_SHELVES, ...availableShelves],
-    [availableShelves],
-  );
-
-  const rackDropdownItems = useMemo(
-    () => [ALL_RACKS, ...availableRacks],
-    [availableRacks],
-  );
-
-  const getQCTag = useCallback((qcResult) => {
-    if (!qcResult) {
-      return <Tag type="gray">Pending</Tag>;
+  useEffect(() => {
+    if (
+      bulkApplyValues.correctionActionType === "MARK_MISSING" &&
+      !isMissingDiscrepancyType(bulkApplyValues.discrepancyType)
+    ) {
+      setBulkApplyValues((prev) => ({
+        ...prev,
+        correctionActionType: "",
+        correctionBoxId: "",
+        correctionPositionCoordinate: "",
+      }));
     }
-    if (qcResult === "VERIFIED") {
-      return <Tag type="green">Verified</Tag>;
-    }
-    if (qcResult === "DISCREPANCY_FOUND") {
+  }, [bulkApplyValues.correctionActionType, bulkApplyValues.discrepancyType]);
+
+  // Get QC result tag
+  const getQCTag = (qcResult, qcStatus) => {
+    if (!qcResult) return <Tag type="gray">Pending</Tag>;
+    if (qcStatus === "MISSING") return <Tag type="purple">Missing</Tag>;
+    if (qcResult === "VERIFIED") return <Tag type="green">Verified</Tag>;
+    if (qcResult === "DISCREPANCY_FOUND")
       return <Tag type="red">Discrepancy</Tag>;
-    }
     return <Tag type="gray">{qcResult}</Tag>;
-  }, []);
+  };
+
+  // Table headers
+  const headers = [
+    {
+      key: "accessionNumber",
+      header: intl.formatMessage({
+        id: "biorepository.sample.accessionNumber",
+        defaultMessage: "Sample Number",
+      }),
+    },
+    {
+      key: "sampleType",
+      header: intl.formatMessage({
+        id: "biorepository.sample.type",
+        defaultMessage: "Sample Type",
+      }),
+    },
+    {
+      key: "locationPath",
+      header: intl.formatMessage({
+        id: "biorepository.sample.storageLocation",
+        defaultMessage: "Storage Location",
+      }),
+    },
+    {
+      key: "biosafetyLevel",
+      header: intl.formatMessage({
+        id: "biorepository.sample.bsl",
+        defaultMessage: "BSL",
+      }),
+    },
+    {
+      key: "lastQCInspection",
+      header: intl.formatMessage({
+        id: "biorepository.qc.lastInspection",
+        defaultMessage: "Last QC Inspection",
+      }),
+    },
+  ];
 
   return (
     <div className="biorepository-qc-inspection-page">
+      {/* Page Header */}
       <div className="page-section-header">
         <h4>
           <FormattedMessage
             id="biorepository.qc.title"
-            defaultMessage="Biorepository Periodic QC"
+            defaultMessage="Quality Control Inspection"
           />
         </h4>
         <p className="page-description">
           <FormattedMessage
             id="biorepository.qc.description"
-            defaultMessage="Start with a room overview, scope the location to check, generate a randomized QC round, then record outcomes individually or in bulk with required failure documentation."
+            defaultMessage="Perform visual inspection and verification of stored samples. Use the QC checklist to assess physical presence, label integrity, container condition, volume/appearance, and storage position. Samples with discrepancies require corrective action documentation."
           />
         </p>
       </div>
 
+      {/* Progress Summary */}
+      <Grid fullWidth className="progress-section">
+        <Column lg={16} md={8} sm={4}>
+          <div className="progress-tiles">
+            <Tile className="progress-tile">
+              <span className="progress-label">
+                <FormattedMessage
+                  id="biorepository.qc.totalStored"
+                  defaultMessage="Total Stored"
+                />
+              </span>
+              <span className="progress-value">{totalSamples}</span>
+            </Tile>
+            <Tile className="progress-tile verified">
+              <span className="progress-label">
+                <FormattedMessage
+                  id="biorepository.qc.verified"
+                  defaultMessage="Verified"
+                />
+              </span>
+              <span className="progress-value">{verifiedCount}</span>
+            </Tile>
+            <Tile className="progress-tile error">
+              <span className="progress-label">
+                <FormattedMessage
+                  id="biorepository.qc.discrepancies"
+                  defaultMessage="Discrepancies"
+                />
+              </span>
+              <span className="progress-value">{discrepanciesCount}</span>
+            </Tile>
+            <Tile className="progress-tile pending">
+              <span className="progress-label">
+                <FormattedMessage
+                  id="biorepository.qc.pending"
+                  defaultMessage="Pending"
+                />
+              </span>
+              <span className="progress-value">{pendingCount}</span>
+            </Tile>
+          </div>
+        </Column>
+      </Grid>
+
+      {/* Messages */}
       {error && (
         <InlineNotification
           kind="error"
           title={error}
-          lowContrast
           onClose={() => setError(null)}
+          lowContrast
         />
       )}
-
       {successMessage && (
         <InlineNotification
           kind="success"
           title={successMessage}
-          lowContrast
           onClose={() => setSuccessMessage(null)}
+          lowContrast
         />
       )}
 
-      <Grid fullWidth style={{ marginTop: "1rem" }}>
-        <Column lg={16} md={8} sm={4}>
-          <Tile>
-            <h5 style={{ marginTop: 0, marginBottom: "0.75rem" }}>
-              Room Overview
-            </h5>
-            <p style={{ marginTop: 0, marginBottom: "1rem", color: "#525252" }}>
-              Review storage scale before starting QC. Filters below let you plan a
-              focused QC round.
-            </p>
-
-            {overviewLoading && (
-              <div style={{ marginBottom: "1rem" }}>
-                <Loading small withOverlay={false} />
-              </div>
-            )}
-
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
-                gap: "0.75rem",
-                marginBottom: "1rem",
-              }}
-            >
-              <Tile>
-                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                  Total Stored Samples
-                </div>
-                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-                  {fullOverviewFallback.totalStoredSamples}
-                </div>
-              </Tile>
-              <Tile>
-                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                  Matching Current Filters
-                </div>
-                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-                  {filteredOverview.totalStoredSamples}
-                </div>
-              </Tile>
-              <Tile>
-                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                  Freezers
-                </div>
-                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-                  {activeOverview.freezerCount || 0}
-                </div>
-              </Tile>
-              <Tile>
-                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                  Shelves
-                </div>
-                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-                  {activeOverview.shelfCount || 0}
-                </div>
-              </Tile>
-              <Tile>
-                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                  Racks
-                </div>
-                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-                  {activeOverview.rackCount || 0}
-                </div>
-              </Tile>
-              <Tile>
-                <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                  Boxes
-                </div>
-                <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-                  {activeOverview.boxCount || 0}
-                </div>
-              </Tile>
-            </div>
-
-            <Grid condensed fullWidth>
-              <Column lg={4} md={4} sm={4}>
-                <Dropdown
-                  id="qc-filter-freezer"
-                  titleText="Freezer"
-                  label={ALL_FREEZERS}
-                  items={freezerDropdownItems}
-                  selectedItem={filters.freezer || ALL_FREEZERS}
-                  itemToString={(item) => (item ? String(item) : "")}
-                  onChange={({ selectedItem }) => {
-                    const value = selectedItem === ALL_FREEZERS ? "" : selectedItem;
-                    setFilters((previous) => ({
-                      ...previous,
-                      freezer: value,
-                      shelf: "",
-                      rack: "",
-                    }));
-                  }}
-                />
-              </Column>
-              <Column lg={4} md={4} sm={4}>
-                <Dropdown
-                  id="qc-filter-shelf"
-                  titleText="Shelf"
-                  label={ALL_SHELVES}
-                  items={shelfDropdownItems}
-                  selectedItem={filters.shelf || ALL_SHELVES}
-                  itemToString={(item) => (item ? String(item) : "")}
-                  onChange={({ selectedItem }) => {
-                    const value = selectedItem === ALL_SHELVES ? "" : selectedItem;
-                    setFilters((previous) => ({
-                      ...previous,
-                      shelf: value,
-                      rack: "",
-                    }));
-                  }}
-                />
-              </Column>
-              <Column lg={4} md={4} sm={4}>
-                <Dropdown
-                  id="qc-filter-rack"
-                  titleText="Rack"
-                  label={ALL_RACKS}
-                  items={rackDropdownItems}
-                  selectedItem={filters.rack || ALL_RACKS}
-                  itemToString={(item) => (item ? String(item) : "")}
-                  onChange={({ selectedItem }) => {
-                    const value = selectedItem === ALL_RACKS ? "" : selectedItem;
-                    setFilters((previous) => ({
-                      ...previous,
-                      rack: value,
-                    }));
-                  }}
-                />
-              </Column>
-              <Column lg={4} md={4} sm={4}>
-                <TextInput
-                  id="qc-filter-box"
-                  labelText="Box (optional text filter)"
-                  placeholder="e.g. BX078"
-                  value={filters.box}
-                  onChange={(event) =>
-                    setFilters((previous) => ({
-                      ...previous,
-                      box: event.target.value,
-                    }))
-                  }
-                />
-              </Column>
-            </Grid>
-
-            <div style={{ marginTop: "0.75rem", display: "flex", gap: "0.5rem" }}>
-              <Button
-                kind="ghost"
-                size="sm"
-                onClick={() =>
-                  setFilters({ freezer: "", shelf: "", rack: "", box: "" })
-                }
-              >
-                Clear location filters
-              </Button>
-              <Button kind="ghost" size="sm" renderIcon={Renew} onClick={loadStoredSamples}>
-                Refresh samples
-              </Button>
-              <Button kind="ghost" size="sm" renderIcon={Renew} onClick={loadLocationOverview}>
-                Refresh overview
-              </Button>
-            </div>
-          </Tile>
-        </Column>
-      </Grid>
-
-      <Grid fullWidth style={{ marginTop: "1rem" }}>
-        <Column lg={16} md={8} sm={4}>
-          <Tile>
-            <h5 style={{ marginTop: 0, marginBottom: "0.75rem" }}>
-              QC Round Planning
-            </h5>
-            <p style={{ marginTop: 0, marginBottom: "1rem", color: "#525252" }}>
-              Choose how many boxes and positions to sample for this periodic QC
-              round. The system will generate a randomized list from the selected
-              location scope.
-            </p>
-
-            <Grid condensed fullWidth>
-              <Column lg={4} md={4} sm={4}>
-                <TextInput
-                  id="qc-round-boxes"
-                  type="number"
-                  min="1"
-                  max="200"
-                  labelText="Boxes per round"
-                  value={roundSettings.boxesPerRound}
-                  onChange={(event) =>
-                    setRoundSettings((previous) => ({
-                      ...previous,
-                      boxesPerRound: event.target.value,
-                    }))
-                  }
-                />
-              </Column>
-              <Column lg={4} md={4} sm={4}>
-                <TextInput
-                  id="qc-round-samples-per-box"
-                  type="number"
-                  min="1"
-                  max="50"
-                  labelText="Samples per box"
-                  value={roundSettings.samplesPerBox}
-                  onChange={(event) =>
-                    setRoundSettings((previous) => ({
-                      ...previous,
-                      samplesPerBox: event.target.value,
-                    }))
-                  }
-                />
-              </Column>
-              <Column lg={4} md={4} sm={4}>
-                <TextInput
-                  id="qc-round-seed"
-                  type="number"
-                  labelText="Random seed (optional)"
-                  placeholder="Leave empty for true random"
-                  value={roundSettings.seed}
-                  onChange={(event) =>
-                    setRoundSettings((previous) => ({
-                      ...previous,
-                      seed: event.target.value,
-                    }))
-                  }
-                />
-              </Column>
-              <Column lg={4} md={4} sm={4} style={{ display: "flex", alignItems: "end" }}>
-                <Button size="sm" onClick={handleGenerateQCRound}>
-                  Generate random QC round
-                </Button>
-              </Column>
-            </Grid>
-
-            {qcRoundInfo && (
-              <div style={{ marginTop: "1rem" }}>
-                <InlineNotification
-                  kind="info"
-                  lowContrast
-                  title={intl.formatMessage(
-                    {
-                      id: "biorepository.qc.round.generated",
-                      defaultMessage:
-                        "Round {batch}: {boxes} box(es), {samples} sample(s) selected.",
-                    },
-                    {
-                      batch: qcRoundInfo.qcBatchId,
-                      boxes: qcRoundInfo.boxesSelected || 0,
-                      samples: qcRoundInfo.samplesSelected || 0,
-                    },
-                  )}
-                />
-
-                <div style={{ marginTop: "0.75rem" }}>
-                  <ButtonSet>
-                    <Button
-                      kind="primary"
-                      size="sm"
-                      onClick={() => {
-                        const selectedIds = (qcRoundInfo.samples || [])
-                          .map((sample) => String(sample.bioSampleId))
-                          .filter(Boolean);
-                        const preview = displayedSamples
-                          .filter((sample) => selectedIds.includes(String(sample.id)))
-                          .slice(0, 6);
-                        openInspectionModal("bulk", selectedIds, preview);
-                      }}
-                    >
-                      Bulk inspect generated round
-                    </Button>
-                    <Button kind="tertiary" size="sm" onClick={handleDownloadRoundCSV}>
-                      Download round list (CSV)
-                    </Button>
-                    <Button
-                      kind="ghost"
-                      size="sm"
-                      onClick={() => {
-                        setQcRoundInfo(null);
-                        setShowSelectedOnly(false);
-                      }}
-                    >
-                      Clear round
-                    </Button>
-                  </ButtonSet>
-                </div>
-
-                <div style={{ marginTop: "0.75rem" }}>
-                  <Toggle
-                    id="show-selected-round-only"
-                    labelText="Show only generated round samples in main table"
-                    toggled={showSelectedOnly}
-                    onToggle={(nextValue) => setShowSelectedOnly(Boolean(nextValue))}
-                  />
-                </div>
-              </div>
-            )}
-          </Tile>
-        </Column>
-      </Grid>
-
-      {qcRoundInfo && roundRows.length > 0 && (
-        <Grid fullWidth style={{ marginTop: "1rem" }}>
-          <Column lg={16} md={8} sm={4}>
-            <DataTable rows={roundRows} headers={roundHeaders}>
-              {({
-                rows,
-                headers,
-                getTableProps,
-                getHeaderProps,
-                getRowProps,
-              }) => (
-                <TableContainer
-                  title="Generated QC Checklist"
-                  description="Technician path guidance: Freezer > Shelf > Rack > Box > Position"
-                >
-                  <Table {...getTableProps()}>
-                    <TableHead>
-                      <TableRow>
-                        {headers.map((header) => (
-                          <TableHeader key={header.key} {...getHeaderProps({ header })}>
-                            {header.header}
-                          </TableHeader>
-                        ))}
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {rows.map((row) => (
-                        <TableRow key={row.id} {...getRowProps({ row })}>
-                          {row.cells.map((cell) => (
-                            <TableCell key={cell.id}>{cell.value}</TableCell>
-                          ))}
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              )}
-            </DataTable>
-          </Column>
-        </Grid>
+      {roundInfo && (
+        <InlineNotification
+          kind="info"
+          title={intl.formatMessage(
+            {
+              id: "biorepository.qc.round.generated",
+              defaultMessage:
+                "QC round generated from filtered storage scope: {boxes} box(es), {samples} sample(s) from {pool} eligible sample(s).",
+            },
+            {
+              boxes: roundInfo.boxesSelected,
+              samples: roundInfo.samplesSelected,
+              pool: roundInfo.filteredSamplePool,
+            },
+          )}
+          lowContrast
+        />
       )}
 
-      <Grid fullWidth style={{ marginTop: "1rem" }}>
+      {/* Storage overview + scope filters (must be correct before random generation) */}
+      <Grid
+        fullWidth
+        className="progress-section"
+        style={{ marginTop: "1rem" }}
+      >
         <Column lg={16} md={8} sm={4}>
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
-              gap: "0.75rem",
-              marginBottom: "1rem",
-            }}
-          >
-            <Tile>
-              <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                In View
-              </div>
-              <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-                {displayedSamples.length}
-              </div>
+          <div className="progress-tiles">
+            <Tile className="progress-tile">
+              <span className="progress-label">Freezers</span>
+              <span className="progress-value">{storageOverview.freezers}</span>
             </Tile>
-            <Tile>
-              <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                Verified
-              </div>
-              <div style={{ fontSize: "1.5rem", fontWeight: 600, color: "#198038" }}>
-                {verifiedCount}
-              </div>
+            <Tile className="progress-tile">
+              <span className="progress-label">Shelves</span>
+              <span className="progress-value">{storageOverview.shelves}</span>
             </Tile>
-            <Tile>
-              <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                Discrepancies
-              </div>
-              <div style={{ fontSize: "1.5rem", fontWeight: 600, color: "#da1e28" }}>
-                {discrepancyCount}
-              </div>
+            <Tile className="progress-tile">
+              <span className="progress-label">Racks</span>
+              <span className="progress-value">{storageOverview.racks}</span>
             </Tile>
-            <Tile>
-              <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-                Pending
-              </div>
-              <div style={{ fontSize: "1.5rem", fontWeight: 600 }}>{pendingCount}</div>
+            <Tile className="progress-tile">
+              <span className="progress-label">Boxes</span>
+              <span className="progress-value">{storageOverview.boxes}</span>
+            </Tile>
+            <Tile className="progress-tile pending">
+              <span className="progress-label">Eligible Samples</span>
+              <span className="progress-value">{storageOverview.samples}</span>
             </Tile>
           </div>
         </Column>
       </Grid>
 
-      <div className="sample-table-section" style={{ marginTop: "0.5rem" }}>
+      <Grid fullWidth style={{ marginTop: "0.75rem", marginBottom: "0.75rem" }}>
+        <Column lg={4} md={4} sm={4}>
+          <Dropdown
+            id="qc-filter-freezer"
+            titleText="Freezer"
+            items={filterOptionItems.freezer}
+            selectedItem={
+              filterOptionItems.freezer.find(
+                (item) => item.id === storageFilters.freezer,
+              ) || filterOptionItems.freezer[0]
+            }
+            itemToString={(item) => item?.label || ""}
+            onChange={({ selectedItem }) =>
+              setStorageFilters((prev) => ({
+                ...prev,
+                freezer: selectedItem?.id || ALL_OPTION,
+                shelf: ALL_OPTION,
+                rack: ALL_OPTION,
+                box: ALL_OPTION,
+              }))
+            }
+            disabled={loadingStorageOverview}
+          />
+        </Column>
+        <Column lg={4} md={4} sm={4}>
+          <Dropdown
+            id="qc-filter-shelf"
+            titleText="Shelf"
+            items={filterOptionItems.shelf}
+            selectedItem={
+              filterOptionItems.shelf.find(
+                (item) => item.id === storageFilters.shelf,
+              ) || filterOptionItems.shelf[0]
+            }
+            itemToString={(item) => item?.label || ""}
+            onChange={({ selectedItem }) =>
+              setStorageFilters((prev) => ({
+                ...prev,
+                shelf: selectedItem?.id || ALL_OPTION,
+                rack: ALL_OPTION,
+                box: ALL_OPTION,
+              }))
+            }
+            disabled={loadingStorageOverview}
+          />
+        </Column>
+        <Column lg={4} md={4} sm={4}>
+          <Dropdown
+            id="qc-filter-rack"
+            titleText="Rack"
+            items={filterOptionItems.rack}
+            selectedItem={
+              filterOptionItems.rack.find(
+                (item) => item.id === storageFilters.rack,
+              ) || filterOptionItems.rack[0]
+            }
+            itemToString={(item) => item?.label || ""}
+            onChange={({ selectedItem }) =>
+              setStorageFilters((prev) => ({
+                ...prev,
+                rack: selectedItem?.id || ALL_OPTION,
+                box: ALL_OPTION,
+              }))
+            }
+            disabled={loadingStorageOverview}
+          />
+        </Column>
+        <Column lg={4} md={4} sm={4}>
+          <Dropdown
+            id="qc-filter-box"
+            titleText="Box"
+            items={filterOptionItems.box}
+            selectedItem={
+              filterOptionItems.box.find(
+                (item) => item.id === storageFilters.box,
+              ) || filterOptionItems.box[0]
+            }
+            itemToString={(item) => item?.label || ""}
+            onChange={({ selectedItem }) =>
+              setStorageFilters((prev) => ({
+                ...prev,
+                box: selectedItem?.id || ALL_OPTION,
+              }))
+            }
+            disabled={loadingStorageOverview}
+          />
+        </Column>
+      </Grid>
+
+      <Grid fullWidth style={{ marginBottom: "1rem" }}>
+        <Column lg={4} md={4} sm={4}>
+          <TextInput
+            id="qc-boxes-per-round"
+            labelText="Boxes per round"
+            value={roundSettings.boxesPerRound}
+            onChange={(e) =>
+              setRoundSettings((prev) => ({
+                ...prev,
+                boxesPerRound: e.target.value.replace(/[^\d]/g, ""),
+              }))
+            }
+          />
+        </Column>
+        <Column lg={4} md={4} sm={4}>
+          <TextInput
+            id="qc-samples-per-box"
+            labelText="Samples per box"
+            value={roundSettings.samplesPerBox}
+            onChange={(e) =>
+              setRoundSettings((prev) => ({
+                ...prev,
+                samplesPerBox: e.target.value.replace(/[^\d]/g, ""),
+              }))
+            }
+          />
+        </Column>
+        <Column
+          lg={8}
+          md={8}
+          sm={4}
+          style={{ display: "flex", alignItems: "flex-end" }}
+        >
+          <Button
+            kind="secondary"
+            size="sm"
+            onClick={generateRandomRound}
+            disabled={
+              isGeneratingRound ||
+              loadingStorageOverview ||
+              storageOverview.samples === 0
+            }
+          >
+            Generate Random QC Round
+          </Button>
+        </Column>
+      </Grid>
+
+      {/* Samples Table */}
+      <div className="sample-table-section" style={{ marginTop: "1rem" }}>
         {loading ? (
           <div style={{ padding: "2rem", textAlign: "center" }}>
             <Loading withOverlay={false} />
           </div>
-        ) : tableRows.length === 0 ? (
+        ) : filteredSamples.length === 0 ? (
           <InlineNotification
             kind="info"
+            title={intl.formatMessage({
+              id: "biorepository.qc.noSamples",
+              defaultMessage: "No Samples in Current Storage Scope",
+            })}
+            subtitle={intl.formatMessage({
+              id: "biorepository.qc.noSamples.message",
+              defaultMessage:
+                "No STORED samples are currently eligible under the selected freezer/shelf/rack/box scope.",
+            })}
             lowContrast
             hideCloseButton
-            title="No samples found for current view"
-            subtitle="Adjust location filters or generate a new QC round."
           />
         ) : (
-          <DataTable rows={tableRows} headers={tableHeaders}>
+          <DataTable
+            rows={filteredSamples.map((sample) => ({
+              id: sample.id.toString(),
+              accessionNumber: sample.accessionNumber,
+              sampleType: sample.sampleType,
+              locationPath: sample.locationPath,
+              biosafetyLevel: sample.biosafetyLevel,
+              lastQCInspection: sample.lastQCInspection,
+              _raw: sample,
+            }))}
+            headers={headers}
+          >
             {({
               rows,
               headers,
@@ -1428,33 +1221,44 @@ function BiorepositoryQCInspectionPage({
               getBatchActionProps,
               selectedRows,
             }) => {
-              const selectedIds = selectedRows.map((row) => row.id);
+              // Get selected IDs from Carbon's DataTable state (read-only, no setState in render)
+              const currentSelectedIds = selectedRows.map((r) => r.id);
 
               return (
-                <TableContainer title="QC Execution Table">
+                <TableContainer>
                   <TableToolbar>
                     <TableBatchActions {...getBatchActionProps()}>
                       <TableBatchAction
                         renderIcon={Edit}
-                        iconDescription="Bulk inspect selected"
+                        iconDescription={intl.formatMessage({
+                          id: "biorepository.qc.bulkApply",
+                          defaultMessage: "Bulk Apply QC",
+                        })}
                         onClick={() => {
-                          const preview = displayedSamples
-                            .filter((sample) => selectedIds.includes(String(sample.id)))
-                            .slice(0, 6);
-                          openInspectionModal("bulk", selectedIds, preview);
+                          // Capture selection when modal opens
+                          setSelectedForBulkApply(currentSelectedIds);
+                          resetBulkApplyValues();
+                          setBulkApplyModalOpen(true);
                         }}
                       >
-                        Bulk inspect selected
+                        <FormattedMessage
+                          id="biorepository.qc.bulkApply"
+                          defaultMessage="Bulk Apply QC"
+                        />
                       </TableBatchAction>
                     </TableBatchActions>
                     <TableToolbarContent>
                       <Button
                         kind="ghost"
-                        hasIconOnly
                         size="sm"
-                        iconDescription="Refresh"
                         renderIcon={Renew}
+                        iconDescription={intl.formatMessage({
+                          id: "label.refresh",
+                          defaultMessage: "Refresh",
+                        })}
+                        hasIconOnly
                         onClick={loadStoredSamples}
+                        disabled={loading}
                       />
                     </TableToolbarContent>
                   </TableToolbar>
@@ -1463,7 +1267,10 @@ function BiorepositoryQCInspectionPage({
                       <TableRow>
                         <TableSelectAll {...getSelectionProps()} />
                         {headers.map((header) => (
-                          <TableHeader key={header.key} {...getHeaderProps({ header })}>
+                          <TableHeader
+                            {...getHeaderProps({ header })}
+                            key={header.key}
+                          >
                             {header.header}
                           </TableHeader>
                         ))}
@@ -1471,72 +1278,66 @@ function BiorepositoryQCInspectionPage({
                     </TableHead>
                     <TableBody>
                       {rows.map((row) => {
-                        const raw = row.cells.find((cell) => cell.info.header === "actions")
-                          ? displayedSamples.find(
-                              (sample) => String(sample.id) === String(row.id),
-                            )
-                          : null;
-
+                        const sample = filteredSamples.find(
+                          (s) => s.id.toString() === row.id,
+                        );
                         return (
-                          <TableRow key={row.id} {...getRowProps({ row })}>
+                          <TableRow {...getRowProps({ row })} key={row.id}>
                             <TableSelectRow {...getSelectionProps({ row })} />
                             {row.cells.map((cell) => {
                               if (cell.info.header === "biosafetyLevel") {
                                 let bslColor = "gray";
-                                if (cell.value === "BSL_1") {
-                                  bslColor = "green";
-                                } else if (cell.value === "BSL_2") {
+                                if (cell.value === "BSL_1") bslColor = "green";
+                                else if (cell.value === "BSL_2")
                                   bslColor = "teal";
-                                } else if (cell.value === "BSL_3") {
+                                else if (cell.value === "BSL_3")
                                   bslColor = "purple";
-                                } else if (cell.value === "BSL_4") {
+                                else if (cell.value === "BSL_4")
                                   bslColor = "red";
-                                }
                                 return (
                                   <TableCell key={cell.id}>
                                     <Tag type={bslColor}>{cell.value}</Tag>
                                   </TableCell>
                                 );
                               }
-
                               if (cell.info.header === "lastQCInspection") {
-                                const inspection = raw?.lastQCInspection;
-                                if (!inspection) {
+                                if (!sample?.lastQCInspection) {
                                   return (
                                     <TableCell key={cell.id}>
-                                      <Tag type="gray">Never inspected</Tag>
+                                      <Tag type="gray">Never Inspected</Tag>
                                     </TableCell>
                                   );
                                 }
+                                const qc = sample.lastQCInspection;
                                 return (
                                   <TableCell key={cell.id}>
-                                    <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-                                      {getQCTag(inspection.qcResult)}
-                                      <span style={{ fontSize: "0.75rem", color: "#525252" }}>
-                                        {new Date(inspection.inspectionDate).toLocaleDateString()}
+                                    <div
+                                      style={{
+                                        display: "flex",
+                                        gap: "0.5rem",
+                                        alignItems: "center",
+                                      }}
+                                    >
+                                      {getQCTag(qc.qcResult, qc.qcStatus)}
+                                      <span
+                                        style={{
+                                          fontSize: "0.75rem",
+                                          color: "#525252",
+                                        }}
+                                      >
+                                        {new Date(
+                                          qc.inspectionDate,
+                                        ).toLocaleDateString()}
                                       </span>
                                     </div>
                                   </TableCell>
                                 );
                               }
-
-                              if (cell.info.header === "actions") {
-                                return (
-                                  <TableCell key={cell.id}>
-                                    <Button
-                                      kind="ghost"
-                                      size="sm"
-                                      onClick={() =>
-                                        openInspectionModal("single", [row.id], [raw])
-                                      }
-                                    >
-                                      Inspect
-                                    </Button>
-                                  </TableCell>
-                                );
-                              }
-
-                              return <TableCell key={cell.id}>{cell.value}</TableCell>;
+                              return (
+                                <TableCell key={cell.id}>
+                                  {cell.value}
+                                </TableCell>
+                              );
                             })}
                           </TableRow>
                         );
@@ -1550,187 +1351,422 @@ function BiorepositoryQCInspectionPage({
         )}
       </div>
 
+      {/* Bulk Apply QC Modal */}
       <Modal
-        open={inspectionModalOpen}
-        onRequestClose={closeInspectionModal}
-        modalHeading={
-          inspectionContext.mode === "single"
-            ? "Individual QC Inspection"
-            : "Bulk QC Inspection"
-        }
+        open={bulkApplyModalOpen}
+        onRequestClose={() => setBulkApplyModalOpen(false)}
+        modalHeading={intl.formatMessage({
+          id: "biorepository.qc.bulkApply.title",
+          defaultMessage: "Bulk QC Inspection",
+        })}
         primaryButtonText={
-          isSubmittingInspection
-            ? "Saving..."
-            : inspectionValues.qcResult === "DISCREPANCY_FOUND"
-              ? "Record Failed QC"
-              : "Record QC"
+          isBulkApplying
+            ? intl.formatMessage({
+                id: "label.applying",
+                defaultMessage: "Applying...",
+              })
+            : bulkApplyValues.qcResult === "VERIFIED"
+              ? intl.formatMessage({
+                  id: "biorepository.qc.action.verify",
+                  defaultMessage: "Record Verification",
+                })
+              : bulkApplyValues.qcResult === "DISCREPANCY_FOUND"
+                ? intl.formatMessage({
+                    id: "biorepository.qc.action.recordDiscrepancy",
+                    defaultMessage: "Record Discrepancy",
+                  })
+                : intl.formatMessage({
+                    id: "label.apply",
+                    defaultMessage: "Apply",
+                  })
         }
-        secondaryButtonText="Cancel"
-        onRequestSubmit={handleSubmitInspection}
-        onSecondarySubmit={closeInspectionModal}
-        primaryButtonDisabled={isSubmittingInspection || !inspectionValues.qcResult}
-        danger={inspectionValues.qcResult === "DISCREPANCY_FOUND"}
+        secondaryButtonText={intl.formatMessage({
+          id: "label.cancel",
+          defaultMessage: "Cancel",
+        })}
+        onRequestSubmit={handleBulkApply}
+        onSecondarySubmit={() => setBulkApplyModalOpen(false)}
         size="md"
+        primaryButtonDisabled={isBulkApplying || !bulkApplyValues.qcResult}
+        danger={bulkApplyValues.qcResult === "DISCREPANCY_FOUND"}
       >
-        <p style={{ marginTop: 0 }}>
-          {inspectionContext.mode === "single"
-            ? "Record QC for one selected sample."
-            : `Record QC for ${inspectionContext.sampleIds.length} selected sample(s).`}
-        </p>
-
-        {inspectionContext.samplePreview.length > 0 && (
-          <Tile style={{ marginBottom: "1rem" }}>
-            <div style={{ fontSize: "0.75rem", color: "#6f6f6f" }}>
-              Selected preview
-            </div>
-            {inspectionContext.samplePreview.slice(0, 4).map((sample) => (
-              <div key={`preview-${sample.id}`} style={{ marginTop: "0.35rem" }}>
-                {sample.accessionNumber} - {sample.freezer} / {sample.shelf} / {sample.rack} / {sample.box} / {sample.positionCoordinate}
-              </div>
-            ))}
-            {inspectionContext.samplePreview.length > 4 && (
-              <div style={{ marginTop: "0.35rem", color: "#6f6f6f" }}>
-                +{inspectionContext.samplePreview.length - 4} more sample(s)
-              </div>
-            )}
-          </Tile>
-        )}
-
-        <Grid fullWidth>
-          <Column lg={8} md={4} sm={4}>
-            <TextInput
-              id="qc-inspector-name"
-              labelText="Inspector name (required)"
-              value={inspectionValues.inspectorName}
-              onChange={(event) =>
-                setInspectionValues((previous) => ({
-                  ...previous,
-                  inspectorName: event.target.value,
-                }))
-              }
+        <div className="qc-bulk-apply-modal">
+          <p className="modal-description">
+            <FormattedMessage
+              id="biorepository.qc.bulkApply.description"
+              defaultMessage="Apply QC inspection to {count} selected sample(s)."
+              values={{ count: selectedForBulkApply.length }}
             />
-          </Column>
-          <Column lg={8} md={4} sm={4}>
-            <div className="cds--form-item">
-              <label className="cds--label">Inspection date and time</label>
-              <input
-                type="datetime-local"
-                className="cds--text-input"
-                value={inspectionValues.inspectionDate}
-                onChange={(event) =>
-                  setInspectionValues((previous) => ({
-                    ...previous,
-                    inspectionDate: event.target.value,
-                  }))
-                }
+          </p>
+
+          {/* Inspector Information */}
+          <div className="qc-section">
+            <h5 className="qc-section-header">
+              <FormattedMessage
+                id="biorepository.qc.section.inspector"
+                defaultMessage="Inspector Information"
               />
-            </div>
-          </Column>
-        </Grid>
+            </h5>
+            <Grid fullWidth>
+              <Column lg={8} md={4} sm={4}>
+                <TextInput
+                  id="inspectorName"
+                  labelText={intl.formatMessage({
+                    id: "biorepository.qc.inspectorName",
+                    defaultMessage: "Inspector Name (Required)",
+                  })}
+                  value={bulkApplyValues.inspectorName}
+                  onChange={(e) =>
+                    setBulkApplyValues((prev) => ({
+                      ...prev,
+                      inspectorName: e.target.value,
+                    }))
+                  }
+                  placeholder={intl.formatMessage({
+                    id: "biorepository.qc.inspectorName.placeholder",
+                    defaultMessage: "Enter inspector name",
+                  })}
+                />
+              </Column>
+              <Column lg={8} md={4} sm={4}>
+                <div className="cds--form-item">
+                  <label className="cds--label">
+                    <FormattedMessage
+                      id="biorepository.qc.inspectionDate"
+                      defaultMessage="Inspection Date & Time"
+                    />
+                  </label>
+                  <input
+                    type="datetime-local"
+                    className="cds--text-input"
+                    value={bulkApplyValues.inspectionDate}
+                    onChange={(e) =>
+                      setBulkApplyValues((prev) => ({
+                        ...prev,
+                        inspectionDate: e.target.value,
+                      }))
+                    }
+                  />
+                </div>
+              </Column>
+            </Grid>
+          </div>
 
-        <div style={{ marginTop: "1rem" }}>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              marginBottom: "0.5rem",
-            }}
-          >
-            <strong>
-              QC Checklist ({checkedCount}/{QC_CHECKLIST.length})
-            </strong>
-            <div style={{ display: "flex", gap: "0.5rem" }}>
-              <Button kind="ghost" size="sm" onClick={() => handleSetAllChecklist(true)}>
-                Check all
+          {/* QC Checklist Section */}
+          <div className="qc-section">
+            <h5 className="qc-section-header">
+              <FormattedMessage
+                id="biorepository.qc.section.checklist"
+                defaultMessage="QC Checklist"
+              />
+              <span className="qc-checklist-count">
+                ({checkedCount}/{QC_CHECKLIST.length})
+              </span>
+            </h5>
+            <div className="qc-checklist-actions">
+              <Button kind="ghost" size="sm" onClick={handleCheckAll}>
+                <FormattedMessage
+                  id="biorepository.qc.checkAll"
+                  defaultMessage="Check All (Verify)"
+                />
               </Button>
-              <Button kind="ghost" size="sm" onClick={() => handleSetAllChecklist(false)}>
-                Clear all
+              <Button kind="ghost" size="sm" onClick={handleClearAll}>
+                <FormattedMessage
+                  id="biorepository.qc.clearAll"
+                  defaultMessage="Clear All"
+                />
               </Button>
+            </div>
+            <div className="qc-checklist-items">
+              {QC_CHECKLIST.map((criteria) => (
+                <Checkbox
+                  key={criteria.id}
+                  id={`qc-${criteria.id}`}
+                  labelText={intl.formatMessage({
+                    id: criteria.labelId,
+                    defaultMessage: criteria.defaultLabel,
+                  })}
+                  checked={bulkApplyValues.qcChecklist[criteria.id]}
+                  onChange={(_, { checked }) =>
+                    handleChecklistChange(criteria.id, checked)
+                  }
+                />
+              ))}
             </div>
           </div>
 
-          {QC_CHECKLIST.map((item) => (
-            <Checkbox
-              key={item.id}
-              id={`qc-check-${item.id}`}
-              labelText={intl.formatMessage({
-                id: item.labelId,
-                defaultMessage: item.defaultLabel,
-              })}
-              checked={inspectionValues.qcChecklist[item.id]}
-              onChange={(_, { checked }) => handleChecklistChange(item.id, checked)}
-            />
-          ))}
-        </div>
-
-        <div style={{ marginTop: "1rem" }}>
-          {inspectionValues.qcResult === "VERIFIED" && (
-            <Tag type="green">
-              <Checkmark size={16} style={{ marginRight: "0.25rem" }} />
-              QC VERIFIED
-            </Tag>
-          )}
-          {inspectionValues.qcResult === "DISCREPANCY_FOUND" && (
-            <Tag type="red">
-              <WarningAlt size={16} style={{ marginRight: "0.25rem" }} />
-              DISCREPANCY FOUND
-            </Tag>
-          )}
-          {!inspectionValues.qcResult && <Tag type="gray">Complete checklist</Tag>}
-        </div>
-
-        {inspectionValues.qcResult === "DISCREPANCY_FOUND" && (
-          <div style={{ marginTop: "1rem" }}>
-            <Dropdown
-              id="qc-discrepancy-type"
-              titleText="Discrepancy type (required)"
-              label="Choose discrepancy"
-              items={DISCREPANCY_TYPES}
-              itemToString={(item) => (item ? item.label : "")}
-              selectedItem={DISCREPANCY_TYPES.find(
-                (item) => item.id === inspectionValues.discrepancyType,
+          {/* QC Result Indicator */}
+          <div className="qc-section qc-decision-section">
+            <h5 className="qc-section-header">
+              <FormattedMessage
+                id="biorepository.qc.section.result"
+                defaultMessage="QC Result"
+              />
+            </h5>
+            <div
+              className={`qc-result-indicator ${bulkApplyValues.qcResult === "VERIFIED" ? "pass" : bulkApplyValues.qcResult === "DISCREPANCY_FOUND" ? "fail" : ""}`}
+            >
+              {bulkApplyValues.qcResult === "VERIFIED" && (
+                <Tag type="green" size="md">
+                  <Checkmark size={16} style={{ marginRight: "0.5rem" }} />
+                  <FormattedMessage
+                    id="biorepository.qc.result.verified"
+                    defaultMessage="QC VERIFIED - All checks passed"
+                  />
+                </Tag>
               )}
-              onChange={({ selectedItem }) =>
-                setInspectionValues((previous) => ({
-                  ...previous,
-                  discrepancyType: selectedItem?.id || "",
-                }))
-              }
-            />
-
-            <TextArea
-              id="qc-corrective-action"
-              labelText="Corrective action (required)"
-              rows={3}
-              value={inspectionValues.correctiveAction}
-              onChange={(event) =>
-                setInspectionValues((previous) => ({
-                  ...previous,
-                  correctiveAction: event.target.value,
-                }))
-              }
-            />
+              {bulkApplyValues.qcResult === "DISCREPANCY_FOUND" && (
+                <Tag type="red" size="md">
+                  <WarningAlt size={16} style={{ marginRight: "0.5rem" }} />
+                  <FormattedMessage
+                    id="biorepository.qc.result.discrepancy"
+                    defaultMessage="DISCREPANCY FOUND - Corrective action required"
+                  />
+                </Tag>
+              )}
+              {!bulkApplyValues.qcResult && (
+                <Tag type="gray" size="md">
+                  <FormattedMessage
+                    id="biorepository.qc.result.pending"
+                    defaultMessage="Complete checklist to determine result"
+                  />
+                </Tag>
+              )}
+            </div>
           </div>
-        )}
 
-        <div style={{ marginTop: "1rem" }}>
-          <TextArea
-            id="qc-remarks"
-            labelText={
-              inspectionValues.qcResult === "DISCREPANCY_FOUND"
-                ? "Comment/remarks (required for failed QC)"
-                : "Comment/remarks (optional)"
-            }
-            rows={2}
-            value={inspectionValues.remarks}
-            onChange={(event) =>
-              setInspectionValues((previous) => ({
-                ...previous,
-                remarks: event.target.value,
-              }))
-            }
-          />
+          {/* Discrepancy Details - Only show if QC result is DISCREPANCY_FOUND */}
+          {bulkApplyValues.qcResult === "DISCREPANCY_FOUND" && (
+            <div className="qc-section">
+              <h5 className="qc-section-header">
+                <WarningAlt size={16} style={{ marginRight: "0.5rem" }} />
+                <FormattedMessage
+                  id="biorepository.qc.section.discrepancy"
+                  defaultMessage="Discrepancy Details"
+                />
+              </h5>
+              <Grid fullWidth>
+                <Column lg={16} md={8} sm={4}>
+                  <Dropdown
+                    id="discrepancyType"
+                    titleText={intl.formatMessage({
+                      id: "biorepository.qc.discrepancyType",
+                      defaultMessage: "Discrepancy Type (Required)",
+                    })}
+                    label={intl.formatMessage({
+                      id: "biorepository.qc.discrepancyType.placeholder",
+                      defaultMessage: "Select discrepancy type",
+                    })}
+                    items={DISCREPANCY_TYPES}
+                    itemToString={(item) => (item ? item.label : "")}
+                    selectedItem={DISCREPANCY_TYPES.find(
+                      (d) => d.id === bulkApplyValues.discrepancyType,
+                    )}
+                    onChange={({ selectedItem }) => {
+                      const nextDiscrepancyType = selectedItem?.id || "";
+                      setBulkApplyValues((prev) => {
+                        const shouldClearMarkMissing =
+                          prev.correctionActionType === "MARK_MISSING" &&
+                          !isMissingDiscrepancyType(nextDiscrepancyType);
+                        return {
+                          ...prev,
+                          discrepancyType: nextDiscrepancyType,
+                          correctionActionType: shouldClearMarkMissing
+                            ? ""
+                            : prev.correctionActionType,
+                          correctionBoxId: shouldClearMarkMissing
+                            ? ""
+                            : prev.correctionBoxId,
+                          correctionPositionCoordinate: shouldClearMarkMissing
+                            ? ""
+                            : prev.correctionPositionCoordinate,
+                        };
+                      });
+                    }}
+                  />
+                </Column>
+                <Column lg={16} md={8} sm={4}>
+                  <TextArea
+                    id="correctiveAction"
+                    labelText={intl.formatMessage({
+                      id: "biorepository.qc.correctiveAction",
+                      defaultMessage: "Corrective Action Taken (Required)",
+                    })}
+                    value={bulkApplyValues.correctiveAction}
+                    onChange={(e) =>
+                      setBulkApplyValues((prev) => ({
+                        ...prev,
+                        correctiveAction: e.target.value,
+                      }))
+                    }
+                    placeholder={intl.formatMessage({
+                      id: "biorepository.qc.correctiveAction.placeholder",
+                      defaultMessage:
+                        "Describe the corrective action taken to resolve the discrepancy...",
+                    })}
+                    rows={3}
+                  />
+                </Column>
+              </Grid>
+
+              {selectedForBulkApply.length > 1 && (
+                <InlineNotification
+                  kind="info"
+                  title={intl.formatMessage({
+                    id: "biorepository.qc.correction.multipleSelection",
+                    defaultMessage:
+                      "Correction workflow actions can be executed for one sample at a time.",
+                  })}
+                  subtitle={intl.formatMessage({
+                    id: "biorepository.qc.correction.multipleSelectionSubtitle",
+                    defaultMessage:
+                      "For this bulk discrepancy record, correction action fields are optional. Re-open with a single sample to apply location/missing corrections.",
+                  })}
+                  lowContrast
+                />
+              )}
+
+              <Grid fullWidth style={{ marginTop: "1rem" }}>
+                <Column lg={16} md={8} sm={4}>
+                  <Dropdown
+                    id="correctionActionType"
+                    titleText={intl.formatMessage({
+                      id: "biorepository.qc.correctionAction",
+                      defaultMessage:
+                        selectedForBulkApply.length === 1
+                          ? "Correction Workflow Action (Required for single-sample fail)"
+                          : "Correction Workflow Action (Optional for bulk fail)",
+                    })}
+                    label={intl.formatMessage({
+                      id: "biorepository.qc.correctionAction.placeholder",
+                      defaultMessage: "Select correction action",
+                    })}
+                    items={correctionActionOptions}
+                    itemToString={(item) => (item ? item.label : "")}
+                    selectedItem={correctionActionOptions.find(
+                      (action) => action.id === bulkApplyValues.correctionActionType,
+                    )}
+                    onChange={({ selectedItem }) =>
+                      setBulkApplyValues((prev) => ({
+                        ...prev,
+                        correctionActionType: selectedItem?.id || "",
+                        correctionBoxId: "",
+                        correctionPositionCoordinate: "",
+                      }))
+                    }
+                  />
+                </Column>
+
+                {["UPDATE_LOCATION", "REASSIGN_POSITION"].includes(
+                  bulkApplyValues.correctionActionType,
+                ) && (
+                  <Column lg={16} md={8} sm={4} style={{ marginTop: "1rem" }}>
+                    <Dropdown
+                      id="correctionBoxId"
+                      titleText={intl.formatMessage({
+                        id: "biorepository.qc.correctionTargetBox",
+                        defaultMessage: "Target Box",
+                      })}
+                      label={intl.formatMessage({
+                        id: "biorepository.qc.correctionTargetBox.placeholder",
+                        defaultMessage: "Select target box",
+                      })}
+                      items={availableBoxes}
+                      itemToString={(item) => (item ? item.label : "")}
+                      selectedItem={availableBoxes.find(
+                        (box) => box.id === bulkApplyValues.correctionBoxId,
+                      )}
+                      onChange={({ selectedItem }) =>
+                        setBulkApplyValues((prev) => ({
+                          ...prev,
+                          correctionBoxId: selectedItem?.id || "",
+                        }))
+                      }
+                      disabled={loadingBoxes}
+                    />
+                  </Column>
+                )}
+
+                {bulkApplyValues.correctionActionType === "REASSIGN_POSITION" && (
+                  <Column lg={16} md={8} sm={4} style={{ marginTop: "1rem" }}>
+                    <TextInput
+                      id="correctionPositionCoordinate"
+                      labelText={intl.formatMessage({
+                        id: "biorepository.qc.correctionPositionCoordinate",
+                        defaultMessage: "New Position Coordinate",
+                      })}
+                      value={bulkApplyValues.correctionPositionCoordinate}
+                      onChange={(e) =>
+                        setBulkApplyValues((prev) => ({
+                          ...prev,
+                          correctionPositionCoordinate: e.target.value,
+                        }))
+                      }
+                      placeholder={intl.formatMessage({
+                        id: "biorepository.qc.correctionPositionCoordinate.placeholder",
+                        defaultMessage: "e.g., A3",
+                      })}
+                    />
+                  </Column>
+                )}
+
+                {bulkApplyValues.correctionActionType && (
+                  <Column lg={16} md={8} sm={4} style={{ marginTop: "1rem" }}>
+                    <TextArea
+                      id="correctionReason"
+                      labelText={intl.formatMessage({
+                        id: "biorepository.qc.correctionReason",
+                        defaultMessage: "Correction Reason (Optional)",
+                      })}
+                      value={bulkApplyValues.correctionReason}
+                      onChange={(e) =>
+                        setBulkApplyValues((prev) => ({
+                          ...prev,
+                          correctionReason: e.target.value,
+                        }))
+                      }
+                      rows={2}
+                      placeholder={intl.formatMessage({
+                        id: "biorepository.qc.correctionReason.placeholder",
+                        defaultMessage:
+                          "Reason shown in audit trail (falls back to corrective action text if empty)",
+                      })}
+                    />
+                  </Column>
+                )}
+              </Grid>
+            </div>
+          )}
+
+          {/* Remarks (Optional) */}
+          <div className="qc-section">
+            <Grid fullWidth>
+              <Column lg={16} md={8} sm={4}>
+                <TextArea
+                  id="remarks"
+                  labelText={intl.formatMessage({
+                    id: "biorepository.qc.remarks",
+                    defaultMessage:
+                      bulkApplyValues.qcResult === "DISCREPANCY_FOUND"
+                        ? "Remarks / Comment (Required for discrepancy)"
+                        : "Remarks (Optional)",
+                  })}
+                  value={bulkApplyValues.remarks}
+                  onChange={(e) =>
+                    setBulkApplyValues((prev) => ({
+                      ...prev,
+                      remarks: e.target.value,
+                    }))
+                  }
+                  placeholder={intl.formatMessage({
+                    id: "biorepository.qc.remarks.placeholder",
+                    defaultMessage: "Additional observations or notes...",
+                  })}
+                  rows={2}
+                />
+              </Column>
+            </Grid>
+          </div>
         </div>
       </Modal>
     </div>

--- a/frontend/src/components/notebook/pages/biorepository/BiorepositoryQCInspectionPage.js
+++ b/frontend/src/components/notebook/pages/biorepository/BiorepositoryQCInspectionPage.js
@@ -27,18 +27,13 @@ import {
   TableBatchAction,
   Loading,
 } from "@carbon/react";
-import { Checkmark, Edit, Renew, WarningAlt } from "@carbon/react/icons";
+import { Checkmark, Catalog, Renew, WarningAlt } from "@carbon/react/icons";
 import { FormattedMessage, useIntl } from "react-intl";
 import PropTypes from "prop-types";
 import {
   getFromOpenElisServer,
   postToOpenElisServerJsonResponse,
 } from "../../../utils/Utils";
-import {
-  getAllowedCorrectionActions,
-  hasInvalidMarkMissingLocationFields,
-  isMissingDiscrepancyType,
-} from "./qcCorrectionGuardrails";
 
 /**
  * QC Checklist items for Biorepository sample inspection
@@ -107,7 +102,7 @@ const CORRECTION_ACTIONS = [
 
 const ALL_OPTION = "__ALL__";
 
-const buildStorageOverviewQuery = (filters) => {
+const buildStorageOverviewQuery = (filters, includeInspected) => {
   const params = new URLSearchParams();
   ["freezer", "shelf", "rack", "box"].forEach((key) => {
     const value = filters?.[key];
@@ -115,6 +110,8 @@ const buildStorageOverviewQuery = (filters) => {
       params.set(key, value);
     }
   });
+  // Backend defaults to true; always send so unchecking the box applies this-quarter exclusion.
+  params.set("includeInspected", includeInspected ? "true" : "false");
   const query = params.toString();
   return query ? `?${query}` : "";
 };
@@ -165,11 +162,17 @@ function BiorepositoryQCInspectionPage({
     rack: ALL_OPTION,
     box: ALL_OPTION,
   });
+  const [includeInspectedSamples, setIncludeInspectedSamples] = useState(true);
   const [storageOverviewData, setStorageOverviewData] = useState({
     counts: { freezers: 0, shelves: 0, racks: 0, boxes: 0, eligibleSamples: 0 },
     filters: { freezers: [], shelves: [], racks: [], boxes: [] },
     eligibleSamples: [],
+    qcExclusionWindow: null,
   });
+  const [historyModalOpen, setHistoryModalOpen] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyRows, setHistoryRows] = useState([]);
+  const [historySampleLabel, setHistorySampleLabel] = useState("");
   const [roundSettings, setRoundSettings] = useState({
     boxesPerRound: "10",
     samplesPerBox: "3",
@@ -181,6 +184,10 @@ function BiorepositoryQCInspectionPage({
   const [bulkApplyModalOpen, setBulkApplyModalOpen] = useState(false);
   const [isBulkApplying, setIsBulkApplying] = useState(false);
   const [selectedForBulkApply, setSelectedForBulkApply] = useState([]); // Capture selection when modal opens
+  const [generatedRoundSampleIds, setGeneratedRoundSampleIds] = useState([]);
+  /** Snapshot of generate-round API `samples` so the checklist and table stay fixed until you exit round mode. */
+  const [generatedRoundResponseSamples, setGeneratedRoundResponseSamples] =
+    useState([]);
 
   // Bulk apply form values
   const [bulkApplyValues, setBulkApplyValues] = useState({
@@ -234,14 +241,31 @@ function BiorepositoryQCInspectionPage({
     );
   }, []);
 
+  const openInspectionHistory = useCallback((sample) => {
+    if (!sample?.id) {
+      return;
+    }
+    setHistorySampleLabel(sample.accessionNumber || String(sample.id));
+    setHistoryModalOpen(true);
+    setHistoryLoading(true);
+    setHistoryRows([]);
+    getFromOpenElisServer(
+      `/rest/biorepository/qc-inspection/history/${sample.id}`,
+      (response) => {
+        setHistoryLoading(false);
+        setHistoryRows(Array.isArray(response) ? response : []);
+      },
+    );
+  }, []);
+
   // Load samples on mount
   useEffect(() => {
     loadStoredSamples();
   }, [loadStoredSamples]);
 
-  const loadStorageOverview = useCallback((filters) => {
+  const loadStorageOverview = useCallback((filters, includeInspected) => {
     setLoadingStorageOverview(true);
-    const query = buildStorageOverviewQuery(filters);
+    const query = buildStorageOverviewQuery(filters, includeInspected);
     getFromOpenElisServer(
       `/rest/biorepository/qc-inspection/storage-overview${query}`,
       (response) => {
@@ -266,14 +290,15 @@ function BiorepositoryQCInspectionPage({
           eligibleSamples: Array.isArray(response.eligibleSamples)
             ? response.eligibleSamples
             : [],
+          qcExclusionWindow: response.qcExclusionWindow || null,
         });
       },
     );
   }, []);
 
   useEffect(() => {
-    loadStorageOverview(storageFilters);
-  }, [storageFilters, loadStorageOverview]);
+    loadStorageOverview(storageFilters, includeInspectedSamples);
+  }, [storageFilters, includeInspectedSamples, loadStorageOverview]);
 
   useEffect(() => {
     setLoadingBoxes(true);
@@ -328,6 +353,55 @@ function BiorepositoryQCInspectionPage({
     [samples, eligibleSampleIdSet],
   );
 
+  const selectedSamplesForBulkApply = useMemo(
+    () =>
+      samples.filter((sample) =>
+        selectedForBulkApply.includes(String(sample.id)),
+      ),
+    [samples, selectedForBulkApply],
+  );
+
+  const generatedRoundSampleSet = useMemo(
+    () => new Set(generatedRoundSampleIds.map((id) => String(id))),
+    [generatedRoundSampleIds],
+  );
+
+  const visibleSamples = useMemo(() => {
+    if (generatedRoundSampleIds.length === 0) {
+      return filteredSamples;
+    }
+    // During an active round, keep the same batch in the table. Do not re-apply
+    // the current eligible pool: after an inspection, "exclude this quarter" can
+    // drop rows from the pool and would make the batch disappear.
+    return samples.filter((sample) =>
+      generatedRoundSampleSet.has(String(sample.id)),
+    );
+  }, [
+    samples,
+    filteredSamples,
+    generatedRoundSampleIds.length,
+    generatedRoundSampleSet,
+  ]);
+
+  const sampleByBioSampleId = useMemo(
+    () => new Map(samples.map((sample) => [String(sample.id), sample])),
+    [samples],
+  );
+
+  const generatedRoundSamples = useMemo(
+    () =>
+      generatedRoundResponseSamples.length > 0
+        ? generatedRoundResponseSamples
+        : (storageOverviewData.eligibleSamples || []).filter((sample) =>
+            generatedRoundSampleSet.has(String(sample.bioSampleId)),
+          ),
+    [
+      generatedRoundResponseSamples,
+      storageOverviewData.eligibleSamples,
+      generatedRoundSampleSet,
+    ],
+  );
+
   const storageOverview = useMemo(
     () => ({
       freezers: storageOverviewData.counts.freezers || 0,
@@ -349,8 +423,7 @@ function BiorepositoryQCInspectionPage({
       1,
     );
 
-    const eligibleSamples = storageOverviewData.eligibleSamples || [];
-    if (eligibleSamples.length === 0) {
+    if ((storageOverviewData.eligibleSamples || []).length === 0) {
       setError(
         intl.formatMessage({
           id: "biorepository.qc.error.noSamplesForFilters",
@@ -363,136 +436,128 @@ function BiorepositoryQCInspectionPage({
 
     setIsGeneratingRound(true);
     setError(null);
-
-    const groupedByBox = new Map();
-    eligibleSamples.forEach((sample) => {
-      const key = [
-        sample.freezer || "Unknown",
-        sample.shelf || "Unknown",
-        sample.rack || "Unknown",
-        sample.box || "Unknown",
-      ].join(" > ");
-      if (!groupedByBox.has(key)) {
-        groupedByBox.set(key, []);
-      }
-      groupedByBox.get(key).push(sample);
-    });
-
-    const shuffle = (arr) => {
-      const copy = [...arr];
-      for (let i = copy.length - 1; i > 0; i -= 1) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [copy[i], copy[j]] = [copy[j], copy[i]];
-      }
-      return copy;
+    const payload = {
+      boxesPerRound,
+      samplesPerBox,
+      freezer:
+        storageFilters.freezer && storageFilters.freezer !== ALL_OPTION
+          ? storageFilters.freezer
+          : null,
+      shelf:
+        storageFilters.shelf && storageFilters.shelf !== ALL_OPTION
+          ? storageFilters.shelf
+          : null,
+      rack:
+        storageFilters.rack && storageFilters.rack !== ALL_OPTION
+          ? storageFilters.rack
+          : null,
+      box:
+        storageFilters.box && storageFilters.box !== ALL_OPTION
+          ? storageFilters.box
+          : null,
+      includeInspected: Boolean(includeInspectedSamples),
     };
 
-    const boxDescriptors = Array.from(groupedByBox.keys()).map((boxKey) => {
-      const [freezer, shelf, rack] = boxKey.split(" > ");
-      return {
-        boxKey,
-        shelfKey: `${freezer || "Unknown"} > ${shelf || "Unknown"}`,
-        rackKey: `${freezer || "Unknown"} > ${shelf || "Unknown"} > ${
-          rack || "Unknown"
-        }`,
-      };
-    });
+    postToOpenElisServerJsonResponse(
+      `/rest/biorepository/qc-inspection/generate-round`,
+      JSON.stringify(payload),
+      (response) => {
+        setIsGeneratingRound(false);
+        if (!response || response.error) {
+          setError(
+            response?.error ||
+              intl.formatMessage({
+                id: "biorepository.qc.error.generateRoundFailed",
+                defaultMessage: "Failed to generate QC round.",
+              }),
+          );
+          return;
+        }
 
-    const targetBoxCount = Math.min(boxesPerRound, boxDescriptors.length);
-    const selectedBoxKeys = [];
-    const selectedSet = new Set();
+        const selectedSamples = Array.isArray(response.samples)
+          ? response.samples
+          : [];
+        if (!selectedSamples.length) {
+          setError(
+            intl.formatMessage({
+              id: "biorepository.qc.error.emptyRound",
+              defaultMessage:
+                "No eligible samples were found to generate a QC round.",
+            }),
+          );
+          return;
+        }
 
-    // Pass 1: maximize shelf distribution.
-    const boxesByShelf = new Map();
-    boxDescriptors.forEach((descriptor) => {
-      if (!boxesByShelf.has(descriptor.shelfKey)) {
-        boxesByShelf.set(descriptor.shelfKey, []);
-      }
-      boxesByShelf.get(descriptor.shelfKey).push(descriptor.boxKey);
-    });
-
-    shuffle(Array.from(boxesByShelf.keys())).forEach((shelfKey) => {
-      if (selectedBoxKeys.length >= targetBoxCount) return;
-      const candidate = shuffle(boxesByShelf.get(shelfKey)).find(
-        (boxKey) => !selectedSet.has(boxKey),
-      );
-      if (candidate) {
-        selectedBoxKeys.push(candidate);
-        selectedSet.add(candidate);
-      }
-    });
-
-    // Pass 2: maximize rack distribution.
-    const boxesByRack = new Map();
-    boxDescriptors.forEach((descriptor) => {
-      if (!boxesByRack.has(descriptor.rackKey)) {
-        boxesByRack.set(descriptor.rackKey, []);
-      }
-      boxesByRack.get(descriptor.rackKey).push(descriptor.boxKey);
-    });
-
-    shuffle(Array.from(boxesByRack.keys())).forEach((rackKey) => {
-      if (selectedBoxKeys.length >= targetBoxCount) return;
-      const candidate = shuffle(boxesByRack.get(rackKey)).find(
-        (boxKey) => !selectedSet.has(boxKey),
-      );
-      if (candidate) {
-        selectedBoxKeys.push(candidate);
-        selectedSet.add(candidate);
-      }
-    });
-
-    // Pass 3: fill remaining slots randomly from any unselected boxes.
-    const remainingBoxes = shuffle(boxDescriptors.map((d) => d.boxKey)).filter(
-      (boxKey) => !selectedSet.has(boxKey),
+        setGeneratedRoundResponseSamples(selectedSamples);
+        setGeneratedRoundSampleIds(
+          selectedSamples.map((sample) => String(sample.bioSampleId)),
+        );
+        setRoundInfo({
+          qcBatchId: response.qcBatchId || null,
+          boxesSelected: response.boxesSelected || 0,
+          samplesSelected: selectedSamples.length,
+          filteredSamplePool:
+            response.filteredSamplePool ||
+            (storageOverviewData.eligibleSamples || []).length,
+        });
+      },
     );
-    remainingBoxes.forEach((boxKey) => {
-      if (selectedBoxKeys.length >= targetBoxCount) return;
-      selectedBoxKeys.push(boxKey);
-      selectedSet.add(boxKey);
-    });
+  }, [
+    intl,
+    roundSettings.boxesPerRound,
+    roundSettings.samplesPerBox,
+    storageFilters.box,
+    storageFilters.freezer,
+    storageFilters.rack,
+    storageFilters.shelf,
+    includeInspectedSamples,
+    storageOverviewData.eligibleSamples,
+  ]);
 
-    const selectedSamples = [];
-    selectedBoxKeys.forEach((boxKey) => {
-      const boxSamples = [...(groupedByBox.get(boxKey) || [])];
-      for (let i = boxSamples.length - 1; i > 0; i -= 1) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [boxSamples[i], boxSamples[j]] = [boxSamples[j], boxSamples[i]];
-      }
-      selectedSamples.push(
-        ...boxSamples.slice(0, Math.min(samplesPerBox, boxSamples.length)),
-      );
-    });
+  const generatedRoundRows = useMemo(
+    () =>
+      generatedRoundSamples.map((sample, index) => {
+        const linkedSample = sampleByBioSampleId.get(String(sample.bioSampleId));
+        return {
+          id: `${sample.bioSampleId || "sample"}-${index}`,
+          freezer: sample.freezer || "Unknown",
+          shelf: sample.shelf || "Unknown",
+          rack: sample.rack || "Unknown",
+          box: sample.box || "Unknown",
+          position: sample.positionCoordinate || "-",
+          sampleNumber:
+            linkedSample?.accessionNumber || sample.accessionNumber || "-",
+          sampleId: linkedSample?.externalId || "-",
+        };
+      }),
+    [generatedRoundSamples, sampleByBioSampleId],
+  );
 
-    if (selectedSamples.length === 0) {
-      setIsGeneratingRound(false);
+  const generatedRoundHeaders = [
+    { key: "freezer", header: "Freezer" },
+    { key: "shelf", header: "Shelf" },
+    { key: "rack", header: "Rack" },
+    { key: "box", header: "Box" },
+    { key: "position", header: "Position" },
+    { key: "sampleNumber", header: "Sample Number" },
+    { key: "sampleId", header: "Sample ID" },
+  ];
+
+  const openInspectionModal = useCallback((sampleIds) => {
+    if (!Array.isArray(sampleIds) || sampleIds.length === 0) {
       setError(
         intl.formatMessage({
-          id: "biorepository.qc.error.emptyRound",
-          defaultMessage:
-            "No eligible samples were found to generate a QC round.",
+          id: "biorepository.qc.error.noSelection",
+          defaultMessage: "Please select samples to inspect.",
         }),
       );
       return;
     }
 
-    setSelectedForBulkApply(
-      selectedSamples.map((sample) => String(sample.bioSampleId)),
-    );
-    setRoundInfo({
-      boxesSelected: selectedBoxKeys.length,
-      samplesSelected: selectedSamples.length,
-      filteredSamplePool: eligibleSamples.length,
-    });
+    setSelectedForBulkApply(sampleIds);
     resetBulkApplyValues();
     setBulkApplyModalOpen(true);
-    setIsGeneratingRound(false);
-  }, [
-    intl,
-    roundSettings.boxesPerRound,
-    roundSettings.samplesPerBox,
-    storageOverviewData.eligibleSamples,
-  ]);
+  }, [intl]);
 
   // Reset bulk apply values
   const resetBulkApplyValues = () => {
@@ -668,31 +733,6 @@ function BiorepositoryQCInspectionPage({
       }
 
       if (
-        bulkApplyValues.correctionActionType === "MARK_MISSING" &&
-        !isMissingDiscrepancyType(bulkApplyValues.discrepancyType)
-      ) {
-        setError(
-          intl.formatMessage({
-            id: "biorepository.qc.error.markMissingRequiresMissingDiscrepancy",
-            defaultMessage:
-              "Mark missing is only allowed when discrepancy type is Sample missing.",
-          }),
-        );
-        return;
-      }
-
-      if (hasInvalidMarkMissingLocationFields(bulkApplyValues)) {
-        setError(
-          intl.formatMessage({
-            id: "biorepository.qc.error.markMissingLocationFieldsNotAllowed",
-            defaultMessage:
-              "Location and position inputs are not allowed for Mark missing correction.",
-          }),
-        );
-        return;
-      }
-
-      if (
         ["UPDATE_LOCATION", "REASSIGN_POSITION"].includes(
           bulkApplyValues.correctionActionType,
         ) &&
@@ -723,16 +763,107 @@ function BiorepositoryQCInspectionPage({
       }
     }
 
+    const parsedInspectionDate = bulkApplyValues.inspectionDate
+      ? new Date(bulkApplyValues.inspectionDate)
+      : null;
+    if (!parsedInspectionDate || Number.isNaN(parsedInspectionDate.getTime())) {
+      setError(
+        intl.formatMessage({
+          id: "biorepository.qc.error.invalidInspectionDate",
+          defaultMessage:
+            "Please provide a valid inspection date and time before recording verification.",
+        }),
+      );
+      return;
+    }
+
     setIsBulkApplying(true);
     setError(null);
+
+    const getFriendlyBulkApplyError = (response) => {
+      const rawError = response?.error || response?.message || "";
+      const normalized = String(rawError).toLowerCase();
+
+      if (!rawError) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.apply",
+          defaultMessage: "Failed to apply QC inspection. Please try again.",
+        });
+      }
+
+      if (normalized.includes("supports exactly one sample")) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.correctionSingleOnly",
+          defaultMessage:
+            "Correction workflow currently supports one sample at a time. Select a single sample for correction.",
+        });
+      }
+
+      if (normalized.includes("correction workflow can only be used")) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.correctionRequiresDiscrepancy",
+          defaultMessage:
+            "Correction workflow actions are only available when QC result is discrepancy.",
+        });
+      }
+
+      if (normalized.includes("discrepancy type is required")) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.noDiscrepancyType",
+          defaultMessage: "Please select a discrepancy type.",
+        });
+      }
+
+      if (normalized.includes("corrective action is required")) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.noCorrectiveAction",
+          defaultMessage: "Please describe the corrective action taken.",
+        });
+      }
+
+      if (normalized.includes("comment/remarks is required")) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.noRemarks",
+          defaultMessage: "Please enter comment/remarks for discrepancy findings.",
+        });
+      }
+
+      if (normalized.includes("unsupported correction action")) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.unsupportedCorrection",
+          defaultMessage:
+            "Unsupported correction workflow action selected. Please choose a valid option.",
+        });
+      }
+
+      if (normalized.includes("locationid and locationtype are required")) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.noCorrectionLocation",
+          defaultMessage:
+            "Select a target storage box for update/reassign correction.",
+        });
+      }
+
+      if (response?.status === 401 || response?.status === 403) {
+        return intl.formatMessage({
+          id: "biorepository.qc.error.sessionExpired",
+          defaultMessage:
+            "Your session has expired or you do not have permission. Please log in again and retry.",
+        });
+      }
+
+      return intl.formatMessage({
+        id: "biorepository.qc.error.apply",
+        defaultMessage: "Failed to apply QC inspection. Please try again.",
+      });
+    };
 
     // Prepare request payload
     const payload = {
       bioSampleIds: selectedForBulkApply.map((id) => parseInt(id, 10)),
       inspectorName: bulkApplyValues.inspectorName.trim(),
-      inspectionDate: bulkApplyValues.inspectionDate
-        ? new Date(bulkApplyValues.inspectionDate).toISOString()
-        : null,
+      inspectionDate: parsedInspectionDate.toISOString(),
+      qcBatchId: roundInfo?.qcBatchId || null,
       samplePresent: bulkApplyValues.qcChecklist.samplePresent,
       labelIntegrity: bulkApplyValues.qcChecklist.labelIntegrity,
       containerIntegrity: bulkApplyValues.qcChecklist.containerIntegrity,
@@ -789,7 +920,8 @@ function BiorepositoryQCInspectionPage({
             intl.formatMessage(
               {
                 id: "biorepository.qc.success.applied",
-                defaultMessage: "QC inspection applied to {count} sample(s).",
+                defaultMessage:
+                  "QC record saved for {count} sample(s). Review status in this table and Reporting & Audit.",
               },
               { count },
             ),
@@ -798,18 +930,12 @@ function BiorepositoryQCInspectionPage({
           resetBulkApplyValues();
           setSelectedForBulkApply([]); // Clear captured selection
           loadStoredSamples();
+          loadStorageOverview(storageFilters, includeInspectedSamples);
           if (onProgressUpdate) {
             onProgressUpdate();
           }
         } else {
-          setError(
-            response?.error ||
-              intl.formatMessage({
-                id: "biorepository.qc.error.apply",
-                defaultMessage:
-                  "Failed to apply QC inspection. Please try again.",
-              }),
-          );
+          setError(getFriendlyBulkApplyError(response));
         }
       },
     );
@@ -818,6 +944,9 @@ function BiorepositoryQCInspectionPage({
     bulkApplyValues,
     intl,
     loadStoredSamples,
+    loadStorageOverview,
+    storageFilters,
+    includeInspectedSamples,
     onProgressUpdate,
   ]);
 
@@ -837,29 +966,6 @@ function BiorepositoryQCInspectionPage({
     return Object.values(bulkApplyValues.qcChecklist).filter((v) => v).length;
   }, [bulkApplyValues.qcChecklist]);
 
-  const correctionActionOptions = useMemo(
-    () =>
-      getAllowedCorrectionActions(
-        CORRECTION_ACTIONS,
-        bulkApplyValues.discrepancyType,
-      ),
-    [bulkApplyValues.discrepancyType],
-  );
-
-  useEffect(() => {
-    if (
-      bulkApplyValues.correctionActionType === "MARK_MISSING" &&
-      !isMissingDiscrepancyType(bulkApplyValues.discrepancyType)
-    ) {
-      setBulkApplyValues((prev) => ({
-        ...prev,
-        correctionActionType: "",
-        correctionBoxId: "",
-        correctionPositionCoordinate: "",
-      }));
-    }
-  }, [bulkApplyValues.correctionActionType, bulkApplyValues.discrepancyType]);
-
   // Get QC result tag
   const getQCTag = (qcResult, qcStatus) => {
     if (!qcResult) return <Tag type="gray">Pending</Tag>;
@@ -869,6 +975,46 @@ function BiorepositoryQCInspectionPage({
       return <Tag type="red">Discrepancy</Tag>;
     return <Tag type="gray">{qcResult}</Tag>;
   };
+
+  const getDiscrepancyResolutionLabel = (inspection) => {
+    if (!inspection || inspection.qcResult !== "DISCREPANCY_FOUND") {
+      return "";
+    }
+    if (inspection.lifecycleOutcome === "FAILED_CORRECTED") {
+      return "Correction logged";
+    }
+    if (
+      inspection.lifecycleOutcome === "FAILED_MARKED_MISSING" ||
+      inspection.qcStatus === "MISSING"
+    ) {
+      return "Marked missing";
+    }
+    if (inspection.lifecycleOutcome === "FAILED_PENDING_CORRECTION") {
+      return "Correction required";
+    }
+    if (inspection.correctionActionType) {
+      return "Correction logged";
+    }
+    return "Correction required";
+  };
+
+  const unresolvedDiscrepancyCount = useMemo(
+    () =>
+      samples.filter((sample) => {
+        const inspection = sample.lastQCInspection;
+        if (!inspection || inspection.qcResult !== "DISCREPANCY_FOUND") {
+          return false;
+        }
+        return getDiscrepancyResolutionLabel(inspection) === "Correction required";
+      }).length,
+    [samples],
+  );
+
+  const discrepancyLabelById = useMemo(
+    () =>
+      new Map(DISCREPANCY_TYPES.map((type) => [String(type.id), type.label])),
+    [],
+  );
 
   // Table headers
   const headers = [
@@ -905,6 +1051,20 @@ function BiorepositoryQCInspectionPage({
       header: intl.formatMessage({
         id: "biorepository.qc.lastInspection",
         defaultMessage: "Last QC Inspection",
+      }),
+    },
+    {
+      key: "inspectionHistory",
+      header: intl.formatMessage({
+        id: "biorepository.qc.historyColumn",
+        defaultMessage: "History",
+      }),
+    },
+    {
+      key: "actions",
+      header: intl.formatMessage({
+        id: "biorepository.qc.actions",
+        defaultMessage: "Actions",
       }),
     },
   ];
@@ -988,6 +1148,25 @@ function BiorepositoryQCInspectionPage({
           lowContrast
         />
       )}
+      {unresolvedDiscrepancyCount > 0 && (
+        <InlineNotification
+          kind="warning"
+          title={intl.formatMessage(
+            {
+              id: "biorepository.qc.unresolvedDiscrepancies",
+              defaultMessage:
+                "{count} discrepancy record(s) still need correction review.",
+            },
+            { count: unresolvedDiscrepancyCount },
+          )}
+          subtitle={intl.formatMessage({
+            id: "biorepository.qc.unresolvedDiscrepancies.message",
+            defaultMessage:
+              "Use Inspect to complete correction, open History for the full per-sample log, and review pending items in Reporting & Audit > Detailed Metrics > QC History.",
+          })}
+          lowContrast
+        />
+      )}
 
       {roundInfo && (
         <InlineNotification
@@ -996,9 +1175,10 @@ function BiorepositoryQCInspectionPage({
             {
               id: "biorepository.qc.round.generated",
               defaultMessage:
-                "QC round generated from filtered storage scope: {boxes} box(es), {samples} sample(s) from {pool} eligible sample(s).",
+                "QC batch {batch} generated from filtered storage scope: {boxes} box(es), {samples} sample(s) from {pool} eligible sample(s). Inspect rows individually or with Bulk Inspect.",
             },
             {
+              batch: roundInfo.qcBatchId || "N/A",
               boxes: roundInfo.boxesSelected,
               samples: roundInfo.samplesSelected,
               pool: roundInfo.filteredSamplePool,
@@ -1127,6 +1307,54 @@ function BiorepositoryQCInspectionPage({
             disabled={loadingStorageOverview}
           />
         </Column>
+        <Column
+          lg={16}
+          md={8}
+          sm={4}
+          style={{ marginTop: "0.75rem", marginBottom: "0.25rem" }}
+        >
+          <Checkbox
+            id="qc-include-inspected"
+            labelText={intl.formatMessage({
+              id: "biorepository.qc.includeInspected.quarterly",
+              defaultMessage:
+                "Include samples already inspected in the current calendar quarter (full pool)",
+            })}
+            checked={includeInspectedSamples}
+            onChange={(_, { checked }) =>
+              setIncludeInspectedSamples(Boolean(checked))
+            }
+            disabled={loadingStorageOverview || isGeneratingRound}
+          />
+          {storageOverviewData.qcExclusionWindow && (
+            <p
+              className="cds--form__helper-text"
+              style={{ marginTop: "0.35rem", maxWidth: "48rem" }}
+            >
+              {includeInspectedSamples
+                ? intl.formatMessage(
+                    {
+                      id: "biorepository.qc.poolHelp.inclusive",
+                      defaultMessage:
+                        "Current calendar quarter: {period}. Eligible pool includes all placed samples in scope (you can re-QC the same aliquot in the same quarter when needed).",
+                    },
+                    {
+                      period: storageOverviewData.qcExclusionWindow.label,
+                    },
+                  )
+                : intl.formatMessage(
+                    {
+                      id: "biorepository.qc.poolHelp.exclusive",
+                      defaultMessage:
+                        "Current calendar quarter: {period}. Excludes samples that already have at least one QC inspection dated in this window (not-yet-this-quarter worklist).",
+                    },
+                    {
+                      period: storageOverviewData.qcExclusionWindow.label,
+                    },
+                  )}
+            </p>
+          )}
+        </Column>
       </Grid>
 
       <Grid fullWidth style={{ marginBottom: "1rem" }}>
@@ -1160,7 +1388,12 @@ function BiorepositoryQCInspectionPage({
           lg={8}
           md={8}
           sm={4}
-          style={{ display: "flex", alignItems: "flex-end" }}
+          style={{
+            display: "flex",
+            alignItems: "flex-end",
+            gap: "0.75rem",
+            flexWrap: "wrap",
+          }}
         >
           <Button
             kind="secondary"
@@ -1174,8 +1407,60 @@ function BiorepositoryQCInspectionPage({
           >
             Generate Random QC Round
           </Button>
+          {generatedRoundSampleIds.length > 0 && (
+            <Button
+              kind="ghost"
+              size="sm"
+              onClick={() => {
+                setGeneratedRoundSampleIds([]);
+                setGeneratedRoundResponseSamples([]);
+                setRoundInfo(null);
+              }}
+            >
+              Show all eligible samples
+            </Button>
+          )}
         </Column>
       </Grid>
+
+      {generatedRoundRows.length > 0 && (
+        <Grid fullWidth style={{ marginTop: "1rem" }}>
+          <Column lg={16} md={8} sm={4}>
+            <DataTable rows={generatedRoundRows} headers={generatedRoundHeaders}>
+              {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
+                <TableContainer
+                  title="Generated QC Checklist"
+                  description="Technician path guidance: Freezer > Shelf > Rack > Box > Position"
+                >
+                  <Table {...getTableProps()}>
+                    <TableHead>
+                      <TableRow>
+                        {headers.map((header) => (
+                          <TableHeader
+                            key={header.key}
+                            {...getHeaderProps({ header })}
+                          >
+                            {header.header}
+                          </TableHeader>
+                        ))}
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {rows.map((row) => (
+                        <TableRow key={row.id} {...getRowProps({ row })}>
+                          {row.cells.map((cell) => (
+                            <TableCell key={cell.id}>{cell.value}</TableCell>
+                          ))}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              )}
+            </DataTable>
+          </Column>
+        </Grid>
+      )}
 
       {/* Samples Table */}
       <div className="sample-table-section" style={{ marginTop: "1rem" }}>
@@ -1183,7 +1468,7 @@ function BiorepositoryQCInspectionPage({
           <div style={{ padding: "2rem", textAlign: "center" }}>
             <Loading withOverlay={false} />
           </div>
-        ) : filteredSamples.length === 0 ? (
+        ) : visibleSamples.length === 0 ? (
           <InlineNotification
             kind="info"
             title={intl.formatMessage({
@@ -1200,13 +1485,15 @@ function BiorepositoryQCInspectionPage({
           />
         ) : (
           <DataTable
-            rows={filteredSamples.map((sample) => ({
+            rows={visibleSamples.map((sample) => ({
               id: sample.id.toString(),
               accessionNumber: sample.accessionNumber,
               sampleType: sample.sampleType,
               locationPath: sample.locationPath,
               biosafetyLevel: sample.biosafetyLevel,
               lastQCInspection: sample.lastQCInspection,
+              inspectionHistory: sample.id.toString(),
+              actions: sample.id.toString(),
               _raw: sample,
             }))}
             headers={headers}
@@ -1229,21 +1516,20 @@ function BiorepositoryQCInspectionPage({
                   <TableToolbar>
                     <TableBatchActions {...getBatchActionProps()}>
                       <TableBatchAction
-                        renderIcon={Edit}
+                        renderIcon={Renew}
                         iconDescription={intl.formatMessage({
                           id: "biorepository.qc.bulkApply",
-                          defaultMessage: "Bulk Apply QC",
+                          defaultMessage: "Bulk Inspect",
                         })}
                         onClick={() => {
                           // Capture selection when modal opens
                           setSelectedForBulkApply(currentSelectedIds);
-                          resetBulkApplyValues();
-                          setBulkApplyModalOpen(true);
+                          openInspectionModal(currentSelectedIds);
                         }}
                       >
                         <FormattedMessage
                           id="biorepository.qc.bulkApply"
-                          defaultMessage="Bulk Apply QC"
+                          defaultMessage="Bulk Inspect"
                         />
                       </TableBatchAction>
                     </TableBatchActions>
@@ -1278,7 +1564,7 @@ function BiorepositoryQCInspectionPage({
                     </TableHead>
                     <TableBody>
                       {rows.map((row) => {
-                        const sample = filteredSamples.find(
+                        const sample = visibleSamples.find(
                           (s) => s.id.toString() === row.id,
                         );
                         return (
@@ -1309,6 +1595,11 @@ function BiorepositoryQCInspectionPage({
                                   );
                                 }
                                 const qc = sample.lastQCInspection;
+                                const discrepancyLabel = qc?.discrepancyType
+                                  ? discrepancyLabelById.get(
+                                      String(qc.discrepancyType),
+                                    ) || String(qc.discrepancyType)
+                                  : null;
                                 return (
                                   <TableCell key={cell.id}>
                                     <div
@@ -1330,6 +1621,65 @@ function BiorepositoryQCInspectionPage({
                                         ).toLocaleDateString()}
                                       </span>
                                     </div>
+                                    {qc.qcResult === "DISCREPANCY_FOUND" && (
+                                      <div
+                                        style={{
+                                          marginTop: "0.25rem",
+                                          fontSize: "0.75rem",
+                                          color: "#8a3c00",
+                                        }}
+                                      >
+                                        {discrepancyLabel
+                                          ? `Failed: ${discrepancyLabel}. ${getDiscrepancyResolutionLabel(
+                                              qc,
+                                            )}.`
+                                          : `Failed QC. ${getDiscrepancyResolutionLabel(
+                                              qc,
+                                            )}.`}
+                                      </div>
+                                    )}
+                                  </TableCell>
+                                );
+                              }
+                              if (cell.info.header === "inspectionHistory") {
+                                return (
+                                  <TableCell key={cell.id}>
+                                    <Button
+                                      kind="ghost"
+                                      size="sm"
+                                      renderIcon={Catalog}
+                                      iconDescription={intl.formatMessage({
+                                        id: "biorepository.qc.openHistory",
+                                        defaultMessage: "Open inspection history",
+                                      })}
+                                      onClick={() =>
+                                        openInspectionHistory(sample)
+                                      }
+                                    >
+                                      <FormattedMessage
+                                        id="biorepository.qc.viewHistory"
+                                        defaultMessage="View history"
+                                      />
+                                    </Button>
+                                  </TableCell>
+                                );
+                              }
+                              if (cell.info.header === "actions") {
+                                return (
+                                  <TableCell key={cell.id}>
+                                    <Button
+                                      kind="ghost"
+                                      size="sm"
+                                      renderIcon={Checkmark}
+                                      onClick={() =>
+                                        openInspectionModal([row.id])
+                                      }
+                                    >
+                                      <FormattedMessage
+                                        id="biorepository.qc.inspect"
+                                        defaultMessage="Inspect"
+                                      />
+                                    </Button>
                                   </TableCell>
                                 );
                               }
@@ -1356,8 +1706,14 @@ function BiorepositoryQCInspectionPage({
         open={bulkApplyModalOpen}
         onRequestClose={() => setBulkApplyModalOpen(false)}
         modalHeading={intl.formatMessage({
-          id: "biorepository.qc.bulkApply.title",
-          defaultMessage: "Bulk QC Inspection",
+          id:
+            selectedForBulkApply.length === 1
+              ? "biorepository.qc.singleInspect.title"
+              : "biorepository.qc.bulkApply.title",
+          defaultMessage:
+            selectedForBulkApply.length === 1
+              ? "Individual QC Inspection"
+              : "Bulk QC Inspection",
         })}
         primaryButtonText={
           isBulkApplying
@@ -1392,11 +1748,25 @@ function BiorepositoryQCInspectionPage({
       >
         <div className="qc-bulk-apply-modal">
           <p className="modal-description">
-            <FormattedMessage
-              id="biorepository.qc.bulkApply.description"
-              defaultMessage="Apply QC inspection to {count} selected sample(s)."
-              values={{ count: selectedForBulkApply.length }}
-            />
+            {selectedForBulkApply.length === 1 &&
+            selectedSamplesForBulkApply[0] ? (
+              <FormattedMessage
+                id="biorepository.qc.singleInspect.description"
+                defaultMessage="Inspect sample {sample} at {location}."
+                values={{
+                  sample:
+                    selectedSamplesForBulkApply[0].accessionNumber || "-",
+                  location:
+                    selectedSamplesForBulkApply[0].locationPath || "Unknown",
+                }}
+              />
+            ) : (
+              <FormattedMessage
+                id="biorepository.qc.bulkApply.description"
+                defaultMessage="Apply QC inspection to {count} selected sample(s)."
+                values={{ count: selectedForBulkApply.length }}
+              />
+            )}
           </p>
 
           {/* Inspector Information */}
@@ -1562,27 +1932,12 @@ function BiorepositoryQCInspectionPage({
                     selectedItem={DISCREPANCY_TYPES.find(
                       (d) => d.id === bulkApplyValues.discrepancyType,
                     )}
-                    onChange={({ selectedItem }) => {
-                      const nextDiscrepancyType = selectedItem?.id || "";
-                      setBulkApplyValues((prev) => {
-                        const shouldClearMarkMissing =
-                          prev.correctionActionType === "MARK_MISSING" &&
-                          !isMissingDiscrepancyType(nextDiscrepancyType);
-                        return {
-                          ...prev,
-                          discrepancyType: nextDiscrepancyType,
-                          correctionActionType: shouldClearMarkMissing
-                            ? ""
-                            : prev.correctionActionType,
-                          correctionBoxId: shouldClearMarkMissing
-                            ? ""
-                            : prev.correctionBoxId,
-                          correctionPositionCoordinate: shouldClearMarkMissing
-                            ? ""
-                            : prev.correctionPositionCoordinate,
-                        };
-                      });
-                    }}
+                    onChange={({ selectedItem }) =>
+                      setBulkApplyValues((prev) => ({
+                        ...prev,
+                        discrepancyType: selectedItem?.id || "",
+                      }))
+                    }
                   />
                 </Column>
                 <Column lg={16} md={8} sm={4}>
@@ -1606,6 +1961,20 @@ function BiorepositoryQCInspectionPage({
                     })}
                     rows={3}
                   />
+                </Column>
+                <Column lg={16} md={8} sm={4}>
+                  <p
+                    style={{
+                      marginTop: "0.5rem",
+                      marginBottom: 0,
+                      color: "#525252",
+                      fontSize: "0.875rem",
+                    }}
+                  >
+                    Recorded discrepancies appear in this table immediately and
+                    in Reporting &amp; Audit &gt; Detailed Metrics &gt; QC
+                    History Snapshot.
+                  </p>
                 </Column>
               </Grid>
 
@@ -1641,9 +2010,9 @@ function BiorepositoryQCInspectionPage({
                       id: "biorepository.qc.correctionAction.placeholder",
                       defaultMessage: "Select correction action",
                     })}
-                    items={correctionActionOptions}
+                    items={CORRECTION_ACTIONS}
                     itemToString={(item) => (item ? item.label : "")}
-                    selectedItem={correctionActionOptions.find(
+                    selectedItem={CORRECTION_ACTIONS.find(
                       (action) => action.id === bulkApplyValues.correctionActionType,
                     )}
                     onChange={({ selectedItem }) =>
@@ -1768,6 +2137,87 @@ function BiorepositoryQCInspectionPage({
             </Grid>
           </div>
         </div>
+      </Modal>
+
+      <Modal
+        open={historyModalOpen}
+        passiveModal
+        onRequestClose={() => setHistoryModalOpen(false)}
+        modalHeading={intl.formatMessage(
+          {
+            id: "biorepository.qc.historyModal.title",
+            defaultMessage: "QC inspection history — {sample}",
+          },
+          { sample: historySampleLabel },
+        )}
+        size="lg"
+      >
+        {historyLoading ? (
+          <div style={{ padding: "2rem" }}>
+            <Loading withOverlay={false} description="Loading" />
+          </div>
+        ) : historyRows.length === 0 ? (
+          <p className="cds--form__helper-text">
+            <FormattedMessage
+              id="biorepository.qc.historyModal.empty"
+              defaultMessage="No inspection records for this sample yet."
+            />
+          </p>
+        ) : (
+          <div style={{ maxHeight: "24rem", overflow: "auto" }}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableHeader>ID</TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="biorepository.qc.historyModal.col.date"
+                      defaultMessage="Date / time"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="biorepository.qc.historyModal.col.result"
+                      defaultMessage="Result"
+                    />
+                  </TableHeader>
+                  <TableHeader>
+                    <FormattedMessage
+                      id="biorepository.qc.historyModal.col.inspector"
+                      defaultMessage="Inspector"
+                    />
+                  </TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {historyRows.map((h) => (
+                  <TableRow key={h.id || h.inspectionDate}>
+                    <TableCell>{h.id}</TableCell>
+                    <TableCell>
+                      {h.inspectionDate
+                        ? new Date(h.inspectionDate).toLocaleString()
+                        : "—"}
+                    </TableCell>
+                    <TableCell>
+                      {h.qcResult}
+                      {h.qcStatus ? ` (${h.qcStatus})` : ""}
+                    </TableCell>
+                    <TableCell>{h.inspectorName || "—"}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <p
+              className="cds--form__helper-text"
+              style={{ marginTop: "0.75rem" }}
+            >
+              <FormattedMessage
+                id="biorepository.qc.historyModal.hint"
+                defaultMessage="Full audit and correction detail for the lab is available under Reporting & Audit."
+              />
+            </p>
+          </div>
+        )}
       </Modal>
     </div>
   );

--- a/frontend/src/components/notebook/pages/biorepository/ManifestUploadModal.js
+++ b/frontend/src/components/notebook/pages/biorepository/ManifestUploadModal.js
@@ -19,6 +19,10 @@ import { FormattedMessage, useIntl } from "react-intl";
 import PropTypes from "prop-types";
 import * as XLSX from "xlsx";
 import { postToOpenElisServerJsonResponse } from "../../../utils/Utils";
+import {
+  translateManifestImportMessage,
+  translateManifestImportMessages,
+} from "./manifestImportErrorMessages";
 
 const MANIFEST_FIELDS = [
   "barcode",
@@ -215,6 +219,11 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
   const conditionalFields = CONDITIONAL_FIELDS;
   const optionalFields = OPTIONAL_FIELDS;
   const expectedHeaders = MANIFEST_FIELDS;
+
+  const formatImportMessage = useCallback(
+    (message) => translateManifestImportMessage(message, intl.formatMessage),
+    [intl],
+  );
 
   /**
    * Generate and download CSV template per spec FR-MAN-002
@@ -745,7 +754,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
       setLoading(false);
 
       if (validationResult?.error) {
-        setError(validationResult.message || validationResult.error);
+        setError(formatImportMessage(validationResult.message || validationResult.error));
         setImportStatus("parsed");
         return;
       }
@@ -772,7 +781,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
             backendErrors.push({
               row: row._rowNumber,
               field: "backend",
-              message: errMsg,
+              message: formatImportMessage(errMsg),
             });
           });
         }
@@ -816,6 +825,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     parsedData,
     validationErrors,
     intl,
+    formatImportMessage,
     transformToBackendFormat,
     validateWithBackend,
   ]);
@@ -875,12 +885,13 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
           );
           setImportStatus("preview");
         } else if (response?.error) {
-          setError(response.message || response.error);
+          setError(formatImportMessage(response.message || response.error));
           setImportStatus("preview");
         } else {
-          const rowErrors = Array.isArray(response?.rowErrors)
-            ? response.rowErrors
-            : [];
+          const rowErrors = translateManifestImportMessages(
+            response?.rowErrors,
+            intl.formatMessage,
+          );
           const registeredCount = Number(
             response?.registeredCount ?? response?.samples?.length ?? 0,
           );
@@ -922,6 +933,7 @@ function ManifestUploadModal({ open, onClose, shipmentId, onImportComplete }) {
     shipmentId,
     onImportComplete,
     intl,
+    formatImportMessage,
     transformToBackendFormat,
   ]);
 

--- a/frontend/src/components/notebook/pages/biorepository/manifestImportErrorMessages.js
+++ b/frontend/src/components/notebook/pages/biorepository/manifestImportErrorMessages.js
@@ -1,0 +1,289 @@
+const interpolate = (template, values = {}) =>
+  Object.entries(values).reduce((result, [key, value]) => {
+    return result.replace(new RegExp(`\\{${key}\\}`, "g"), String(value));
+  }, template);
+
+const renderMessage = (formatMessage, id, defaultMessage, values) => {
+  if (typeof formatMessage === "function") {
+    return formatMessage({ id, defaultMessage }, values);
+  }
+  return interpolate(defaultMessage, values);
+};
+
+const extractSampleContext = (message) => {
+  const match = String(message || "").match(/^Sample\s+'([^']+)'\s*:\s*(.+)$/i);
+  if (!match) {
+    return { sampleRef: null, detail: String(message || "").trim() };
+  }
+
+  return {
+    sampleRef: match[1],
+    detail: match[2].trim(),
+  };
+};
+
+const withSampleContext = (sampleRef, detail, formatMessage) => {
+  if (!sampleRef) {
+    return detail;
+  }
+
+  return renderMessage(
+    formatMessage,
+    "biorepository.manifest.error.sampleContext",
+    'Sample "{sampleRef}": {detail}',
+    { sampleRef, detail },
+  );
+};
+
+export const translateManifestImportMessage = (message, formatMessage) => {
+  if (!message) {
+    return "";
+  }
+
+  const { sampleRef, detail } = extractSampleContext(message);
+  const normalized = detail.toLowerCase();
+
+  if (normalized.startsWith("duplicate sample id in manifest:")) {
+    const sampleId = detail.split(":").slice(1).join(":").trim();
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.duplicateInManifest",
+        'This file contains the Sample ID "{sampleId}" more than once. Keep only one row for each sample.',
+        { sampleId },
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.startsWith("sample id already exists:")) {
+    const sampleId = detail.split(":").slice(1).join(":").trim();
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.sampleIdExists",
+        'Sample ID "{sampleId}" is already registered in the system.',
+        { sampleId },
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.startsWith("invalid sample type:")) {
+    const sampleType = detail.split(":").slice(1).join(":").trim();
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.invalidSampleTypeFriendly",
+        'Sample type "{sampleType}" is not recognized. Please correct it or use an existing sample type.',
+        { sampleType },
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("barcode is required")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.sampleIdRequiredFriendly",
+        "Sample ID is required.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("sample type is required")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.sampleTypeRequiredFriendly",
+        "Sample type is required.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("origin lab is required")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.originLabRequiredFriendly",
+        "Origin lab is required.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("receipt date is required")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.receiptDateRequiredFriendly",
+        "Receipt date is required.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("minimum storage temperature is required")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.minTempRequiredFriendly",
+        "Minimum storage temperature is required.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("maximum storage temperature is required")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.maxTempRequiredFriendly",
+        "Maximum storage temperature is required.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("maximum storage temperature must be greater than or equal to minimum storage temperature")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.tempRangeFriendly",
+        "Maximum storage temperature must be greater than or equal to the minimum storage temperature.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("invalid receipt date format")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.invalidReceiptDateFriendly",
+        "Receipt date is not in a supported format. Use yyyy-MM-dd or yyyy-MM-dd HH:mm:ss.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("invalid collection date format")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.invalidCollectionDateFriendly",
+        "Collection date is not in a supported format. Use yyyy-MM-dd, dd/MM/yyyy, or dd-MM-yyyy.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("invalid biosafety level")) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.invalidBiosafetyLevelFriendly",
+        "Biosafety level is invalid. Use BSL_1, BSL_2, BSL_3, or BSL_4.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.includes("user session not found") || normalized.includes("please log in again")) {
+    return renderMessage(
+      formatMessage,
+      "biorepository.manifest.error.sessionExpiredFriendly",
+      "Your session has expired. Please sign in again and retry the import.",
+    );
+  }
+
+  if (normalized.includes("no samples provided")) {
+    return renderMessage(
+      formatMessage,
+      "biorepository.manifest.error.noSamplesProvidedFriendly",
+      "The selected file does not contain any samples to import.",
+    );
+  }
+
+  if (normalized.includes("duplicate key value violates unique constraint")) {
+    let friendlyDetail = renderMessage(
+      formatMessage,
+      "biorepository.manifest.error.duplicateRecordFriendly",
+      "This row matches a record that already exists in the system.",
+    );
+
+    if (
+      normalized.includes("sample_item")
+      || normalized.includes("biosample")
+      || normalized.includes("barcode")
+      || normalized.includes("external_id")
+    ) {
+      friendlyDetail = renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.duplicateSampleFriendly",
+        "A sample with the same Sample ID already exists in the system.",
+      );
+    } else if (
+      normalized.includes("type_of_sample")
+      || normalized.includes("typeofsample")
+      || normalized.includes("local_abbreviation")
+    ) {
+      friendlyDetail = renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.duplicateSampleTypeFriendly",
+        "This sample type already exists in the system. Please validate the file again and retry the import.",
+      );
+    }
+
+    return withSampleContext(sampleRef, friendlyDetail, formatMessage);
+  }
+
+  if (
+    normalized.includes("could not execute statement")
+    || normalized.includes("constraint")
+    || normalized.includes("batch entry")
+    || normalized.includes("null value in column")
+    || normalized.includes("invalid input syntax")
+  ) {
+    return withSampleContext(
+      sampleRef,
+      renderMessage(
+        formatMessage,
+        "biorepository.manifest.error.genericDataFriendly",
+        "This row contains a value that could not be saved. Please review the row and try again.",
+      ),
+      formatMessage,
+    );
+  }
+
+  if (normalized.startsWith("failed to register samples:")) {
+    return renderMessage(
+      formatMessage,
+      "biorepository.manifest.error.failedToRegisterFriendly",
+      "Some samples could not be imported. Please review the row errors and correct the file before trying again.",
+    );
+  }
+
+  return withSampleContext(sampleRef, detail, formatMessage);
+};
+
+export const translateManifestImportMessages = (messages, formatMessage) =>
+  (Array.isArray(messages) ? messages : []).map((message) =>
+    translateManifestImportMessage(message, formatMessage),
+  );

--- a/frontend/src/components/notebook/pages/biorepository/manifestImportErrorMessages.test.js
+++ b/frontend/src/components/notebook/pages/biorepository/manifestImportErrorMessages.test.js
@@ -1,0 +1,68 @@
+import {
+  translateManifestImportMessage,
+  translateManifestImportMessages,
+} from "./manifestImportErrorMessages";
+
+const formatMessage = ({ defaultMessage }, values = {}) =>
+  Object.entries(values).reduce((result, [key, value]) => {
+    return result.replace(new RegExp(`\\{${key}\\}`, "g"), String(value));
+  }, defaultMessage);
+
+describe("manifestImportErrorMessages", () => {
+  it("translates duplicate sample ids in the manifest", () => {
+    expect(
+      translateManifestImportMessage(
+        "Duplicate sample ID in manifest: BIO-001",
+        formatMessage,
+      ),
+    ).toBe(
+      'This file contains the Sample ID "BIO-001" more than once. Keep only one row for each sample.',
+    );
+  });
+
+  it("translates existing sample ids in the system", () => {
+    expect(
+      translateManifestImportMessage(
+        "Sample ID already exists: BIO-002",
+        formatMessage,
+      ),
+    ).toBe('Sample ID "BIO-002" is already registered in the system.');
+  });
+
+  it("translates invalid sample types into user language", () => {
+    expect(
+      translateManifestImportMessage(
+        "Invalid sample type: old type",
+        formatMessage,
+      ),
+    ).toBe(
+      'Sample type "old type" is not recognized. Please correct it or use an existing sample type.',
+    );
+  });
+
+  it("translates raw duplicate-key errors with sample context", () => {
+    expect(
+      translateManifestImportMessage(
+        "Sample 'BIO-003': duplicate key value violates unique constraint \"type_of_sample_local_abbreviation_key\"",
+        formatMessage,
+      ),
+    ).toBe(
+      'Sample "BIO-003": This sample type already exists in the system. Please validate the file again and retry the import.',
+    );
+  });
+
+  it("translates arrays of backend row errors", () => {
+    expect(
+      translateManifestImportMessages(
+        [
+          "Duplicate sample ID in manifest: BIO-001",
+          "Sample 'BIO-004': duplicate key value violates unique constraint \"sample_item_external_id_key\"",
+        ],
+        formatMessage,
+      ),
+    ).toEqual([
+      'This file contains the Sample ID "BIO-001" more than once. Keep only one row for each sample.',
+      'Sample "BIO-004": A sample with the same Sample ID already exists in the system.',
+    ]);
+  });
+});

--- a/frontend/src/components/notebook/pages/biorepository/qcCorrectionGuardrails.js
+++ b/frontend/src/components/notebook/pages/biorepository/qcCorrectionGuardrails.js
@@ -1,0 +1,24 @@
+const MISSING_DISCREPANCY_TYPES = new Set(["SAMPLE_MISSING", "MISSING_SAMPLE"]);
+
+export const isMissingDiscrepancyType = (discrepancyType) =>
+  MISSING_DISCREPANCY_TYPES.has((discrepancyType || "").trim().toUpperCase());
+
+export const getAllowedCorrectionActions = (allActions, discrepancyType) => {
+  if (!Array.isArray(allActions)) {
+    return [];
+  }
+  if (isMissingDiscrepancyType(discrepancyType)) {
+    return allActions;
+  }
+  return allActions.filter((action) => action?.id !== "MARK_MISSING");
+};
+
+export const hasInvalidMarkMissingLocationFields = (values) => {
+  if (!values || values.correctionActionType !== "MARK_MISSING") {
+    return false;
+  }
+  return Boolean(
+    values.correctionBoxId ||
+      (values.correctionPositionCoordinate || "").trim(),
+  );
+};

--- a/frontend/src/components/notebook/pages/biorepository/qcCorrectionGuardrails.test.js
+++ b/frontend/src/components/notebook/pages/biorepository/qcCorrectionGuardrails.test.js
@@ -1,0 +1,70 @@
+import {
+  getAllowedCorrectionActions,
+  hasInvalidMarkMissingLocationFields,
+  isMissingDiscrepancyType,
+} from "./qcCorrectionGuardrails";
+
+const CORRECTION_ACTIONS = [
+  { id: "UPDATE_LOCATION", label: "Update correct location" },
+  { id: "REASSIGN_POSITION", label: "Reassign position" },
+  { id: "MARK_MISSING", label: "Mark sample as Missing" },
+];
+
+describe("qcCorrectionGuardrails", () => {
+  test("isMissingDiscrepancyType only accepts missing discrepancy types", () => {
+    expect(isMissingDiscrepancyType("SAMPLE_MISSING")).toBe(true);
+    expect(isMissingDiscrepancyType("missing_sample")).toBe(true);
+    expect(isMissingDiscrepancyType("MISPLACED_SAMPLE_FOUND")).toBe(false);
+  });
+
+  test("getAllowedCorrectionActions excludes MARK_MISSING for non-missing discrepancy", () => {
+    const options = getAllowedCorrectionActions(
+      CORRECTION_ACTIONS,
+      "MISPLACED_SAMPLE_FOUND",
+    );
+
+    expect(options.map((action) => action.id)).toEqual([
+      "UPDATE_LOCATION",
+      "REASSIGN_POSITION",
+    ]);
+  });
+
+  test("getAllowedCorrectionActions includes MARK_MISSING for missing discrepancy", () => {
+    const options = getAllowedCorrectionActions(
+      CORRECTION_ACTIONS,
+      "SAMPLE_MISSING",
+    );
+
+    expect(options.map((action) => action.id)).toEqual([
+      "UPDATE_LOCATION",
+      "REASSIGN_POSITION",
+      "MARK_MISSING",
+    ]);
+  });
+
+  test("hasInvalidMarkMissingLocationFields guards stale location/position fields", () => {
+    expect(
+      hasInvalidMarkMissingLocationFields({
+        correctionActionType: "MARK_MISSING",
+        correctionBoxId: "123",
+        correctionPositionCoordinate: "",
+      }),
+    ).toBe(true);
+
+    expect(
+      hasInvalidMarkMissingLocationFields({
+        correctionActionType: "MARK_MISSING",
+        correctionBoxId: "",
+        correctionPositionCoordinate: "A1",
+      }),
+    ).toBe(true);
+
+    expect(
+      hasInvalidMarkMissingLocationFields({
+        correctionActionType: "MARK_MISSING",
+        correctionBoxId: "",
+        correctionPositionCoordinate: "",
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/components/notebook/pages/biorepository/reporting/AuditTrailTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/AuditTrailTab.js
@@ -22,7 +22,7 @@ import {
   Tag,
 } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { Reset } from "@carbon/icons-react";
+import { Download, Reset } from "@carbon/icons-react";
 import PropTypes from "prop-types";
 import config from "../../../../../config.json";
 
@@ -45,6 +45,7 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
   const [actions, setActions] = useState([]);
   const [qcAuditData, setQCAuditData] = useState(null);
   const [qcAuditError, setQCAuditError] = useState(null);
+  const [expandedQcBatches, setExpandedQcBatches] = useState({});
 
   // Filter states
   const [searchQuery, setSearchQuery] = useState("");
@@ -280,6 +281,40 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
     return `${numeric.toFixed(1)}%`;
   };
 
+  const downloadBlob = (blob, filename) => {
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    window.URL.revokeObjectURL(url);
+  };
+
+  const exportQcBatch = (qcBatchId, format = "pdf") => {
+    if (!qcBatchId || qcBatchId === "UNBATCHED") {
+      return;
+    }
+    fetch(
+      `${config.serverBaseUrl}/rest/biorepository/qc/export/${format}?qcBatchId=${encodeURIComponent(qcBatchId)}`,
+      {
+        credentials: "include",
+      },
+    )
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to export QC batch ${qcBatchId}`);
+        }
+        return response.blob();
+      })
+      .then((blob) => {
+        const stamp = new Date().toISOString().slice(0, 10);
+        downloadBlob(blob, `qc_batch_${qcBatchId}_${stamp}.${format}`);
+      })
+      .catch((err) => setQCAuditError(err.message));
+  };
+
   const qcMetrics = qcAuditData?.qcMetrics || {};
   const escalationSignals = qcMetrics.escalationSignals || {};
   const qcHistoryItems = Array.isArray(qcAuditData?.qcHistory?.items)
@@ -287,9 +322,32 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
     : [];
   const qcDiscrepancyEntries = Object.entries(qcAuditData?.qcDiscrepancies || {});
 
-  const deriveQcStatus = (item) => item.qcStatus || "UNKNOWN";
+  const deriveQcStatus = (item) => {
+    if (item.qcStatus) return item.qcStatus;
+    if (item.qcResult === "VERIFIED") return "VALID";
+    if (item.qcResult === "DISCREPANCY_FOUND") {
+      return item.discrepancyType === "SAMPLE_MISSING" ? "MISSING" : "QC_FAILED";
+    }
+    return "UNKNOWN";
+  };
 
-  const deriveLifecycleOutcome = (item) => item.lifecycleOutcome || "UNKNOWN";
+  const deriveLifecycleOutcome = (item) => {
+    if (item.lifecycleOutcome) return item.lifecycleOutcome;
+    const status = deriveQcStatus(item);
+    if (item.qcResult === "VERIFIED" || status === "VALID") {
+      return "PASSED";
+    }
+    if (status === "MISSING") {
+      return "FAILED_MARKED_MISSING";
+    }
+    if (item.qcResult === "DISCREPANCY_FOUND" && item.correctiveAction) {
+      return "FAILED_CORRECTED";
+    }
+    if (item.qcResult === "DISCREPANCY_FOUND") {
+      return "FAILED_PENDING_CORRECTION";
+    }
+    return "UNKNOWN";
+  };
 
   const formatLifecycleOutcome = (value) => {
     const labels = {
@@ -309,20 +367,17 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
   };
 
   const lifecycleOutcomes = qcHistoryItems.map(deriveLifecycleOutcome);
-  const correctedOutcomeCount =
-    qcMetrics?.failureResolutionSummary?.correctedVsUnresolved?.corrected ??
-    lifecycleOutcomes.filter(
-      (outcome) =>
-        outcome === "FAILED_CORRECTED" || outcome === "FAILED_MARKED_MISSING",
-    ).length;
-  const pendingCorrectionCount =
-    qcMetrics?.failureResolutionSummary?.correctedVsUnresolved?.unresolved ??
-    lifecycleOutcomes.filter(
-      (outcome) => outcome === "FAILED_PENDING_CORRECTION",
-    ).length;
+  const correctedOutcomeCount = lifecycleOutcomes.filter(
+    (outcome) => outcome === "FAILED_CORRECTED" || outcome === "FAILED_MARKED_MISSING",
+  ).length;
+  const pendingCorrectionCount = lifecycleOutcomes.filter(
+    (outcome) => outcome === "FAILED_PENDING_CORRECTION",
+  ).length;
 
   const qcHistoryRows = qcHistoryItems.map((item, idx) => ({
     id: `qc-audit-${idx}`,
+    qcBatchId: item.qcBatchId || "UNBATCHED",
+    inspectionDateRaw: item.inspectionDate || null,
     inspectionDate: item.inspectionDate
       ? new Date(item.inspectionDate).toLocaleString()
       : "-",
@@ -333,11 +388,7 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
     sampleFlag: item.sampleFlag || "-",
     qcFailed: item.qcFailed ? "Yes" : "No",
     freezer: item.freezer || "Unknown",
-    freezerFlag: item.freezerFlag || "NORMAL",
     rack: item.rack || "Unknown",
-    boxFlag: item.boxFlag || "NORMAL",
-    escalationTriggered: item.escalationTriggered ? "Yes" : "No",
-    failureResolution: item.failureResolution || "N/A",
     discrepancyType: item.discrepancyType || "-",
     failureComment: item.failureComment || item.remarks || "-",
     correctiveAction: item.correctiveAction || "-",
@@ -354,6 +405,50 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
       : "-",
     correctionReason: item.auditTrail?.reason || "-",
   }));
+
+  const qcHistoryBatchRows = (() => {
+    const grouped = new Map();
+    qcHistoryRows.forEach((row) => {
+      const key = row.qcBatchId || "UNBATCHED";
+      if (!grouped.has(key)) {
+        grouped.set(key, {
+          id: `qc-batch-${key}`,
+          qcBatchId: key,
+          latestInspectionDate: row.inspectionDate || "-",
+          latestInspectionDateRaw: row.inspectionDateRaw,
+          sampleCount: 0,
+          passCount: 0,
+          failCount: 0,
+          pendingCorrectionCount: 0,
+          details: [],
+        });
+      }
+      const batch = grouped.get(key);
+      batch.details.push(row);
+      batch.sampleCount += 1;
+      if (row.result === "VERIFIED" || row.status === "VALID") {
+        batch.passCount += 1;
+      } else {
+        batch.failCount += 1;
+      }
+      if (row.lifecycleOutcome === "Failed (pending correction)") {
+        batch.pendingCorrectionCount += 1;
+      }
+      if (
+        row.inspectionDateRaw &&
+        (!batch.latestInspectionDateRaw ||
+          new Date(row.inspectionDateRaw) > new Date(batch.latestInspectionDateRaw))
+      ) {
+        batch.latestInspectionDate = row.inspectionDate;
+        batch.latestInspectionDateRaw = row.inspectionDateRaw;
+      }
+    });
+    return Array.from(grouped.values()).sort(
+      (a, b) =>
+        new Date(b.latestInspectionDateRaw || 0).getTime() -
+        new Date(a.latestInspectionDateRaw || 0).getTime(),
+    );
+  })();
 
   const qcCorrectiveActionsLogged = qcHistoryRows.filter(
     (row) => row.correctiveAction && row.correctiveAction !== "-",
@@ -413,6 +508,7 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
 
   const qcHistoryHeaders = [
     { key: "inspectionDate", header: "Inspection Date" },
+    { key: "qcBatchId", header: "QC Batch ID" },
     { key: "result", header: "Result" },
     { key: "lifecycleOutcome", header: "Lifecycle Outcome" },
     { key: "status", header: "QC Status" },
@@ -420,11 +516,7 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
     { key: "sampleFlag", header: "Sample Flag" },
     { key: "qcFailed", header: "QC Failed" },
     { key: "freezer", header: "Freezer" },
-    { key: "freezerFlag", header: "Freezer Flag" },
     { key: "rack", header: "Rack" },
-    { key: "boxFlag", header: "Box Flag" },
-    { key: "escalationTriggered", header: "Escalation Triggered" },
-    { key: "failureResolution", header: "Failure Resolution" },
     { key: "discrepancyType", header: "Discrepancy Type" },
     { key: "failureComment", header: "Failure Comment" },
     { key: "correctiveAction", header: "Corrective Action" },
@@ -433,6 +525,16 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
     { key: "correctedBy", header: "Corrected By" },
     { key: "correctedAt", header: "Corrected At" },
     { key: "correctionReason", header: "Correction Reason" },
+  ];
+
+  const qcBatchHeaders = [
+    { key: "qcBatchId", header: "QC Batch ID" },
+    { key: "latestInspectionDate", header: "Latest Inspection" },
+    { key: "sampleCount", header: "Samples" },
+    { key: "passCount", header: "Pass" },
+    { key: "failCount", header: "Fail" },
+    { key: "pendingCorrectionCount", header: "Pending Correction" },
+    { key: "actions", header: "Actions" },
   ];
 
   const qcDiscrepancyRows = qcDiscrepancyEntries.map(([type, count], idx) => ({
@@ -471,7 +573,9 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
         </Column>
 
         <Column lg={16} md={8} sm={4} style={{ marginBottom: "1.5rem" }}>
-          <h5 style={{ marginBottom: "0.75rem" }}>QC Outcome Audit Visibility</h5>
+          <h5 style={{ marginBottom: "0.75rem" }}>
+            QC Outcome Audit Visibility (Batch Grouped)
+          </h5>
           <p
             style={{
               fontSize: "0.875rem",
@@ -533,7 +637,7 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
               </DataTable>
 
               <div style={{ marginTop: "1rem" }}>
-                <DataTable rows={qcHistoryRows} headers={qcHistoryHeaders}>
+                <DataTable rows={qcHistoryBatchRows} headers={qcBatchHeaders}>
                   {({
                     rows,
                     headers,
@@ -542,8 +646,8 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
                     getRowProps,
                   }) => (
                     <TableContainer
-                      title="Recent QC Outcomes and Corrections"
-                      description="Persisted QC lifecycle/audit fields plus per-record escalation and resolution flags"
+                      title="QC History by Batch ID"
+                      description="NEW: one row per QC batch ID. Use Show details to expand records, then Print PDF/CSV for reporting."
                     >
                       <Table {...getTableProps()}>
                         <TableHead>
@@ -559,13 +663,138 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
                           </TableRow>
                         </TableHead>
                         <TableBody>
-                          {rows.map((row) => (
-                            <TableRow key={row.id} {...getRowProps({ row })}>
-                              {row.cells.map((cell) => (
-                                <TableCell key={cell.id}>{cell.value}</TableCell>
-                              ))}
-                            </TableRow>
-                          ))}
+                          {rows.map((row) => {
+                            const batchId =
+                              row.cells.find(
+                                (cell) => cell.info.header === "qcBatchId",
+                              )?.value || "UNBATCHED";
+                            const detailRows =
+                              qcHistoryBatchRows.find(
+                                (batch) => batch.qcBatchId === batchId,
+                              )?.details || [];
+                            const isExpanded = Boolean(expandedQcBatches[batchId]);
+
+                            return (
+                              <React.Fragment key={row.id}>
+                                <TableRow {...getRowProps({ row })}>
+                                  {row.cells.map((cell) => {
+                                    if (cell.info.header === "actions") {
+                                      return (
+                                        <TableCell key={cell.id}>
+                                          <div
+                                            style={{
+                                              display: "flex",
+                                              gap: "0.5rem",
+                                              flexWrap: "wrap",
+                                            }}
+                                          >
+                                            <Button
+                                              kind="ghost"
+                                              size="sm"
+                                              onClick={() =>
+                                                setExpandedQcBatches((prev) => ({
+                                                  ...prev,
+                                                  [batchId]: !prev[batchId],
+                                                }))
+                                              }
+                                            >
+                                              {isExpanded
+                                                ? "Hide details"
+                                                : "Show details"}
+                                            </Button>
+                                            {batchId !== "UNBATCHED" && (
+                                              <>
+                                                <Button
+                                                  kind="ghost"
+                                                  size="sm"
+                                                  renderIcon={Download}
+                                                  onClick={() =>
+                                                    exportQcBatch(batchId, "pdf")
+                                                  }
+                                                >
+                                                  Print PDF
+                                                </Button>
+                                                <Button
+                                                  kind="ghost"
+                                                  size="sm"
+                                                  onClick={() =>
+                                                    exportQcBatch(batchId, "csv")
+                                                  }
+                                                >
+                                                  CSV
+                                                </Button>
+                                              </>
+                                            )}
+                                          </div>
+                                        </TableCell>
+                                      );
+                                    }
+                                    return (
+                                      <TableCell key={cell.id}>
+                                        {cell.value}
+                                      </TableCell>
+                                    );
+                                  })}
+                                </TableRow>
+                                {isExpanded && (
+                                  <TableRow>
+                                    <TableCell
+                                      colSpan={qcBatchHeaders.length}
+                                      style={{ backgroundColor: "#f4f4f4" }}
+                                    >
+                                      <DataTable
+                                        rows={detailRows}
+                                        headers={qcHistoryHeaders}
+                                      >
+                                        {({
+                                          rows: nestedRows,
+                                          headers: nestedHeaders,
+                                          getTableProps: getNestedTableProps,
+                                          getHeaderProps: getNestedHeaderProps,
+                                          getRowProps: getNestedRowProps,
+                                        }) => (
+                                          <TableContainer title="">
+                                            <Table {...getNestedTableProps()}>
+                                              <TableHead>
+                                                <TableRow>
+                                                  {nestedHeaders.map((header) => (
+                                                    <TableHeader
+                                                      key={header.key}
+                                                      {...getNestedHeaderProps({
+                                                        header,
+                                                      })}
+                                                    >
+                                                      {header.header}
+                                                    </TableHeader>
+                                                  ))}
+                                                </TableRow>
+                                              </TableHead>
+                                              <TableBody>
+                                                {nestedRows.map((nestedRow) => (
+                                                  <TableRow
+                                                    key={nestedRow.id}
+                                                    {...getNestedRowProps({
+                                                      row: nestedRow,
+                                                    })}
+                                                  >
+                                                    {nestedRow.cells.map((cell) => (
+                                                      <TableCell key={cell.id}>
+                                                        {cell.value}
+                                                      </TableCell>
+                                                    ))}
+                                                  </TableRow>
+                                                ))}
+                                              </TableBody>
+                                            </Table>
+                                          </TableContainer>
+                                        )}
+                                      </DataTable>
+                                    </TableCell>
+                                  </TableRow>
+                                )}
+                              </React.Fragment>
+                            );
+                          })}
                         </TableBody>
                       </Table>
                     </TableContainer>

--- a/frontend/src/components/notebook/pages/biorepository/reporting/AuditTrailTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/AuditTrailTab.js
@@ -43,6 +43,8 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
   const [auditLogs, setAuditLogs] = useState([]);
   const [error, setError] = useState(null);
   const [actions, setActions] = useState([]);
+  const [qcAuditData, setQCAuditData] = useState(null);
+  const [qcAuditError, setQCAuditError] = useState(null);
 
   // Filter states
   const [searchQuery, setSearchQuery] = useState("");
@@ -73,6 +75,38 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
       .then((r) => r.json())
       .then((data) => setActions(data))
       .catch((err) => console.error("Failed to load action types:", err));
+  }, []);
+
+  // Fetch QC-focused reporting/audit snapshots from dashboard endpoints.
+  useEffect(() => {
+    Promise.all([
+      fetch(`${config.serverBaseUrl}/rest/biorepository/dashboard/qc-metrics`, {
+        credentials: "include",
+      }).then((r) => r.json()),
+      fetch(
+        `${config.serverBaseUrl}/rest/biorepository/dashboard/qc-history?limit=100`,
+        {
+          credentials: "include",
+        },
+      ).then((r) => r.json()),
+      fetch(
+        `${config.serverBaseUrl}/rest/biorepository/dashboard/qc-discrepancies`,
+        {
+          credentials: "include",
+        },
+      ).then((r) => r.json()),
+    ])
+      .then(([qcMetrics, qcHistory, qcDiscrepancies]) => {
+        setQCAuditData({
+          qcMetrics: qcMetrics || {},
+          qcHistory: qcHistory || { items: [] },
+          qcDiscrepancies: qcDiscrepancies || {},
+        });
+        setQCAuditError(null);
+      })
+      .catch((err) => {
+        setQCAuditError(err.message || "Failed to load QC audit snapshot");
+      });
   }, []);
 
   // Fetch audit logs
@@ -126,7 +160,7 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
   };
 
   // Store current filters in a ref to access in useEffect
-  const currentFiltersRef = React.useRef({
+  const currentFiltersRef = useRef({
     searchQuery: "",
     selectedAction: "ALL",
     startDate: "",
@@ -238,6 +272,180 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
     { key: "toLocation", header: "To Location" },
   ];
 
+  const formatPercent = (value) => {
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) {
+      return "N/A";
+    }
+    return `${numeric.toFixed(1)}%`;
+  };
+
+  const qcMetrics = qcAuditData?.qcMetrics || {};
+  const escalationSignals = qcMetrics.escalationSignals || {};
+  const qcHistoryItems = Array.isArray(qcAuditData?.qcHistory?.items)
+    ? qcAuditData.qcHistory.items
+    : [];
+  const qcDiscrepancyEntries = Object.entries(qcAuditData?.qcDiscrepancies || {});
+
+  const deriveQcStatus = (item) => item.qcStatus || "UNKNOWN";
+
+  const deriveLifecycleOutcome = (item) => item.lifecycleOutcome || "UNKNOWN";
+
+  const formatLifecycleOutcome = (value) => {
+    const labels = {
+      PASSED: "Passed",
+      FAILED_PENDING_CORRECTION: "Failed (pending correction)",
+      FAILED_CORRECTED: "Failed (correction logged)",
+      FAILED_MARKED_MISSING: "Failed (marked missing)",
+      UNKNOWN: "Unknown",
+    };
+    return labels[value] || value || "Unknown";
+  };
+
+  const extractAuditField = (item, primaryKey, fallbackKey) => {
+    if (item?.auditTrail?.[primaryKey]) return item.auditTrail[primaryKey];
+    if (item?.auditTrail?.[fallbackKey]) return item.auditTrail[fallbackKey];
+    return "-";
+  };
+
+  const lifecycleOutcomes = qcHistoryItems.map(deriveLifecycleOutcome);
+  const correctedOutcomeCount =
+    qcMetrics?.failureResolutionSummary?.correctedVsUnresolved?.corrected ??
+    lifecycleOutcomes.filter(
+      (outcome) =>
+        outcome === "FAILED_CORRECTED" || outcome === "FAILED_MARKED_MISSING",
+    ).length;
+  const pendingCorrectionCount =
+    qcMetrics?.failureResolutionSummary?.correctedVsUnresolved?.unresolved ??
+    lifecycleOutcomes.filter(
+      (outcome) => outcome === "FAILED_PENDING_CORRECTION",
+    ).length;
+
+  const qcHistoryRows = qcHistoryItems.map((item, idx) => ({
+    id: `qc-audit-${idx}`,
+    inspectionDate: item.inspectionDate
+      ? new Date(item.inspectionDate).toLocaleString()
+      : "-",
+    result: item.qcResult || "-",
+    lifecycleOutcome: formatLifecycleOutcome(deriveLifecycleOutcome(item)),
+    status: deriveQcStatus(item),
+    technician: item.inspectorName || item.technicianId || "-",
+    sampleFlag: item.sampleFlag || "-",
+    qcFailed: item.qcFailed ? "Yes" : "No",
+    freezer: item.freezer || "Unknown",
+    freezerFlag: item.freezerFlag || "NORMAL",
+    rack: item.rack || "Unknown",
+    boxFlag: item.boxFlag || "NORMAL",
+    escalationTriggered: item.escalationTriggered ? "Yes" : "No",
+    failureResolution: item.failureResolution || "N/A",
+    discrepancyType: item.discrepancyType || "-",
+    failureComment: item.failureComment || item.remarks || "-",
+    correctiveAction: item.correctiveAction || "-",
+    correctionFrom: extractAuditField(item, "fromCoordinates", "oldCoordinate"),
+    correctionTo: extractAuditField(item, "toCoordinates", "newCoordinate"),
+    correctedBy:
+      item.auditTrail?.correctedBy ||
+      item.auditTrail?.user ||
+      item.inspectorName ||
+      item.technicianId ||
+      "-",
+    correctedAt: item.auditTrail?.correctedAt || item.auditTrail?.timestamp
+      ? new Date(item.auditTrail.correctedAt || item.auditTrail.timestamp).toLocaleString()
+      : "-",
+    correctionReason: item.auditTrail?.reason || "-",
+  }));
+
+  const qcCorrectiveActionsLogged = qcHistoryRows.filter(
+    (row) => row.correctiveAction && row.correctiveAction !== "-",
+  ).length;
+
+  const qcSummaryRows = [
+    {
+      id: "qc-summary-pass-rate",
+      metric: "Pass Rate",
+      value: formatPercent(qcMetrics.passRate ?? qcMetrics.complianceRate),
+    },
+    {
+      id: "qc-summary-fail-count",
+      metric: "Fail Count",
+      value: qcMetrics.failCount ?? qcMetrics.failedInspections ?? 0,
+    },
+    {
+      id: "qc-summary-fail-trend",
+      metric: "Fail Trend Basis",
+      value: qcMetrics.failTrendBasis
+        ? `${qcMetrics.failTrendBasis.granularity || "day"}, ${qcMetrics.failTrendBasis.windowDays || 30} days, source: ${qcMetrics.failTrendBasis.source || "N/A"}`
+        : "N/A",
+    },
+    {
+      id: "qc-summary-corrective-actions",
+      metric: "Corrective Actions Logged",
+      value: qcCorrectiveActionsLogged,
+    },
+    {
+      id: "qc-summary-corrected-outcomes",
+      metric: "Failed Outcomes Corrected",
+      value: correctedOutcomeCount,
+    },
+    {
+      id: "qc-summary-pending-corrections",
+      metric: "Pending Corrections",
+      value: pendingCorrectionCount,
+    },
+    {
+      id: "qc-summary-missing",
+      metric: "Missing Samples (QC)",
+      value: escalationSignals.criticalMissingSamples || 0,
+    },
+    {
+      id: "qc-summary-triggers",
+      metric: "Escalation Rules Triggered",
+      value: Array.isArray(escalationSignals.triggeredRules)
+        ? escalationSignals.triggeredRules.join(", ") || "None"
+        : "None",
+    },
+  ];
+
+  const qcSummaryHeaders = [
+    { key: "metric", header: "QC Audit Metric" },
+    { key: "value", header: "Value" },
+  ];
+
+  const qcHistoryHeaders = [
+    { key: "inspectionDate", header: "Inspection Date" },
+    { key: "result", header: "Result" },
+    { key: "lifecycleOutcome", header: "Lifecycle Outcome" },
+    { key: "status", header: "QC Status" },
+    { key: "technician", header: "Technician" },
+    { key: "sampleFlag", header: "Sample Flag" },
+    { key: "qcFailed", header: "QC Failed" },
+    { key: "freezer", header: "Freezer" },
+    { key: "freezerFlag", header: "Freezer Flag" },
+    { key: "rack", header: "Rack" },
+    { key: "boxFlag", header: "Box Flag" },
+    { key: "escalationTriggered", header: "Escalation Triggered" },
+    { key: "failureResolution", header: "Failure Resolution" },
+    { key: "discrepancyType", header: "Discrepancy Type" },
+    { key: "failureComment", header: "Failure Comment" },
+    { key: "correctiveAction", header: "Corrective Action" },
+    { key: "correctionFrom", header: "Correction From" },
+    { key: "correctionTo", header: "Correction To" },
+    { key: "correctedBy", header: "Corrected By" },
+    { key: "correctedAt", header: "Corrected At" },
+    { key: "correctionReason", header: "Correction Reason" },
+  ];
+
+  const qcDiscrepancyRows = qcDiscrepancyEntries.map(([type, count], idx) => ({
+    id: `qc-discrepancy-${idx}`,
+    type,
+    count,
+  }));
+
+  const qcDiscrepancyHeaders = [
+    { key: "type", header: "Discrepancy Type" },
+    { key: "count", header: "Count" },
+  ];
+
   return (
     <div className="audit-trail-tab" style={{ padding: "1.5rem" }}>
       <Grid fullWidth>
@@ -260,6 +468,156 @@ function AuditTrailTab({ entryId, notebookId, pageData }) {
               defaultMessage="Complete immutable audit trail of all sample custody changes. Search by barcode, filter by action type or date range."
             />
           </p>
+        </Column>
+
+        <Column lg={16} md={8} sm={4} style={{ marginBottom: "1.5rem" }}>
+          <h5 style={{ marginBottom: "0.75rem" }}>QC Outcome Audit Visibility</h5>
+          <p
+            style={{
+              fontSize: "0.875rem",
+              color: "#525252",
+              marginBottom: "0.75rem",
+            }}
+          >
+            Summary metrics above provide quick indicators; the history table below
+            provides record-level lifecycle details (failed, corrected, or marked
+            missing) from existing dashboard data sources.
+          </p>
+
+          {qcAuditError ? (
+            <InlineNotification
+              kind="warning"
+              title="QC audit snapshot unavailable"
+              subtitle={qcAuditError}
+              lowContrast
+            />
+          ) : (
+            <div>
+              <DataTable rows={qcSummaryRows} headers={qcSummaryHeaders}>
+                {({
+                  rows,
+                  headers,
+                  getTableProps,
+                  getHeaderProps,
+                  getRowProps,
+                }) => (
+                  <TableContainer
+                    title="QC Reporting Snapshot"
+                    description={`History source: ${qcAuditData?.qcHistory?.source || "N/A"} | Records: ${qcAuditData?.qcHistory?.count || 0}`}
+                  >
+                    <Table {...getTableProps()}>
+                      <TableHead>
+                        <TableRow>
+                          {headers.map((header) => (
+                            <TableHeader
+                              key={header.key}
+                              {...getHeaderProps({ header })}
+                            >
+                              {header.header}
+                            </TableHeader>
+                          ))}
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {rows.map((row) => (
+                          <TableRow key={row.id} {...getRowProps({ row })}>
+                            {row.cells.map((cell) => (
+                              <TableCell key={cell.id}>{cell.value}</TableCell>
+                            ))}
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                )}
+              </DataTable>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable rows={qcHistoryRows} headers={qcHistoryHeaders}>
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="Recent QC Outcomes and Corrections"
+                      description="Persisted QC lifecycle/audit fields plus per-record escalation and resolution flags"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable
+                  rows={qcDiscrepancyRows}
+                  headers={qcDiscrepancyHeaders}
+                >
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="QC Discrepancy Type Breakdown"
+                      description="Supports quick review of most common discrepancy classes"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+            </div>
+          )}
         </Column>
 
         {/* Filters */}

--- a/frontend/src/components/notebook/pages/biorepository/reporting/DetailedMetricsTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/DetailedMetricsTab.js
@@ -19,7 +19,7 @@ import {
   Button,
 } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { Search, Reset } from "@carbon/icons-react";
+import { Search, Reset, Download } from "@carbon/icons-react";
 import PropTypes from "prop-types";
 import config from "../../../../../config.json";
 
@@ -67,12 +67,6 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
         },
       ).then((r) => r.json()),
       fetch(
-        `${config.serverBaseUrl}/rest/biorepository/dashboard/storage-utilization`,
-        {
-          credentials: "include",
-        },
-      ).then((r) => r.json()),
-      fetch(
         `${config.serverBaseUrl}/rest/biorepository/dashboard/sample-aging`,
         {
           credentials: "include",
@@ -109,7 +103,6 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
       .then(
         ([
           capacity,
-          storageUtilization,
           aging,
           qc,
           discrepancies,
@@ -119,7 +112,6 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
         ]) => {
         setMetricsData({
           capacity,
-          storageUtilization,
           aging,
           qc,
           discrepancies,
@@ -197,16 +189,7 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     );
   }
 
-  const {
-    capacity,
-    storageUtilization,
-    aging,
-    qc,
-    discrepancies,
-    qcHistory,
-    retrieval,
-    disposal,
-  } =
+  const { capacity, aging, qc, discrepancies, qcHistory, retrieval, disposal } =
     metricsData;
 
   const formatPercent = (value) => {
@@ -215,6 +198,40 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
       return "N/A";
     }
     return `${numeric.toFixed(1)}%`;
+  };
+
+  const downloadBlob = (blob, filename) => {
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    window.URL.revokeObjectURL(url);
+  };
+
+  const exportQcBatch = (qcBatchId, format = "pdf") => {
+    if (!qcBatchId || qcBatchId === "UNBATCHED") {
+      return;
+    }
+    fetch(
+      `${config.serverBaseUrl}/rest/biorepository/qc/export/${format}?qcBatchId=${encodeURIComponent(qcBatchId)}`,
+      {
+        credentials: "include",
+      },
+    )
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to export QC batch ${qcBatchId}`);
+        }
+        return response.blob();
+      })
+      .then((blob) => {
+        const stamp = new Date().toISOString().slice(0, 10);
+        downloadBlob(blob, `qc_batch_${qcBatchId}_${stamp}.${format}`);
+      })
+      .catch((err) => setError(err.message));
   };
 
   // Storage capacity rows
@@ -237,27 +254,6 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     { key: "status", header: "Status" },
     { key: "count", header: "Sample Count" },
     { key: "percentage", header: "Percentage" },
-  ];
-
-  const storageUtilizationRows = (storageUtilization?.devices || []).map(
-    (device, idx) => ({
-      id: `storage-device-${idx}`,
-      deviceName: device.deviceName || device.deviceCode || "Unknown",
-      deviceType: device.deviceType || "N/A",
-      currentUsage: device.currentUsage ?? 0,
-      totalCapacity: device.totalCapacity ?? 0,
-      utilizationPercent: formatPercent(device.utilizationPercent),
-      capacitySource: device.capacitySource || "UNDEFINED",
-    }),
-  );
-
-  const storageUtilizationHeaders = [
-    { key: "deviceName", header: "Device" },
-    { key: "deviceType", header: "Type" },
-    { key: "currentUsage", header: "Current Usage" },
-    { key: "totalCapacity", header: "Total Capacity" },
-    { key: "utilizationPercent", header: "Utilization" },
-    { key: "capacitySource", header: "Capacity Source" },
   ];
 
   // Sample aging rows
@@ -495,9 +491,32 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     { key: "failRate", header: "Fail Rate" },
   ];
 
-  const deriveQcStatus = (item) => item.qcStatus || "UNKNOWN";
+  const deriveQcStatus = (item) => {
+    if (item.qcStatus) return item.qcStatus;
+    if (item.qcResult === "VERIFIED") return "VALID";
+    if (item.qcResult === "DISCREPANCY_FOUND") {
+      return item.discrepancyType === "SAMPLE_MISSING" ? "MISSING" : "QC_FAILED";
+    }
+    return "UNKNOWN";
+  };
 
-  const deriveLifecycleOutcome = (item) => item.lifecycleOutcome || "UNKNOWN";
+  const deriveLifecycleOutcome = (item) => {
+    if (item.lifecycleOutcome) return item.lifecycleOutcome;
+    const status = deriveQcStatus(item);
+    if (item.qcResult === "VERIFIED" || status === "VALID") {
+      return "PASSED";
+    }
+    if (status === "MISSING") {
+      return "FAILED_MARKED_MISSING";
+    }
+    if (item.qcResult === "DISCREPANCY_FOUND" && item.correctiveAction) {
+      return "FAILED_CORRECTED";
+    }
+    if (item.qcResult === "DISCREPANCY_FOUND") {
+      return "FAILED_PENDING_CORRECTION";
+    }
+    return "UNKNOWN";
+  };
 
   const formatLifecycleOutcome = (value) => {
     const labels = {
@@ -512,6 +531,8 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
 
   const historyRows = (qcHistory?.items || []).map((item, idx) => ({
     id: `qc-history-${idx}`,
+    qcBatchId: item.qcBatchId || "UNBATCHED",
+    inspectionDateRaw: item.inspectionDate || null,
     inspectionDate: item.inspectionDate
       ? new Date(item.inspectionDate).toLocaleString()
       : "-",
@@ -522,11 +543,7 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     qcFailed: item.qcFailed ? "Yes" : "No",
     inspectorName: item.inspectorName || item.technicianId || "-",
     freezer: item.freezer || "Unknown",
-    freezerFlag: item.freezerFlag || "NORMAL",
     rack: item.rack || "Unknown",
-    boxFlag: item.boxFlag || "NORMAL",
-    escalationTriggered: item.escalationTriggered ? "Yes" : "No",
-    failureResolution: item.failureResolution || "N/A",
     discrepancyType: item.discrepancyType || "-",
     failureComment: item.failureComment || item.remarks || "-",
     correctiveAction: item.correctiveAction || "-",
@@ -547,27 +564,62 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     remarks: item.remarks || "-",
   }));
 
+  const historyBatchRows = (() => {
+    const grouped = new Map();
+    historyRows.forEach((row) => {
+      const key = row.qcBatchId || "UNBATCHED";
+      if (!grouped.has(key)) {
+        grouped.set(key, {
+          id: `qc-history-batch-${key}`,
+          qcBatchId: key,
+          latestInspectionDate: row.inspectionDate || "-",
+          latestInspectionDateRaw: row.inspectionDateRaw,
+          sampleCount: 0,
+          passCount: 0,
+          failCount: 0,
+        });
+      }
+      const batch = grouped.get(key);
+      batch.sampleCount += 1;
+      if (row.qcResult === "VERIFIED" || row.qcStatus === "VALID") {
+        batch.passCount += 1;
+      } else {
+        batch.failCount += 1;
+      }
+      if (
+        row.inspectionDateRaw &&
+        (!batch.latestInspectionDateRaw ||
+          new Date(row.inspectionDateRaw) > new Date(batch.latestInspectionDateRaw))
+      ) {
+        batch.latestInspectionDate = row.inspectionDate;
+        batch.latestInspectionDateRaw = row.inspectionDateRaw;
+      }
+    });
+    return Array.from(grouped.values()).sort(
+      (a, b) =>
+        new Date(b.latestInspectionDateRaw || 0).getTime() -
+        new Date(a.latestInspectionDateRaw || 0).getTime(),
+    );
+  })();
+
   const discrepancyHistoryCount = historyRows.filter(
     (row) => row.qcResult === "DISCREPANCY_FOUND",
   ).length;
   const correctiveActionCount = historyRows.filter(
     (row) => row.correctiveAction && row.correctiveAction !== "-",
   ).length;
-  const correctedOutcomeCount =
-    qc?.failureResolutionSummary?.correctedVsUnresolved?.corrected ??
-    historyRows.filter(
-      (row) =>
-        row.lifecycleOutcome === "Failed (correction logged)" ||
-        row.lifecycleOutcome === "Failed (marked missing)",
-    ).length;
-  const pendingCorrectionCount =
-    qc?.failureResolutionSummary?.correctedVsUnresolved?.unresolved ??
-    historyRows.filter(
-      (row) => row.lifecycleOutcome === "Failed (pending correction)",
-    ).length;
+  const correctedOutcomeCount = historyRows.filter(
+    (row) =>
+      row.lifecycleOutcome === "Failed (correction logged)" ||
+      row.lifecycleOutcome === "Failed (marked missing)",
+  ).length;
+  const pendingCorrectionCount = historyRows.filter(
+    (row) => row.lifecycleOutcome === "Failed (pending correction)",
+  ).length;
 
   const historyHeaders = [
     { key: "inspectionDate", header: "Inspection Date" },
+    { key: "qcBatchId", header: "QC Batch ID" },
     { key: "qcResult", header: "Result" },
     { key: "qcStatus", header: "QC Status" },
     { key: "lifecycleOutcome", header: "Lifecycle Outcome" },
@@ -575,11 +627,7 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     { key: "qcFailed", header: "QC Failed" },
     { key: "inspectorName", header: "Technician" },
     { key: "freezer", header: "Freezer" },
-    { key: "freezerFlag", header: "Freezer Flag" },
     { key: "rack", header: "Rack" },
-    { key: "boxFlag", header: "Box Flag" },
-    { key: "escalationTriggered", header: "Escalation Triggered" },
-    { key: "failureResolution", header: "Failure Resolution" },
     { key: "discrepancyType", header: "Discrepancy Type" },
     { key: "failureComment", header: "Failure Comment" },
     { key: "correctiveAction", header: "Corrective Action" },
@@ -589,6 +637,15 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     { key: "correctedAt", header: "Corrected At" },
     { key: "correctionReason", header: "Correction Reason" },
     { key: "remarks", header: "Remarks" },
+  ];
+
+  const historyBatchHeaders = [
+    { key: "qcBatchId", header: "QC Batch ID" },
+    { key: "latestInspectionDate", header: "Latest Inspection" },
+    { key: "sampleCount", header: "Samples" },
+    { key: "passCount", header: "Pass" },
+    { key: "failCount", header: "Fail" },
+    { key: "actions", header: "Batch Report" },
   ];
 
   // Retrieval stats rows
@@ -664,12 +721,29 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     <div className="detailed-metrics-tab" style={{ padding: "1.5rem" }}>
       <Grid fullWidth>
         <Column lg={16} md={8} sm={4}>
-          <h4 style={{ marginBottom: "1rem" }}>
-            <FormattedMessage
-              id="biorepository.reporting.metrics.title"
-              defaultMessage="Detailed Metrics"
-            />
-          </h4>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: "1rem",
+              gap: "1rem",
+              flexWrap: "wrap",
+            }}
+          >
+            <h4 style={{ marginBottom: 0 }}>
+              <FormattedMessage
+                id="biorepository.reporting.metrics.title"
+                defaultMessage="Detailed Metrics"
+              />
+            </h4>
+            <Button kind="secondary" size="sm" onClick={() => window.print()}>
+              <FormattedMessage
+                id="biorepository.reporting.metrics.print"
+                defaultMessage="Print Current View"
+              />
+            </Button>
+          </div>
         </Column>
 
         {/* Date Range Filters */}
@@ -790,49 +864,6 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
                   </TableContainer>
                 )}
               </DataTable>
-              <div style={{ marginTop: "1rem" }}>
-                <DataTable
-                  rows={storageUtilizationRows}
-                  headers={storageUtilizationHeaders}
-                >
-                  {({
-                    rows,
-                    headers,
-                    getTableProps,
-                    getHeaderProps,
-                    getRowProps,
-                  }) => (
-                    <TableContainer
-                      title="Storage Utilization by Device"
-                      description={`Devices: ${storageUtilization?.totalDevices ?? 0} | Capacity-defined: ${storageUtilization?.capacityDefinedDevices ?? 0} | Undefined capacity: ${storageUtilization?.capacityUndefinedDevices ?? 0} | Weighted utilization: ${formatPercent(storageUtilization?.averageUtilization)}`}
-                    >
-                      <Table {...getTableProps()}>
-                        <TableHead>
-                          <TableRow>
-                            {headers.map((header) => (
-                              <TableHeader
-                                key={header.key}
-                                {...getHeaderProps({ header })}
-                              >
-                                {header.header}
-                              </TableHeader>
-                            ))}
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {rows.map((row) => (
-                            <TableRow key={row.id} {...getRowProps({ row })}>
-                              {row.cells.map((cell) => (
-                                <TableCell key={cell.id}>{cell.value}</TableCell>
-                              ))}
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  )}
-                </DataTable>
-              </div>
             </AccordionItem>
 
             {/* Sample Aging Breakdown */}
@@ -1327,6 +1358,93 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
                 defaultMessage: "QC History (Completed Checks)",
               })}
             >
+              <DataTable rows={historyBatchRows} headers={historyBatchHeaders}>
+                {({
+                  rows,
+                  headers,
+                  getTableProps,
+                  getHeaderProps,
+                  getRowProps,
+                }) => (
+                  <TableContainer
+                    title="QC Batch Summary"
+                    description="Grouped by QC Batch ID for quick reporting and printable exports."
+                  >
+                    <Table {...getTableProps()}>
+                      <TableHead>
+                        <TableRow>
+                          {headers.map((header) => (
+                            <TableHeader
+                              key={header.key}
+                              {...getHeaderProps({ header })}
+                            >
+                              {header.header}
+                            </TableHeader>
+                          ))}
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {rows.map((row) => {
+                          const batchId =
+                            row.cells.find(
+                              (cell) => cell.info.header === "qcBatchId",
+                            )?.value || "UNBATCHED";
+                          return (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => {
+                                if (cell.info.header === "actions") {
+                                  return (
+                                    <TableCell key={cell.id}>
+                                      <div
+                                        style={{
+                                          display: "flex",
+                                          gap: "0.5rem",
+                                          flexWrap: "wrap",
+                                        }}
+                                      >
+                                        {batchId !== "UNBATCHED" ? (
+                                          <>
+                                            <Button
+                                              kind="ghost"
+                                              size="sm"
+                                              renderIcon={Download}
+                                              onClick={() =>
+                                                exportQcBatch(batchId, "pdf")
+                                              }
+                                            >
+                                              Print PDF
+                                            </Button>
+                                            <Button
+                                              kind="ghost"
+                                              size="sm"
+                                              onClick={() =>
+                                                exportQcBatch(batchId, "csv")
+                                              }
+                                            >
+                                              CSV
+                                            </Button>
+                                          </>
+                                        ) : (
+                                          "N/A"
+                                        )}
+                                      </div>
+                                    </TableCell>
+                                  );
+                                }
+                                return (
+                                  <TableCell key={cell.id}>{cell.value}</TableCell>
+                                );
+                              })}
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                )}
+              </DataTable>
+
+              <div style={{ marginTop: "1rem" }}>
               <DataTable rows={historyRows} headers={historyHeaders}>
                 {({
                   rows,
@@ -1337,7 +1455,7 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
                 }) => (
                   <TableContainer
                     title="Completed QC Check History"
-                    description={`Source: ${qcHistory?.source || "N/A"} | Records: ${qcHistory?.count || 0} | Discrepancies: ${discrepancyHistoryCount} | Corrective actions logged: ${correctiveActionCount} | Failed outcomes corrected: ${correctedOutcomeCount} | Pending corrections: ${pendingCorrectionCount} | Per-record flags: sample/box/freezer escalation visibility enabled`}
+                    description={`Source: ${qcHistory?.source || "N/A"} | Records: ${qcHistory?.count || 0} | Discrepancies: ${discrepancyHistoryCount} | Corrective actions logged: ${correctiveActionCount} | Failed outcomes corrected: ${correctedOutcomeCount} | Pending corrections: ${pendingCorrectionCount}`}
                   >
                     <Table {...getTableProps()}>
                       <TableHead>
@@ -1365,6 +1483,7 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
                   </TableContainer>
                 )}
               </DataTable>
+              </div>
             </AccordionItem>
 
             {/* Retrieval Statistics */}

--- a/frontend/src/components/notebook/pages/biorepository/reporting/DetailedMetricsTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/DetailedMetricsTab.js
@@ -67,6 +67,12 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
         },
       ).then((r) => r.json()),
       fetch(
+        `${config.serverBaseUrl}/rest/biorepository/dashboard/storage-utilization`,
+        {
+          credentials: "include",
+        },
+      ).then((r) => r.json()),
+      fetch(
         `${config.serverBaseUrl}/rest/biorepository/dashboard/sample-aging`,
         {
           credentials: "include",
@@ -77,6 +83,12 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
       }).then((r) => r.json()),
       fetch(
         `${config.serverBaseUrl}/rest/biorepository/dashboard/qc-discrepancies`,
+        {
+          credentials: "include",
+        },
+      ).then((r) => r.json()),
+      fetch(
+        `${config.serverBaseUrl}/rest/biorepository/dashboard/qc-history?limit=100`,
         {
           credentials: "include",
         },
@@ -94,17 +106,30 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
         },
       ).then((r) => r.json()),
     ])
-      .then(([capacity, aging, qc, discrepancies, retrieval, disposal]) => {
-        setMetricsData({
+      .then(
+        ([
           capacity,
+          storageUtilization,
           aging,
           qc,
           discrepancies,
+          qcHistory,
+          retrieval,
+          disposal,
+        ]) => {
+        setMetricsData({
+          capacity,
+          storageUtilization,
+          aging,
+          qc,
+          discrepancies,
+          qcHistory,
           retrieval,
           disposal,
         });
         setIsLoading(false);
-      })
+      },
+      )
       .catch((err) => {
         setError(err.message);
         setIsLoading(false);
@@ -172,8 +197,25 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     );
   }
 
-  const { capacity, aging, qc, discrepancies, retrieval, disposal } =
+  const {
+    capacity,
+    storageUtilization,
+    aging,
+    qc,
+    discrepancies,
+    qcHistory,
+    retrieval,
+    disposal,
+  } =
     metricsData;
+
+  const formatPercent = (value) => {
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) {
+      return "N/A";
+    }
+    return `${numeric.toFixed(1)}%`;
+  };
 
   // Storage capacity rows
   const storageRows = [
@@ -195,6 +237,27 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     { key: "status", header: "Status" },
     { key: "count", header: "Sample Count" },
     { key: "percentage", header: "Percentage" },
+  ];
+
+  const storageUtilizationRows = (storageUtilization?.devices || []).map(
+    (device, idx) => ({
+      id: `storage-device-${idx}`,
+      deviceName: device.deviceName || device.deviceCode || "Unknown",
+      deviceType: device.deviceType || "N/A",
+      currentUsage: device.currentUsage ?? 0,
+      totalCapacity: device.totalCapacity ?? 0,
+      utilizationPercent: formatPercent(device.utilizationPercent),
+      capacitySource: device.capacitySource || "UNDEFINED",
+    }),
+  );
+
+  const storageUtilizationHeaders = [
+    { key: "deviceName", header: "Device" },
+    { key: "deviceType", header: "Type" },
+    { key: "currentUsage", header: "Current Usage" },
+    { key: "totalCapacity", header: "Total Capacity" },
+    { key: "utilizationPercent", header: "Utilization" },
+    { key: "capacitySource", header: "Capacity Source" },
   ];
 
   // Sample aging rows
@@ -284,6 +347,248 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
   const qcHeaders = [
     { key: "checkpoint", header: "Checkpoint" },
     { key: "passRate", header: "Pass Rate" },
+  ];
+
+  const qcSummaryRows = [
+    {
+      id: "qc-summary-1",
+      metric: "Pass Rate",
+      value: formatPercent(qc.passRate ?? qc.complianceRate),
+    },
+    {
+      id: "qc-summary-2",
+      metric: "Fail Count",
+      value: qc.failCount ?? qc.failedInspections ?? 0,
+    },
+    {
+      id: "qc-summary-3",
+      metric: "Fail Trend Basis",
+      value: qc.failTrendBasis
+        ? `${qc.failTrendBasis.granularity || "day"}, ${qc.failTrendBasis.windowDays || 30} days, source: ${qc.failTrendBasis.source || "N/A"}`
+        : "N/A",
+    },
+  ];
+
+  const qcSummaryHeaders = [
+    { key: "metric", header: "QC Summary Metric" },
+    { key: "value", header: "Value" },
+  ];
+
+  const failTrendRows = (qc.failTrend || []).map((point, idx) => ({
+    id: `fail-trend-${idx}`,
+    date: point.date || "-",
+    failedInspections: point.failedInspections ?? 0,
+    totalInspections: point.totalInspections ?? 0,
+    passRate: formatPercent(point.passRate),
+  }));
+
+  const failTrendHeaders = [
+    { key: "date", header: "Date" },
+    { key: "failedInspections", header: "Fail Count" },
+    { key: "totalInspections", header: "Total Checks" },
+    { key: "passRate", header: "Pass Rate" },
+  ];
+
+  const mapBreakdownRows = (rows, prefix) =>
+    (rows || []).map((entry, idx) => ({
+      id: `${prefix}-${idx}`,
+      key: entry.key || "Unknown",
+      totalInspections: entry.totalInspections ?? 0,
+      failedInspections: entry.failedInspections ?? 0,
+      passRate: formatPercent(entry.passRate),
+    }));
+
+  const breakdownHeaders = [
+    { key: "key", header: "Dimension" },
+    { key: "totalInspections", header: "Total Checks" },
+    { key: "failedInspections", header: "Fail Count" },
+    { key: "passRate", header: "Pass Rate" },
+  ];
+
+  const freezerBreakdownRows = mapBreakdownRows(
+    qc.breakdownByFreezer,
+    "freezer-breakdown",
+  );
+  const rackBreakdownRows = mapBreakdownRows(
+    qc.breakdownByRack,
+    "rack-breakdown",
+  );
+  const technicianBreakdownRows = mapBreakdownRows(
+    qc.breakdownByTechnician,
+    "technician-breakdown",
+  );
+
+  const escalationSignals = qc.escalationSignals || {};
+  const escalationSummaryRows = [
+    {
+      id: "qc-escalation-1",
+      signal: "Batch Fail Rate",
+      value: `${formatPercent(escalationSignals.batchFailRatePercent)} (threshold ${Number.isFinite(Number(escalationSignals.batchFailRateThresholdPercent)) ? Number(escalationSignals.batchFailRateThresholdPercent).toFixed(1) : "5.0"}%)`,
+    },
+    {
+      id: "qc-escalation-2",
+      signal: "Threshold Exceeded",
+      value: escalationSignals.batchFailRateExceeded ? "Yes" : "No",
+    },
+    {
+      id: "qc-escalation-3",
+      signal: "Repeated Failure (Box/Rack)",
+      value: escalationSignals.repeatedFailureInSameBoxOrRack
+        ? `Yes (boxes: ${escalationSignals.repeatedFailureBoxesCount || 0}, racks: ${escalationSignals.repeatedFailureRacksCount || 0})`
+        : "No",
+    },
+    {
+      id: "qc-escalation-4",
+      signal: "Critical Missing Samples",
+      value: escalationSignals.criticalMissingSamples || 0,
+    },
+    {
+      id: "qc-escalation-5",
+      signal: "Triggered Rules",
+      value: Array.isArray(escalationSignals.triggeredRules)
+        ? escalationSignals.triggeredRules.join(", ") || "None"
+        : "None",
+    },
+  ];
+
+  const escalationSummaryHeaders = [
+    { key: "signal", header: "Escalation Signal" },
+    { key: "value", header: "Value" },
+  ];
+
+  const investigationBoxRows = (qc.underInvestigationBoxes || []).map(
+    (entry, idx) => ({
+      id: `investigation-box-${idx}`,
+      key: entry.key || "Unknown",
+      failedInspections: entry.failedInspections ?? 0,
+      totalInspections: entry.totalInspections ?? 0,
+      failRate: formatPercent(entry.failRate),
+    }),
+  );
+
+  const flaggedFreezerRows = (
+    escalationSignals.flaggedFreezers || []
+  ).map((entry, idx) => ({
+    id: `flagged-freezer-${idx}`,
+    key: entry.key || "Unknown",
+    failedInspections: entry.failedInspections ?? 0,
+    totalInspections: entry.totalInspections ?? 0,
+    failRate: formatPercent(entry.failRate),
+  }));
+
+  const problematicLocationRows = (
+    qc.frequentlyProblematicLocations || []
+  ).map((entry, idx) => ({
+    id: `problematic-location-${idx}`,
+    locationType: entry.locationType || "Unknown",
+    key: entry.key || "Unknown",
+    failedInspections: entry.failedInspections ?? 0,
+    totalInspections: entry.totalInspections ?? 0,
+    failRate: formatPercent(entry.failRate),
+  }));
+
+  const problematicLocationHeaders = [
+    { key: "locationType", header: "Type" },
+    { key: "key", header: "Location" },
+    { key: "failedInspections", header: "Fail Count" },
+    { key: "totalInspections", header: "Total Checks" },
+    { key: "failRate", header: "Fail Rate" },
+  ];
+
+  const deriveQcStatus = (item) => item.qcStatus || "UNKNOWN";
+
+  const deriveLifecycleOutcome = (item) => item.lifecycleOutcome || "UNKNOWN";
+
+  const formatLifecycleOutcome = (value) => {
+    const labels = {
+      PASSED: "Passed",
+      FAILED_PENDING_CORRECTION: "Failed (pending correction)",
+      FAILED_CORRECTED: "Failed (correction logged)",
+      FAILED_MARKED_MISSING: "Failed (marked missing)",
+      UNKNOWN: "Unknown",
+    };
+    return labels[value] || value || "Unknown";
+  };
+
+  const historyRows = (qcHistory?.items || []).map((item, idx) => ({
+    id: `qc-history-${idx}`,
+    inspectionDate: item.inspectionDate
+      ? new Date(item.inspectionDate).toLocaleString()
+      : "-",
+    qcResult: item.qcResult || "-",
+    qcStatus: deriveQcStatus(item),
+    lifecycleOutcome: formatLifecycleOutcome(deriveLifecycleOutcome(item)),
+    sampleFlag: item.sampleFlag || "-",
+    qcFailed: item.qcFailed ? "Yes" : "No",
+    inspectorName: item.inspectorName || item.technicianId || "-",
+    freezer: item.freezer || "Unknown",
+    freezerFlag: item.freezerFlag || "NORMAL",
+    rack: item.rack || "Unknown",
+    boxFlag: item.boxFlag || "NORMAL",
+    escalationTriggered: item.escalationTriggered ? "Yes" : "No",
+    failureResolution: item.failureResolution || "N/A",
+    discrepancyType: item.discrepancyType || "-",
+    failureComment: item.failureComment || item.remarks || "-",
+    correctiveAction: item.correctiveAction || "-",
+    correctionFrom:
+      item.auditTrail?.fromCoordinates || item.auditTrail?.oldCoordinate || "-",
+    correctionTo:
+      item.auditTrail?.toCoordinates || item.auditTrail?.newCoordinate || "-",
+    correctedBy:
+      item.auditTrail?.correctedBy ||
+      item.auditTrail?.user ||
+      item.inspectorName ||
+      item.technicianId ||
+      "-",
+    correctedAt: item.auditTrail?.correctedAt || item.auditTrail?.timestamp
+      ? new Date(item.auditTrail.correctedAt || item.auditTrail.timestamp).toLocaleString()
+      : "-",
+    correctionReason: item.auditTrail?.reason || "-",
+    remarks: item.remarks || "-",
+  }));
+
+  const discrepancyHistoryCount = historyRows.filter(
+    (row) => row.qcResult === "DISCREPANCY_FOUND",
+  ).length;
+  const correctiveActionCount = historyRows.filter(
+    (row) => row.correctiveAction && row.correctiveAction !== "-",
+  ).length;
+  const correctedOutcomeCount =
+    qc?.failureResolutionSummary?.correctedVsUnresolved?.corrected ??
+    historyRows.filter(
+      (row) =>
+        row.lifecycleOutcome === "Failed (correction logged)" ||
+        row.lifecycleOutcome === "Failed (marked missing)",
+    ).length;
+  const pendingCorrectionCount =
+    qc?.failureResolutionSummary?.correctedVsUnresolved?.unresolved ??
+    historyRows.filter(
+      (row) => row.lifecycleOutcome === "Failed (pending correction)",
+    ).length;
+
+  const historyHeaders = [
+    { key: "inspectionDate", header: "Inspection Date" },
+    { key: "qcResult", header: "Result" },
+    { key: "qcStatus", header: "QC Status" },
+    { key: "lifecycleOutcome", header: "Lifecycle Outcome" },
+    { key: "sampleFlag", header: "Sample Flag" },
+    { key: "qcFailed", header: "QC Failed" },
+    { key: "inspectorName", header: "Technician" },
+    { key: "freezer", header: "Freezer" },
+    { key: "freezerFlag", header: "Freezer Flag" },
+    { key: "rack", header: "Rack" },
+    { key: "boxFlag", header: "Box Flag" },
+    { key: "escalationTriggered", header: "Escalation Triggered" },
+    { key: "failureResolution", header: "Failure Resolution" },
+    { key: "discrepancyType", header: "Discrepancy Type" },
+    { key: "failureComment", header: "Failure Comment" },
+    { key: "correctiveAction", header: "Corrective Action" },
+    { key: "correctionFrom", header: "Correction From" },
+    { key: "correctionTo", header: "Correction To" },
+    { key: "correctedBy", header: "Corrected By" },
+    { key: "correctedAt", header: "Corrected At" },
+    { key: "correctionReason", header: "Correction Reason" },
+    { key: "remarks", header: "Remarks" },
   ];
 
   // Retrieval stats rows
@@ -485,6 +790,49 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
                   </TableContainer>
                 )}
               </DataTable>
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable
+                  rows={storageUtilizationRows}
+                  headers={storageUtilizationHeaders}
+                >
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="Storage Utilization by Device"
+                      description={`Devices: ${storageUtilization?.totalDevices ?? 0} | Capacity-defined: ${storageUtilization?.capacityDefinedDevices ?? 0} | Undefined capacity: ${storageUtilization?.capacityUndefinedDevices ?? 0} | Weighted utilization: ${formatPercent(storageUtilization?.averageUtilization)}`}
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
             </AccordionItem>
 
             {/* Sample Aging Breakdown */}
@@ -544,6 +892,45 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
                 defaultMessage: "QC Checkpoint Statistics",
               })}
             >
+              <DataTable rows={qcSummaryRows} headers={qcSummaryHeaders}>
+                {({
+                  rows,
+                  headers,
+                  getTableProps,
+                  getHeaderProps,
+                  getRowProps,
+                }) => (
+                  <TableContainer
+                    title="QC Core Summary"
+                    description="Pass rate, fail count, and fail trend basis used by the dashboard"
+                  >
+                    <Table {...getTableProps()}>
+                      <TableHead>
+                        <TableRow>
+                          {headers.map((header) => (
+                            <TableHeader
+                              key={header.key}
+                              {...getHeaderProps({ header })}
+                            >
+                              {header.header}
+                            </TableHeader>
+                          ))}
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {rows.map((row) => (
+                          <TableRow key={row.id} {...getRowProps({ row })}>
+                            {row.cells.map((cell) => (
+                              <TableCell key={cell.id}>{cell.value}</TableCell>
+                            ))}
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                )}
+              </DataTable>
+
               <DataTable rows={qcCheckpointRows} headers={qcHeaders}>
                 {({
                   rows,
@@ -570,6 +957,387 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
                         failed: qc.failedInspections || 0,
                       },
                     )}
+                  >
+                    <Table {...getTableProps()}>
+                      <TableHead>
+                        <TableRow>
+                          {headers.map((header) => (
+                            <TableHeader
+                              key={header.key}
+                              {...getHeaderProps({ header })}
+                            >
+                              {header.header}
+                            </TableHeader>
+                          ))}
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {rows.map((row) => (
+                          <TableRow key={row.id} {...getRowProps({ row })}>
+                            {row.cells.map((cell) => (
+                              <TableCell key={cell.id}>{cell.value}</TableCell>
+                            ))}
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                )}
+              </DataTable>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable rows={failTrendRows} headers={failTrendHeaders}>
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="Fail Trend (Daily Basis)"
+                      description="Trend basis: QC inspection date, daily aggregation, rolling 30-day window"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable rows={freezerBreakdownRows} headers={breakdownHeaders}>
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="QC Breakdown by Freezer"
+                      description="Grouped where expected location snapshot data is available"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable rows={rackBreakdownRows} headers={breakdownHeaders}>
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="QC Breakdown by Rack"
+                      description="Grouped where expected location snapshot data is available"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable rows={technicianBreakdownRows} headers={breakdownHeaders}>
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="QC Breakdown by Technician"
+                      description="Grouped by inspector/technician where current data supports it"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable
+                  rows={escalationSummaryRows}
+                  headers={escalationSummaryHeaders}
+                >
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="Escalation Basis Snapshot"
+                      description="Minimal rule basis from AHRI guidance: batch fail rate, repeated location failures, and missing-sample triggers"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable rows={investigationBoxRows} headers={breakdownHeaders}>
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="Boxes Under Investigation"
+                      description="Boxes with repeated failures (two or more failed checks)"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable rows={flaggedFreezerRows} headers={breakdownHeaders}>
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="Flagged Freezers"
+                      description="Freezers whose fail rate exceeds the 5% threshold"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable
+                  rows={problematicLocationRows}
+                  headers={problematicLocationHeaders}
+                >
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="Frequently Problematic Locations"
+                      description="Highest-failure locations based on current QC history"
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
+            </AccordionItem>
+
+            {/* QC History for Completed Checks */}
+            <AccordionItem
+              title={intl.formatMessage({
+                id: "biorepository.reporting.metrics.qc.history.title",
+                defaultMessage: "QC History (Completed Checks)",
+              })}
+            >
+              <DataTable rows={historyRows} headers={historyHeaders}>
+                {({
+                  rows,
+                  headers,
+                  getTableProps,
+                  getHeaderProps,
+                  getRowProps,
+                }) => (
+                  <TableContainer
+                    title="Completed QC Check History"
+                    description={`Source: ${qcHistory?.source || "N/A"} | Records: ${qcHistory?.count || 0} | Discrepancies: ${discrepancyHistoryCount} | Corrective actions logged: ${correctiveActionCount} | Failed outcomes corrected: ${correctedOutcomeCount} | Pending corrections: ${pendingCorrectionCount} | Per-record flags: sample/box/freezer escalation visibility enabled`}
                   >
                     <Table {...getTableProps()}>
                       <TableHead>

--- a/frontend/src/components/notebook/pages/biorepository/reporting/DetailedMetricsTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/DetailedMetricsTab.js
@@ -67,6 +67,12 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
         },
       ).then((r) => r.json()),
       fetch(
+        `${config.serverBaseUrl}/rest/biorepository/dashboard/storage-utilization`,
+        {
+          credentials: "include",
+        },
+      ).then((r) => r.json()),
+      fetch(
         `${config.serverBaseUrl}/rest/biorepository/dashboard/sample-aging`,
         {
           credentials: "include",
@@ -103,6 +109,7 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
       .then(
         ([
           capacity,
+          storageUtilization,
           aging,
           qc,
           discrepancies,
@@ -112,6 +119,7 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
         ]) => {
         setMetricsData({
           capacity,
+          storageUtilization,
           aging,
           qc,
           discrepancies,
@@ -189,7 +197,16 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     );
   }
 
-  const { capacity, aging, qc, discrepancies, qcHistory, retrieval, disposal } =
+  const {
+    capacity,
+    storageUtilization,
+    aging,
+    qc,
+    discrepancies,
+    qcHistory,
+    retrieval,
+    disposal,
+  } =
     metricsData;
 
   const formatPercent = (value) => {
@@ -254,6 +271,25 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
     { key: "status", header: "Status" },
     { key: "count", header: "Sample Count" },
     { key: "percentage", header: "Percentage" },
+  ];
+
+  const storageUtilizationRows = (storageUtilization?.devices || []).map(
+    (device, idx) => ({
+      id: `storage-device-${idx}`,
+      deviceName: device.deviceName || "-",
+      currentUsage: device.currentUsage ?? 0,
+      totalCapacity: device.totalCapacity ?? 0,
+      utilizationPercent: formatPercent(device.utilizationPercent),
+      capacitySource: device.capacitySource || "UNDEFINED",
+    }),
+  );
+
+  const storageUtilizationHeaders = [
+    { key: "deviceName", header: "Device" },
+    { key: "currentUsage", header: "Current Usage" },
+    { key: "totalCapacity", header: "Total Capacity" },
+    { key: "utilizationPercent", header: "Utilization" },
+    { key: "capacitySource", header: "Capacity Source" },
   ];
 
   // Sample aging rows
@@ -864,6 +900,50 @@ function DetailedMetricsTab({ entryId, notebookId, pageData }) {
                   </TableContainer>
                 )}
               </DataTable>
+
+              <div style={{ marginTop: "1rem" }}>
+                <DataTable
+                  rows={storageUtilizationRows}
+                  headers={storageUtilizationHeaders}
+                >
+                  {({
+                    rows,
+                    headers,
+                    getTableProps,
+                    getHeaderProps,
+                    getRowProps,
+                  }) => (
+                    <TableContainer
+                      title="Storage Utilization by Device"
+                      description="Configured and derived capacity confidence for each active device."
+                    >
+                      <Table {...getTableProps()}>
+                        <TableHead>
+                          <TableRow>
+                            {headers.map((header) => (
+                              <TableHeader
+                                key={header.key}
+                                {...getHeaderProps({ header })}
+                              >
+                                {header.header}
+                              </TableHeader>
+                            ))}
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {rows.map((row) => (
+                            <TableRow key={row.id} {...getRowProps({ row })}>
+                              {row.cells.map((cell) => (
+                                <TableCell key={cell.id}>{cell.value}</TableCell>
+                              ))}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </div>
             </AccordionItem>
 
             {/* Sample Aging Breakdown */}

--- a/frontend/src/components/notebook/pages/biorepository/reporting/ExportReportsTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/ExportReportsTab.js
@@ -8,6 +8,7 @@ import {
   InlineNotification,
   InlineLoading,
   Search,
+  TextInput,
   Select,
   SelectItem,
   DatePicker,
@@ -44,6 +45,14 @@ function ExportReportsTab({ entryId, notebookId, pageData }) {
   const [auditError, setAuditError] = useState(null);
   const [auditSuccess, setAuditSuccess] = useState(false);
 
+  // QC batch export state
+  const [qcBatchId, setQcBatchId] = useState("");
+  const [qcBatchFormat, setQcBatchFormat] = useState("csv");
+  const [qcBatchLoading, setQcBatchLoading] = useState(false);
+  const [qcBatchError, setQcBatchError] = useState(null);
+  const [qcBatchSuccess, setQcBatchSuccess] = useState(false);
+  const [recentQcBatchIds, setRecentQcBatchIds] = useState([]);
+
   // Audit trail filter state
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedAction, setSelectedAction] = useState("ALL");
@@ -69,6 +78,36 @@ function ExportReportsTab({ entryId, notebookId, pageData }) {
       .then((r) => r.json())
       .then((data) => setActions(data))
       .catch((err) => console.error("Failed to load action types:", err));
+  }, []);
+
+  // Fetch recent QC batch IDs to make export easier.
+  useEffect(() => {
+    fetch(`${config.serverBaseUrl}/rest/biorepository/dashboard/qc-history?limit=300`, {
+      credentials: "include",
+    })
+      .then((r) => {
+        if (!r.ok) {
+          throw new Error("Failed to load QC history");
+        }
+        return r.json();
+      })
+      .then((payload) => {
+        const items = Array.isArray(payload?.items) ? payload.items : [];
+        const seen = new Set();
+        const batchIds = [];
+        items.forEach((item) => {
+          const batchId = (item?.qcBatchId || "").trim();
+          if (!batchId || seen.has(batchId)) {
+            return;
+          }
+          seen.add(batchId);
+          batchIds.push(batchId);
+        });
+        setRecentQcBatchIds(batchIds);
+      })
+      .catch(() => {
+        setRecentQcBatchIds([]);
+      });
   }, []);
 
   // Generic download handler
@@ -176,6 +215,45 @@ function ExportReportsTab({ entryId, notebookId, pageData }) {
     setSelectedAction("ALL");
     setStartDate("");
     setEndDate("");
+  };
+
+  const handleQcBatchExport = () => {
+    if (!qcBatchId.trim()) {
+      setQcBatchError("QC batch ID is required.");
+      return;
+    }
+    setQcBatchLoading(true);
+    setQcBatchError(null);
+    setQcBatchSuccess(false);
+    const timestamp = new Date().toISOString().split("T")[0];
+    const endpoint = `/rest/biorepository/qc/export/${qcBatchFormat}?qcBatchId=${encodeURIComponent(
+      qcBatchId.trim(),
+    )}`;
+    fetch(`${config.serverBaseUrl}${endpoint}`, {
+      credentials: "include",
+      method: "GET",
+    })
+      .then((response) => {
+        if (!response.ok)
+          throw new Error(
+            `Export failed: ${response.status} ${response.statusText}`,
+          );
+        return response.blob();
+      })
+      .then((blob) => {
+        downloadFile(
+          blob,
+          `biorepository_qc_batch_${qcBatchId.trim()}_${timestamp}`,
+          qcBatchFormat,
+        );
+        setQcBatchSuccess(true);
+        setQcBatchLoading(false);
+        setTimeout(() => setQcBatchSuccess(false), 5000);
+      })
+      .catch((err) => {
+        setQcBatchError(err.message);
+        setQcBatchLoading(false);
+      });
   };
 
   return (
@@ -297,6 +375,156 @@ function ExportReportsTab({ entryId, notebookId, pageData }) {
                     <FormattedMessage
                       id="biorepository.reporting.export.downloadButton"
                       defaultMessage="Download Dashboard Metrics"
+                    />
+                  </Button>
+                )}
+              </div>
+            </AccordionItem>
+
+            {/* QC Batch Export Section */}
+            <AccordionItem
+              title={intl.formatMessage({
+                id: "biorepository.reporting.export.qcBatch.title",
+                defaultMessage: "QC Batch Export",
+              })}
+            >
+              <div style={{ padding: "1rem" }}>
+                <p
+                  style={{
+                    fontSize: "0.875rem",
+                    color: "#525252",
+                    marginBottom: "1rem",
+                  }}
+                >
+                  <FormattedMessage
+                    id="biorepository.reporting.export.qcBatch.subtitle"
+                    defaultMessage="Export a printable QC record set for one generated batch ID."
+                  />
+                </p>
+
+                <div
+                  style={{
+                    display: "flex",
+                    gap: "1rem",
+                    flexWrap: "wrap",
+                    marginBottom: "1rem",
+                  }}
+                >
+                  <Select
+                    id="qc-batch-id-recent"
+                    labelText={intl.formatMessage({
+                      id: "biorepository.reporting.export.qcBatch.recent",
+                      defaultMessage: "Recent QC Batch IDs",
+                    })}
+                    value={qcBatchId}
+                    onChange={(e) => setQcBatchId(e.target.value)}
+                    size="md"
+                    style={{ minWidth: "320px" }}
+                  >
+                    <SelectItem
+                      value=""
+                      text={intl.formatMessage({
+                        id: "biorepository.reporting.export.qcBatch.recentPlaceholder",
+                        defaultMessage: "Select from recent batches...",
+                      })}
+                    />
+                    {recentQcBatchIds.map((batchId) => (
+                      <SelectItem key={batchId} value={batchId} text={batchId} />
+                    ))}
+                  </Select>
+                  <TextInput
+                    id="qc-batch-id"
+                    labelText={intl.formatMessage({
+                      id: "biorepository.reporting.export.qcBatch.id",
+                      defaultMessage: "QC Batch ID",
+                    })}
+                    placeholder={intl.formatMessage({
+                      id: "biorepository.reporting.export.qcBatch.placeholder",
+                      defaultMessage: "QCBATCH-...",
+                    })}
+                    value={qcBatchId}
+                    onChange={(e) => setQcBatchId(e.target.value)}
+                    style={{ minWidth: "320px" }}
+                  />
+                </div>
+                <p style={{ fontSize: "0.75rem", color: "#6f6f6f", marginTop: "-0.5rem", marginBottom: "1rem" }}>
+                  <FormattedMessage
+                    id="biorepository.reporting.export.qcBatch.hint"
+                    defaultMessage="Batch IDs come from generated QC rounds in QC Inspection. Pick one above or paste manually."
+                  />
+                </p>
+
+                <RadioButtonGroup
+                  legendText={intl.formatMessage({
+                    id: "biorepository.reporting.export.formatLabel",
+                    defaultMessage: "Export Format",
+                  })}
+                  name="qc-batch-format"
+                  valueSelected={qcBatchFormat}
+                  onChange={setQcBatchFormat}
+                  style={{ marginBottom: "1rem" }}
+                >
+                  <RadioButton labelText="CSV" value="csv" id="qc-batch-csv" />
+                  <RadioButton
+                    labelText="Excel"
+                    value="excel"
+                    id="qc-batch-excel"
+                  />
+                  <RadioButton
+                    labelText="JSON"
+                    value="json"
+                    id="qc-batch-json"
+                  />
+                  <RadioButton labelText="PDF" value="pdf" id="qc-batch-pdf" />
+                </RadioButtonGroup>
+
+                {qcBatchSuccess && (
+                  <InlineNotification
+                    kind="success"
+                    title={intl.formatMessage({
+                      id: "biorepository.reporting.export.success",
+                      defaultMessage: "Export Successful",
+                    })}
+                    subtitle={intl.formatMessage({
+                      id: "biorepository.reporting.export.successMessage",
+                      defaultMessage: "File downloaded successfully",
+                    })}
+                    lowContrast
+                    hideCloseButton
+                    style={{ marginBottom: "1rem" }}
+                  />
+                )}
+
+                {qcBatchError && (
+                  <InlineNotification
+                    kind="error"
+                    title={intl.formatMessage({
+                      id: "biorepository.reporting.export.error",
+                      defaultMessage: "Export Failed",
+                    })}
+                    subtitle={qcBatchError}
+                    lowContrast
+                    onClose={() => setQcBatchError(null)}
+                    style={{ marginBottom: "1rem" }}
+                  />
+                )}
+
+                {qcBatchLoading ? (
+                  <InlineLoading
+                    description={intl.formatMessage({
+                      id: "biorepository.reporting.export.loading",
+                      defaultMessage: "Generating export...",
+                    })}
+                  />
+                ) : (
+                  <Button
+                    kind="primary"
+                    renderIcon={Download}
+                    onClick={handleQcBatchExport}
+                  >
+                    <FormattedMessage
+                      id="biorepository.reporting.export.qcBatch.downloadButton"
+                      defaultMessage="Download QC Batch Report"
                     />
                   </Button>
                 )}

--- a/frontend/src/components/notebook/pages/biorepository/reporting/OverviewDashboardTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/OverviewDashboardTab.js
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from "react";
-import { Grid, Column, Loading, InlineNotification, Tile } from "@carbon/react";
+import {
+  Grid,
+  Column,
+  Loading,
+  InlineNotification,
+  Tile,
+  Button,
+  InlineLoading,
+} from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
+import { Download } from "@carbon/icons-react";
 import PropTypes from "prop-types";
 import config from "../../../../../config.json";
 
@@ -18,6 +27,9 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
   const [isLoading, setIsLoading] = useState(true);
   const [dashboardData, setDashboardData] = useState(null);
   const [error, setError] = useState(null);
+  const [csvLoading, setCsvLoading] = useState(false);
+  const [csvError, setCsvError] = useState(null);
+  const [notificationCopyState, setNotificationCopyState] = useState(null);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -79,6 +91,57 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
     return () => controller.abort();
   }, []);
 
+  const downloadBlob = (blob, filename) => {
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    window.URL.revokeObjectURL(url);
+  };
+
+  const handleExportCsv = () => {
+    setCsvLoading(true);
+    setCsvError(null);
+    const stamp = new Date().toISOString().split("T")[0];
+    fetch(`${config.serverBaseUrl}/rest/biorepository/dashboard/export/csv`, {
+      credentials: "include",
+      method: "GET",
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Export failed: ${response.status} ${response.statusText}`,
+          );
+        }
+        return response.blob();
+      })
+      .then((blob) => {
+        downloadBlob(blob, `biorepository_dashboard_${stamp}.csv`);
+        setCsvLoading(false);
+      })
+      .catch((err) => {
+        setCsvError(err.message);
+        setCsvLoading(false);
+      });
+  };
+
+  const handleCopyNotification = async () => {
+    const message = dashboardData?.qc?.escalationSignals?.supervisorNotificationMessage;
+    if (!message) {
+      setNotificationCopyState("error");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(message);
+      setNotificationCopyState("success");
+    } catch (e) {
+      setNotificationCopyState("error");
+    }
+  };
+
   if (isLoading) {
     return (
       <div style={{ padding: "2rem" }}>
@@ -129,7 +192,6 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
 
   const { capacity, aging, qc, retrieval } = dashboardData;
   const escalationSignals = qc?.escalationSignals || {};
-  const failureResolutionSummary = qc?.failureResolutionSummary || {};
   const triggeredRules = Array.isArray(escalationSignals.triggeredRules)
     ? escalationSignals.triggeredRules
     : [];
@@ -142,12 +204,100 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
       <Grid fullWidth>
         {/* Page Header */}
         <Column lg={16} md={8} sm={4}>
-          <h4 style={{ marginBottom: "1.5rem" }}>
-            <FormattedMessage
-              id="biorepository.reporting.overview.title"
-              defaultMessage="Biorepository Overview Dashboard"
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: "1.5rem",
+              gap: "1rem",
+              flexWrap: "wrap",
+            }}
+          >
+            <h4 style={{ marginBottom: 0 }}>
+              <FormattedMessage
+                id="biorepository.reporting.overview.title"
+                defaultMessage="Biorepository Overview Dashboard"
+              />
+            </h4>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.75rem",
+                flexWrap: "wrap",
+              }}
+            >
+              {csvLoading ? (
+                <InlineLoading
+                  description={intl.formatMessage({
+                    id: "biorepository.reporting.overview.csv.loading",
+                    defaultMessage: "Preparing CSV export...",
+                  })}
+                />
+              ) : (
+                <Button kind="primary" size="sm" renderIcon={Download} onClick={handleExportCsv}>
+                  <FormattedMessage
+                    id="biorepository.reporting.overview.csv.export"
+                    defaultMessage="Export CSV"
+                  />
+                </Button>
+              )}
+              <Button kind="secondary" size="sm" onClick={() => window.print()}>
+                <FormattedMessage
+                  id="biorepository.reporting.overview.print"
+                  defaultMessage="Print Dashboard"
+                />
+              </Button>
+            </div>
+          </div>
+          {csvError && (
+            <InlineNotification
+              kind="error"
+              title={intl.formatMessage({
+                id: "biorepository.reporting.overview.csv.error.title",
+                defaultMessage: "CSV Export Failed",
+              })}
+              subtitle={csvError}
+              lowContrast
+              onClose={() => setCsvError(null)}
+              style={{ marginBottom: "1rem" }}
             />
-          </h4>
+          )}
+          {notificationCopyState === "success" && (
+            <InlineNotification
+              kind="success"
+              title={intl.formatMessage({
+                id: "biorepository.reporting.overview.notification.copy.success.title",
+                defaultMessage: "Supervisor Alert Copied",
+              })}
+              subtitle={intl.formatMessage({
+                id: "biorepository.reporting.overview.notification.copy.success.subtitle",
+                defaultMessage:
+                  "Escalation notification text copied. Paste it to your supervisor channel.",
+              })}
+              lowContrast
+              onClose={() => setNotificationCopyState(null)}
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+          {notificationCopyState === "error" && (
+            <InlineNotification
+              kind="warning"
+              title={intl.formatMessage({
+                id: "biorepository.reporting.overview.notification.copy.error.title",
+                defaultMessage: "Could Not Copy Alert",
+              })}
+              subtitle={intl.formatMessage({
+                id: "biorepository.reporting.overview.notification.copy.error.subtitle",
+                defaultMessage:
+                  "Copy the escalation text manually from the Escalation Summary section.",
+              })}
+              lowContrast
+              onClose={() => setNotificationCopyState(null)}
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
         </Column>
 
         {/* KPI Cards Row */}
@@ -440,9 +590,6 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
                     />
                   </li>
                   <li>
-                    {`Storage utilization (weighted): ${Number.isFinite(Number(capacity?.averageUtilization)) ? Number(capacity.averageUtilization).toFixed(1) : "N/A"}% across ${capacity?.totalDevices ?? 0} active devices`}
-                  </li>
-                  <li>
                     {`QC fail rate: ${Number.isFinite(Number(escalationSignals.batchFailRatePercent)) ? Number(escalationSignals.batchFailRatePercent).toFixed(1) : "N/A"}% (threshold ${Number.isFinite(Number(escalationSignals.batchFailRateThresholdPercent)) ? Number(escalationSignals.batchFailRateThresholdPercent).toFixed(1) : "5.0"}%)`}
                   </li>
                   <li>
@@ -460,18 +607,36 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
                     }`}
                   </li>
                   <li>
-                    {`Failed outcomes corrected vs unresolved: ${
-                      failureResolutionSummary?.correctedVsUnresolved?.corrected ??
-                      0
-                    } / ${
-                      failureResolutionSummary?.correctedVsUnresolved
-                        ?.unresolved ?? 0
+                    {`Supervisor notification required: ${
+                      escalationSignals.supervisorNotificationRequired
+                        ? "Yes"
+                        : "No"
                     }`}
                   </li>
                   {recommendedActions.length > 0 && (
                     <li>{`Recommended actions: ${recommendedActions.join("; ")}`}</li>
                   )}
                 </ul>
+                {escalationSignals.supervisorNotificationRequired &&
+                  escalationSignals.supervisorNotificationMessage && (
+                    <div style={{ marginTop: "0.75rem" }}>
+                      <p style={{ marginBottom: "0.5rem", fontWeight: 600 }}>
+                        <FormattedMessage
+                          id="biorepository.reporting.overview.notification.preview.title"
+                          defaultMessage="Supervisor alert preview"
+                        />
+                      </p>
+                      <p style={{ marginBottom: "0.75rem" }}>
+                        {escalationSignals.supervisorNotificationMessage}
+                      </p>
+                      <Button kind="tertiary" size="sm" onClick={handleCopyNotification}>
+                        <FormattedMessage
+                          id="biorepository.reporting.overview.notification.copy"
+                          defaultMessage="Copy Supervisor Alert"
+                        />
+                      </Button>
+                    </div>
+                  )}
               </Column>
             </Grid>
           </Tile>

--- a/frontend/src/components/notebook/pages/biorepository/reporting/OverviewDashboardTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/OverviewDashboardTab.js
@@ -128,6 +128,14 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
   }
 
   const { capacity, aging, qc, retrieval } = dashboardData;
+  const escalationSignals = qc?.escalationSignals || {};
+  const failureResolutionSummary = qc?.failureResolutionSummary || {};
+  const triggeredRules = Array.isArray(escalationSignals.triggeredRules)
+    ? escalationSignals.triggeredRules
+    : [];
+  const recommendedActions = Array.isArray(escalationSignals.recommendedActions)
+    ? escalationSignals.recommendedActions
+    : [];
 
   return (
     <div className="overview-dashboard-tab" style={{ padding: "1.5rem" }}>
@@ -221,7 +229,9 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
                 margin: "0.5rem 0 0 0",
               }}
             >
-              {qc?.complianceRate ? `${qc.complianceRate.toFixed(1)}%` : "N/A"}
+              {Number.isFinite(Number(qc?.passRate ?? qc?.complianceRate))
+                ? `${Number(qc?.passRate ?? qc?.complianceRate).toFixed(1)}%`
+                : "N/A"}
             </h2>
             <p
               style={{
@@ -232,12 +242,24 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
             >
               <FormattedMessage
                 id="biorepository.reporting.kpi.qcInspections"
-                defaultMessage="{passed} of {total} inspections passed"
+                defaultMessage="{passed} of {total} inspections passed | {failed} failed"
                 values={{
                   passed: qc?.passedInspections || 0,
                   total: qc?.totalInspections || 0,
+                  failed: (qc?.failCount ?? qc?.failedInspections) || 0,
                 }}
               />
+            </p>
+            <p
+              style={{
+                fontSize: "0.75rem",
+                color: triggeredRules.length ? "#da1e28" : "#525252",
+                marginTop: "0.25rem",
+              }}
+            >
+              {triggeredRules.length
+                ? `Escalation: ${triggeredRules.join(", ")}`
+                : "Escalation: none triggered"}
             </p>
           </Tile>
         </Column>
@@ -417,6 +439,38 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
                       values={{ count: retrieval?.overdueReturns || 0 }}
                     />
                   </li>
+                  <li>
+                    {`Storage utilization (weighted): ${Number.isFinite(Number(capacity?.averageUtilization)) ? Number(capacity.averageUtilization).toFixed(1) : "N/A"}% across ${capacity?.totalDevices ?? 0} active devices`}
+                  </li>
+                  <li>
+                    {`QC fail rate: ${Number.isFinite(Number(escalationSignals.batchFailRatePercent)) ? Number(escalationSignals.batchFailRatePercent).toFixed(1) : "N/A"}% (threshold ${Number.isFinite(Number(escalationSignals.batchFailRateThresholdPercent)) ? Number(escalationSignals.batchFailRateThresholdPercent).toFixed(1) : "5.0"}%)`}
+                  </li>
+                  <li>
+                    {`Repeated failure flags (box/rack): ${
+                      escalationSignals.repeatedFailureInSameBoxOrRack
+                        ? "Yes"
+                        : "No"
+                    }`}
+                  </li>
+                  <li>
+                    {`Flagged freezers: ${
+                      Array.isArray(escalationSignals.flaggedFreezers)
+                        ? escalationSignals.flaggedFreezers.length
+                        : 0
+                    }`}
+                  </li>
+                  <li>
+                    {`Failed outcomes corrected vs unresolved: ${
+                      failureResolutionSummary?.correctedVsUnresolved?.corrected ??
+                      0
+                    } / ${
+                      failureResolutionSummary?.correctedVsUnresolved
+                        ?.unresolved ?? 0
+                    }`}
+                  </li>
+                  {recommendedActions.length > 0 && (
+                    <li>{`Recommended actions: ${recommendedActions.join("; ")}`}</li>
+                  )}
                 </ul>
               </Column>
             </Grid>

--- a/frontend/src/components/notebook/pages/biorepository/reporting/OverviewDashboardTab.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/OverviewDashboardTab.js
@@ -550,6 +550,13 @@ function OverviewDashboardTab({ entryId, notebookId, pageData }) {
                     />
                   </li>
                 </ul>
+                <p style={{ fontSize: "0.875rem", marginBottom: "0.5rem" }}>
+                  {`Storage utilization (weighted): ${
+                    Number.isFinite(Number(capacity?.averageUtilization))
+                      ? Number(capacity.averageUtilization).toFixed(1)
+                      : "0.0"
+                  }% across ${capacity?.totalDevices || 0} active devices`}
+                </p>
               </Column>
               <Column lg={8} md={4} sm={4}>
                 <p style={{ fontSize: "0.875rem", marginBottom: "0.5rem" }}>

--- a/frontend/src/components/notebook/pages/biorepository/reporting/ReportingStorageConfidence.test.js
+++ b/frontend/src/components/notebook/pages/biorepository/reporting/ReportingStorageConfidence.test.js
@@ -1,0 +1,179 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import messages from "../../../../../languages/en.json";
+import DetailedMetricsTab from "./DetailedMetricsTab";
+import OverviewDashboardTab from "./OverviewDashboardTab";
+
+const renderWithIntl = (component) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      {component}
+    </IntlProvider>,
+  );
+
+describe("Biorepository reporting storage confidence checks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn((url) => {
+      if (url.includes("/dashboard/storage-capacity")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              totalSamplesStored: 12,
+              pendingStorage: 2,
+              totalDevices: 3,
+              averageUtilization: 42.5,
+            }),
+        });
+      }
+
+      if (url.includes("/dashboard/storage-utilization")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              totalDevices: 2,
+              capacityDefinedDevices: 2,
+              capacityUndefinedDevices: 0,
+              averageUtilization: 30.0,
+              devices: [
+                {
+                  deviceName: "Freezer-A",
+                  deviceType: "freezer",
+                  currentUsage: 20,
+                  totalCapacity: 100,
+                  utilizationPercent: 20.0,
+                  capacitySource: "DEVICE_CAPACITY_LIMIT",
+                },
+                {
+                  deviceName: "Freezer-B",
+                  deviceType: "freezer",
+                  currentUsage: 10,
+                  totalCapacity: 40,
+                  utilizationPercent: 25.0,
+                  capacitySource: "BOX_GRID_SUM",
+                },
+              ],
+            }),
+        });
+      }
+
+      if (url.includes("/dashboard/sample-aging")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              expired: 1,
+              expiring30Days: 2,
+              expiring60Days: 1,
+              expiring90Days: 0,
+              total: 12,
+            }),
+        });
+      }
+
+      if (url.includes("/dashboard/qc-metrics")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              passRate: 90.0,
+              complianceRate: 90.0,
+              passedInspections: 9,
+              totalInspections: 10,
+              failCount: 1,
+              failedInspections: 1,
+              failTrend: [],
+              failTrendBasis: {
+                source: "biorepository_qc_inspection.inspection_date",
+                granularity: "day",
+                windowDays: 30,
+              },
+              breakdownByFreezer: [],
+              breakdownByRack: [],
+              breakdownByTechnician: [],
+              underInvestigationBoxes: [],
+              frequentlyProblematicLocations: [],
+              failureResolutionSummary: {
+                correctedVsUnresolved: {
+                  corrected: 1,
+                  unresolved: 0,
+                },
+              },
+              escalationSignals: {
+                batchFailRatePercent: 10.0,
+                batchFailRateThresholdPercent: 5.0,
+                batchFailRateExceeded: true,
+                repeatedFailureInSameBoxOrRack: false,
+                flaggedFreezers: [],
+                triggeredRules: ["BATCH_FAIL_RATE_OVER_5_PERCENT"],
+                recommendedActions: ["Notify supervisor"],
+              },
+            }),
+        });
+      }
+
+      if (url.includes("/dashboard/qc-discrepancies")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ SAMPLE_MISSING: 1 }),
+        });
+      }
+
+      if (url.includes("/dashboard/qc-history")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ source: "biorepository_qc_inspection", count: 0, items: [] }),
+        });
+      }
+
+      if (url.includes("/dashboard/retrieval-stats")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              totalRequests: 3,
+              completedRequests: 2,
+              pendingRequests: 1,
+              overdueReturns: 0,
+            }),
+        });
+      }
+
+      if (url.includes("/dashboard/disposal-stats")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              totalDisposed: 0,
+              disposalsByProject: {},
+            }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+    });
+  });
+
+  test("DetailedMetricsTab renders storage utilization device table", async () => {
+    const view = renderWithIntl(<DetailedMetricsTab />);
+
+    expect(await view.findByText("Storage Utilization by Device")).toBeTruthy();
+    expect(await view.findByText("Freezer-A")).toBeTruthy();
+    expect(await view.findByText("Freezer-B")).toBeTruthy();
+    expect(await view.findByText("DEVICE_CAPACITY_LIMIT")).toBeTruthy();
+    expect(await view.findByText("BOX_GRID_SUM")).toBeTruthy();
+  });
+
+  test("OverviewDashboardTab renders storage utilization summary line", async () => {
+    const view = renderWithIntl(<OverviewDashboardTab />);
+    expect(
+      await view.findByText("Storage utilization (weighted): 42.5% across 3 active devices"),
+    ).toBeTruthy();
+  });
+});

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryDashboardRestController.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryDashboardRestController.java
@@ -2,6 +2,7 @@ package org.openelisglobal.biorepository.controller.rest;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.biorepository.service.BiorepositoryDashboardService;
@@ -147,6 +148,26 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
     }
 
     /**
+     * Get completed QC inspection history for dashboard/reporting.
+     *
+     * Returns map with source metadata and most recent completed checks.
+     *
+     * @param limit maximum rows to return (default 50)
+     * @return ResponseEntity with QC history source/list map
+     */
+    @GetMapping(value = "/qc-history", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> getQCHistory(
+            @RequestParam(required = false, defaultValue = "50") Integer limit) {
+        try {
+            Map<String, Object> history = dashboardService.getQCHistory(limit);
+            return ResponseEntity.ok(history);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError()
+                    .body(Map.of("error", "Failed to load QC history: " + e.getMessage()));
+        }
+    }
+
+    /**
      * Get retrieval statistics within date range.
      *
      * Returns: - totalRequests, completedRequests, pendingRequests,
@@ -162,11 +183,13 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
     public ResponseEntity<Map<String, Object>> getRetrievalStats(@RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         try {
-            LocalDate start = startDate != null ? LocalDate.parse(startDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
-            LocalDate end = endDate != null ? LocalDate.parse(endDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
+            LocalDate start = parseOptionalIsoDate(startDate);
+            LocalDate end = parseOptionalIsoDate(endDate);
 
             Map<String, Object> stats = dashboardService.getRetrievalStatistics(start, end);
             return ResponseEntity.ok(stats);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "Failed to load retrieval statistics: " + e.getMessage()));
@@ -188,11 +211,13 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
     public ResponseEntity<Map<String, Object>> getDisposalStats(@RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         try {
-            LocalDate start = startDate != null ? LocalDate.parse(startDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
-            LocalDate end = endDate != null ? LocalDate.parse(endDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
+            LocalDate start = parseOptionalIsoDate(startDate);
+            LocalDate end = parseOptionalIsoDate(endDate);
 
             Map<String, Object> stats = dashboardService.getDisposalStatistics(start, end);
             return ResponseEntity.ok(stats);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "Failed to load disposal statistics: " + e.getMessage()));
@@ -216,8 +241,8 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
             @RequestParam(required = false) String startDate, @RequestParam(required = false) String endDate,
             @RequestParam(required = false) String freezerId) {
         try {
-            LocalDate start = startDate != null ? LocalDate.parse(startDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
-            LocalDate end = endDate != null ? LocalDate.parse(endDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
+            LocalDate start = parseOptionalIsoDate(startDate);
+            LocalDate end = parseOptionalIsoDate(endDate);
 
             List<Map<String, Object>> excursions = dashboardService.getTemperatureExcursions(start, end);
 
@@ -227,8 +252,21 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
             }
 
             return ResponseEntity.ok(excursions);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(List.of(Map.of("error", e.getMessage())));
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    private LocalDate parseOptionalIsoDate(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Invalid date format '" + value + "'. Expected YYYY-MM-DD");
         }
     }
 

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryDashboardRestController.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryDashboardRestController.java
@@ -183,13 +183,14 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
     public ResponseEntity<Map<String, Object>> getRetrievalStats(@RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         try {
-            LocalDate start = parseOptionalIsoDate(startDate);
-            LocalDate end = parseOptionalIsoDate(endDate);
+            LocalDate start = startDate != null ? LocalDate.parse(startDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
+            LocalDate end = endDate != null ? LocalDate.parse(endDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
 
             Map<String, Object> stats = dashboardService.getRetrievalStatistics(start, end);
             return ResponseEntity.ok(stats);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (DateTimeParseException e) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Invalid date format. Expected YYYY-MM-DD"));
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "Failed to load retrieval statistics: " + e.getMessage()));
@@ -211,13 +212,14 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
     public ResponseEntity<Map<String, Object>> getDisposalStats(@RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         try {
-            LocalDate start = parseOptionalIsoDate(startDate);
-            LocalDate end = parseOptionalIsoDate(endDate);
+            LocalDate start = startDate != null ? LocalDate.parse(startDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
+            LocalDate end = endDate != null ? LocalDate.parse(endDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
 
             Map<String, Object> stats = dashboardService.getDisposalStatistics(start, end);
             return ResponseEntity.ok(stats);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (DateTimeParseException e) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Invalid date format. Expected YYYY-MM-DD"));
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "Failed to load disposal statistics: " + e.getMessage()));
@@ -241,8 +243,8 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
             @RequestParam(required = false) String startDate, @RequestParam(required = false) String endDate,
             @RequestParam(required = false) String freezerId) {
         try {
-            LocalDate start = parseOptionalIsoDate(startDate);
-            LocalDate end = parseOptionalIsoDate(endDate);
+            LocalDate start = startDate != null ? LocalDate.parse(startDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
+            LocalDate end = endDate != null ? LocalDate.parse(endDate, DateTimeFormatter.ISO_LOCAL_DATE) : null;
 
             List<Map<String, Object>> excursions = dashboardService.getTemperatureExcursions(start, end);
 
@@ -252,21 +254,10 @@ public class BiorepositoryDashboardRestController extends BaseRestController {
             }
 
             return ResponseEntity.ok(excursions);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(List.of(Map.of("error", e.getMessage())));
+        } catch (DateTimeParseException e) {
+            return ResponseEntity.badRequest().build();
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();
-        }
-    }
-
-    private LocalDate parseOptionalIsoDate(String value) {
-        if (value == null || value.trim().isEmpty()) {
-            return null;
-        }
-        try {
-            return LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE);
-        } catch (DateTimeParseException e) {
-            throw new IllegalArgumentException("Invalid date format '" + value + "'. Expected YYYY-MM-DD");
         }
     }
 

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryExportRestController.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryExportRestController.java
@@ -189,4 +189,56 @@ public class BiorepositoryExportRestController extends BaseRestController {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Export failed: " + e.getMessage(), e);
         }
     }
+
+    /**
+     * Export a specific QC batch in specified format.
+     */
+    @GetMapping("/qc/export/{format}")
+    public void exportQcBatch(@PathVariable("format") String format, @RequestParam String qcBatchId,
+            HttpServletResponse response) throws IOException {
+        if (qcBatchId == null || qcBatchId.trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "qcBatchId is required");
+        }
+        try {
+            byte[] exportData;
+            String contentType;
+            String fileExtension;
+            switch (format.toLowerCase()) {
+            case "csv":
+                exportData = exportService.exportQcBatchToCSV(qcBatchId.trim());
+                contentType = "text/csv";
+                fileExtension = "csv";
+                break;
+            case "excel":
+                exportData = exportService.exportQcBatchToExcel(qcBatchId.trim());
+                contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+                fileExtension = "xlsx";
+                break;
+            case "json":
+                exportData = exportService.exportQcBatchToJSON(qcBatchId.trim());
+                contentType = "application/json";
+                fileExtension = "json";
+                break;
+            case "pdf":
+                exportData = exportService.exportQcBatchToPDF(qcBatchId.trim());
+                contentType = "application/pdf";
+                fileExtension = "pdf";
+                break;
+            default:
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Unsupported format: " + format + ". Supported formats: csv, excel, json, pdf");
+            }
+            String timestamp = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+            String filename = "biorepository_qc_batch_" + qcBatchId.trim() + "_" + timestamp + "." + fileExtension;
+            response.setContentType(contentType);
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+            response.setContentLength(exportData.length);
+            response.getOutputStream().write(exportData);
+            response.getOutputStream().flush();
+        } catch (ResponseStatusException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Export failed: " + e.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestController.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestController.java
@@ -3,13 +3,14 @@ package org.openelisglobal.biorepository.controller.rest;
 import jakarta.servlet.http.HttpServletRequest;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.openelisglobal.biorepository.service.BioSampleService;
+import org.openelisglobal.biorepository.service.BiorepositoryQcOutcomeDerivation;
 import org.openelisglobal.biorepository.service.BiorepositoryQCInspectionService;
 import org.openelisglobal.biorepository.valueholder.BioSample;
 import org.openelisglobal.biorepository.valueholder.BioSample.WorkflowStatus;
@@ -17,6 +18,12 @@ import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
 import org.openelisglobal.common.rest.BaseRestController;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.storage.service.SampleStorageService;
+import org.openelisglobal.storage.service.StorageLocationService;
+import org.openelisglobal.storage.valueholder.StorageBox;
+import org.openelisglobal.storage.valueholder.StorageRack;
+import org.openelisglobal.storage.valueholder.StorageShelf;
+import org.openelisglobal.storage.valueholder.StorageDevice;
+import org.openelisglobal.storage.valueholder.StorageDevice.DeviceType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +34,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * REST controller for Biorepository QC Inspection operations.
@@ -39,9 +47,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/rest/biorepository/qc-inspection")
 public class BiorepositoryQCInspectionRestController extends BaseRestController {
 
-    private static final int MAX_BOXES_PER_ROUND = 200;
-    private static final int MAX_SAMPLES_PER_BOX = 50;
-
     @Autowired
     private BiorepositoryQCInspectionService qcInspectionService;
 
@@ -51,6 +56,9 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
     @Autowired
     private SampleStorageService storageService;
 
+    @Autowired
+    private StorageLocationService storageLocationService;
+
     /**
      * Get all BioSamples with workflowStatus = STORED along with their storage
      * locations. This endpoint provides samples ready for QC inspection.
@@ -58,43 +66,18 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
     @GetMapping(value = "/samples", produces = MediaType.APPLICATION_JSON_VALUE)
     @Transactional(readOnly = true)
     public ResponseEntity<List<Map<String, Object>>> getStoredSamplesForQC() {
-        List<BioSample> storedSamples = bioSampleService.getAllWithRelationships(50000).stream()
-                .filter(sample -> sample != null && sample.getWorkflowStatus() == WorkflowStatus.STORED)
-                .collect(Collectors.toList());
-
-        List<Integer> bioSampleIds = new ArrayList<>();
-        List<String> sampleItemIds = new ArrayList<>();
-        for (BioSample bioSample : storedSamples) {
-            if (bioSample == null || bioSample.getId() == null) {
-                continue;
-            }
-            bioSampleIds.add(bioSample.getId());
-
-            SampleItem sampleItem = bioSample.getSampleItem();
-            if (sampleItem != null && sampleItem.getId() != null && !sampleItem.getId().trim().isEmpty()) {
-                sampleItemIds.add(sampleItem.getId().trim());
-            }
-        }
-
-        Map<String, Map<String, Object>> locationsBySampleItemId = storageService.getSampleItemLocations(sampleItemIds);
-        Map<Integer, BiorepositoryQCInspection> latestInspectionByBioSampleId = qcInspectionService
-                .getMostRecentByBioSampleIds(bioSampleIds);
+        List<BioSample> storedSamples = bioSampleService.getAll().stream()
+                .filter(bs -> WorkflowStatus.STORED.equals(bs.getWorkflowStatus())).toList();
 
         List<Map<String, Object>> result = new ArrayList<>();
 
         for (BioSample bioSample : storedSamples) {
-            if (bioSample == null || bioSample.getId() == null) {
-                continue;
-            }
-
             Map<String, Object> sampleData = new HashMap<>();
 
             // BioSample basic info
             sampleData.put("bioSampleId", bioSample.getId());
-            sampleData.put("workflowStatus",
-                    bioSample.getWorkflowStatus() != null ? bioSample.getWorkflowStatus().name() : null);
-            sampleData.put("biosafetyLevel",
-                    bioSample.getBiosafetyLevel() != null ? bioSample.getBiosafetyLevel().name() : null);
+            sampleData.put("workflowStatus", bioSample.getWorkflowStatus().name());
+            sampleData.put("biosafetyLevel", bioSample.getBiosafetyLevel().name());
 
             if (bioSample.getProjectId() != null) {
                 sampleData.put("projectId", bioSample.getProjectId());
@@ -102,41 +85,43 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
 
             // SampleItem info
             SampleItem sampleItem = bioSample.getSampleItem();
-            if (sampleItem == null || sampleItem.getId() == null || sampleItem.getId().trim().isEmpty()) {
-                continue;
+            if (sampleItem != null) {
+                sampleData.put("sampleItemId", sampleItem.getId());
+                sampleData.put("externalId", sampleItem.getExternalId());
+
+                if (sampleItem.getTypeOfSample() != null) {
+                    sampleData.put("sampleType", sampleItem.getTypeOfSample().getDescription());
+                    sampleData.put("sampleTypeId", sampleItem.getTypeOfSample().getId());
+                }
+
+                if (sampleItem.getSample() != null) {
+                    sampleData.put("accessionNumber", sampleItem.getSample().getAccessionNumber());
+                }
+
+                // Get storage location
+                Map<String, Object> location = storageService.getSampleItemLocation(sampleItem.getId().toString());
+                if (location != null && !location.isEmpty()) {
+                    sampleData.put("storageLocation", location);
+                    // Extract hierarchical path for display
+                    if (location.containsKey("hierarchicalPath")) {
+                        sampleData.put("locationPath", location.get("hierarchicalPath"));
+                    }
+                }
             }
 
-            sampleData.put("sampleItemId", sampleItem.getId());
-            sampleData.put("externalId", sampleItem.getExternalId());
-
-            if (sampleItem.getTypeOfSample() != null) {
-                sampleData.put("sampleType", sampleItem.getTypeOfSample().getDescription());
-                sampleData.put("sampleTypeId", sampleItem.getTypeOfSample().getId());
-            }
-
-            if (sampleItem.getSample() != null) {
-                sampleData.put("accessionNumber", sampleItem.getSample().getAccessionNumber());
-            }
-
-            // Use pre-fetched storage location map to avoid per-sample query
-            String sampleItemId = sampleItem.getId().trim();
-            Map<String, Object> location = locationsBySampleItemId.get(sampleItemId);
-            if (location == null || location.isEmpty()
-                    || !Boolean.TRUE.equals(location.get("deviceBiorepositoryStorage"))
-                    || !"freezer".equalsIgnoreCase(String.valueOf(location.get("deviceType")))) {
-                continue;
-            }
-
-            sampleData.put("storageLocation", location);
-            // Extract hierarchical path for display
-            if (location.containsKey("hierarchicalPath")) {
-                sampleData.put("locationPath", location.get("hierarchicalPath"));
-            }
-
-            // Use pre-fetched latest QC map to avoid per-sample query
-            BiorepositoryQCInspection mostRecent = latestInspectionByBioSampleId.get(bioSample.getId());
+            // Check if sample has existing QC inspection
+            BiorepositoryQCInspection mostRecent = qcInspectionService.getMostRecentByBioSampleId(bioSample.getId());
             if (mostRecent != null) {
-                sampleData.put("lastQCInspection", mapQCInspection(mostRecent));
+                Map<String, Object> mappedInspection = mapQCInspection(mostRecent);
+                sampleData.put("lastQCInspection", mappedInspection);
+                sampleData.put("lastQCDate", mappedInspection.get("lastQCDate"));
+                sampleData.put("qcStatus", mappedInspection.get("qcStatus"));
+                sampleData.put("sampleFlag", mappedInspection.get("sampleFlag"));
+                sampleData.put("qcFailed", mappedInspection.get("qcFailed"));
+            } else {
+                sampleData.put("qcStatus", "NOT_CHECKED");
+                sampleData.put("sampleFlag", "PENDING_QC");
+                sampleData.put("qcFailed", false);
             }
 
             result.add(sampleData);
@@ -158,24 +143,26 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
 
         try {
             // Validate required fields
-            if (request == null) {
-                return ResponseEntity.badRequest().body(Map.of("error", "Request payload is required"));
-            }
             if (request.getBioSampleIds() == null || request.getBioSampleIds().isEmpty()) {
                 return ResponseEntity.badRequest().body(Map.of("error", "At least one biosample ID is required"));
             }
-            if (request.getBioSampleIds().stream().anyMatch(id -> id == null || id <= 0)) {
-                return ResponseEntity.badRequest().body(Map.of("error", "BioSample IDs must be positive integers"));
-            }
-
-            Set<Integer> uniqueBioSampleIds = new LinkedHashSet<>(request.getBioSampleIds());
-            if (uniqueBioSampleIds.size() != request.getBioSampleIds().size()) {
-                return ResponseEntity.badRequest()
-                        .body(Map.of("error", "Duplicate biosample IDs are not allowed in bulk QC request"));
-            }
-
             if (request.getInspectorName() == null || request.getInspectorName().trim().isEmpty()) {
                 return ResponseEntity.badRequest().body(Map.of("error", "Inspector name is required"));
+            }
+
+            if (requiresCorrectionWorkflow(request) && request.getBioSampleIds().size() != 1) {
+                return ResponseEntity.badRequest().body(
+                        Map.of("error", "Correction workflow currently supports exactly one sample per request"));
+            }
+
+            if (requiresCorrectionWorkflow(request) && allChecklistPassed(request)) {
+                return ResponseEntity.badRequest().body(
+                        Map.of("error", "Correction workflow can only be used when QC result is discrepancy"));
+            }
+
+            String correctionValidationError = validateCorrectionWorkflowRequest(request);
+            if (correctionValidationError != null) {
+                return ResponseEntity.badRequest().body(Map.of("error", correctionValidationError));
             }
 
             // Use current timestamp if not provided
@@ -183,15 +170,28 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
                     : new Timestamp(System.currentTimeMillis());
 
             List<BiorepositoryQCInspection> inspections = qcInspectionService.createBulkInspections(
-                    new ArrayList<>(uniqueBioSampleIds), request.getInspectorName(), inspectionDate,
-                    request.isSamplePresent(),
+                    request.getBioSampleIds(), request.getInspectorName(), inspectionDate, request.isSamplePresent(),
                     request.isLabelIntegrity(), request.isContainerIntegrity(), request.isVolumeAppearanceAcceptable(),
                     request.isCorrectPosition(), request.getDiscrepancyType(), request.getCorrectiveAction(),
-                    request.getRemarks(), request.getQcBatchId(), request.getExpectedCoordinateSnapshot(), sysUserId);
+                    request.getRemarks(), sysUserId);
 
             List<Map<String, Object>> result = new ArrayList<>();
             for (BiorepositoryQCInspection inspection : inspections) {
-                result.add(mapQCInspection(inspection));
+                Map<String, Object> correctionDetails = null;
+                if (requiresCorrectionWorkflow(request)) {
+                    correctionDetails = qcInspectionService.applyCorrectionWorkflow(inspection,
+                            request.getCorrectionActionType(), request.getCorrectionLocationId(),
+                            request.getCorrectionLocationType(), request.getCorrectionPositionCoordinate(),
+                            request.getCorrectionReason(), request.getCorrectiveAction(), request.getRemarks(),
+                            sysUserId);
+                }
+
+                Map<String, Object> inspectionMap = mapQCInspection(inspection, correctionDetails);
+                if (correctionDetails != null) {
+                    inspectionMap.put("correction", correctionDetails);
+                }
+
+                result.add(inspectionMap);
             }
 
             return ResponseEntity.ok(Map.of("inspections", result, "count", inspections.size()));
@@ -201,89 +201,6 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "Failed to create QC inspections: " + e.getMessage()));
-        }
-    }
-
-    /**
-     * Generate a random QC round (N boxes x M samples per box) from current stored
-     * inventory.
-     */
-    @PostMapping(value = "/generate-round", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> generateQCRound(@RequestBody(required = false) GenerateQCRoundRequest request,
-            HttpServletRequest httpRequest) {
-        String sysUserId = getSysUserId(httpRequest);
-        if (sysUserId == null) {
-            return ResponseEntity.status(401).body(Map.of("error", "User session not found. Please log in again."));
-        }
-
-        if (request != null && (request.getBoxesPerRound() < 1 || request.getBoxesPerRound() > MAX_BOXES_PER_ROUND)) {
-            return ResponseEntity.badRequest().body(Map.of("error", "boxesPerRound must be between 1 and "
-                    + MAX_BOXES_PER_ROUND));
-        }
-        if (request != null
-                && (request.getSamplesPerBox() < 1 || request.getSamplesPerBox() > MAX_SAMPLES_PER_BOX)) {
-            return ResponseEntity.badRequest().body(Map.of("error", "samplesPerBox must be between 1 and "
-                    + MAX_SAMPLES_PER_BOX));
-        }
-
-        int boxesPerRound = request != null ? request.getBoxesPerRound() : 10;
-        int samplesPerBox = request != null ? request.getSamplesPerBox() : 3;
-        Long seed = request != null ? request.getSeed() : null;
-
-        Map<String, String> locationFilters = new HashMap<>();
-        if (request != null) {
-            putIfNotBlank(locationFilters, "freezer", request.getFreezer());
-            putIfNotBlank(locationFilters, "shelf", request.getShelf());
-            putIfNotBlank(locationFilters, "rack", request.getRack());
-            putIfNotBlank(locationFilters, "box", request.getBox());
-        }
-
-        try {
-            Map<String, Object> generated = qcInspectionService.generateRandomQCRound(boxesPerRound, samplesPerBox,
-                    seed, sysUserId, locationFilters);
-            return ResponseEntity.ok(generated);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError()
-                    .body(Map.of("error", "Failed to generate QC round: " + e.getMessage()));
-        }
-    }
-
-    /**
-     * Get storage location overview for QC planning (room-level summary).
-     */
-    @GetMapping(value = "/location-overview", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Transactional(readOnly = true)
-    public ResponseEntity<Map<String, Object>> getLocationOverview() {
-        return ResponseEntity.ok(qcInspectionService.getLocationOverview());
-    }
-
-    /**
-     * Apply corrective action for a failed QC inspection and capture coordinate
-     * audit details.
-     */
-    @PostMapping(value = "/{inspectionId}/corrective-action", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> applyCorrectiveAction(@PathVariable("inspectionId") Integer inspectionId,
-            @RequestBody CorrectiveActionRequest request, HttpServletRequest httpRequest) {
-        String sysUserId = getSysUserId(httpRequest);
-        if (sysUserId == null) {
-            return ResponseEntity.status(401).body(Map.of("error", "User session not found. Please log in again."));
-        }
-
-        if (request == null || request.getReason() == null || request.getReason().trim().isEmpty()) {
-            return ResponseEntity.badRequest().body(Map.of("error", "Corrective reason is required"));
-        }
-
-        try {
-            Map<String, Object> result = qcInspectionService.applyCorrectiveAction(inspectionId,
-                    request.getObservedCoordinate(), request.getCorrectedCoordinate(), request.getReason(), sysUserId);
-            return ResponseEntity.ok(result);
-        } catch (IllegalArgumentException | IllegalStateException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError()
-                    .body(Map.of("error", "Failed to apply corrective action: " + e.getMessage()));
         }
     }
 
@@ -322,15 +239,370 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         return ResponseEntity.ok(stats);
     }
 
+    /**
+     * Storage overview for QC filter structure before random generation.
+     * Uses active storage hierarchy entities for freezer/shelf/rack/box options and
+     * counts, plus current STORED biosample assignments for eligible sample scope.
+     *
+     * Note: This worktree has no explicit device-level biorepository scope flag
+     * (for example biorepositoryStorage), so hierarchy scope is not
+     * biorepository-only.
+     */
+    @GetMapping(value = "/storage-overview", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Transactional(readOnly = true)
+    public ResponseEntity<Map<String, Object>> getQCStorageOverview(@RequestParam(required = false) String freezer,
+            @RequestParam(required = false) String shelf, @RequestParam(required = false) String rack,
+            @RequestParam(required = false) String box) {
+        String freezerFilter = normalizeFilter(freezer);
+        String shelfFilter = normalizeFilter(shelf);
+        String rackFilter = normalizeFilter(rack);
+        String boxFilter = normalizeFilter(box);
+
+        List<BioSample> storedSamples = bioSampleService.getAll().stream()
+                .filter(bs -> WorkflowStatus.STORED.equals(bs.getWorkflowStatus())).toList();
+
+        // Hierarchy scope in this branch is all active freezer entities.
+        List<StorageDevice> allDevices = storageLocationService.getAllDevices().stream()
+            .filter(this::isActive)
+            .filter(this::isFreezer)
+            .toList();
+
+        Set<Integer> activeFreezerIds = allDevices.stream().map(StorageDevice::getId)
+            .filter(id -> id != null).collect(java.util.stream.Collectors.toSet());
+
+        List<StorageShelf> allShelves = storageLocationService.getAllShelves().stream()
+            .filter(this::isActive)
+            .filter(shelfEntity -> shelfEntity.getParentDevice() != null
+                && activeFreezerIds.contains(shelfEntity.getParentDevice().getId()))
+            .toList();
+
+        Set<Integer> activeShelfIds = allShelves.stream().map(StorageShelf::getId)
+            .filter(id -> id != null).collect(java.util.stream.Collectors.toSet());
+
+        List<StorageRack> allRacks = storageLocationService.getAllRacks().stream()
+            .filter(this::isActive)
+            .filter(rackEntity -> rackEntity.getParentShelf() != null
+                && activeShelfIds.contains(rackEntity.getParentShelf().getId()))
+            .toList();
+
+        Set<Integer> activeRackIds = allRacks.stream().map(StorageRack::getId)
+            .filter(id -> id != null).collect(java.util.stream.Collectors.toSet());
+
+        List<StorageBox> allBoxes = storageLocationService.getAllBoxes().stream()
+            .filter(this::isActive)
+            .filter(boxEntity -> boxEntity.getParentRack() != null
+                && activeRackIds.contains(boxEntity.getParentRack().getId()))
+            .toList();
+
+        List<StorageDevice> scopedDevices = allDevices.stream()
+                .filter(device -> matches(deviceName(device), freezerFilter)).toList();
+
+        List<StorageShelf> scopedShelves = allShelves.stream().filter(s -> {
+            String deviceName = s.getParentDevice() != null ? deviceName(s.getParentDevice()) : null;
+            return matches(deviceName, freezerFilter) && matches(s.getLabel(), shelfFilter);
+        }).toList();
+
+        List<StorageRack> scopedRacks = allRacks.stream().filter(r -> {
+            StorageShelf parentShelf = r.getParentShelf();
+            StorageDevice parentDevice = parentShelf != null ? parentShelf.getParentDevice() : null;
+            String deviceName = parentDevice != null ? deviceName(parentDevice) : null;
+            String shelfLabel = parentShelf != null ? parentShelf.getLabel() : null;
+            return matches(deviceName, freezerFilter) && matches(shelfLabel, shelfFilter)
+                    && matches(r.getLabel(), rackFilter);
+        }).toList();
+
+        List<StorageBox> scopedBoxes = allBoxes.stream().filter(b -> {
+            StorageRack parentRack = b.getParentRack();
+            StorageShelf parentShelf = parentRack != null ? parentRack.getParentShelf() : null;
+            StorageDevice parentDevice = parentShelf != null ? parentShelf.getParentDevice() : null;
+            String deviceName = parentDevice != null ? deviceName(parentDevice) : null;
+            String shelfLabel = parentShelf != null ? parentShelf.getLabel() : null;
+            String rackLabel = parentRack != null ? parentRack.getLabel() : null;
+            return matches(deviceName, freezerFilter) && matches(shelfLabel, shelfFilter)
+                    && matches(rackLabel, rackFilter) && matches(b.getLabel(), boxFilter);
+        }).toList();
+
+        Set<String> freezerOptions = new LinkedHashSet<>();
+        for (StorageDevice d : allDevices) {
+            freezerOptions.add(deviceName(d));
+        }
+        Set<String> shelfOptions = new LinkedHashSet<>();
+        for (StorageShelf s : allShelves) {
+            String parentFreezer = s.getParentDevice() != null ? deviceName(s.getParentDevice()) : null;
+            if (matches(parentFreezer, freezerFilter)) {
+                shelfOptions.add(s.getLabel());
+            }
+        }
+        Set<String> rackOptions = new LinkedHashSet<>();
+        for (StorageRack r : allRacks) {
+            StorageShelf parentShelf = r.getParentShelf();
+            StorageDevice parentDevice = parentShelf != null ? parentShelf.getParentDevice() : null;
+            String parentFreezer = parentDevice != null ? deviceName(parentDevice) : null;
+            String parentShelfLabel = parentShelf != null ? parentShelf.getLabel() : null;
+            if (matches(parentFreezer, freezerFilter) && matches(parentShelfLabel, shelfFilter)) {
+                rackOptions.add(r.getLabel());
+            }
+        }
+        Set<String> boxOptions = new LinkedHashSet<>();
+        for (StorageBox b : allBoxes) {
+            StorageRack parentRack = b.getParentRack();
+            StorageShelf parentShelf = parentRack != null ? parentRack.getParentShelf() : null;
+            StorageDevice parentDevice = parentShelf != null ? parentShelf.getParentDevice() : null;
+            String parentFreezer = parentDevice != null ? deviceName(parentDevice) : null;
+            String parentShelfLabel = parentShelf != null ? parentShelf.getLabel() : null;
+            String parentRackLabel = parentRack != null ? parentRack.getLabel() : null;
+            if (matches(parentFreezer, freezerFilter) && matches(parentShelfLabel, shelfFilter)
+                    && matches(parentRackLabel, rackFilter)) {
+                boxOptions.add(b.getLabel());
+            }
+        }
+
+        Set<String> validShelfKeys = new LinkedHashSet<>();
+        for (StorageShelf shelfEntity : allShelves) {
+            StorageDevice parentDevice = shelfEntity.getParentDevice();
+            String freezerName = parentDevice != null ? deviceName(parentDevice) : null;
+            String shelfLabel = shelfEntity.getLabel();
+            if (freezerName != null && shelfLabel != null && !shelfLabel.isBlank()) {
+                validShelfKeys.add(buildHierarchyKey(freezerName, shelfLabel));
+            }
+        }
+
+        Set<String> validRackKeys = new LinkedHashSet<>();
+        for (StorageRack rackEntity : allRacks) {
+            StorageShelf parentShelf = rackEntity.getParentShelf();
+            StorageDevice parentDevice = parentShelf != null ? parentShelf.getParentDevice() : null;
+            String freezerName = parentDevice != null ? deviceName(parentDevice) : null;
+            String shelfLabel = parentShelf != null ? parentShelf.getLabel() : null;
+            String rackLabel = rackEntity.getLabel();
+            if (freezerName != null && shelfLabel != null && !shelfLabel.isBlank()
+                    && rackLabel != null && !rackLabel.isBlank()) {
+                validRackKeys.add(buildHierarchyKey(freezerName, shelfLabel, rackLabel));
+            }
+        }
+
+        Set<String> validBoxKeys = new LinkedHashSet<>();
+        for (StorageBox boxEntity : allBoxes) {
+            StorageRack parentRack = boxEntity.getParentRack();
+            StorageShelf parentShelf = parentRack != null ? parentRack.getParentShelf() : null;
+            StorageDevice parentDevice = parentShelf != null ? parentShelf.getParentDevice() : null;
+            String freezerName = parentDevice != null ? deviceName(parentDevice) : null;
+            String shelfLabel = parentShelf != null ? parentShelf.getLabel() : null;
+            String rackLabel = parentRack != null ? parentRack.getLabel() : null;
+            String boxLabel = boxEntity.getLabel();
+            if (freezerName != null && shelfLabel != null && !shelfLabel.isBlank()
+                    && rackLabel != null && !rackLabel.isBlank()
+                    && boxLabel != null && !boxLabel.isBlank()) {
+                validBoxKeys.add(buildHierarchyKey(freezerName, shelfLabel, rackLabel, boxLabel));
+            }
+        }
+
+        List<Map<String, Object>> eligibleSamples = new ArrayList<>();
+        for (BioSample bioSample : storedSamples) {
+            SampleItem sampleItem = bioSample.getSampleItem();
+            if (sampleItem == null || sampleItem.getId() == null) {
+                continue;
+            }
+            Map<String, Object> location = storageService.getSampleItemLocation(sampleItem.getId().toString());
+            if (location == null || location.isEmpty()) {
+                continue;
+            }
+            String locationPath = asString(location.get("hierarchicalPath"));
+            String[] levels = parseHierarchyLevels(locationPath);
+
+            String parsedFreezer = levels[0];
+            String parsedShelf = levels[1];
+            String parsedRack = levels[2];
+            String parsedBox = levels[3];
+
+            if (!validShelfKeys.contains(buildHierarchyKey(parsedFreezer, parsedShelf))) {
+                continue;
+            }
+            if (!validRackKeys.contains(buildHierarchyKey(parsedFreezer, parsedShelf, parsedRack))) {
+                continue;
+            }
+            if (!validBoxKeys.contains(buildHierarchyKey(parsedFreezer, parsedShelf, parsedRack, parsedBox))) {
+                continue;
+            }
+
+            if (!matches(levels[0], freezerFilter) || !matches(levels[1], shelfFilter) || !matches(levels[2], rackFilter)
+                    || !matches(levels[3], boxFilter)) {
+                continue;
+            }
+            Map<String, Object> sampleSummary = new HashMap<>();
+            sampleSummary.put("bioSampleId", bioSample.getId());
+            sampleSummary.put("sampleItemId", sampleItem.getId());
+            sampleSummary.put("freezer", levels[0]);
+            sampleSummary.put("shelf", levels[1]);
+            sampleSummary.put("rack", levels[2]);
+            sampleSummary.put("box", levels[3]);
+            sampleSummary.put("locationPath", locationPath);
+            sampleSummary.put("positionCoordinate", asString(location.get("positionCoordinate")));
+            sampleSummary.put("accessionNumber",
+                    sampleItem.getSample() != null ? sampleItem.getSample().getAccessionNumber() : null);
+            eligibleSamples.add(sampleSummary);
+        }
+
+        Map<String, Object> counts = new HashMap<>();
+        counts.put("freezers", scopedDevices.size());
+        counts.put("shelves", scopedShelves.size());
+        counts.put("racks", scopedRacks.size());
+        counts.put("boxes", scopedBoxes.size());
+        counts.put("eligibleSamples", eligibleSamples.size());
+
+        Map<String, Object> filterOptions = new HashMap<>();
+        filterOptions.put("freezers", freezerOptions.stream().filter(v -> v != null && !v.isBlank()).sorted().toList());
+        filterOptions.put("shelves", shelfOptions.stream().filter(v -> v != null && !v.isBlank()).sorted().toList());
+        filterOptions.put("racks", rackOptions.stream().filter(v -> v != null && !v.isBlank()).sorted().toList());
+        filterOptions.put("boxes", boxOptions.stream().filter(v -> v != null && !v.isBlank()).sorted().toList());
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("counts", counts);
+        response.put("filters", filterOptions);
+        response.put("eligibleSamples", eligibleSamples);
+        response.put("biorepositoryScope", Map.of(
+            "deviceHierarchyBiorepositoryOnly", false,
+            "reason", "No explicit device biorepository scope field exists in this branch"));
+        return ResponseEntity.ok(response);
+    }
+
     // ========== Helper Methods ==========
 
+    private String normalizeFilter(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String v = raw.trim();
+        if (v.isEmpty() || "__ALL__".equals(v)) {
+            return null;
+        }
+        return v;
+    }
+
+    private boolean matches(String value, String filter) {
+        if (filter == null) {
+            return true;
+        }
+        if (value == null) {
+            return false;
+        }
+        return filter.equals(value);
+    }
+
+    private String[] parseHierarchyLevels(String locationPath) {
+        String[] defaults = new String[] { "Unknown", "Unknown", "Unknown", "Unknown" };
+        if (locationPath == null || locationPath.isBlank()) {
+            return defaults;
+        }
+        List<String> segments = Arrays.stream(locationPath.split("\\s*>\\s*")).map(String::trim).filter(s -> !s.isBlank())
+                .toList();
+        if (segments.isEmpty()) {
+            return defaults;
+        }
+        int end = segments.size();
+        String tail = segments.get(end - 1);
+        if (tail.matches("^[A-Za-z]+\\d+$")) {
+            end = end - 1;
+        }
+        List<String> structural = segments.subList(0, Math.max(end, 0));
+        if (structural.isEmpty()) {
+            return defaults;
+        }
+        int boxIdx = structural.size() - 1;
+        int rackIdx = structural.size() - 2;
+        int shelfIdx = structural.size() - 3;
+        int freezerIdx = structural.size() - 4;
+        return new String[] { freezerIdx >= 0 ? structural.get(freezerIdx) : "Unknown",
+                shelfIdx >= 0 ? structural.get(shelfIdx) : "Unknown",
+                rackIdx >= 0 ? structural.get(rackIdx) : "Unknown",
+                boxIdx >= 0 ? structural.get(boxIdx) : "Unknown" };
+    }
+
+    private String deviceName(StorageDevice device) {
+        if (device == null) {
+            return null;
+        }
+        if (device.getName() != null && !device.getName().isBlank()) {
+            return device.getName().trim();
+        }
+        if (device.getCode() != null && !device.getCode().isBlank()) {
+            return device.getCode().trim();
+        }
+        return null;
+    }
+
+    private boolean isActive(StorageDevice device) {
+        return device != null && Boolean.TRUE.equals(device.getActive());
+    }
+
+    private boolean isActive(StorageShelf shelfEntity) {
+        return shelfEntity != null && Boolean.TRUE.equals(shelfEntity.getActive());
+    }
+
+    private boolean isActive(StorageRack rackEntity) {
+        return rackEntity != null && Boolean.TRUE.equals(rackEntity.getActive());
+    }
+
+    private boolean isActive(StorageBox boxEntity) {
+        return boxEntity != null && Boolean.TRUE.equals(boxEntity.getActive());
+    }
+
+    private boolean isFreezer(StorageDevice device) {
+        return device != null
+                && (DeviceType.FREEZER.getValue().equalsIgnoreCase(asString(device.getType()))
+                        || DeviceType.FREEZER.getValue().equalsIgnoreCase(asString(device.getTypeAsString())));
+    }
+
+    private String buildHierarchyKey(String... levels) {
+        if (levels == null || levels.length == 0) {
+            return "";
+        }
+        StringBuilder keyBuilder = new StringBuilder();
+        for (String level : levels) {
+            if (level == null || level.isBlank()) {
+                return "";
+            }
+            if (keyBuilder.length() > 0) {
+                keyBuilder.append(" > ");
+            }
+            keyBuilder.append(level.trim());
+        }
+        return keyBuilder.toString();
+    }
+
+    private String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String s = String.valueOf(value);
+        return s.isBlank() ? null : s;
+    }
+
     private Map<String, Object> mapQCInspection(BiorepositoryQCInspection inspection) {
+        return mapQCInspection(inspection, null);
+    }
+
+    private Map<String, Object> mapQCInspection(BiorepositoryQCInspection inspection,
+            Map<String, Object> correctionDetails) {
         Map<String, Object> map = new HashMap<>();
         map.put("id", inspection.getId());
-        map.put("bioSampleId", inspection.getBioSample() != null ? inspection.getBioSample().getId() : null);
+        map.put("bioSampleId", inspection.getBioSample().getId());
         map.put("inspectorName", inspection.getInspectorName());
-        map.put("inspectionDate", inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
-        map.put("qcResult", inspection.getQcResult() != null ? inspection.getQcResult().name() : null);
+        map.put("technicianId", inspection.getSysUserId());
+        map.put("inspectionDate", inspection.getInspectionDate().toString());
+        map.put("lastQCDate", inspection.getInspectionDate().toString());
+        map.put("qcResult", inspection.getQcResult().name());
+        String qcStatus = BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection);
+        map.put("qcStatus", qcStatus);
+        map.put("sampleFlag", "VALID".equals(qcStatus) ? "QC_VALID" : "QC_FAILED");
+        map.put("qcFailed", !"VALID".equals(qcStatus));
+        map.put("lifecycleOutcome", BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection));
+        map.put("expectedLocationPath", inspection.getExpectedLocationPath());
+        map.put("expectedPositionCoordinate", inspection.getExpectedPositionCoordinate());
+        map.put("correctionActionType", inspection.getCorrectionActionType());
+        map.put("correctionReason", inspection.getCorrectionReason());
+        map.put("correctionByUser", inspection.getCorrectionByUser());
+        map.put("correctionTimestamp",
+                inspection.getCorrectionTimestamp() != null ? inspection.getCorrectionTimestamp().toString() : null);
 
         // Checklist items
         map.put("samplePresent", inspection.isSamplePresent());
@@ -348,21 +620,160 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         }
         if (inspection.getRemarks() != null) {
             map.put("remarks", inspection.getRemarks());
+            map.put("failureComment", inspection.getRemarks());
         }
-        if (inspection.getQcBatchId() != null) {
-            map.put("qcBatchId", inspection.getQcBatchId());
-        }
-        if (inspection.getExpectedCoordinateSnapshot() != null) {
-            map.put("expectedCoordinateSnapshot", inspection.getExpectedCoordinateSnapshot());
-        }
+
+        map.put("auditTrail", buildAuditTrail(inspection, correctionDetails));
 
         return map;
     }
 
-    private void putIfNotBlank(Map<String, String> target, String key, String value) {
-        if (value != null && !value.trim().isEmpty()) {
-            target.put(key, value.trim());
+    private boolean allChecklistPassed(BulkQCInspectionRequest request) {
+        return request.isSamplePresent() && request.isLabelIntegrity() && request.isContainerIntegrity()
+                && request.isVolumeAppearanceAcceptable() && request.isCorrectPosition();
+    }
+
+    private boolean requiresCorrectionWorkflow(BulkQCInspectionRequest request) {
+        return trimToNull(request.getCorrectionActionType()) != null;
+    }
+
+    private String validateCorrectionWorkflowRequest(BulkQCInspectionRequest request) {
+        String correctionActionType = trimToNull(request.getCorrectionActionType());
+        if (correctionActionType == null) {
+            return null;
         }
+
+        String normalizedActionType = correctionActionType.toUpperCase();
+        boolean hasCorrectionLocationId = trimToNull(request.getCorrectionLocationId()) != null;
+        boolean hasCorrectionLocationType = trimToNull(request.getCorrectionLocationType()) != null;
+        boolean hasCorrectionLocation = hasCorrectionLocationId || hasCorrectionLocationType;
+        boolean hasCorrectionPosition = trimToNull(request.getCorrectionPositionCoordinate()) != null;
+
+        if ("MARK_MISSING".equals(normalizedActionType)) {
+            BiorepositoryQCInspection.DiscrepancyType discrepancyType = BiorepositoryQCInspection.DiscrepancyType
+                    .fromString(request.getDiscrepancyType());
+            if (!isSampleMissingDiscrepancy(discrepancyType)) {
+                return "MARK_MISSING requires discrepancy type SAMPLE_MISSING";
+            }
+            if (hasCorrectionLocation || hasCorrectionPosition) {
+                return "MARK_MISSING does not allow correction location/position fields";
+            }
+            return null;
+        }
+
+        if ("UPDATE_LOCATION".equals(normalizedActionType) || "REASSIGN_POSITION".equals(normalizedActionType)) {
+            if (!hasCorrectionLocationId || !hasCorrectionLocationType) {
+                return "UPDATE_LOCATION/REASSIGN_POSITION require correctionLocationId and correctionLocationType";
+            }
+            if ("REASSIGN_POSITION".equals(normalizedActionType) && !hasCorrectionPosition) {
+                return "REASSIGN_POSITION requires correctionPositionCoordinate";
+            }
+            return null;
+        }
+
+        return "Unsupported correction action type: " + correctionActionType;
+    }
+
+    private boolean isSampleMissingDiscrepancy(BiorepositoryQCInspection.DiscrepancyType discrepancyType) {
+        if (discrepancyType == null) {
+            return false;
+        }
+        return BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.equals(discrepancyType)
+                || BiorepositoryQCInspection.DiscrepancyType.MISSING_SAMPLE.equals(discrepancyType);
+    }
+
+    private Map<String, Object> buildAuditTrail(BiorepositoryQCInspection inspection,
+            Map<String, Object> correctionDetails) {
+        Map<String, Object> auditTrail = new HashMap<>();
+
+        String oldCoordinate = trimToNull(inspection.getCorrectionOldCoordinate());
+        if (oldCoordinate == null) {
+            oldCoordinate = composeCoordinate(inspection.getExpectedLocationPath(), inspection.getExpectedPositionCoordinate());
+        }
+        String newCoordinate = trimToNull(inspection.getCorrectionNewCoordinate());
+        String reason = trimToNull(inspection.getCorrectionReason());
+        if (reason == null) {
+            reason = trimToNull(inspection.getCorrectiveAction());
+        }
+        String auditTimestamp = inspection.getCorrectionTimestamp() != null ? inspection.getCorrectionTimestamp().toString()
+                : (inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
+        String auditUser = trimToNull(inspection.getCorrectionByUser()) != null ? inspection.getCorrectionByUser()
+                : inspection.getSysUserId();
+        if (correctionDetails != null) {
+            if (reason == null) {
+                reason = trimToNull(asString(correctionDetails.get("reason")));
+            }
+            String correctionTimestamp = trimToNull(asString(correctionDetails.get("correctionTimestamp")));
+            if (correctionTimestamp != null) {
+                auditTimestamp = correctionTimestamp;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> updatedLocation = correctionDetails.get("updatedLocation") instanceof Map
+                    ? (Map<String, Object>) correctionDetails.get("updatedLocation")
+                    : null;
+            if (updatedLocation != null) {
+                newCoordinate = composeCoordinate(asString(updatedLocation.get("hierarchicalPath")),
+                        asString(updatedLocation.get("positionCoordinate")));
+            }
+        }
+
+        if (newCoordinate == null && "MISSING".equals(BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection))) {
+            newCoordinate = "Missing (not found during QC)";
+        }
+
+        boolean correctionApplied = BiorepositoryQcOutcomeDerivation.hasAppliedCorrectionWorkflow(inspection);
+        if (!correctionApplied
+                && BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+            SampleItem sampleItem = inspection.getBioSample() != null ? inspection.getBioSample().getSampleItem() : null;
+            if (sampleItem != null && sampleItem.getId() != null) {
+                Map<String, Object> currentLocation = storageService.getSampleItemLocation(sampleItem.getId().toString());
+                String currentCoordinate = composeCoordinate(asString(currentLocation.get("hierarchicalPath")),
+                        asString(currentLocation.get("positionCoordinate")));
+                if (trimToNull(currentCoordinate) != null) {
+                    newCoordinate = currentCoordinate;
+                }
+            }
+        }
+
+        if (newCoordinate == null) {
+            newCoordinate = oldCoordinate;
+        }
+
+        auditTrail.put("oldCoordinate", oldCoordinate);
+        auditTrail.put("newCoordinate", newCoordinate);
+        auditTrail.put("fromCoordinates", oldCoordinate);
+        auditTrail.put("toCoordinates", newCoordinate);
+        auditTrail.put("user", auditUser);
+        auditTrail.put("correctedBy", auditUser);
+        auditTrail.put("timestamp", auditTimestamp);
+        auditTrail.put("correctedAt", auditTimestamp);
+        auditTrail.put("reason", reason);
+
+        return auditTrail;
+    }
+
+    private String composeCoordinate(String locationPath, String positionCoordinate) {
+        String path = trimToNull(locationPath);
+        String coordinate = trimToNull(positionCoordinate);
+
+        if (path == null && coordinate == null) {
+            return null;
+        }
+        if (path == null) {
+            return coordinate;
+        }
+        if (coordinate == null) {
+            return path;
+        }
+        return path + " > " + coordinate;
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     // ========== Request DTOs ==========
@@ -379,8 +790,11 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         private String discrepancyType;
         private String correctiveAction;
         private String remarks;
-        private String qcBatchId;
-        private String expectedCoordinateSnapshot;
+        private String correctionActionType;
+        private String correctionLocationId;
+        private String correctionLocationType;
+        private String correctionPositionCoordinate;
+        private String correctionReason;
 
         // Getters and setters
         public List<Integer> getBioSampleIds() {
@@ -471,116 +885,44 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
             this.remarks = remarks;
         }
 
-        public String getQcBatchId() {
-            return qcBatchId;
+        public String getCorrectionActionType() {
+            return correctionActionType;
         }
 
-        public void setQcBatchId(String qcBatchId) {
-            this.qcBatchId = qcBatchId;
+        public void setCorrectionActionType(String correctionActionType) {
+            this.correctionActionType = correctionActionType;
         }
 
-        public String getExpectedCoordinateSnapshot() {
-            return expectedCoordinateSnapshot;
+        public String getCorrectionLocationId() {
+            return correctionLocationId;
         }
 
-        public void setExpectedCoordinateSnapshot(String expectedCoordinateSnapshot) {
-            this.expectedCoordinateSnapshot = expectedCoordinateSnapshot;
-        }
-    }
-
-    public static class GenerateQCRoundRequest {
-        private int boxesPerRound = 10;
-        private int samplesPerBox = 3;
-        private Long seed;
-        private String freezer;
-        private String shelf;
-        private String rack;
-        private String box;
-
-        public int getBoxesPerRound() {
-            return boxesPerRound;
+        public void setCorrectionLocationId(String correctionLocationId) {
+            this.correctionLocationId = correctionLocationId;
         }
 
-        public void setBoxesPerRound(int boxesPerRound) {
-            this.boxesPerRound = boxesPerRound;
+        public String getCorrectionLocationType() {
+            return correctionLocationType;
         }
 
-        public int getSamplesPerBox() {
-            return samplesPerBox;
+        public void setCorrectionLocationType(String correctionLocationType) {
+            this.correctionLocationType = correctionLocationType;
         }
 
-        public void setSamplesPerBox(int samplesPerBox) {
-            this.samplesPerBox = samplesPerBox;
+        public String getCorrectionPositionCoordinate() {
+            return correctionPositionCoordinate;
         }
 
-        public Long getSeed() {
-            return seed;
+        public void setCorrectionPositionCoordinate(String correctionPositionCoordinate) {
+            this.correctionPositionCoordinate = correctionPositionCoordinate;
         }
 
-        public void setSeed(Long seed) {
-            this.seed = seed;
+        public String getCorrectionReason() {
+            return correctionReason;
         }
 
-        public String getFreezer() {
-            return freezer;
-        }
-
-        public void setFreezer(String freezer) {
-            this.freezer = freezer;
-        }
-
-        public String getShelf() {
-            return shelf;
-        }
-
-        public void setShelf(String shelf) {
-            this.shelf = shelf;
-        }
-
-        public String getRack() {
-            return rack;
-        }
-
-        public void setRack(String rack) {
-            this.rack = rack;
-        }
-
-        public String getBox() {
-            return box;
-        }
-
-        public void setBox(String box) {
-            this.box = box;
-        }
-    }
-
-    public static class CorrectiveActionRequest {
-        private String observedCoordinate;
-        private String correctedCoordinate;
-        private String reason;
-
-        public String getObservedCoordinate() {
-            return observedCoordinate;
-        }
-
-        public void setObservedCoordinate(String observedCoordinate) {
-            this.observedCoordinate = observedCoordinate;
-        }
-
-        public String getCorrectedCoordinate() {
-            return correctedCoordinate;
-        }
-
-        public void setCorrectedCoordinate(String correctedCoordinate) {
-            this.correctedCoordinate = correctedCoordinate;
-        }
-
-        public String getReason() {
-            return reason;
-        }
-
-        public void setReason(String reason) {
-            this.reason = reason;
+        public void setCorrectionReason(String correctionReason) {
+            this.correctionReason = correctionReason;
         }
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestController.java
+++ b/src/main/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestController.java
@@ -2,15 +2,21 @@ package org.openelisglobal.biorepository.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import org.openelisglobal.biorepository.service.BioSampleService;
-import org.openelisglobal.biorepository.service.BiorepositoryQcOutcomeDerivation;
 import org.openelisglobal.biorepository.service.BiorepositoryQCInspectionService;
 import org.openelisglobal.biorepository.valueholder.BioSample;
 import org.openelisglobal.biorepository.valueholder.BioSample.WorkflowStatus;
@@ -159,11 +165,7 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
                 return ResponseEntity.badRequest().body(
                         Map.of("error", "Correction workflow can only be used when QC result is discrepancy"));
             }
-
-            String correctionValidationError = validateCorrectionWorkflowRequest(request);
-            if (correctionValidationError != null) {
-                return ResponseEntity.badRequest().body(Map.of("error", correctionValidationError));
-            }
+            validateCorrectionWorkflowRequest(request);
 
             // Use current timestamp if not provided
             Timestamp inspectionDate = request.getInspectionDate() != null ? request.getInspectionDate()
@@ -173,17 +175,13 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
                     request.getBioSampleIds(), request.getInspectorName(), inspectionDate, request.isSamplePresent(),
                     request.isLabelIntegrity(), request.isContainerIntegrity(), request.isVolumeAppearanceAcceptable(),
                     request.isCorrectPosition(), request.getDiscrepancyType(), request.getCorrectiveAction(),
-                    request.getRemarks(), sysUserId);
+                    request.getRemarks(), request.getQcBatchId(), request.getExpectedCoordinateSnapshot(), sysUserId);
 
             List<Map<String, Object>> result = new ArrayList<>();
             for (BiorepositoryQCInspection inspection : inspections) {
                 Map<String, Object> correctionDetails = null;
                 if (requiresCorrectionWorkflow(request)) {
-                    correctionDetails = qcInspectionService.applyCorrectionWorkflow(inspection,
-                            request.getCorrectionActionType(), request.getCorrectionLocationId(),
-                            request.getCorrectionLocationType(), request.getCorrectionPositionCoordinate(),
-                            request.getCorrectionReason(), request.getCorrectiveAction(), request.getRemarks(),
-                            sysUserId);
+                    correctionDetails = applyCorrectionWorkflow(inspection, request);
                 }
 
                 Map<String, Object> inspectionMap = mapQCInspection(inspection, correctionDetails);
@@ -252,11 +250,104 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
     @Transactional(readOnly = true)
     public ResponseEntity<Map<String, Object>> getQCStorageOverview(@RequestParam(required = false) String freezer,
             @RequestParam(required = false) String shelf, @RequestParam(required = false) String rack,
-            @RequestParam(required = false) String box) {
-        String freezerFilter = normalizeFilter(freezer);
-        String shelfFilter = normalizeFilter(shelf);
-        String rackFilter = normalizeFilter(rack);
-        String boxFilter = normalizeFilter(box);
+            @RequestParam(required = false) String box,
+            @RequestParam(required = false, defaultValue = "true") Boolean includeInspected) {
+        return ResponseEntity
+                .ok(buildStorageOverviewMap(normalizeFilter(freezer), normalizeFilter(shelf), normalizeFilter(rack),
+                        normalizeFilter(box), Boolean.TRUE.equals(includeInspected)));
+    }
+
+    private static final int MAX_BOXES_PER_ROUND = 200;
+    private static final int MAX_SAMPLES_PER_BOX = 200;
+
+    /**
+     * Random QC round using the same eligible pool as storage-overview (including quarter rule).
+     */
+    @PostMapping(value = "/generate-round", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Transactional(readOnly = true)
+    public ResponseEntity<?> generateQCRound(@RequestBody(required = false) GenerateQCRoundRequest request,
+            HttpServletRequest httpRequest) {
+        if (getSysUserId(httpRequest) == null) {
+            return ResponseEntity.status(401).body(Map.of("error", "User session not found. Please log in again."));
+        }
+        if (request == null) {
+            request = new GenerateQCRoundRequest();
+        }
+        int boxesPerRound = request.getBoxesPerRound() > 0 ? request.getBoxesPerRound() : 10;
+        int samplesPerBox = request.getSamplesPerBox() > 0 ? request.getSamplesPerBox() : 3;
+        if (boxesPerRound > MAX_BOXES_PER_ROUND || samplesPerBox > MAX_SAMPLES_PER_BOX) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Parameters exceed allowed limits for this environment"));
+        }
+        boolean includeAll = request.getIncludeInspected() == null || Boolean.TRUE.equals(request.getIncludeInspected());
+        Map<String, Object> overview = buildStorageOverviewMap(
+                normalizeFilter(request.getFreezer()), normalizeFilter(request.getShelf()), normalizeFilter(request.getRack()),
+                normalizeFilter(request.getBox()), includeAll);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> eligible = (List<Map<String, Object>>) overview.get("eligibleSamples");
+        if (eligible == null || eligible.isEmpty()) {
+            Map<String, Object> empty = new HashMap<>();
+            empty.put("qcBatchId", null);
+            empty.put("boxesSelected", 0);
+            empty.put("samplesSelected", 0);
+            empty.put("filteredSamplePool", 0);
+            empty.put("includeInspected", includeAll);
+            empty.put("samples", List.of());
+            return ResponseEntity.ok(empty);
+        }
+        String qcBatchId = "QCBATCH-" + System.currentTimeMillis() + "-" + UUID.randomUUID().toString().substring(0, 8);
+        Random random = request.getSeed() != null ? new Random(request.getSeed()) : new Random();
+        Map<String, List<Map<String, Object>>> candidatesByBox = new HashMap<>();
+        for (Map<String, Object> row : eligible) {
+            String boxKey = asString(row.get("boxKey"));
+            if (boxKey == null) {
+                continue;
+            }
+            candidatesByBox.computeIfAbsent(boxKey, k -> new ArrayList<>()).add(row);
+        }
+        if (candidatesByBox.isEmpty()) {
+            Map<String, Object> empty = new HashMap<>();
+            empty.put("qcBatchId", null);
+            empty.put("boxesSelected", 0);
+            empty.put("samplesSelected", 0);
+            empty.put("filteredSamplePool", eligible.size());
+            empty.put("includeInspected", includeAll);
+            empty.put("samples", List.of());
+            return ResponseEntity.ok(empty);
+        }
+        List<String> selectedBoxKeys = selectDistributedBoxKeys(candidatesByBox, Math.min(boxesPerRound, candidatesByBox.size()), random);
+        List<Map<String, Object>> selectedSamples = new ArrayList<>();
+        for (String boxKey : selectedBoxKeys) {
+            List<Map<String, Object>> inBox = new ArrayList<>(candidatesByBox.getOrDefault(boxKey, List.of()));
+            Collections.shuffle(inBox, random);
+            int limit = Math.min(samplesPerBox, inBox.size());
+            for (int i = 0; i < limit; i++) {
+                Map<String, Object> row = new HashMap<>(inBox.get(i));
+                row.put("qcBatchId", qcBatchId);
+                selectedSamples.add(row);
+            }
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("qcBatchId", qcBatchId);
+        result.put("boxesSelected", selectedBoxKeys.size());
+        result.put("samplesSelected", selectedSamples.size());
+        result.put("boxesPerRound", boxesPerRound);
+        result.put("samplesPerBox", samplesPerBox);
+        result.put("seed", request.getSeed());
+        result.put("includeInspected", includeAll);
+        result.put("filteredSamplePool", eligible.size());
+        result.put("samples", selectedSamples);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * When true: all STORED samples in scope with valid path are in the pool (including
+     * re-QC the same quarter). When false: exclude samples that already have a QC
+     * inspection in the current calendar quarter.
+     */
+    private Map<String, Object> buildStorageOverviewMap(String freezerFilter, String shelfFilter, String rackFilter,
+            String boxFilter, boolean includeAllQcVisits) {
+        CalendarQuarter currentQuarter = resolveCurrentCalendarQuarter(ZoneId.systemDefault());
 
         List<BioSample> storedSamples = bioSampleService.getAll().stream()
                 .filter(bs -> WorkflowStatus.STORED.equals(bs.getWorkflowStatus())).toList();
@@ -402,6 +493,14 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
             if (sampleItem == null || sampleItem.getId() == null) {
                 continue;
             }
+
+            boolean anyPriorInspection = qcInspectionService.existsByBioSampleId(bioSample.getId());
+            boolean inspectedThisQuarter = qcInspectionService.hasInspectionBetween(bioSample.getId(), currentQuarter.start,
+                    currentQuarter.end);
+            if (!includeAllQcVisits && inspectedThisQuarter) {
+                continue;
+            }
+
             Map<String, Object> location = storageService.getSampleItemLocation(sampleItem.getId().toString());
             if (location == null || location.isEmpty()) {
                 continue;
@@ -439,6 +538,11 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
             sampleSummary.put("positionCoordinate", asString(location.get("positionCoordinate")));
             sampleSummary.put("accessionNumber",
                     sampleItem.getSample() != null ? sampleItem.getSample().getAccessionNumber() : null);
+            sampleSummary.put("anyPriorInspection", anyPriorInspection);
+            sampleSummary.put("hasInspectionHistory", anyPriorInspection);
+            sampleSummary.put("inspectedThisQuarter", inspectedThisQuarter);
+            sampleSummary.put("shelfKey", buildHierarchyKey(parsedFreezer, parsedShelf));
+            sampleSummary.put("boxKey", buildHierarchyKey(parsedFreezer, parsedShelf, parsedRack, parsedBox));
             eligibleSamples.add(sampleSummary);
         }
 
@@ -462,7 +566,82 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         response.put("biorepositoryScope", Map.of(
             "deviceHierarchyBiorepositoryOnly", false,
             "reason", "No explicit device biorepository scope field exists in this branch"));
-        return ResponseEntity.ok(response);
+        response.put("qcExclusionWindow", Map.of("mode", "CALENDAR_QUARTER", "label", currentQuarter.label, "start",
+                currentQuarter.start.toString(), "end", currentQuarter.end.toString(),
+                "poolIncludesRepeatInspectionThisQuarter", includeAllQcVisits,
+                "whenPoolExcludesCompletedThisQuarter", !includeAllQcVisits));
+        return response;
+    }
+
+    private static List<String> selectDistributedBoxKeys(Map<String, List<Map<String, Object>>> candidatesByBox,
+            int boxesToSelect, Random random) {
+        Map<String, List<String>> boxesByShelf = new HashMap<>();
+        for (Map.Entry<String, List<Map<String, Object>>> entry : candidatesByBox.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
+            String shelfKey = asStringHelper(entry.getValue().get(0).get("shelfKey"));
+            String bucket = shelfKey != null ? shelfKey : "Unknown Shelf";
+            boxesByShelf.computeIfAbsent(bucket, key -> new ArrayList<>()).add(entry.getKey());
+        }
+        for (List<String> boxList : boxesByShelf.values()) {
+            Collections.shuffle(boxList, random);
+        }
+        List<String> shelfKeys = new ArrayList<>(boxesByShelf.keySet());
+        Collections.shuffle(shelfKeys, random);
+        List<String> selected = new ArrayList<>();
+        while (selected.size() < boxesToSelect) {
+            boolean addedInCycle = false;
+            for (String shelfKey : shelfKeys) {
+                List<String> boxes = boxesByShelf.get(shelfKey);
+                if (boxes == null || boxes.isEmpty()) {
+                    continue;
+                }
+                selected.add(boxes.remove(0));
+                addedInCycle = true;
+                if (selected.size() >= boxesToSelect) {
+                    break;
+                }
+            }
+            if (!addedInCycle) {
+                break;
+            }
+        }
+        return selected;
+    }
+
+    private static String asStringHelper(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String s = String.valueOf(value);
+        return s.isBlank() ? null : s;
+    }
+
+    private static final class CalendarQuarter {
+        final Timestamp start;
+        final Timestamp end;
+        final String label;
+
+        private CalendarQuarter(Timestamp start, Timestamp end, String label) {
+            this.start = start;
+            this.end = end;
+            this.label = label;
+        }
+    }
+
+    static CalendarQuarter resolveCurrentCalendarQuarter(ZoneId zone) {
+        ZonedDateTime now = ZonedDateTime.now(zone);
+        int year = now.getYear();
+        int month = now.getMonthValue();
+        int quarter = (month - 1) / 3 + 1;
+        int firstMonth = (quarter - 1) * 3 + 1;
+        LocalDate firstDay = LocalDate.of(year, firstMonth, 1);
+        LocalDate lastDay = firstDay.plusMonths(3).minusDays(1);
+        ZonedDateTime start = firstDay.atStartOfDay(zone);
+        ZonedDateTime end = lastDay.atTime(LocalTime.of(23, 59, 59, 999_000_000)).atZone(zone);
+        return new CalendarQuarter(Timestamp.from(start.toInstant()), Timestamp.from(end.toInstant()),
+                year + " Q" + quarter);
     }
 
     // ========== Helper Methods ==========
@@ -590,19 +769,16 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         map.put("technicianId", inspection.getSysUserId());
         map.put("inspectionDate", inspection.getInspectionDate().toString());
         map.put("lastQCDate", inspection.getInspectionDate().toString());
+        map.put("qcBatchId", inspection.getQcBatchId());
         map.put("qcResult", inspection.getQcResult().name());
-        String qcStatus = BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection);
+        String qcStatus = deriveQcStatus(inspection);
         map.put("qcStatus", qcStatus);
         map.put("sampleFlag", "VALID".equals(qcStatus) ? "QC_VALID" : "QC_FAILED");
         map.put("qcFailed", !"VALID".equals(qcStatus));
-        map.put("lifecycleOutcome", BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection));
+        map.put("lifecycleOutcome", deriveLifecycleOutcome(inspection));
         map.put("expectedLocationPath", inspection.getExpectedLocationPath());
         map.put("expectedPositionCoordinate", inspection.getExpectedPositionCoordinate());
-        map.put("correctionActionType", inspection.getCorrectionActionType());
-        map.put("correctionReason", inspection.getCorrectionReason());
-        map.put("correctionByUser", inspection.getCorrectionByUser());
-        map.put("correctionTimestamp",
-                inspection.getCorrectionTimestamp() != null ? inspection.getCorrectionTimestamp().toString() : null);
+        map.put("expectedCoordinateSnapshot", inspection.getExpectedCoordinateSnapshot());
 
         // Checklist items
         map.put("samplePresent", inspection.isSamplePresent());
@@ -622,6 +798,15 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
             map.put("remarks", inspection.getRemarks());
             map.put("failureComment", inspection.getRemarks());
         }
+        if (inspection.getCorrectionActionType() != null) {
+            map.put("correctionActionType", inspection.getCorrectionActionType());
+        }
+        if (inspection.getCorrectionByUser() != null) {
+            map.put("correctionByUser", inspection.getCorrectionByUser());
+        }
+        if (inspection.getCorrectionTimestamp() != null) {
+            map.put("correctionTimestamp", inspection.getCorrectionTimestamp().toString());
+        }
 
         map.put("auditTrail", buildAuditTrail(inspection, correctionDetails));
 
@@ -637,72 +822,222 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         return trimToNull(request.getCorrectionActionType()) != null;
     }
 
-    private String validateCorrectionWorkflowRequest(BulkQCInspectionRequest request) {
+    private void validateCorrectionWorkflowRequest(BulkQCInspectionRequest request) {
+        if (!requiresCorrectionWorkflow(request)) {
+            return;
+        }
+
         String correctionActionType = trimToNull(request.getCorrectionActionType());
-        if (correctionActionType == null) {
-            return null;
+        String discrepancyType = trimToNull(request.getDiscrepancyType());
+        String locationId = trimToNull(request.getCorrectionLocationId());
+        String locationType = trimToNull(request.getCorrectionLocationType());
+        String positionCoordinate = trimToNull(request.getCorrectionPositionCoordinate());
+
+        if ("MARK_MISSING".equalsIgnoreCase(correctionActionType)) {
+            boolean isMissingDiscrepancy = BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.name()
+                    .equals(discrepancyType)
+                    || BiorepositoryQCInspection.DiscrepancyType.MISSING_SAMPLE.name().equals(discrepancyType);
+            if (!isMissingDiscrepancy) {
+                throw new IllegalArgumentException("MARK_MISSING requires discrepancy type SAMPLE_MISSING");
+            }
+            if (locationId != null || locationType != null || positionCoordinate != null) {
+                throw new IllegalArgumentException(
+                        "MARK_MISSING does not allow correction location/position fields");
+            }
+            return;
         }
 
-        String normalizedActionType = correctionActionType.toUpperCase();
-        boolean hasCorrectionLocationId = trimToNull(request.getCorrectionLocationId()) != null;
-        boolean hasCorrectionLocationType = trimToNull(request.getCorrectionLocationType()) != null;
-        boolean hasCorrectionLocation = hasCorrectionLocationId || hasCorrectionLocationType;
-        boolean hasCorrectionPosition = trimToNull(request.getCorrectionPositionCoordinate()) != null;
-
-        if ("MARK_MISSING".equals(normalizedActionType)) {
-            BiorepositoryQCInspection.DiscrepancyType discrepancyType = BiorepositoryQCInspection.DiscrepancyType
-                    .fromString(request.getDiscrepancyType());
-            if (!isSampleMissingDiscrepancy(discrepancyType)) {
-                return "MARK_MISSING requires discrepancy type SAMPLE_MISSING";
+        if ("UPDATE_LOCATION".equalsIgnoreCase(correctionActionType)
+                || "REASSIGN_POSITION".equalsIgnoreCase(correctionActionType)) {
+            if (locationId == null || locationType == null) {
+                throw new IllegalArgumentException(
+                        "UPDATE_LOCATION/REASSIGN_POSITION require correctionLocationId and correctionLocationType");
             }
-            if (hasCorrectionLocation || hasCorrectionPosition) {
-                return "MARK_MISSING does not allow correction location/position fields";
+            if ("REASSIGN_POSITION".equalsIgnoreCase(correctionActionType) && positionCoordinate == null) {
+                throw new IllegalArgumentException("REASSIGN_POSITION requires correctionPositionCoordinate");
             }
-            return null;
+            return;
         }
 
-        if ("UPDATE_LOCATION".equals(normalizedActionType) || "REASSIGN_POSITION".equals(normalizedActionType)) {
-            if (!hasCorrectionLocationId || !hasCorrectionLocationType) {
-                return "UPDATE_LOCATION/REASSIGN_POSITION require correctionLocationId and correctionLocationType";
-            }
-            if ("REASSIGN_POSITION".equals(normalizedActionType) && !hasCorrectionPosition) {
-                return "REASSIGN_POSITION requires correctionPositionCoordinate";
-            }
-            return null;
-        }
-
-        return "Unsupported correction action type: " + correctionActionType;
+        throw new IllegalArgumentException("Unsupported correction action type: " + correctionActionType);
     }
 
-    private boolean isSampleMissingDiscrepancy(BiorepositoryQCInspection.DiscrepancyType discrepancyType) {
-        if (discrepancyType == null) {
+    private Map<String, Object> applyCorrectionWorkflow(BiorepositoryQCInspection inspection, BulkQCInspectionRequest request) {
+        if (inspection.getQcResult() != BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND) {
+            throw new IllegalArgumentException("Correction workflow requires discrepancy QC result");
+        }
+
+        BioSample bioSample = inspection.getBioSample();
+        if (bioSample == null || bioSample.getSampleItem() == null || bioSample.getSampleItem().getId() == null) {
+            throw new IllegalArgumentException("Sample item is required for correction workflow");
+        }
+
+        String correctionActionType = trimToNull(request.getCorrectionActionType());
+        String sampleItemId = bioSample.getSampleItem().getId();
+
+        if ("MARK_MISSING".equalsIgnoreCase(correctionActionType)) {
+            if (!isSampleMissingDiscrepancy(inspection)) {
+                throw new IllegalArgumentException("MARK_MISSING requires discrepancy type SAMPLE_MISSING");
+            }
+
+            String reason = trimToNull(request.getCorrectionReason());
+            if (reason == null) {
+                reason = trimToNull(request.getCorrectiveAction());
+            }
+            if (reason == null) {
+                reason = "Sample marked as missing during QC";
+            }
+
+            String normalizedReason = reason;
+            if (!normalizedReason.toUpperCase().startsWith("MARK_MISSING")) {
+                normalizedReason = "MARK_MISSING: " + normalizedReason;
+            }
+
+            Timestamp correctionTimestamp = new Timestamp(System.currentTimeMillis());
+            Map<String, Object> missingUpdate = storageService.markSampleItemMissing(sampleItemId, normalizedReason,
+                    trimToNull(request.getRemarks()));
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> updatedLocation = missingUpdate.get("updatedLocation") instanceof Map
+                    ? (Map<String, Object>) missingUpdate.get("updatedLocation")
+                    : Map.of("hierarchicalPath", "Missing (not found during QC)", "positionCoordinate", null,
+                            "status", "MISSING");
+
+            Map<String, Object> correction = new HashMap<>();
+            correction.put("actionType", "MARK_MISSING");
+            correction.put("movementId", asString(missingUpdate.get("movementId")));
+            correction.put("reason", normalizedReason);
+            correction.put("updatedLocation", updatedLocation);
+            correction.put("correctionTimestamp", correctionTimestamp.toString());
+            persistCorrectionAuditFields(inspection, "MARK_MISSING", normalizedReason, updatedLocation,
+                    correctionTimestamp);
+            correction.put("auditTrail", buildAuditTrail(inspection, correction));
+            return correction;
+        }
+
+        if (!"UPDATE_LOCATION".equalsIgnoreCase(correctionActionType)
+                && !"REASSIGN_POSITION".equalsIgnoreCase(correctionActionType)) {
+            throw new IllegalArgumentException("Unsupported correction action type: " + correctionActionType);
+        }
+
+        String locationId = trimToNull(request.getCorrectionLocationId());
+        String locationType = trimToNull(request.getCorrectionLocationType());
+        if (locationId == null || locationType == null) {
+            throw new IllegalArgumentException(
+                    "Correction locationId and locationType are required for UPDATE_LOCATION/REASSIGN_POSITION");
+        }
+
+        String reason = trimToNull(request.getCorrectionReason());
+        if (reason == null) {
+            reason = trimToNull(request.getCorrectiveAction());
+        }
+        if (reason == null) {
+            reason = "QC discrepancy correction";
+        }
+
+        String movementId = storageService.moveSampleItemWithLocation(sampleItemId, locationId, locationType,
+                trimToNull(request.getCorrectionPositionCoordinate()), reason, trimToNull(request.getRemarks()));
+
+        String normalizedActionReason = reason;
+        if (!normalizedActionReason.toUpperCase().startsWith(correctionActionType.toUpperCase())) {
+            normalizedActionReason = correctionActionType + ": " + reason;
+        }
+        Map<String, Object> updatedLocation = storageService.getSampleItemLocation(sampleItemId);
+        Timestamp correctionTimestamp = new Timestamp(System.currentTimeMillis());
+        persistCorrectionAuditFields(inspection, correctionActionType, normalizedActionReason, updatedLocation,
+                correctionTimestamp);
+        Map<String, Object> correction = new HashMap<>();
+        correction.put("actionType", correctionActionType);
+        correction.put("movementId", movementId);
+        correction.put("reason", normalizedActionReason);
+        correction.put("updatedLocation", updatedLocation);
+        correction.put("correctionTimestamp", correctionTimestamp.toString());
+        correction.put("auditTrail", buildAuditTrail(inspection, correction));
+        return correction;
+    }
+
+    private void persistCorrectionAuditFields(BiorepositoryQCInspection inspection, String actionType, String reason,
+            Map<String, Object> updatedLocation, Timestamp correctionTimestamp) {
+        String oldCoordinate = composeCoordinate(inspection.getExpectedLocationPath(),
+                inspection.getExpectedPositionCoordinate());
+        String newCoordinate = null;
+        if (updatedLocation != null) {
+            newCoordinate = composeCoordinate(asString(updatedLocation.get("hierarchicalPath")),
+                    asString(updatedLocation.get("positionCoordinate")));
+        }
+        if (newCoordinate == null && "MARK_MISSING".equalsIgnoreCase(actionType)) {
+            newCoordinate = "Missing (not found during QC)";
+        }
+
+        inspection.setCorrectiveAction(reason);
+        if (trimToNull(inspection.getRemarks()) == null && "MARK_MISSING".equalsIgnoreCase(actionType)) {
+            inspection.setRemarks("Marked as missing during QC correction workflow");
+        }
+        inspection.setCorrectionActionType(actionType);
+        inspection.setCorrectionOldCoordinate(oldCoordinate);
+        inspection.setCorrectionNewCoordinate(newCoordinate != null ? newCoordinate : oldCoordinate);
+        inspection.setCorrectionReason(reason);
+        inspection.setCorrectionByUser(inspection.getSysUserId());
+        inspection.setCorrectionTimestamp(correctionTimestamp);
+        qcInspectionService.update(inspection);
+    }
+
+    private String deriveQcStatus(BiorepositoryQCInspection inspection) {
+        if (inspection == null || inspection.getQcResult() == null) {
+            return "UNKNOWN";
+        }
+        if (BiorepositoryQCInspection.QCResult.VERIFIED.equals(inspection.getQcResult())) {
+            return "VALID";
+        }
+        if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+            if (isSampleMissingDiscrepancy(inspection)
+                    && "MARK_MISSING".equalsIgnoreCase(trimToNull(inspection.getCorrectionActionType()))) {
+                return "MISSING";
+            }
+            return "QC_FAILED";
+        }
+        return "UNKNOWN";
+    }
+
+    private String deriveLifecycleOutcome(BiorepositoryQCInspection inspection) {
+        if (inspection == null || inspection.getQcResult() == null) {
+            return "UNKNOWN";
+        }
+        if (BiorepositoryQCInspection.QCResult.VERIFIED.equals(inspection.getQcResult())) {
+            return "PASSED";
+        }
+        if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+            if ("MISSING".equals(deriveQcStatus(inspection))) {
+                return "FAILED_MARKED_MISSING";
+            }
+            if (trimToNull(inspection.getCorrectionActionType()) != null) {
+                return "FAILED_CORRECTED";
+            }
+            return "FAILED_PENDING_CORRECTION";
+        }
+        return "UNKNOWN";
+    }
+
+    private boolean isSampleMissingDiscrepancy(BiorepositoryQCInspection inspection) {
+        if (inspection == null || inspection.getDiscrepancyType() == null) {
             return false;
         }
-        return BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.equals(discrepancyType)
-                || BiorepositoryQCInspection.DiscrepancyType.MISSING_SAMPLE.equals(discrepancyType);
+        return BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.equals(inspection.getDiscrepancyType())
+                || BiorepositoryQCInspection.DiscrepancyType.MISSING_SAMPLE.equals(inspection.getDiscrepancyType());
     }
 
     private Map<String, Object> buildAuditTrail(BiorepositoryQCInspection inspection,
             Map<String, Object> correctionDetails) {
         Map<String, Object> auditTrail = new HashMap<>();
 
-        String oldCoordinate = trimToNull(inspection.getCorrectionOldCoordinate());
-        if (oldCoordinate == null) {
-            oldCoordinate = composeCoordinate(inspection.getExpectedLocationPath(), inspection.getExpectedPositionCoordinate());
-        }
-        String newCoordinate = trimToNull(inspection.getCorrectionNewCoordinate());
-        String reason = trimToNull(inspection.getCorrectionReason());
-        if (reason == null) {
-            reason = trimToNull(inspection.getCorrectiveAction());
-        }
-        String auditTimestamp = inspection.getCorrectionTimestamp() != null ? inspection.getCorrectionTimestamp().toString()
-                : (inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
-        String auditUser = trimToNull(inspection.getCorrectionByUser()) != null ? inspection.getCorrectionByUser()
-                : inspection.getSysUserId();
+        String oldCoordinate = composeCoordinate(inspection.getExpectedLocationPath(),
+                inspection.getExpectedPositionCoordinate());
+
+        String newCoordinate = null;
+        String reason = trimToNull(inspection.getCorrectiveAction());
+        String auditTimestamp = inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null;
         if (correctionDetails != null) {
-            if (reason == null) {
-                reason = trimToNull(asString(correctionDetails.get("reason")));
-            }
+            reason = trimToNull(asString(correctionDetails.get("reason")));
             String correctionTimestamp = trimToNull(asString(correctionDetails.get("correctionTimestamp")));
             if (correctionTimestamp != null) {
                 auditTimestamp = correctionTimestamp;
@@ -717,20 +1052,19 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
             }
         }
 
-        if (newCoordinate == null && "MISSING".equals(BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection))) {
+        if (newCoordinate == null && "MISSING".equals(deriveQcStatus(inspection))) {
             newCoordinate = "Missing (not found during QC)";
         }
 
-        boolean correctionApplied = BiorepositoryQcOutcomeDerivation.hasAppliedCorrectionWorkflow(inspection);
-        if (!correctionApplied
+        if (newCoordinate == null && correctionDetails == null
                 && BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
-            SampleItem sampleItem = inspection.getBioSample() != null ? inspection.getBioSample().getSampleItem() : null;
+            BioSample bioSample = inspection.getBioSample();
+            SampleItem sampleItem = bioSample != null ? bioSample.getSampleItem() : null;
             if (sampleItem != null && sampleItem.getId() != null) {
                 Map<String, Object> currentLocation = storageService.getSampleItemLocation(sampleItem.getId().toString());
-                String currentCoordinate = composeCoordinate(asString(currentLocation.get("hierarchicalPath")),
-                        asString(currentLocation.get("positionCoordinate")));
-                if (trimToNull(currentCoordinate) != null) {
-                    newCoordinate = currentCoordinate;
+                if (currentLocation != null) {
+                    newCoordinate = composeCoordinate(asString(currentLocation.get("hierarchicalPath")),
+                            asString(currentLocation.get("positionCoordinate")));
                 }
             }
         }
@@ -743,8 +1077,8 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
         auditTrail.put("newCoordinate", newCoordinate);
         auditTrail.put("fromCoordinates", oldCoordinate);
         auditTrail.put("toCoordinates", newCoordinate);
-        auditTrail.put("user", auditUser);
-        auditTrail.put("correctedBy", auditUser);
+        auditTrail.put("user", inspection.getSysUserId());
+        auditTrail.put("correctedBy", inspection.getSysUserId());
         auditTrail.put("timestamp", auditTimestamp);
         auditTrail.put("correctedAt", auditTimestamp);
         auditTrail.put("reason", reason);
@@ -778,10 +1112,88 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
 
     // ========== Request DTOs ==========
 
+    public static class GenerateQCRoundRequest {
+        private int boxesPerRound = 10;
+        private int samplesPerBox = 3;
+        private Long seed;
+        private String freezer;
+        private String shelf;
+        private String rack;
+        private String box;
+        /** When true (default), full eligible pool. When false, exclude if inspected this calendar quarter. */
+        private Boolean includeInspected = Boolean.TRUE;
+
+        public int getBoxesPerRound() {
+            return boxesPerRound;
+        }
+
+        public void setBoxesPerRound(int boxesPerRound) {
+            this.boxesPerRound = boxesPerRound;
+        }
+
+        public int getSamplesPerBox() {
+            return samplesPerBox;
+        }
+
+        public void setSamplesPerBox(int samplesPerBox) {
+            this.samplesPerBox = samplesPerBox;
+        }
+
+        public Long getSeed() {
+            return seed;
+        }
+
+        public void setSeed(Long seed) {
+            this.seed = seed;
+        }
+
+        public String getFreezer() {
+            return freezer;
+        }
+
+        public void setFreezer(String freezer) {
+            this.freezer = freezer;
+        }
+
+        public String getShelf() {
+            return shelf;
+        }
+
+        public void setShelf(String shelf) {
+            this.shelf = shelf;
+        }
+
+        public String getRack() {
+            return rack;
+        }
+
+        public void setRack(String rack) {
+            this.rack = rack;
+        }
+
+        public String getBox() {
+            return box;
+        }
+
+        public void setBox(String box) {
+            this.box = box;
+        }
+
+        public Boolean getIncludeInspected() {
+            return includeInspected;
+        }
+
+        public void setIncludeInspected(Boolean includeInspected) {
+            this.includeInspected = includeInspected;
+        }
+    }
+
     public static class BulkQCInspectionRequest {
         private List<Integer> bioSampleIds;
         private String inspectorName;
         private Timestamp inspectionDate;
+        private String qcBatchId;
+        private String expectedCoordinateSnapshot;
         private boolean samplePresent;
         private boolean labelIntegrity;
         private boolean containerIntegrity;
@@ -819,6 +1231,22 @@ public class BiorepositoryQCInspectionRestController extends BaseRestController 
 
         public void setInspectionDate(Timestamp inspectionDate) {
             this.inspectionDate = inspectionDate;
+        }
+
+        public String getQcBatchId() {
+            return qcBatchId;
+        }
+
+        public void setQcBatchId(String qcBatchId) {
+            this.qcBatchId = qcBatchId;
+        }
+
+        public String getExpectedCoordinateSnapshot() {
+            return expectedCoordinateSnapshot;
+        }
+
+        public void setExpectedCoordinateSnapshot(String expectedCoordinateSnapshot) {
+            this.expectedCoordinateSnapshot = expectedCoordinateSnapshot;
         }
 
         public boolean isSamplePresent() {

--- a/src/main/java/org/openelisglobal/biorepository/dao/BiorepositoryQCInspectionDAO.java
+++ b/src/main/java/org/openelisglobal/biorepository/dao/BiorepositoryQCInspectionDAO.java
@@ -54,6 +54,14 @@ public interface BiorepositoryQCInspectionDAO extends BaseDAO<BiorepositoryQCIns
     List<BiorepositoryQCInspection> getByInspectorName(String inspectorName);
 
     /**
+     * Find inspections by QC batch ID.
+     *
+     * @param qcBatchId QC batch identifier
+     * @return list of inspections ordered by inspection date ascending
+     */
+    List<BiorepositoryQCInspection> getByQcBatchId(String qcBatchId);
+
+    /**
      * Count inspections by QC result.
      *
      * @param qcResult the QC result
@@ -77,4 +85,10 @@ public interface BiorepositoryQCInspectionDAO extends BaseDAO<BiorepositoryQCIns
      * @return list of inspections ordered by inspection date
      */
     List<BiorepositoryQCInspection> getInspectionsByDateRange(java.sql.Timestamp startDate, java.sql.Timestamp endDate);
+
+    /**
+     * True if the biosample has at least one inspection with inspection date in
+     * {@code [startDate, endDate]} (inclusive).
+     */
+    boolean hasInspectionBetween(Integer bioSampleId, java.sql.Timestamp startDate, java.sql.Timestamp endDate);
 }

--- a/src/main/java/org/openelisglobal/biorepository/daoimpl/BiorepositoryQCInspectionDAOImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/daoimpl/BiorepositoryQCInspectionDAOImpl.java
@@ -86,6 +86,18 @@ public class BiorepositoryQCInspectionDAOImpl extends BaseDAOImpl<BiorepositoryQ
     }
 
     @Override
+    public List<BiorepositoryQCInspection> getByQcBatchId(String qcBatchId) {
+        if (qcBatchId == null || qcBatchId.isBlank()) {
+            return List.of();
+        }
+        Session session = entityManager.unwrap(Session.class);
+        String hql = "FROM BiorepositoryQCInspection qc WHERE qc.qcBatchId = :qcBatchId "
+                + "ORDER BY qc.inspectionDate ASC, qc.id ASC";
+        return session.createQuery(hql, BiorepositoryQCInspection.class).setParameter("qcBatchId", qcBatchId.trim())
+                .getResultList();
+    }
+
+    @Override
     public long countByQCResult(QCResult qcResult) {
         Session session = entityManager.unwrap(Session.class);
         String hql = "SELECT COUNT(qc) FROM BiorepositoryQCInspection qc WHERE qc.qcResult = :qcResult";
@@ -107,5 +119,18 @@ public class BiorepositoryQCInspectionDAOImpl extends BaseDAOImpl<BiorepositoryQ
                 + "ORDER BY qc.inspectionDate ASC";
         return session.createQuery(hql, BiorepositoryQCInspection.class).setParameter("startDate", startDate)
                 .setParameter("endDate", endDate).getResultList();
+    }
+
+    @Override
+    public boolean hasInspectionBetween(Integer bioSampleId, Timestamp startDate, Timestamp endDate) {
+        if (bioSampleId == null || startDate == null || endDate == null) {
+            return false;
+        }
+        Session session = entityManager.unwrap(Session.class);
+        String hql = "SELECT COUNT(qc) FROM BiorepositoryQCInspection qc WHERE qc.bioSample.id = :bioSampleId "
+                + "AND qc.inspectionDate >= :startDate AND qc.inspectionDate <= :endDate";
+        Long count = session.createQuery(hql, Long.class).setParameter("bioSampleId", bioSampleId)
+                .setParameter("startDate", startDate).setParameter("endDate", endDate).getSingleResult();
+        return count > 0;
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardService.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardService.java
@@ -86,6 +86,18 @@ public interface BiorepositoryDashboardService {
     Map<String, Object> getQCDiscrepancyBreakdown();
 
     /**
+     * Get completed QC inspection history for reporting dashboards.
+     *
+     * @param limit maximum number of most-recent records to return (optional,
+     *              defaults to 50)
+     * @return Map with keys: - source (String): underlying source table/entity -
+     *         count (Integer): number of returned records - items (List<Map>):
+     *         completed inspection records with date/result/technician/location
+     *         context
+     */
+    Map<String, Object> getQCHistory(Integer limit);
+
+    /**
      * Get retrieval statistics within a date range.
      *
      * @param startDate Start date (optional, defaults to 30 days ago)

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardServiceImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardServiceImpl.java
@@ -19,6 +19,11 @@ import org.openelisglobal.notebook.valueholder.NotebookEntryRoomEnvironmentLog;
 import org.openelisglobal.notebook.valueholder.NotebookEntryTemperatureLog;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.storage.service.SampleStorageService;
+import org.openelisglobal.storage.service.StorageLocationService;
+import org.openelisglobal.storage.valueholder.StorageBox;
+import org.openelisglobal.storage.valueholder.StorageDevice;
+import org.openelisglobal.storage.valueholder.StorageRack;
+import org.openelisglobal.storage.valueholder.StorageShelf;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,6 +57,9 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
         @Autowired
         private SampleStorageService storageService;
 
+    @Autowired
+    private StorageLocationService storageLocationService;
+
     @Override
     @Transactional(readOnly = true)
     public Map<String, Object> getStorageCapacityMetrics() {
@@ -70,10 +78,24 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
         metrics.put("totalSamplesStored", totalStored);
         metrics.put("pendingStorage", pendingStorage);
 
-        // Note: Device-level utilization requires SampleStorageAssignment integration
-        // For MVP, provide basic counts
-        metrics.put("totalDevices", 0L); // Placeholder for Phase 2
-        metrics.put("averageUtilization", 0.0); // Placeholder for Phase 2
+        List<Map<String, Object>> deviceRows = buildStorageDeviceRows();
+        long totalConfiguredCapacity = deviceRows.stream()
+                .mapToLong(row -> ((Number) row.getOrDefault("totalCapacity", 0)).longValue())
+                .sum();
+        long totalCurrentUsage = deviceRows.stream()
+                .mapToLong(row -> ((Number) row.getOrDefault("currentUsage", 0)).longValue())
+                .sum();
+        long capacityDefinedDevices = deviceRows.stream()
+                .filter(row -> ((Number) row.getOrDefault("totalCapacity", 0)).longValue() > 0)
+                .count();
+
+        metrics.put("totalDevices", deviceRows.size());
+        metrics.put("capacityDefinedDevices", capacityDefinedDevices);
+        metrics.put("capacityUndefinedDevices", Math.max(0, deviceRows.size() - capacityDefinedDevices));
+        metrics.put("totalConfiguredCapacity", totalConfiguredCapacity);
+        metrics.put("totalCurrentUsage", totalCurrentUsage);
+        metrics.put("averageUtilization",
+                totalConfiguredCapacity > 0 ? (totalCurrentUsage * 100.0 / totalConfiguredCapacity) : 0.0);
 
         return metrics;
     }
@@ -82,11 +104,7 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
     @Transactional(readOnly = true)
     public Map<String, Object> getStorageUtilizationByDevice() {
         Map<String, Object> utilization = new HashMap<>();
-
-        // Note: Full implementation requires SampleStorageAssignment service
-        // integration
-        // Placeholder for MVP
-        utilization.put("devices", new ArrayList<>());
+        utilization.put("devices", buildStorageDeviceRows());
 
         return utilization;
     }
@@ -126,8 +144,12 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                     return daysUntil > 60 && daysUntil <= 90;
                 }).count();
 
-        // Calculate average age (placeholder - would need collection dates)
-        double averageAgeYears = 0.0; // Placeholder for more complex calculation
+        double averageAgeYears = activeSamples.stream()
+                .map(this::resolveSampleAgeInDays)
+                .filter(days -> days >= 0)
+                .mapToLong(Long::longValue)
+                .average()
+                .orElse(0.0) / 365.0;
 
         metrics.put("expired", expired);
         metrics.put("expiring30Days", expiring30Days);
@@ -137,6 +159,94 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
         metrics.put("averageAgeYears", averageAgeYears);
 
         return metrics;
+    }
+
+    private List<Map<String, Object>> buildStorageDeviceRows() {
+        List<StorageDevice> activeDevices = storageLocationService.getAllDevices().stream()
+                .filter(device -> Boolean.TRUE.equals(device.getActive()))
+                .sorted(Comparator.comparing(device -> device.getName() != null ? device.getName() : ""))
+                .collect(Collectors.toList());
+
+        Map<Integer, List<StorageBox>> boxesByDeviceId = groupActiveBoxesByDeviceId();
+
+        return activeDevices.stream().map(device -> {
+            long derivedCapacity = boxesByDeviceId.getOrDefault(device.getId(), List.of()).stream()
+                    .map(StorageBox::getCapacity)
+                    .filter(capacity -> capacity != null && capacity > 0)
+                    .mapToLong(Integer::longValue)
+                    .sum();
+
+            Integer configuredCapacity = device.getCapacityLimit();
+            long totalCapacity = configuredCapacity != null && configuredCapacity > 0 ? configuredCapacity : derivedCapacity;
+            String capacitySource = configuredCapacity != null && configuredCapacity > 0
+                    ? "DEVICE_CAPACITY_LIMIT"
+                    : (derivedCapacity > 0 ? "BOX_GRID_SUM" : "UNDEFINED");
+            long currentUsage = device.getId() != null ? storageLocationService.countOccupiedInDevice(device.getId()) : 0;
+
+            Map<String, Object> row = new HashMap<>();
+            row.put("deviceId", device.getId());
+            row.put("deviceName", device.getName());
+            row.put("deviceCode", device.getCode());
+            row.put("totalCapacity", totalCapacity);
+            row.put("currentUsage", currentUsage);
+            row.put("availableCapacity", Math.max(0L, totalCapacity - currentUsage));
+            row.put("utilizationPercent", totalCapacity > 0 ? (currentUsage * 100.0 / totalCapacity) : 0.0);
+            row.put("capacitySource", capacitySource);
+            return row;
+        }).collect(Collectors.toList());
+    }
+
+    private Map<Integer, List<StorageBox>> groupActiveBoxesByDeviceId() {
+        Map<Integer, StorageShelf> activeShelves = storageLocationService.getAllShelves().stream()
+                .filter(shelf -> Boolean.TRUE.equals(shelf.getActive()) && shelf.getId() != null)
+                .collect(Collectors.toMap(StorageShelf::getId, Function.identity(), (left, right) -> left));
+        Map<Integer, StorageRack> activeRacks = storageLocationService.getAllRacks().stream()
+                .filter(rack -> Boolean.TRUE.equals(rack.getActive()) && rack.getId() != null)
+                .collect(Collectors.toMap(StorageRack::getId, Function.identity(), (left, right) -> left));
+
+        Map<Integer, List<StorageBox>> boxesByDeviceId = new HashMap<>();
+        for (StorageBox box : storageLocationService.getAllBoxes()) {
+            if (!Boolean.TRUE.equals(box.getActive()) || box.getParentRack() == null || box.getParentRack().getId() == null) {
+                continue;
+            }
+
+            StorageRack rack = activeRacks.get(box.getParentRack().getId());
+            if (rack == null || rack.getParentShelf() == null || rack.getParentShelf().getId() == null) {
+                continue;
+            }
+
+            StorageShelf shelf = activeShelves.get(rack.getParentShelf().getId());
+            if (shelf == null || shelf.getParentDevice() == null || shelf.getParentDevice().getId() == null) {
+                continue;
+            }
+
+            boxesByDeviceId.computeIfAbsent(shelf.getParentDevice().getId(), ignored -> new ArrayList<>()).add(box);
+        }
+
+        return boxesByDeviceId;
+    }
+
+    private long resolveSampleAgeInDays(BioSample bioSample) {
+        if (bioSample == null) {
+            return -1;
+        }
+
+        SampleItem sampleItem = bioSample.getSampleItem();
+        if (sampleItem == null) {
+            return -1;
+        }
+
+        LocalDate referenceDate = sampleItem.getCollectionDate() != null
+                ? sampleItem.getCollectionDate().toLocalDateTime().toLocalDate()
+                : (sampleItem.getSample() != null && sampleItem.getSample().getReceivedTimestamp() != null
+                        ? sampleItem.getSample().getReceivedTimestamp().toLocalDateTime().toLocalDate()
+                        : null);
+
+        if (referenceDate == null) {
+            return -1;
+        }
+
+        return Math.max(0L, ChronoUnit.DAYS.between(referenceDate, LocalDate.now()));
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardServiceImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardServiceImpl.java
@@ -5,10 +5,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.openelisglobal.biorepository.valueholder.BioSample;
@@ -21,11 +19,6 @@ import org.openelisglobal.notebook.valueholder.NotebookEntryRoomEnvironmentLog;
 import org.openelisglobal.notebook.valueholder.NotebookEntryTemperatureLog;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.storage.service.SampleStorageService;
-import org.openelisglobal.storage.service.StorageLocationService;
-import org.openelisglobal.storage.valueholder.StorageBox;
-import org.openelisglobal.storage.valueholder.StorageDevice;
-import org.openelisglobal.storage.valueholder.StorageRack;
-import org.openelisglobal.storage.valueholder.StorageShelf;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,9 +52,6 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
         @Autowired
         private SampleStorageService storageService;
 
-    @Autowired
-    private StorageLocationService storageLocationService;
-
     @Override
     @Transactional(readOnly = true)
     public Map<String, Object> getStorageCapacityMetrics() {
@@ -79,13 +69,11 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
 
         metrics.put("totalSamplesStored", totalStored);
         metrics.put("pendingStorage", pendingStorage);
-        Map<String, Object> utilizationSummary = buildStorageUtilizationSummary();
-        metrics.put("totalDevices", utilizationSummary.get("totalDevices"));
-        metrics.put("averageUtilization", utilizationSummary.get("averageUtilization"));
-        metrics.put("capacityDefinedDevices", utilizationSummary.get("capacityDefinedDevices"));
-        metrics.put("capacityUndefinedDevices", utilizationSummary.get("capacityUndefinedDevices"));
-        metrics.put("totalConfiguredCapacity", utilizationSummary.get("totalConfiguredCapacity"));
-        metrics.put("totalCurrentUsage", utilizationSummary.get("totalCurrentUsage"));
+
+        // Note: Device-level utilization requires SampleStorageAssignment integration
+        // For MVP, provide basic counts
+        metrics.put("totalDevices", 0L); // Placeholder for Phase 2
+        metrics.put("averageUtilization", 0.0); // Placeholder for Phase 2
 
         return metrics;
     }
@@ -93,7 +81,14 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
     @Override
     @Transactional(readOnly = true)
     public Map<String, Object> getStorageUtilizationByDevice() {
-        return buildStorageUtilizationSummary();
+        Map<String, Object> utilization = new HashMap<>();
+
+        // Note: Full implementation requires SampleStorageAssignment service
+        // integration
+        // Placeholder for MVP
+        utilization.put("devices", new ArrayList<>());
+
+        return utilization;
     }
 
     @Override
@@ -131,10 +126,8 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                     return daysUntil > 60 && daysUntil <= 90;
                 }).count();
 
-        // Calculate average age using collection date first, then received timestamp.
-        double averageAgeYears = activeSamples.stream().map(this::resolveSampleReferenceDate).filter(date -> date != null)
-                .mapToLong(referenceDate -> Math.max(0, ChronoUnit.DAYS.between(referenceDate, today))).average()
-                .orElse(0.0) / 365.0;
+        // Calculate average age (placeholder - would need collection dates)
+        double averageAgeYears = 0.0; // Placeholder for more complex calculation
 
         metrics.put("expired", expired);
         metrics.put("expiring30Days", expiring30Days);
@@ -220,21 +213,26 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 failTrendBasis.put("completedCheckCriteria", "persisted QC inspection records");
                 metrics.put("failTrendBasis", failTrendBasis);
 
-        metrics.put("volumeAppearancePassRate", volumeAcceptablePassRate);
+                                List<Map<String, Object>> breakdownByFreezer = buildDimensionBreakdown(inspections,
+                                                                this::extractFreezerFromPath);
+                                List<Map<String, Object>> breakdownByRack = buildDimensionBreakdown(inspections, this::extractRackFromPath);
+                                List<Map<String, Object>> breakdownByTechnician = buildDimensionBreakdown(inspections,
+                                                                this::extractTechnicianKey);
 
-        QcEscalationSnapshot snapshot = buildQcEscalationSnapshot(inspections);
-        metrics.put("breakdownByFreezer", snapshot.breakdownByFreezer);
-        metrics.put("breakdownByRack", snapshot.breakdownByRack);
-        metrics.put("breakdownByTechnician", snapshot.breakdownByTechnician);
-        metrics.put("underInvestigationBoxes", snapshot.underInvestigationBoxes);
-        metrics.put("frequentlyProblematicLocations", snapshot.frequentlyProblematicLocations);
-        metrics.put("escalationSignals", snapshot.escalationSignals);
+                                metrics.put("breakdownByFreezer", breakdownByFreezer);
+                                metrics.put("breakdownByRack", breakdownByRack);
+                                metrics.put("breakdownByTechnician", breakdownByTechnician);
 
-        Map<String, Object> failureResolution = buildFailureResolutionSummary(inspections);
-        metrics.put("failureResolutionSummary", failureResolution);
-        metrics.put("failedCorrected", failureResolution.get("failedCorrected"));
-        metrics.put("failedPendingCorrection", failureResolution.get("failedPendingCorrection"));
-        metrics.put("failedMarkedMissing", failureResolution.get("failedMarkedMissing"));
+                                List<Map<String, Object>> underInvestigationBoxes = buildUnderInvestigationBoxes(inspections);
+                                List<Map<String, Object>> frequentlyProblematicLocations = buildFrequentlyProblematicLocations(
+                                                                underInvestigationBoxes, breakdownByRack);
+
+                                metrics.put("failureResolutionSummary", buildFailureResolutionSummary(inspections));
+                                metrics.put("underInvestigationBoxes", underInvestigationBoxes);
+                                metrics.put("frequentlyProblematicLocations", frequentlyProblematicLocations);
+                                metrics.put("escalationSignals",
+                                                                buildEscalationSignals(inspections, breakdownByFreezer, breakdownByRack,
+                                                                                                underInvestigationBoxes));
 
         return metrics;
     }
@@ -248,9 +246,9 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 inspections.sort(Comparator.comparing(BiorepositoryQCInspection::getInspectionDate,
                                 Comparator.nullsLast(Comparator.naturalOrder())).reversed());
 
-                QcEscalationSnapshot snapshot = buildQcEscalationSnapshot(inspections);
-                List<Map<String, Object>> items = inspections.stream().limit(safeLimit)
-                                .map(inspection -> toQCHistoryItem(inspection, snapshot)).collect(Collectors.toList());
+                List<Map<String, Object>> items = inspections.stream().limit(safeLimit).map(this::toQCHistoryItem)
+                                .collect(Collectors.toList());
+                decorateQCHistoryFlags(items, inspections);
 
                 Map<String, Object> result = new HashMap<>();
                 result.put("source", "biorepository_qc_inspection");
@@ -258,8 +256,38 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 result.put("count", items.size());
                 result.put("items", items);
                 result.put("failureResolutionSummary", buildFailureResolutionSummary(inspections));
-                result.put("escalationSignals", snapshot.escalationSignals);
                 return result;
+        }
+
+        private void decorateQCHistoryFlags(List<Map<String, Object>> items,
+                        List<BiorepositoryQCInspection> allInspections) {
+                List<Map<String, Object>> underInvestigationBoxes = buildUnderInvestigationBoxes(allInspections);
+                List<Map<String, Object>> breakdownByFreezer = buildDimensionBreakdown(allInspections,
+                                this::extractFreezerFromPath);
+                List<Map<String, Object>> breakdownByRack = buildDimensionBreakdown(allInspections, this::extractRackFromPath);
+                Map<String, Object> escalationSignals = buildEscalationSignals(allInspections, breakdownByFreezer,
+                                breakdownByRack, underInvestigationBoxes);
+
+                java.util.Set<String> underInvestigationBoxKeys = underInvestigationBoxes.stream()
+                                .map(row -> String.valueOf(row.get("key"))).collect(Collectors.toSet());
+                @SuppressWarnings("unchecked")
+                java.util.Set<String> flaggedFreezerKeys = ((List<Map<String, Object>>) escalationSignals
+                                .getOrDefault("flaggedFreezers", List.of())).stream()
+                                                .map(row -> String.valueOf(row.get("key"))).collect(Collectors.toSet());
+
+                for (Map<String, Object> item : items) {
+                        boolean boxUnderInvestigation = underInvestigationBoxKeys.contains(String.valueOf(item.get("boxKey")));
+                        boolean freezerFlagged = flaggedFreezerKeys.contains(String.valueOf(item.get("freezer")));
+                        if (boxUnderInvestigation) {
+                                item.put("boxFlag", "UNDER_INVESTIGATION");
+                        }
+                        if (freezerFlagged) {
+                                item.put("freezerFlag", "THRESHOLD_EXCEEDED");
+                        }
+                        item.put("escalationTriggered", boxUnderInvestigation || freezerFlagged
+                                        || Boolean.TRUE.equals(escalationSignals.get("criticalSamplesMissing"))
+                                        || Boolean.TRUE.equals(escalationSignals.get("batchFailRateExceeded")));
+                }
         }
 
     @Override
@@ -530,27 +558,23 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 }).collect(Collectors.toList());
         }
 
-        private Map<String, Object> toQCHistoryItem(BiorepositoryQCInspection inspection, QcEscalationSnapshot snapshot) {
+        private Map<String, Object> toQCHistoryItem(BiorepositoryQCInspection inspection) {
                 Map<String, Object> item = new HashMap<>();
                 item.put("id", inspection.getId());
                 item.put("bioSampleId", inspection.getBioSample() != null ? inspection.getBioSample().getId() : null);
+                item.put("qcBatchId", inspection.getQcBatchId());
                 item.put("inspectionDate", inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
                 item.put("lastQcDate", inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
                 item.put("qcResult", inspection.getQcResult() != null ? inspection.getQcResult().name() : null);
-                String qcStatus = BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection);
+                String qcStatus = deriveQcStatus(inspection);
                 item.put("qcStatus", qcStatus);
                 item.put("sampleFlag", "VALID".equals(qcStatus) ? "QC_VALID" : "QC_FAILED");
                 item.put("qcFailed", !"VALID".equals(qcStatus));
-                item.put("lifecycleOutcome", BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection));
+                item.put("lifecycleOutcome", deriveLifecycleOutcome(inspection));
                 item.put("inspectorName", inspection.getInspectorName());
                 item.put("technicianId", inspection.getSysUserId());
                 item.put("expectedLocationPath", inspection.getExpectedLocationPath());
                 item.put("expectedPositionCoordinate", inspection.getExpectedPositionCoordinate());
-                item.put("correctionActionType", inspection.getCorrectionActionType());
-                item.put("correctionReason", inspection.getCorrectionReason());
-                item.put("correctionByUser", inspection.getCorrectionByUser());
-                item.put("correctionTimestamp",
-                                inspection.getCorrectionTimestamp() != null ? inspection.getCorrectionTimestamp().toString() : null);
                 item.put("discrepancyType",
                                 inspection.getDiscrepancyType() != null ? inspection.getDiscrepancyType().name() : null);
                 item.put("correctiveAction", inspection.getCorrectiveAction());
@@ -563,15 +587,10 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 item.put("shelf", levels[1]);
                 item.put("rack", levels[2]);
                 item.put("box", levels[3]);
-                String boxKey = normalizeLabel(levels[0]) + " > " + normalizeLabel(levels[1]) + " > " + normalizeLabel(levels[2])
-                                + " > " + normalizeLabel(levels[3]);
-                item.put("boxFlag", snapshot.underInvestigationBoxKeys.contains(boxKey) ? "UNDER_INVESTIGATION" : "NORMAL");
-                item.put("freezerFlag", snapshot.flaggedFreezerKeys.contains(normalizeLabel(levels[0])) ? "QC_FLAGGED" : "NORMAL");
-                item.put("escalationTriggered",
-                                snapshot.batchFailRateExceeded || snapshot.underInvestigationBoxKeys.contains(boxKey)
-                                                || snapshot.flaggedFreezerKeys.contains(normalizeLabel(levels[0]))
-                                                || isMissingDiscrepancy(inspection));
-                item.put("failureResolution", mapFailureResolutionStatus(inspection));
+                String boxKey = normalizeLabel(levels[0]) + " > " + normalizeLabel(levels[1]) + " > "
+                                + normalizeLabel(levels[2]) + " > " + normalizeLabel(levels[3]);
+                item.put("boxKey", boxKey);
+                item.put("failureResolution", toFailureResolution(inspection));
 
                 return item;
         }
@@ -652,122 +671,6 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 return normalized != null ? normalized : "Unknown";
         }
 
-    private LocalDate resolveSampleReferenceDate(BioSample sample) {
-        if (sample == null || sample.getSampleItem() == null) {
-            return null;
-        }
-        if (sample.getSampleItem().getCollectionDate() != null) {
-            return sample.getSampleItem().getCollectionDate().toLocalDateTime().toLocalDate();
-        }
-        if (sample.getSampleItem().getSample() != null && sample.getSampleItem().getSample().getReceivedTimestamp() != null) {
-            return sample.getSampleItem().getSample().getReceivedTimestamp().toLocalDateTime().toLocalDate();
-        }
-        return null;
-    }
-
-    private Map<String, Object> buildStorageUtilizationSummary() {
-        List<Map<String, Object>> deviceRows = buildDeviceUtilizationRows();
-        long totalCurrentUsage = 0;
-        long totalConfiguredCapacity = 0;
-        int capacityDefinedDevices = 0;
-        for (Map<String, Object> row : deviceRows) {
-            totalCurrentUsage += ((Number) row.getOrDefault("currentUsage", 0)).longValue();
-            long deviceCapacity = ((Number) row.getOrDefault("totalCapacity", 0)).longValue();
-            if (deviceCapacity > 0) {
-                totalConfiguredCapacity += deviceCapacity;
-                capacityDefinedDevices++;
-            }
-        }
-
-        double averageUtilization = totalConfiguredCapacity > 0 ? (totalCurrentUsage * 100.0 / totalConfiguredCapacity)
-                : 0.0;
-        Map<String, Object> summary = new LinkedHashMap<>();
-        summary.put("devices", deviceRows);
-        summary.put("totalDevices", deviceRows.size());
-        summary.put("capacityDefinedDevices", capacityDefinedDevices);
-        summary.put("capacityUndefinedDevices", Math.max(deviceRows.size() - capacityDefinedDevices, 0));
-        summary.put("totalConfiguredCapacity", totalConfiguredCapacity);
-        summary.put("totalCurrentUsage", totalCurrentUsage);
-        summary.put("averageUtilization", averageUtilization);
-        return summary;
-    }
-
-    private List<Map<String, Object>> buildDeviceUtilizationRows() {
-        List<StorageDevice> devices = storageLocationService.getAllDevices().stream().filter(this::isActive).toList();
-        List<StorageShelf> shelves = storageLocationService.getAllShelves().stream().filter(this::isActive).toList();
-        List<StorageRack> racks = storageLocationService.getAllRacks().stream().filter(this::isActive).toList();
-        List<StorageBox> boxes = storageLocationService.getAllBoxes().stream().filter(this::isActive).toList();
-        Set<Integer> activeShelfIds = shelves.stream().map(StorageShelf::getId).filter(id -> id != null)
-                .collect(Collectors.toSet());
-
-        Map<Integer, Integer> rackToDevice = new HashMap<>();
-        for (StorageRack rack : racks) {
-            StorageShelf shelf = rack.getParentShelf();
-            StorageDevice device = shelf != null ? shelf.getParentDevice() : null;
-            if (rack.getId() != null && shelf != null && activeShelfIds.contains(shelf.getId()) && device != null
-                    && device.getId() != null) {
-                rackToDevice.put(rack.getId(), device.getId());
-            }
-        }
-
-        Map<Integer, Long> derivedCapacityByDevice = new HashMap<>();
-        for (StorageBox box : boxes) {
-            StorageRack parentRack = box.getParentRack();
-            Integer rackId = parentRack != null ? parentRack.getId() : null;
-            Integer deviceId = rackId != null ? rackToDevice.get(rackId) : null;
-            if (deviceId == null) {
-                continue;
-            }
-            long boxCapacity = box.getCapacity() != null ? box.getCapacity().longValue() : 0L;
-            if (boxCapacity <= 0) {
-                continue;
-            }
-            derivedCapacityByDevice.merge(deviceId, boxCapacity, Long::sum);
-        }
-
-        return devices.stream().map(device -> {
-            long currentUsage = 0L;
-            if (device.getId() != null) {
-                currentUsage = storageLocationService.countOccupiedInDevice(device.getId());
-            }
-            long configuredDeviceCapacity = device.getCapacityLimit() != null ? device.getCapacityLimit().longValue() : 0L;
-            long derivedCapacity = device.getId() != null ? derivedCapacityByDevice.getOrDefault(device.getId(), 0L) : 0L;
-            long totalCapacity = configuredDeviceCapacity > 0 ? configuredDeviceCapacity : derivedCapacity;
-            String capacitySource = configuredDeviceCapacity > 0 ? "DEVICE_CAPACITY_LIMIT"
-                    : (derivedCapacity > 0 ? "BOX_GRID_SUM" : "UNDEFINED");
-            double utilizationPercent = totalCapacity > 0 ? (currentUsage * 100.0 / totalCapacity) : 0.0;
-
-            Map<String, Object> row = new LinkedHashMap<>();
-            row.put("deviceId", device.getId());
-            row.put("deviceName", trimToNull(device.getName()) != null ? device.getName() : device.getCode());
-            row.put("deviceCode", device.getCode());
-            row.put("deviceType", device.getType());
-            row.put("active", Boolean.TRUE.equals(device.getActive()));
-            row.put("currentUsage", currentUsage);
-            row.put("totalCapacity", totalCapacity);
-            row.put("capacitySource", capacitySource);
-            row.put("utilizationPercent", utilizationPercent);
-            return row;
-        }).sorted((a, b) -> String.valueOf(a.getOrDefault("deviceName", ""))
-                .compareToIgnoreCase(String.valueOf(b.getOrDefault("deviceName", "")))).collect(Collectors.toList());
-    }
-
-    private boolean isActive(StorageDevice device) {
-        return device != null && Boolean.TRUE.equals(device.getActive());
-    }
-
-    private boolean isActive(StorageShelf shelf) {
-        return shelf != null && Boolean.TRUE.equals(shelf.getActive());
-    }
-
-    private boolean isActive(StorageRack rack) {
-        return rack != null && Boolean.TRUE.equals(rack.getActive());
-    }
-
-    private boolean isActive(StorageBox box) {
-        return box != null && Boolean.TRUE.equals(box.getActive());
-    }
-
         private List<Map<String, Object>> buildUnderInvestigationBoxes(List<BiorepositoryQCInspection> inspections) {
                 Map<String, long[]> grouped = new HashMap<>();
 
@@ -801,6 +704,37 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                         }
                         return String.valueOf(a.get("key")).compareToIgnoreCase(String.valueOf(b.get("key")));
                 }).collect(Collectors.toList());
+        }
+
+        private Map<String, Object> buildFailureResolutionSummary(List<BiorepositoryQCInspection> inspections) {
+                long failedPendingCorrection = inspections.stream()
+                                .filter(insp -> "FAILED_PENDING_CORRECTION".equals(deriveLifecycleOutcome(insp))).count();
+                long failedCorrected = inspections.stream()
+                                .filter(insp -> "FAILED_CORRECTED".equals(deriveLifecycleOutcome(insp))).count();
+                long failedMarkedMissing = inspections.stream()
+                                .filter(insp -> "FAILED_MARKED_MISSING".equals(deriveLifecycleOutcome(insp))).count();
+
+                Map<String, Object> correctedVsUnresolved = new HashMap<>();
+                correctedVsUnresolved.put("corrected", failedCorrected + failedMarkedMissing);
+                correctedVsUnresolved.put("unresolved", failedPendingCorrection);
+
+                Map<String, Object> summary = new HashMap<>();
+                summary.put("failedPendingCorrection", failedPendingCorrection);
+                summary.put("failedCorrected", failedCorrected);
+                summary.put("failedMarkedMissing", failedMarkedMissing);
+                summary.put("correctedVsUnresolved", correctedVsUnresolved);
+                return summary;
+        }
+
+        private String toFailureResolution(BiorepositoryQCInspection inspection) {
+                String lifecycle = deriveLifecycleOutcome(inspection);
+                if ("FAILED_CORRECTED".equals(lifecycle) || "FAILED_MARKED_MISSING".equals(lifecycle)) {
+                        return "RESOLVED";
+                }
+                if ("FAILED_PENDING_CORRECTION".equals(lifecycle)) {
+                        return "UNRESOLVED";
+                }
+                return "NOT_REQUIRED";
         }
 
         private List<Map<String, Object>> buildFrequentlyProblematicLocations(List<Map<String, Object>> boxCandidates,
@@ -847,7 +781,7 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                                                 .equals(insp.getQcResult()))
                                 .count();
                 double batchFailRate = totalInspections > 0 ? (failedInspections * 100.0 / totalInspections) : 0.0;
-                boolean batchFailRateExceeded = totalInspections > 0 && batchFailRate > 5.0;
+                boolean batchFailRateExceeded = totalInspections > 0 && batchFailRate >= 5.0;
 
                 long repeatedRacks = breakdownByRack.stream()
                                 .filter(row -> ((Number) row.getOrDefault("failedInspections", 0)).longValue() >= 2)
@@ -864,7 +798,7 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                         long failed = ((Number) row.getOrDefault("failedInspections", 0)).longValue();
                         double passRate = ((Number) row.getOrDefault("passRate", 0.0)).doubleValue();
                         double failRate = 100.0 - passRate;
-                        return failed > 0 && failRate > 5.0;
+                        return failed > 0 && failRate >= 5.0;
                 }).map(row -> {
                         Map<String, Object> freezer = new HashMap<>();
                         freezer.put("key", row.get("key"));
@@ -910,8 +844,81 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 signals.put("flaggedFreezers", flaggedFreezers);
                 signals.put("triggeredRules", triggeredRules);
                 signals.put("recommendedActions", recommendedActions);
+                signals.put("supervisorNotificationRequired", !triggeredRules.isEmpty());
+                signals.put("supervisorNotificationMessage",
+                                buildSupervisorNotificationMessage(batchFailRate, batchFailRateExceeded,
+                                                repeatedFailureInSameBoxOrRack, criticalMissingSamples, flaggedFreezers));
 
                 return signals;
+        }
+
+        private String buildSupervisorNotificationMessage(double batchFailRate, boolean batchFailRateExceeded,
+                        boolean repeatedFailureInSameBoxOrRack, long criticalMissingSamples,
+                        List<Map<String, Object>> flaggedFreezers) {
+                List<String> reasons = new ArrayList<>();
+                if (batchFailRateExceeded) {
+                        reasons.add(String.format("QC batch fail rate is %.1f%% (threshold 5.0%%)", batchFailRate));
+                }
+                if (repeatedFailureInSameBoxOrRack) {
+                        reasons.add("Repeated failure detected in the same box/rack");
+                }
+                if (criticalMissingSamples > 0) {
+                        reasons.add(String.format("Critical samples missing: %d", criticalMissingSamples));
+                }
+
+                if (reasons.isEmpty()) {
+                        return null;
+                }
+
+                StringBuilder message = new StringBuilder();
+                message.append("Biorepository QC escalation alert: ");
+                message.append(String.join("; ", reasons));
+                if (flaggedFreezers != null && !flaggedFreezers.isEmpty()) {
+                        String freezerList = flaggedFreezers.stream()
+                                        .map(row -> String.valueOf(row.get("key")))
+                                        .filter(value -> value != null && !"null".equalsIgnoreCase(value))
+                                        .collect(Collectors.joining(", "));
+                        if (!freezerList.isEmpty()) {
+                                message.append(". Flagged freezers: ").append(freezerList);
+                        }
+                }
+                message.append(".");
+                return message.toString();
+        }
+
+        private String deriveQcStatus(BiorepositoryQCInspection inspection) {
+                if (inspection == null || inspection.getQcResult() == null) {
+                        return "UNKNOWN";
+                }
+                if (BiorepositoryQCInspection.QCResult.VERIFIED.equals(inspection.getQcResult())) {
+                        return "VALID";
+                }
+                if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+                        if (isMissingDiscrepancy(inspection) && isMarkedMissingAction(inspection)) {
+                                return "MISSING";
+                        }
+                        return "QC_FAILED";
+                }
+                return "UNKNOWN";
+        }
+
+        private String deriveLifecycleOutcome(BiorepositoryQCInspection inspection) {
+                if (inspection == null || inspection.getQcResult() == null) {
+                        return "UNKNOWN";
+                }
+                if (BiorepositoryQCInspection.QCResult.VERIFIED.equals(inspection.getQcResult())) {
+                        return "PASSED";
+                }
+                if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+                        if ("MISSING".equals(deriveQcStatus(inspection))) {
+                                return "FAILED_MARKED_MISSING";
+                        }
+                        if (trimToNull(inspection.getCorrectionActionType()) != null) {
+                                return "FAILED_CORRECTED";
+                        }
+                        return "FAILED_PENDING_CORRECTION";
+                }
+                return "UNKNOWN";
         }
 
         private boolean isMissingDiscrepancy(BiorepositoryQCInspection inspection) {
@@ -921,6 +928,11 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 return BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.equals(inspection.getDiscrepancyType())
                                 || BiorepositoryQCInspection.DiscrepancyType.MISSING_SAMPLE
                                                 .equals(inspection.getDiscrepancyType());
+        }
+
+        private boolean isMarkedMissingAction(BiorepositoryQCInspection inspection) {
+                String correctionActionType = trimToNull(inspection.getCorrectionActionType());
+                return correctionActionType != null && correctionActionType.equalsIgnoreCase("MARK_MISSING");
         }
 
         private Map<String, Object> buildQCAuditTrail(BiorepositoryQCInspection inspection) {
@@ -935,19 +947,11 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 if (newCoordinate == null) {
                         newCoordinate = oldCoordinate;
                 }
-                String auditUser = trimToNull(inspection.getCorrectionByUser()) != null ? inspection.getCorrectionByUser()
-                                : inspection.getSysUserId();
-                String auditTimestamp = inspection.getCorrectionTimestamp() != null
-                                ? inspection.getCorrectionTimestamp().toString()
-                                : (inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
-                String reason = trimToNull(inspection.getCorrectionReason()) != null ? inspection.getCorrectionReason()
-                                : trimToNull(inspection.getCorrectiveAction());
-                boolean correctionApplied = BiorepositoryQcOutcomeDerivation.hasAppliedCorrectionWorkflow(inspection);
 
-                if ("MISSING".equals(BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection))
-                                && trimToNull(inspection.getCorrectionNewCoordinate()) == null) {
+                boolean hasPersistedNewCoordinate = trimToNull(inspection.getCorrectionNewCoordinate()) != null;
+                if ("MISSING".equals(deriveQcStatus(inspection))) {
                         newCoordinate = "Missing (not found during QC)";
-                } else if (!correctionApplied
+                } else if (!hasPersistedNewCoordinate
                                 && BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
                         SampleItem sampleItem = inspection.getBioSample() != null ? inspection.getBioSample().getSampleItem()
                                         : null;
@@ -966,11 +970,19 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                 auditTrail.put("newCoordinate", newCoordinate);
                 auditTrail.put("fromCoordinates", oldCoordinate);
                 auditTrail.put("toCoordinates", newCoordinate);
+                String auditUser = trimToNull(inspection.getCorrectionByUser()) != null
+                                ? trimToNull(inspection.getCorrectionByUser())
+                                : inspection.getSysUserId();
+                String auditTimestamp = inspection.getCorrectionTimestamp() != null
+                                ? inspection.getCorrectionTimestamp().toString()
+                                : inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null;
                 auditTrail.put("user", auditUser);
                 auditTrail.put("correctedBy", auditUser);
                 auditTrail.put("timestamp", auditTimestamp);
                 auditTrail.put("correctedAt", auditTimestamp);
-                auditTrail.put("reason", reason);
+                auditTrail.put("reason", trimToNull(inspection.getCorrectionReason()) != null
+                                ? trimToNull(inspection.getCorrectionReason())
+                                : trimToNull(inspection.getCorrectiveAction()));
                 return auditTrail;
         }
 
@@ -994,103 +1006,5 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                         return null;
                 }
                 return String.valueOf(value);
-        }
-
-        private String mapFailureResolutionStatus(BiorepositoryQCInspection inspection) {
-                String lifecycleOutcome = BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection);
-                if ("FAILED_CORRECTED".equals(lifecycleOutcome) || "FAILED_MARKED_MISSING".equals(lifecycleOutcome)) {
-                        return "RESOLVED";
-                }
-                if ("FAILED_PENDING_CORRECTION".equals(lifecycleOutcome)) {
-                        return "UNRESOLVED";
-                }
-                return "N/A";
-        }
-
-        private Map<String, Object> buildFailureResolutionSummary(List<BiorepositoryQCInspection> inspections) {
-                long failedCorrected = 0;
-                long failedPendingCorrection = 0;
-                long failedMarkedMissing = 0;
-                for (BiorepositoryQCInspection inspection : inspections) {
-                        String outcome = BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection);
-                        if ("FAILED_CORRECTED".equals(outcome)) {
-                                failedCorrected++;
-                        } else if ("FAILED_PENDING_CORRECTION".equals(outcome)) {
-                                failedPendingCorrection++;
-                        } else if ("FAILED_MARKED_MISSING".equals(outcome)) {
-                                failedMarkedMissing++;
-                        }
-                }
-                Map<String, Object> summary = new HashMap<>();
-                summary.put("failedCorrected", failedCorrected);
-                summary.put("failedPendingCorrection", failedPendingCorrection);
-                summary.put("failedMarkedMissing", failedMarkedMissing);
-                summary.put("correctedVsUnresolved", Map.of("corrected", failedCorrected + failedMarkedMissing, "unresolved",
-                                failedPendingCorrection));
-                return summary;
-        }
-
-        private QcEscalationSnapshot buildQcEscalationSnapshot(List<BiorepositoryQCInspection> inspections) {
-                List<Map<String, Object>> breakdownByFreezer = buildDimensionBreakdown(inspections, this::extractFreezerFromPath);
-                List<Map<String, Object>> breakdownByRack = buildDimensionBreakdown(inspections, this::extractRackFromPath);
-                List<Map<String, Object>> breakdownByTechnician = buildDimensionBreakdown(inspections, this::extractTechnicianKey);
-                List<Map<String, Object>> underInvestigationBoxes = buildUnderInvestigationBoxes(inspections);
-                List<Map<String, Object>> frequentlyProblematicLocations = buildFrequentlyProblematicLocations(
-                                underInvestigationBoxes, breakdownByRack);
-                Map<String, Object> escalationSignals = buildEscalationSignals(inspections, breakdownByFreezer, breakdownByRack,
-                                underInvestigationBoxes);
-
-                List<Map<String, Object>> flaggedFreezers = escalationSignals.get("flaggedFreezers") instanceof List
-                                ? castMapList(escalationSignals.get("flaggedFreezers"))
-                                : List.of();
-                double batchFailRatePercent = ((Number) escalationSignals.getOrDefault("batchFailRatePercent", 0.0))
-                                .doubleValue();
-                boolean batchFailRateExceeded = Boolean.TRUE.equals(escalationSignals.get("batchFailRateExceeded"));
-
-                return new QcEscalationSnapshot(breakdownByFreezer, breakdownByRack, breakdownByTechnician,
-                                underInvestigationBoxes, frequentlyProblematicLocations, escalationSignals,
-                                toKeySet(underInvestigationBoxes), toKeySet(flaggedFreezers), batchFailRatePercent,
-                                batchFailRateExceeded);
-        }
-
-        @SuppressWarnings("unchecked")
-        private List<Map<String, Object>> castMapList(Object value) {
-                return (List<Map<String, Object>>) value;
-        }
-
-        private java.util.Set<String> toKeySet(List<Map<String, Object>> rows) {
-                return rows.stream().map(row -> normalizeLabel(asString(row.get("key")))).collect(Collectors.toSet());
-        }
-
-        private static class QcEscalationSnapshot {
-                private final List<Map<String, Object>> breakdownByFreezer;
-                private final List<Map<String, Object>> breakdownByRack;
-                private final List<Map<String, Object>> breakdownByTechnician;
-                private final List<Map<String, Object>> underInvestigationBoxes;
-                private final List<Map<String, Object>> frequentlyProblematicLocations;
-                private final Map<String, Object> escalationSignals;
-                private final java.util.Set<String> underInvestigationBoxKeys;
-                private final java.util.Set<String> flaggedFreezerKeys;
-                private final double batchFailRatePercent;
-                private final boolean batchFailRateExceeded;
-
-                private QcEscalationSnapshot(List<Map<String, Object>> breakdownByFreezer,
-                                List<Map<String, Object>> breakdownByRack, List<Map<String, Object>> breakdownByTechnician,
-                                List<Map<String, Object>> underInvestigationBoxes,
-                                List<Map<String, Object>> frequentlyProblematicLocations,
-                                Map<String, Object> escalationSignals, java.util.Set<String> underInvestigationBoxKeys,
-                                java.util.Set<String> flaggedFreezerKeys, double batchFailRatePercent,
-                                boolean batchFailRateExceeded) {
-                        this.breakdownByFreezer = breakdownByFreezer;
-                        this.breakdownByRack = breakdownByRack;
-                        this.breakdownByTechnician = breakdownByTechnician;
-                        this.underInvestigationBoxes = underInvestigationBoxes;
-                        this.frequentlyProblematicLocations = frequentlyProblematicLocations;
-                        this.escalationSignals = escalationSignals;
-                        this.underInvestigationBoxKeys = underInvestigationBoxKeys;
-                        this.flaggedFreezerKeys = flaggedFreezerKeys;
-                        this.batchFailRatePercent = batchFailRatePercent;
-                        this.batchFailRateExceeded = batchFailRateExceeded;
-                }
         }
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardServiceImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardServiceImpl.java
@@ -3,9 +3,13 @@ package org.openelisglobal.biorepository.service;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.openelisglobal.biorepository.valueholder.BioSample;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
@@ -15,6 +19,13 @@ import org.openelisglobal.notebook.service.NotebookEntryRoomEnvironmentLogServic
 import org.openelisglobal.notebook.service.NotebookEntryTemperatureLogService;
 import org.openelisglobal.notebook.valueholder.NotebookEntryRoomEnvironmentLog;
 import org.openelisglobal.notebook.valueholder.NotebookEntryTemperatureLog;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.storage.service.SampleStorageService;
+import org.openelisglobal.storage.service.StorageLocationService;
+import org.openelisglobal.storage.valueholder.StorageBox;
+import org.openelisglobal.storage.valueholder.StorageDevice;
+import org.openelisglobal.storage.valueholder.StorageRack;
+import org.openelisglobal.storage.valueholder.StorageShelf;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +56,12 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
     @Autowired
     private NotebookEntryRoomEnvironmentLogService roomEnvironmentLogService;
 
+        @Autowired
+        private SampleStorageService storageService;
+
+    @Autowired
+    private StorageLocationService storageLocationService;
+
     @Override
     @Transactional(readOnly = true)
     public Map<String, Object> getStorageCapacityMetrics() {
@@ -62,11 +79,13 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
 
         metrics.put("totalSamplesStored", totalStored);
         metrics.put("pendingStorage", pendingStorage);
-
-        // Note: Device-level utilization requires SampleStorageAssignment integration
-        // For MVP, provide basic counts
-        metrics.put("totalDevices", 0L); // Placeholder for Phase 2
-        metrics.put("averageUtilization", 0.0); // Placeholder for Phase 2
+        Map<String, Object> utilizationSummary = buildStorageUtilizationSummary();
+        metrics.put("totalDevices", utilizationSummary.get("totalDevices"));
+        metrics.put("averageUtilization", utilizationSummary.get("averageUtilization"));
+        metrics.put("capacityDefinedDevices", utilizationSummary.get("capacityDefinedDevices"));
+        metrics.put("capacityUndefinedDevices", utilizationSummary.get("capacityUndefinedDevices"));
+        metrics.put("totalConfiguredCapacity", utilizationSummary.get("totalConfiguredCapacity"));
+        metrics.put("totalCurrentUsage", utilizationSummary.get("totalCurrentUsage"));
 
         return metrics;
     }
@@ -74,14 +93,7 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
     @Override
     @Transactional(readOnly = true)
     public Map<String, Object> getStorageUtilizationByDevice() {
-        Map<String, Object> utilization = new HashMap<>();
-
-        // Note: Full implementation requires SampleStorageAssignment service
-        // integration
-        // Placeholder for MVP
-        utilization.put("devices", new ArrayList<>());
-
-        return utilization;
+        return buildStorageUtilizationSummary();
     }
 
     @Override
@@ -119,8 +131,10 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
                     return daysUntil > 60 && daysUntil <= 90;
                 }).count();
 
-        // Calculate average age (placeholder - would need collection dates)
-        double averageAgeYears = 0.0; // Placeholder for more complex calculation
+        // Calculate average age using collection date first, then received timestamp.
+        double averageAgeYears = activeSamples.stream().map(this::resolveSampleReferenceDate).filter(date -> date != null)
+                .mapToLong(referenceDate -> Math.max(0, ChronoUnit.DAYS.between(referenceDate, today))).average()
+                .orElse(0.0) / 365.0;
 
         metrics.put("expired", expired);
         metrics.put("expiring30Days", expiring30Days);
@@ -187,15 +201,66 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
         metrics.put("totalInspections", totalInspections);
         metrics.put("passedInspections", passedInspections);
         metrics.put("failedInspections", failedInspections);
+                metrics.put("failCount", failedInspections);
         metrics.put("complianceRate", complianceRate);
+                metrics.put("passRate", complianceRate);
         metrics.put("samplePresentPassRate", samplePresentPassRate);
         metrics.put("labelIntegrityPassRate", labelIntegrityPassRate);
         metrics.put("containerIntegrityPassRate", containerIntegrityPassRate);
         metrics.put("volumeAcceptablePassRate", volumeAcceptablePassRate);
         metrics.put("correctPositionPassRate", correctPositionPassRate);
 
+                metrics.put("failTrend", buildDailyFailTrend(inspections, 30));
+
+                Map<String, Object> failTrendBasis = new HashMap<>();
+                failTrendBasis.put("source", "biorepository_qc_inspection.inspection_date");
+                failTrendBasis.put("granularity", "day");
+                failTrendBasis.put("windowDays", 30);
+                failTrendBasis.put("failureCriteria", BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.name());
+                failTrendBasis.put("completedCheckCriteria", "persisted QC inspection records");
+                metrics.put("failTrendBasis", failTrendBasis);
+
+        metrics.put("volumeAppearancePassRate", volumeAcceptablePassRate);
+
+        QcEscalationSnapshot snapshot = buildQcEscalationSnapshot(inspections);
+        metrics.put("breakdownByFreezer", snapshot.breakdownByFreezer);
+        metrics.put("breakdownByRack", snapshot.breakdownByRack);
+        metrics.put("breakdownByTechnician", snapshot.breakdownByTechnician);
+        metrics.put("underInvestigationBoxes", snapshot.underInvestigationBoxes);
+        metrics.put("frequentlyProblematicLocations", snapshot.frequentlyProblematicLocations);
+        metrics.put("escalationSignals", snapshot.escalationSignals);
+
+        Map<String, Object> failureResolution = buildFailureResolutionSummary(inspections);
+        metrics.put("failureResolutionSummary", failureResolution);
+        metrics.put("failedCorrected", failureResolution.get("failedCorrected"));
+        metrics.put("failedPendingCorrection", failureResolution.get("failedPendingCorrection"));
+        metrics.put("failedMarkedMissing", failureResolution.get("failedMarkedMissing"));
+
         return metrics;
     }
+
+        @Override
+        @Transactional(readOnly = true)
+        public Map<String, Object> getQCHistory(Integer limit) {
+                int safeLimit = limit == null ? 50 : Math.max(1, Math.min(limit, 500));
+
+                List<BiorepositoryQCInspection> inspections = qcInspectionService.getAll();
+                inspections.sort(Comparator.comparing(BiorepositoryQCInspection::getInspectionDate,
+                                Comparator.nullsLast(Comparator.naturalOrder())).reversed());
+
+                QcEscalationSnapshot snapshot = buildQcEscalationSnapshot(inspections);
+                List<Map<String, Object>> items = inspections.stream().limit(safeLimit)
+                                .map(inspection -> toQCHistoryItem(inspection, snapshot)).collect(Collectors.toList());
+
+                Map<String, Object> result = new HashMap<>();
+                result.put("source", "biorepository_qc_inspection");
+                result.put("recordType", "completed_qc_checks");
+                result.put("count", items.size());
+                result.put("items", items);
+                result.put("failureResolutionSummary", buildFailureResolutionSummary(inspections));
+                result.put("escalationSignals", snapshot.escalationSignals);
+                return result;
+        }
 
     @Override
     @Transactional(readOnly = true)
@@ -394,4 +459,638 @@ public class BiorepositoryDashboardServiceImpl implements BiorepositoryDashboard
 
         return (passed * 100.0 / inspections.size());
     }
+
+        private List<Map<String, Object>> buildDailyFailTrend(List<BiorepositoryQCInspection> inspections,
+                        int windowDays) {
+                LocalDate today = LocalDate.now();
+                LocalDate start = today.minusDays(Math.max(windowDays - 1, 0));
+
+                Map<LocalDate, long[]> daily = new HashMap<>();
+                for (BiorepositoryQCInspection inspection : inspections) {
+                        if (inspection.getInspectionDate() == null) {
+                                continue;
+                        }
+                        LocalDate inspectionDay = inspection.getInspectionDate().toLocalDateTime().toLocalDate();
+                        if (inspectionDay.isBefore(start) || inspectionDay.isAfter(today)) {
+                                continue;
+                        }
+                        long[] counts = daily.computeIfAbsent(inspectionDay, k -> new long[2]);
+                        counts[0]++;
+                        if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+                                counts[1]++;
+                        }
+                }
+
+                List<Map<String, Object>> trend = new ArrayList<>();
+                for (int i = 0; i < windowDays; i++) {
+                        LocalDate day = start.plusDays(i);
+                        long[] counts = daily.getOrDefault(day, new long[2]);
+                        long total = counts[0];
+                        long failed = counts[1];
+                        Map<String, Object> row = new HashMap<>();
+                        row.put("date", day.toString());
+                        row.put("totalInspections", total);
+                        row.put("failedInspections", failed);
+                        row.put("passRate", total > 0 ? ((total - failed) * 100.0 / total) : 0.0);
+                        trend.add(row);
+                }
+                return trend;
+        }
+
+        private List<Map<String, Object>> buildDimensionBreakdown(List<BiorepositoryQCInspection> inspections,
+                        Function<BiorepositoryQCInspection, String> keyExtractor) {
+                Map<String, long[]> grouped = new HashMap<>();
+
+                for (BiorepositoryQCInspection inspection : inspections) {
+                        String key = normalizeLabel(keyExtractor.apply(inspection));
+                        long[] counts = grouped.computeIfAbsent(key, k -> new long[2]);
+                        counts[0]++;
+                        if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+                                counts[1]++;
+                        }
+                }
+
+                return grouped.entrySet().stream().map(entry -> {
+                        long total = entry.getValue()[0];
+                        long failed = entry.getValue()[1];
+                        Map<String, Object> row = new HashMap<>();
+                        row.put("key", entry.getKey());
+                        row.put("totalInspections", total);
+                        row.put("failedInspections", failed);
+                        row.put("passRate", total > 0 ? ((total - failed) * 100.0 / total) : 0.0);
+                        return row;
+                }).sorted((a, b) -> {
+                        long totalA = ((Number) a.get("totalInspections")).longValue();
+                        long totalB = ((Number) b.get("totalInspections")).longValue();
+                        int totalCompare = Long.compare(totalB, totalA);
+                        if (totalCompare != 0) {
+                                return totalCompare;
+                        }
+                        return String.valueOf(a.get("key")).compareToIgnoreCase(String.valueOf(b.get("key")));
+                }).collect(Collectors.toList());
+        }
+
+        private Map<String, Object> toQCHistoryItem(BiorepositoryQCInspection inspection, QcEscalationSnapshot snapshot) {
+                Map<String, Object> item = new HashMap<>();
+                item.put("id", inspection.getId());
+                item.put("bioSampleId", inspection.getBioSample() != null ? inspection.getBioSample().getId() : null);
+                item.put("inspectionDate", inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
+                item.put("lastQcDate", inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
+                item.put("qcResult", inspection.getQcResult() != null ? inspection.getQcResult().name() : null);
+                String qcStatus = BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection);
+                item.put("qcStatus", qcStatus);
+                item.put("sampleFlag", "VALID".equals(qcStatus) ? "QC_VALID" : "QC_FAILED");
+                item.put("qcFailed", !"VALID".equals(qcStatus));
+                item.put("lifecycleOutcome", BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection));
+                item.put("inspectorName", inspection.getInspectorName());
+                item.put("technicianId", inspection.getSysUserId());
+                item.put("expectedLocationPath", inspection.getExpectedLocationPath());
+                item.put("expectedPositionCoordinate", inspection.getExpectedPositionCoordinate());
+                item.put("correctionActionType", inspection.getCorrectionActionType());
+                item.put("correctionReason", inspection.getCorrectionReason());
+                item.put("correctionByUser", inspection.getCorrectionByUser());
+                item.put("correctionTimestamp",
+                                inspection.getCorrectionTimestamp() != null ? inspection.getCorrectionTimestamp().toString() : null);
+                item.put("discrepancyType",
+                                inspection.getDiscrepancyType() != null ? inspection.getDiscrepancyType().name() : null);
+                item.put("correctiveAction", inspection.getCorrectiveAction());
+                item.put("remarks", inspection.getRemarks());
+                item.put("failureComment", inspection.getRemarks());
+                item.put("auditTrail", buildQCAuditTrail(inspection));
+
+                String[] levels = parseLocationLevels(inspection.getExpectedLocationPath());
+                item.put("freezer", levels[0]);
+                item.put("shelf", levels[1]);
+                item.put("rack", levels[2]);
+                item.put("box", levels[3]);
+                String boxKey = normalizeLabel(levels[0]) + " > " + normalizeLabel(levels[1]) + " > " + normalizeLabel(levels[2])
+                                + " > " + normalizeLabel(levels[3]);
+                item.put("boxFlag", snapshot.underInvestigationBoxKeys.contains(boxKey) ? "UNDER_INVESTIGATION" : "NORMAL");
+                item.put("freezerFlag", snapshot.flaggedFreezerKeys.contains(normalizeLabel(levels[0])) ? "QC_FLAGGED" : "NORMAL");
+                item.put("escalationTriggered",
+                                snapshot.batchFailRateExceeded || snapshot.underInvestigationBoxKeys.contains(boxKey)
+                                                || snapshot.flaggedFreezerKeys.contains(normalizeLabel(levels[0]))
+                                                || isMissingDiscrepancy(inspection));
+                item.put("failureResolution", mapFailureResolutionStatus(inspection));
+
+                return item;
+        }
+
+        private String extractFreezerFromPath(BiorepositoryQCInspection inspection) {
+                return parseLocationLevels(inspection.getExpectedLocationPath())[0];
+        }
+
+        private String extractRackFromPath(BiorepositoryQCInspection inspection) {
+                String[] levels = parseLocationLevels(inspection.getExpectedLocationPath());
+                if ("Unknown".equals(levels[2])) {
+                        return "Unknown";
+                }
+                return levels[0] + " > " + levels[1] + " > " + levels[2];
+        }
+
+        private String extractTechnicianKey(BiorepositoryQCInspection inspection) {
+                String inspectorName = trimToNull(inspection.getInspectorName());
+                String technicianId = trimToNull(inspection.getSysUserId());
+
+                if (inspectorName != null && technicianId != null) {
+                        return inspectorName + " (" + technicianId + ")";
+                }
+                if (inspectorName != null) {
+                        return inspectorName;
+                }
+                if (technicianId != null) {
+                        return technicianId;
+                }
+                return "Unknown";
+        }
+
+        private String[] parseLocationLevels(String locationPath) {
+                String[] defaults = new String[] { "Unknown", "Unknown", "Unknown", "Unknown" };
+                String raw = trimToNull(locationPath);
+                if (raw == null) {
+                        return defaults;
+                }
+
+                List<String> segments = java.util.Arrays.stream(raw.split("\\s*>\\s*")).map(String::trim)
+                                .filter(s -> !s.isEmpty()).collect(Collectors.toList());
+                if (segments.isEmpty()) {
+                        return defaults;
+                }
+
+                int structuralEnd = segments.size();
+                String tail = segments.get(structuralEnd - 1);
+                if (tail.matches("^[A-Za-z]+\\d+$")) {
+                        structuralEnd = structuralEnd - 1;
+                }
+
+                List<String> structural = segments.subList(0, Math.max(structuralEnd, 0));
+                if (structural.isEmpty()) {
+                        return defaults;
+                }
+
+                int boxIdx = structural.size() - 1;
+                int rackIdx = structural.size() - 2;
+                int shelfIdx = structural.size() - 3;
+                int freezerIdx = structural.size() - 4;
+
+                return new String[] { freezerIdx >= 0 ? structural.get(freezerIdx) : "Unknown",
+                                shelfIdx >= 0 ? structural.get(shelfIdx) : "Unknown",
+                                rackIdx >= 0 ? structural.get(rackIdx) : "Unknown",
+                                boxIdx >= 0 ? structural.get(boxIdx) : "Unknown" };
+        }
+
+        private String trimToNull(String value) {
+                if (value == null) {
+                        return null;
+                }
+                String trimmed = value.trim();
+                return trimmed.isEmpty() ? null : trimmed;
+        }
+
+        private String normalizeLabel(String label) {
+                String normalized = trimToNull(label);
+                return normalized != null ? normalized : "Unknown";
+        }
+
+    private LocalDate resolveSampleReferenceDate(BioSample sample) {
+        if (sample == null || sample.getSampleItem() == null) {
+            return null;
+        }
+        if (sample.getSampleItem().getCollectionDate() != null) {
+            return sample.getSampleItem().getCollectionDate().toLocalDateTime().toLocalDate();
+        }
+        if (sample.getSampleItem().getSample() != null && sample.getSampleItem().getSample().getReceivedTimestamp() != null) {
+            return sample.getSampleItem().getSample().getReceivedTimestamp().toLocalDateTime().toLocalDate();
+        }
+        return null;
+    }
+
+    private Map<String, Object> buildStorageUtilizationSummary() {
+        List<Map<String, Object>> deviceRows = buildDeviceUtilizationRows();
+        long totalCurrentUsage = 0;
+        long totalConfiguredCapacity = 0;
+        int capacityDefinedDevices = 0;
+        for (Map<String, Object> row : deviceRows) {
+            totalCurrentUsage += ((Number) row.getOrDefault("currentUsage", 0)).longValue();
+            long deviceCapacity = ((Number) row.getOrDefault("totalCapacity", 0)).longValue();
+            if (deviceCapacity > 0) {
+                totalConfiguredCapacity += deviceCapacity;
+                capacityDefinedDevices++;
+            }
+        }
+
+        double averageUtilization = totalConfiguredCapacity > 0 ? (totalCurrentUsage * 100.0 / totalConfiguredCapacity)
+                : 0.0;
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("devices", deviceRows);
+        summary.put("totalDevices", deviceRows.size());
+        summary.put("capacityDefinedDevices", capacityDefinedDevices);
+        summary.put("capacityUndefinedDevices", Math.max(deviceRows.size() - capacityDefinedDevices, 0));
+        summary.put("totalConfiguredCapacity", totalConfiguredCapacity);
+        summary.put("totalCurrentUsage", totalCurrentUsage);
+        summary.put("averageUtilization", averageUtilization);
+        return summary;
+    }
+
+    private List<Map<String, Object>> buildDeviceUtilizationRows() {
+        List<StorageDevice> devices = storageLocationService.getAllDevices().stream().filter(this::isActive).toList();
+        List<StorageShelf> shelves = storageLocationService.getAllShelves().stream().filter(this::isActive).toList();
+        List<StorageRack> racks = storageLocationService.getAllRacks().stream().filter(this::isActive).toList();
+        List<StorageBox> boxes = storageLocationService.getAllBoxes().stream().filter(this::isActive).toList();
+        Set<Integer> activeShelfIds = shelves.stream().map(StorageShelf::getId).filter(id -> id != null)
+                .collect(Collectors.toSet());
+
+        Map<Integer, Integer> rackToDevice = new HashMap<>();
+        for (StorageRack rack : racks) {
+            StorageShelf shelf = rack.getParentShelf();
+            StorageDevice device = shelf != null ? shelf.getParentDevice() : null;
+            if (rack.getId() != null && shelf != null && activeShelfIds.contains(shelf.getId()) && device != null
+                    && device.getId() != null) {
+                rackToDevice.put(rack.getId(), device.getId());
+            }
+        }
+
+        Map<Integer, Long> derivedCapacityByDevice = new HashMap<>();
+        for (StorageBox box : boxes) {
+            StorageRack parentRack = box.getParentRack();
+            Integer rackId = parentRack != null ? parentRack.getId() : null;
+            Integer deviceId = rackId != null ? rackToDevice.get(rackId) : null;
+            if (deviceId == null) {
+                continue;
+            }
+            long boxCapacity = box.getCapacity() != null ? box.getCapacity().longValue() : 0L;
+            if (boxCapacity <= 0) {
+                continue;
+            }
+            derivedCapacityByDevice.merge(deviceId, boxCapacity, Long::sum);
+        }
+
+        return devices.stream().map(device -> {
+            long currentUsage = 0L;
+            if (device.getId() != null) {
+                currentUsage = storageLocationService.countOccupiedInDevice(device.getId());
+            }
+            long configuredDeviceCapacity = device.getCapacityLimit() != null ? device.getCapacityLimit().longValue() : 0L;
+            long derivedCapacity = device.getId() != null ? derivedCapacityByDevice.getOrDefault(device.getId(), 0L) : 0L;
+            long totalCapacity = configuredDeviceCapacity > 0 ? configuredDeviceCapacity : derivedCapacity;
+            String capacitySource = configuredDeviceCapacity > 0 ? "DEVICE_CAPACITY_LIMIT"
+                    : (derivedCapacity > 0 ? "BOX_GRID_SUM" : "UNDEFINED");
+            double utilizationPercent = totalCapacity > 0 ? (currentUsage * 100.0 / totalCapacity) : 0.0;
+
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("deviceId", device.getId());
+            row.put("deviceName", trimToNull(device.getName()) != null ? device.getName() : device.getCode());
+            row.put("deviceCode", device.getCode());
+            row.put("deviceType", device.getType());
+            row.put("active", Boolean.TRUE.equals(device.getActive()));
+            row.put("currentUsage", currentUsage);
+            row.put("totalCapacity", totalCapacity);
+            row.put("capacitySource", capacitySource);
+            row.put("utilizationPercent", utilizationPercent);
+            return row;
+        }).sorted((a, b) -> String.valueOf(a.getOrDefault("deviceName", ""))
+                .compareToIgnoreCase(String.valueOf(b.getOrDefault("deviceName", "")))).collect(Collectors.toList());
+    }
+
+    private boolean isActive(StorageDevice device) {
+        return device != null && Boolean.TRUE.equals(device.getActive());
+    }
+
+    private boolean isActive(StorageShelf shelf) {
+        return shelf != null && Boolean.TRUE.equals(shelf.getActive());
+    }
+
+    private boolean isActive(StorageRack rack) {
+        return rack != null && Boolean.TRUE.equals(rack.getActive());
+    }
+
+    private boolean isActive(StorageBox box) {
+        return box != null && Boolean.TRUE.equals(box.getActive());
+    }
+
+        private List<Map<String, Object>> buildUnderInvestigationBoxes(List<BiorepositoryQCInspection> inspections) {
+                Map<String, long[]> grouped = new HashMap<>();
+
+                for (BiorepositoryQCInspection inspection : inspections) {
+                        String[] levels = parseLocationLevels(inspection.getExpectedLocationPath());
+                        String boxKey = normalizeLabel(levels[0]) + " > " + normalizeLabel(levels[1]) + " > "
+                                        + normalizeLabel(levels[2]) + " > " + normalizeLabel(levels[3]);
+                        long[] counts = grouped.computeIfAbsent(boxKey, k -> new long[2]);
+                        counts[0]++;
+                        if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+                                counts[1]++;
+                        }
+                }
+
+                return grouped.entrySet().stream().filter(entry -> entry.getValue()[1] >= 2).map(entry -> {
+                        long total = entry.getValue()[0];
+                        long failed = entry.getValue()[1];
+                        Map<String, Object> row = new HashMap<>();
+                        row.put("key", entry.getKey());
+                        row.put("totalInspections", total);
+                        row.put("failedInspections", failed);
+                        row.put("failRate", total > 0 ? (failed * 100.0 / total) : 0.0);
+                        row.put("investigationFlag", true);
+                        return row;
+                }).sorted((a, b) -> {
+                        long failedA = ((Number) a.get("failedInspections")).longValue();
+                        long failedB = ((Number) b.get("failedInspections")).longValue();
+                        int failCompare = Long.compare(failedB, failedA);
+                        if (failCompare != 0) {
+                                return failCompare;
+                        }
+                        return String.valueOf(a.get("key")).compareToIgnoreCase(String.valueOf(b.get("key")));
+                }).collect(Collectors.toList());
+        }
+
+        private List<Map<String, Object>> buildFrequentlyProblematicLocations(List<Map<String, Object>> boxCandidates,
+                        List<Map<String, Object>> rackBreakdown) {
+                List<Map<String, Object>> rows = new ArrayList<>();
+
+                boxCandidates.stream().limit(10).forEach(box -> {
+                        Map<String, Object> row = new HashMap<>();
+                        row.put("locationType", "BOX");
+                        row.put("key", box.get("key"));
+                        row.put("failedInspections", box.get("failedInspections"));
+                        row.put("totalInspections", box.get("totalInspections"));
+                        row.put("failRate", box.get("failRate"));
+                        rows.add(row);
+                });
+
+                if (rows.size() < 10) {
+                        rackBreakdown.stream()
+                                        .filter(row -> ((Number) row.getOrDefault("failedInspections", 0)).longValue() > 0)
+                                        .limit(10 - rows.size()).forEach(rack -> {
+                                                Map<String, Object> row = new HashMap<>();
+                                                row.put("locationType", "RACK");
+                                                row.put("key", rack.get("key"));
+                                                row.put("failedInspections", rack.get("failedInspections"));
+                                                row.put("totalInspections", rack.get("totalInspections"));
+                                                row.put("failRate", rack.get("passRate") != null
+                                                                ? (100.0 - ((Number) rack.get("passRate")).doubleValue())
+                                                                : 0.0);
+                                                rows.add(row);
+                                        });
+                }
+
+                return rows;
+        }
+
+        private Map<String, Object> buildEscalationSignals(List<BiorepositoryQCInspection> inspections,
+                        List<Map<String, Object>> breakdownByFreezer, List<Map<String, Object>> breakdownByRack,
+                        List<Map<String, Object>> underInvestigationBoxes) {
+                Map<String, Object> signals = new HashMap<>();
+
+                long totalInspections = inspections.size();
+                long failedInspections = inspections.stream()
+                                .filter(insp -> BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND
+                                                .equals(insp.getQcResult()))
+                                .count();
+                double batchFailRate = totalInspections > 0 ? (failedInspections * 100.0 / totalInspections) : 0.0;
+                boolean batchFailRateExceeded = totalInspections > 0 && batchFailRate > 5.0;
+
+                long repeatedRacks = breakdownByRack.stream()
+                                .filter(row -> ((Number) row.getOrDefault("failedInspections", 0)).longValue() >= 2)
+                                .count();
+                boolean repeatedFailureInSameBoxOrRack = !underInvestigationBoxes.isEmpty() || repeatedRacks > 0;
+
+                long criticalMissingSamples = inspections.stream()
+                                .filter(insp -> BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND
+                                                .equals(insp.getQcResult()))
+                                .filter(this::isMissingDiscrepancy)
+                                .count();
+
+                List<Map<String, Object>> flaggedFreezers = breakdownByFreezer.stream().filter(row -> {
+                        long failed = ((Number) row.getOrDefault("failedInspections", 0)).longValue();
+                        double passRate = ((Number) row.getOrDefault("passRate", 0.0)).doubleValue();
+                        double failRate = 100.0 - passRate;
+                        return failed > 0 && failRate > 5.0;
+                }).map(row -> {
+                        Map<String, Object> freezer = new HashMap<>();
+                        freezer.put("key", row.get("key"));
+                        freezer.put("failedInspections", row.get("failedInspections"));
+                        freezer.put("totalInspections", row.get("totalInspections"));
+                        freezer.put("failRate", 100.0 - ((Number) row.getOrDefault("passRate", 0.0)).doubleValue());
+                        freezer.put("thresholdPercent", 5.0);
+                        return freezer;
+                }).collect(Collectors.toList());
+
+                List<String> triggeredRules = new ArrayList<>();
+                if (batchFailRateExceeded) {
+                        triggeredRules.add("BATCH_FAIL_RATE_OVER_5_PERCENT");
+                }
+                if (repeatedFailureInSameBoxOrRack) {
+                        triggeredRules.add("REPEATED_FAILURE_IN_SAME_BOX_OR_RACK");
+                }
+                if (criticalMissingSamples > 0) {
+                        triggeredRules.add("CRITICAL_SAMPLES_MISSING");
+                }
+
+                List<String> recommendedActions = new ArrayList<>();
+                if (!triggeredRules.isEmpty()) {
+                        recommendedActions.add("Notify supervisor");
+                }
+                if (repeatedFailureInSameBoxOrRack) {
+                        recommendedActions.add("Trigger full box audit or targeted rack review");
+                }
+                if (!flaggedFreezers.isEmpty()) {
+                        recommendedActions.add("Trigger freezer-wide QC review for flagged freezers");
+                }
+
+                signals.put("totalInspections", totalInspections);
+                signals.put("failedInspections", failedInspections);
+                signals.put("batchFailRatePercent", batchFailRate);
+                signals.put("batchFailRateThresholdPercent", 5.0);
+                signals.put("batchFailRateExceeded", batchFailRateExceeded);
+                signals.put("repeatedFailureInSameBoxOrRack", repeatedFailureInSameBoxOrRack);
+                signals.put("repeatedFailureBoxesCount", underInvestigationBoxes.size());
+                signals.put("repeatedFailureRacksCount", repeatedRacks);
+                signals.put("criticalMissingSamples", criticalMissingSamples);
+                signals.put("criticalSamplesMissing", criticalMissingSamples > 0);
+                signals.put("flaggedFreezers", flaggedFreezers);
+                signals.put("triggeredRules", triggeredRules);
+                signals.put("recommendedActions", recommendedActions);
+
+                return signals;
+        }
+
+        private boolean isMissingDiscrepancy(BiorepositoryQCInspection inspection) {
+                if (inspection == null || inspection.getDiscrepancyType() == null) {
+                        return false;
+                }
+                return BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.equals(inspection.getDiscrepancyType())
+                                || BiorepositoryQCInspection.DiscrepancyType.MISSING_SAMPLE
+                                                .equals(inspection.getDiscrepancyType());
+        }
+
+        private Map<String, Object> buildQCAuditTrail(BiorepositoryQCInspection inspection) {
+                Map<String, Object> auditTrail = new HashMap<>();
+
+                String oldCoordinate = trimToNull(inspection.getCorrectionOldCoordinate());
+                if (oldCoordinate == null) {
+                        oldCoordinate = composeCoordinate(inspection.getExpectedLocationPath(),
+                                        inspection.getExpectedPositionCoordinate());
+                }
+                String newCoordinate = trimToNull(inspection.getCorrectionNewCoordinate());
+                if (newCoordinate == null) {
+                        newCoordinate = oldCoordinate;
+                }
+                String auditUser = trimToNull(inspection.getCorrectionByUser()) != null ? inspection.getCorrectionByUser()
+                                : inspection.getSysUserId();
+                String auditTimestamp = inspection.getCorrectionTimestamp() != null
+                                ? inspection.getCorrectionTimestamp().toString()
+                                : (inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
+                String reason = trimToNull(inspection.getCorrectionReason()) != null ? inspection.getCorrectionReason()
+                                : trimToNull(inspection.getCorrectiveAction());
+                boolean correctionApplied = BiorepositoryQcOutcomeDerivation.hasAppliedCorrectionWorkflow(inspection);
+
+                if ("MISSING".equals(BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection))
+                                && trimToNull(inspection.getCorrectionNewCoordinate()) == null) {
+                        newCoordinate = "Missing (not found during QC)";
+                } else if (!correctionApplied
+                                && BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+                        SampleItem sampleItem = inspection.getBioSample() != null ? inspection.getBioSample().getSampleItem()
+                                        : null;
+                        if (sampleItem != null && sampleItem.getId() != null) {
+                                Map<String, Object> currentLocation = storageService
+                                                .getSampleItemLocation(sampleItem.getId().toString());
+                                String currentCoordinate = composeCoordinate(asString(currentLocation.get("hierarchicalPath")),
+                                                asString(currentLocation.get("positionCoordinate")));
+                                if (trimToNull(currentCoordinate) != null) {
+                                        newCoordinate = currentCoordinate;
+                                }
+                        }
+                }
+
+                auditTrail.put("oldCoordinate", oldCoordinate);
+                auditTrail.put("newCoordinate", newCoordinate);
+                auditTrail.put("fromCoordinates", oldCoordinate);
+                auditTrail.put("toCoordinates", newCoordinate);
+                auditTrail.put("user", auditUser);
+                auditTrail.put("correctedBy", auditUser);
+                auditTrail.put("timestamp", auditTimestamp);
+                auditTrail.put("correctedAt", auditTimestamp);
+                auditTrail.put("reason", reason);
+                return auditTrail;
+        }
+
+        private String composeCoordinate(String locationPath, String positionCoordinate) {
+                String path = trimToNull(locationPath);
+                String coordinate = trimToNull(positionCoordinate);
+                if (path == null && coordinate == null) {
+                        return null;
+                }
+                if (path == null) {
+                        return coordinate;
+                }
+                if (coordinate == null) {
+                        return path;
+                }
+                return path + " > " + coordinate;
+        }
+
+        private String asString(Object value) {
+                if (value == null) {
+                        return null;
+                }
+                return String.valueOf(value);
+        }
+
+        private String mapFailureResolutionStatus(BiorepositoryQCInspection inspection) {
+                String lifecycleOutcome = BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection);
+                if ("FAILED_CORRECTED".equals(lifecycleOutcome) || "FAILED_MARKED_MISSING".equals(lifecycleOutcome)) {
+                        return "RESOLVED";
+                }
+                if ("FAILED_PENDING_CORRECTION".equals(lifecycleOutcome)) {
+                        return "UNRESOLVED";
+                }
+                return "N/A";
+        }
+
+        private Map<String, Object> buildFailureResolutionSummary(List<BiorepositoryQCInspection> inspections) {
+                long failedCorrected = 0;
+                long failedPendingCorrection = 0;
+                long failedMarkedMissing = 0;
+                for (BiorepositoryQCInspection inspection : inspections) {
+                        String outcome = BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection);
+                        if ("FAILED_CORRECTED".equals(outcome)) {
+                                failedCorrected++;
+                        } else if ("FAILED_PENDING_CORRECTION".equals(outcome)) {
+                                failedPendingCorrection++;
+                        } else if ("FAILED_MARKED_MISSING".equals(outcome)) {
+                                failedMarkedMissing++;
+                        }
+                }
+                Map<String, Object> summary = new HashMap<>();
+                summary.put("failedCorrected", failedCorrected);
+                summary.put("failedPendingCorrection", failedPendingCorrection);
+                summary.put("failedMarkedMissing", failedMarkedMissing);
+                summary.put("correctedVsUnresolved", Map.of("corrected", failedCorrected + failedMarkedMissing, "unresolved",
+                                failedPendingCorrection));
+                return summary;
+        }
+
+        private QcEscalationSnapshot buildQcEscalationSnapshot(List<BiorepositoryQCInspection> inspections) {
+                List<Map<String, Object>> breakdownByFreezer = buildDimensionBreakdown(inspections, this::extractFreezerFromPath);
+                List<Map<String, Object>> breakdownByRack = buildDimensionBreakdown(inspections, this::extractRackFromPath);
+                List<Map<String, Object>> breakdownByTechnician = buildDimensionBreakdown(inspections, this::extractTechnicianKey);
+                List<Map<String, Object>> underInvestigationBoxes = buildUnderInvestigationBoxes(inspections);
+                List<Map<String, Object>> frequentlyProblematicLocations = buildFrequentlyProblematicLocations(
+                                underInvestigationBoxes, breakdownByRack);
+                Map<String, Object> escalationSignals = buildEscalationSignals(inspections, breakdownByFreezer, breakdownByRack,
+                                underInvestigationBoxes);
+
+                List<Map<String, Object>> flaggedFreezers = escalationSignals.get("flaggedFreezers") instanceof List
+                                ? castMapList(escalationSignals.get("flaggedFreezers"))
+                                : List.of();
+                double batchFailRatePercent = ((Number) escalationSignals.getOrDefault("batchFailRatePercent", 0.0))
+                                .doubleValue();
+                boolean batchFailRateExceeded = Boolean.TRUE.equals(escalationSignals.get("batchFailRateExceeded"));
+
+                return new QcEscalationSnapshot(breakdownByFreezer, breakdownByRack, breakdownByTechnician,
+                                underInvestigationBoxes, frequentlyProblematicLocations, escalationSignals,
+                                toKeySet(underInvestigationBoxes), toKeySet(flaggedFreezers), batchFailRatePercent,
+                                batchFailRateExceeded);
+        }
+
+        @SuppressWarnings("unchecked")
+        private List<Map<String, Object>> castMapList(Object value) {
+                return (List<Map<String, Object>>) value;
+        }
+
+        private java.util.Set<String> toKeySet(List<Map<String, Object>> rows) {
+                return rows.stream().map(row -> normalizeLabel(asString(row.get("key")))).collect(Collectors.toSet());
+        }
+
+        private static class QcEscalationSnapshot {
+                private final List<Map<String, Object>> breakdownByFreezer;
+                private final List<Map<String, Object>> breakdownByRack;
+                private final List<Map<String, Object>> breakdownByTechnician;
+                private final List<Map<String, Object>> underInvestigationBoxes;
+                private final List<Map<String, Object>> frequentlyProblematicLocations;
+                private final Map<String, Object> escalationSignals;
+                private final java.util.Set<String> underInvestigationBoxKeys;
+                private final java.util.Set<String> flaggedFreezerKeys;
+                private final double batchFailRatePercent;
+                private final boolean batchFailRateExceeded;
+
+                private QcEscalationSnapshot(List<Map<String, Object>> breakdownByFreezer,
+                                List<Map<String, Object>> breakdownByRack, List<Map<String, Object>> breakdownByTechnician,
+                                List<Map<String, Object>> underInvestigationBoxes,
+                                List<Map<String, Object>> frequentlyProblematicLocations,
+                                Map<String, Object> escalationSignals, java.util.Set<String> underInvestigationBoxKeys,
+                                java.util.Set<String> flaggedFreezerKeys, double batchFailRatePercent,
+                                boolean batchFailRateExceeded) {
+                        this.breakdownByFreezer = breakdownByFreezer;
+                        this.breakdownByRack = breakdownByRack;
+                        this.breakdownByTechnician = breakdownByTechnician;
+                        this.underInvestigationBoxes = underInvestigationBoxes;
+                        this.frequentlyProblematicLocations = frequentlyProblematicLocations;
+                        this.escalationSignals = escalationSignals;
+                        this.underInvestigationBoxKeys = underInvestigationBoxKeys;
+                        this.flaggedFreezerKeys = flaggedFreezerKeys;
+                        this.batchFailRatePercent = batchFailRatePercent;
+                        this.batchFailRateExceeded = batchFailRateExceeded;
+                }
+        }
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryExportService.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryExportService.java
@@ -98,4 +98,24 @@ public interface BiorepositoryExportService {
      */
     byte[] exportAuditTrailToPDF(String sampleExternalId, CustodyAction action, Integer custodianId,
             java.sql.Timestamp startDate, java.sql.Timestamp endDate) throws IOException;
+
+    /**
+     * Export QC inspection records for a specific QC batch.
+     */
+    byte[] exportQcBatchToCSV(String qcBatchId) throws IOException;
+
+    /**
+     * Export QC inspection records for a specific QC batch.
+     */
+    byte[] exportQcBatchToExcel(String qcBatchId) throws IOException;
+
+    /**
+     * Export QC inspection records for a specific QC batch.
+     */
+    byte[] exportQcBatchToJSON(String qcBatchId) throws IOException;
+
+    /**
+     * Export QC inspection records for a specific QC batch.
+     */
+    byte[] exportQcBatchToPDF(String qcBatchId) throws IOException;
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryExportServiceImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryExportServiceImpl.java
@@ -2,6 +2,16 @@ package org.openelisglobal.biorepository.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Element;
+import com.itextpdf.text.Font;
+import com.itextpdf.text.PageSize;
+import com.itextpdf.text.Paragraph;
+import com.itextpdf.text.Phrase;
+import com.itextpdf.text.pdf.PdfPCell;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -14,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -106,7 +115,7 @@ public class BiorepositoryExportServiceImpl implements BiorepositoryExportServic
 
         // Create header style
         CellStyle headerStyle = workbook.createCellStyle();
-        Font headerFont = workbook.createFont();
+        org.apache.poi.ss.usermodel.Font headerFont = workbook.createFont();
         headerFont.setBold(true);
         headerStyle.setFont(headerFont);
 
@@ -190,9 +199,55 @@ public class BiorepositoryExportServiceImpl implements BiorepositoryExportServic
     @Override
     @Transactional(readOnly = true)
     public byte[] exportDashboardToPDF() throws IOException {
-        // Simplified PDF implementation - return JSON for now
-        // TODO: Implement proper PDF generation with iText or PDFBox if needed
-        return exportDashboardToJSON();
+        Map<String, Object> dashboardData = aggregateDashboardMetrics();
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4, 36, 36, 36, 36);
+            PdfWriter.getInstance(document, baos);
+            document.open();
+
+            Font titleFont = new Font(Font.FontFamily.HELVETICA, 16, Font.BOLD);
+            Font sectionFont = new Font(Font.FontFamily.HELVETICA, 12, Font.BOLD);
+            Font bodyFont = new Font(Font.FontFamily.HELVETICA, 10, Font.NORMAL);
+            Paragraph title = new Paragraph("Biorepository Dashboard Metrics", titleFont);
+            title.setAlignment(Element.ALIGN_CENTER);
+            title.setSpacingAfter(16f);
+            document.add(title);
+
+            Map<String, Object> capacity = castMap(dashboardData.get("storageCapacity"));
+            Map<String, Object> aging = castMap(dashboardData.get("sampleAging"));
+            Map<String, Object> qc = castMap(dashboardData.get("qcCompliance"));
+            Map<String, Object> retrieval = castMap(dashboardData.get("retrievalStats"));
+
+            addMetricTable(document, "Storage Capacity", capacity, bodyFont, sectionFont, List.of(
+                    metricRow("Total Devices", capacity.get("totalDevices")),
+                    metricRow("Total Samples Stored", capacity.get("totalSamplesStored")),
+                    metricRow("Pending Storage", capacity.get("pendingStorage")),
+                    metricRow("Average Utilization %", capacity.get("averageUtilization"))));
+
+            addMetricTable(document, "Sample Aging", aging, bodyFont, sectionFont, List.of(
+                    metricRow("Total Active Samples", aging.get("total")),
+                    metricRow("Expiring within 30 days", aging.get("expiring30Days")),
+                    metricRow("Expiring within 60 days", aging.get("expiring60Days")),
+                    metricRow("Expiring within 90 days", aging.get("expiring90Days")),
+                    metricRow("Expired Samples", aging.get("expired"))));
+
+            addMetricTable(document, "QC Compliance", qc, bodyFont, sectionFont, List.of(
+                    metricRow("Total Inspections", qc.get("totalInspections")),
+                    metricRow("Passed Inspections", qc.get("passedInspections")),
+                    metricRow("Failed Inspections", qc.get("failedInspections")),
+                    metricRow("Compliance Rate %", qc.get("complianceRate"))));
+
+            addMetricTable(document, "Retrieval Statistics", retrieval, bodyFont, sectionFont, List.of(
+                    metricRow("Total Requests", retrieval.get("totalRequests")),
+                    metricRow("Pending Requests", retrieval.get("pendingRequests")),
+                    metricRow("Rejected Requests", retrieval.get("rejectedRequests")),
+                    metricRow("Completed Requests", retrieval.get("completedRequests"))));
+
+            document.close();
+            return baos.toByteArray();
+        } catch (DocumentException e) {
+            throw new IOException("Failed to generate dashboard PDF export", e);
+        }
     }
 
     // ==================== Audit Trail Exports ====================
@@ -261,7 +316,7 @@ public class BiorepositoryExportServiceImpl implements BiorepositoryExportServic
 
         // Create header style
         CellStyle headerStyle = workbook.createCellStyle();
-        Font headerFont = workbook.createFont();
+        org.apache.poi.ss.usermodel.Font headerFont = workbook.createFont();
         headerFont.setBold(true);
         headerStyle.setFont(headerFont);
 
@@ -377,9 +432,65 @@ public class BiorepositoryExportServiceImpl implements BiorepositoryExportServic
     @Transactional(readOnly = true)
     public byte[] exportAuditTrailToPDF(String sampleExternalId, CustodyAction action, Integer custodianId,
             Timestamp startDate, Timestamp endDate) throws IOException {
-        // Simplified PDF implementation - return JSON for now
-        // TODO: Implement proper PDF generation with iText or PDFBox if needed
-        return exportAuditTrailToJSON(sampleExternalId, action, custodianId, startDate, endDate);
+        List<ChainOfCustodyLog> logs = custodyService.searchCustodyLogs(sampleExternalId, action, custodianId,
+                startDate, endDate, 0, Integer.MAX_VALUE);
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4.rotate(), 24, 24, 24, 24);
+            PdfWriter.getInstance(document, baos);
+            document.open();
+
+            Font titleFont = new Font(Font.FontFamily.HELVETICA, 14, Font.BOLD);
+            Font headerFont = new Font(Font.FontFamily.HELVETICA, 9, Font.BOLD);
+            Font bodyFont = new Font(Font.FontFamily.HELVETICA, 8, Font.NORMAL);
+            Paragraph title = new Paragraph("Biorepository Audit Trail Export", titleFont);
+            title.setAlignment(Element.ALIGN_CENTER);
+            title.setSpacingAfter(10f);
+            document.add(title);
+            document.add(new Paragraph("Records: " + logs.size(), bodyFont));
+            document.add(new Paragraph("Generated: " + Timestamp.valueOf(java.time.LocalDateTime.now()), bodyFont));
+            document.add(new Paragraph(" ", bodyFont));
+
+            PdfPTable table = new PdfPTable(new float[] { 1.6f, 1.4f, 1.8f, 1.4f, 1.6f, 1.6f, 1.8f, 1.0f, 1.8f });
+            table.setWidthPercentage(100f);
+            addHeaderCell(table, "Timestamp", headerFont);
+            addHeaderCell(table, "Barcode", headerFont);
+            addHeaderCell(table, "Accession", headerFont);
+            addHeaderCell(table, "Action", headerFont);
+            addHeaderCell(table, "From", headerFont);
+            addHeaderCell(table, "To", headerFont);
+            addHeaderCell(table, "Custodian", headerFont);
+            addHeaderCell(table, "Temp (C)", headerFont);
+            addHeaderCell(table, "Notes", headerFont);
+
+            for (ChainOfCustodyLog log : logs) {
+                addBodyCell(table, log.getActionTimestamp() != null ? log.getActionTimestamp().toString() : "", bodyFont);
+                addBodyCell(table,
+                        log.getSampleItem() != null && log.getSampleItem().getExternalId() != null
+                                ? log.getSampleItem().getExternalId()
+                                : "",
+                        bodyFont);
+                addBodyCell(table,
+                        log.getSampleItem() != null && log.getSampleItem().getSample() != null
+                                && log.getSampleItem().getSample().getAccessionNumber() != null
+                                        ? log.getSampleItem().getSample().getAccessionNumber()
+                                        : "",
+                        bodyFont);
+                addBodyCell(table, log.getCustodyAction() != null ? log.getCustodyAction().name() : "", bodyFont);
+                addBodyCell(table, log.getFromLocation() != null ? log.getFromLocation() : "", bodyFont);
+                addBodyCell(table, log.getToLocation() != null ? log.getToLocation() : "", bodyFont);
+                String custodian = log.getToCustodian() != null ? log.getToCustodian().getNameForDisplay()
+                        : (log.getFromCustodian() != null ? log.getFromCustodian().getNameForDisplay() : "");
+                addBodyCell(table, custodian, bodyFont);
+                addBodyCell(table, log.getTemperature() != null ? log.getTemperature().toString() : "", bodyFont);
+                addBodyCell(table, log.getNotes() != null ? log.getNotes() : "", bodyFont);
+            }
+
+            document.add(table);
+            document.close();
+            return baos.toByteArray();
+        } catch (DocumentException e) {
+            throw new IOException("Failed to generate audit trail PDF export", e);
+        }
     }
 
     // ==================== Helper Methods ====================
@@ -439,5 +550,42 @@ public class BiorepositoryExportServiceImpl implements BiorepositoryExportServic
         if (style != null) {
             cell.setCellStyle(style);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> castMap(Object value) {
+        return value instanceof Map ? (Map<String, Object>) value : Map.of();
+    }
+
+    private String[] metricRow(String metric, Object value) {
+        return new String[] { metric, value != null ? String.valueOf(value) : "" };
+    }
+
+    private void addMetricTable(Document document, String sectionTitle, Map<String, Object> source, Font bodyFont,
+            Font sectionFont, List<String[]> rows) throws DocumentException {
+        document.add(new Paragraph(sectionTitle, sectionFont));
+        PdfPTable table = new PdfPTable(new float[] { 2.2f, 1.2f });
+        table.setWidthPercentage(100f);
+        for (String[] row : rows) {
+            addBodyCell(table, row[0], bodyFont);
+            addBodyCell(table, row[1], bodyFont);
+        }
+        table.setSpacingAfter(10f);
+        if (!source.isEmpty()) {
+            document.add(table);
+        } else {
+            document.add(new Paragraph("No data available", bodyFont));
+        }
+    }
+
+    private void addHeaderCell(PdfPTable table, String value, Font font) {
+        PdfPCell cell = new PdfPCell(new Phrase(value, font));
+        cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+        table.addCell(cell);
+    }
+
+    private void addBodyCell(PdfPTable table, String value, Font font) {
+        PdfPCell cell = new PdfPCell(new Phrase(value != null ? value : "", font));
+        table.addCell(cell);
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryExportServiceImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryExportServiceImpl.java
@@ -30,6 +30,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.openelisglobal.biorepository.valueholder.ChainOfCustodyLog;
 import org.openelisglobal.biorepository.valueholder.ChainOfCustodyLog.CustodyAction;
+import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +48,9 @@ public class BiorepositoryExportServiceImpl implements BiorepositoryExportServic
 
     @Autowired
     private ChainOfCustodyService custodyService;
+
+    @Autowired
+    private BiorepositoryQCInspectionService qcInspectionService;
 
     private static final String CSV_SEPARATOR = ",";
     private static final String CSV_QUOTE = "\"";
@@ -493,7 +497,196 @@ public class BiorepositoryExportServiceImpl implements BiorepositoryExportServic
         }
     }
 
+    // ==================== QC Batch Exports ====================
+
+    @Override
+    @Transactional(readOnly = true)
+    public byte[] exportQcBatchToCSV(String qcBatchId) throws IOException {
+        List<BiorepositoryQCInspection> inspections = qcInspectionService.getByQcBatchId(qcBatchId);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8));
+        writer.println(
+                "QC Batch ID,Inspection ID,Date Time,Technician ID,Inspector Name,BioSample ID,Accession Number,Expected Coordinate,Observed Status,QC Outcome,Comment");
+        for (BiorepositoryQCInspection inspection : inspections) {
+            writer.println(String.join(CSV_SEPARATOR,
+                    escapeCSV(safe(inspection.getQcBatchId())),
+                    escapeCSV(String.valueOf(inspection.getId())),
+                    escapeCSV(inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : ""),
+                    escapeCSV(safe(inspection.getSysUserId())),
+                    escapeCSV(safe(inspection.getInspectorName())),
+                    escapeCSV(inspection.getBioSample() != null ? String.valueOf(inspection.getBioSample().getId()) : ""),
+                    escapeCSV(getAccessionNumber(inspection)),
+                    escapeCSV(buildExpectedCoordinate(inspection)),
+                    escapeCSV(buildObservedStatus(inspection)),
+                    escapeCSV(inspection.getQcResult() != null ? inspection.getQcResult().name() : ""),
+                    escapeCSV(safe(inspection.getRemarks()))));
+        }
+        writer.flush();
+        return baos.toByteArray();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public byte[] exportQcBatchToExcel(String qcBatchId) throws IOException {
+        List<BiorepositoryQCInspection> inspections = qcInspectionService.getByQcBatchId(qcBatchId);
+        Workbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("QC Batch");
+        CellStyle headerStyle = workbook.createCellStyle();
+        org.apache.poi.ss.usermodel.Font headerFont = workbook.createFont();
+        headerFont.setBold(true);
+        headerStyle.setFont(headerFont);
+        Row headerRow = sheet.createRow(0);
+        createCell(headerRow, 0, "QC Batch ID", headerStyle);
+        createCell(headerRow, 1, "Inspection ID", headerStyle);
+        createCell(headerRow, 2, "Date Time", headerStyle);
+        createCell(headerRow, 3, "Technician ID", headerStyle);
+        createCell(headerRow, 4, "Inspector Name", headerStyle);
+        createCell(headerRow, 5, "BioSample ID", headerStyle);
+        createCell(headerRow, 6, "Accession Number", headerStyle);
+        createCell(headerRow, 7, "Expected Coordinate", headerStyle);
+        createCell(headerRow, 8, "Observed Status", headerStyle);
+        createCell(headerRow, 9, "QC Outcome", headerStyle);
+        createCell(headerRow, 10, "Comment", headerStyle);
+        int rowNum = 1;
+        for (BiorepositoryQCInspection inspection : inspections) {
+            Row row = sheet.createRow(rowNum++);
+            createCell(row, 0, safe(inspection.getQcBatchId()), null);
+            createCell(row, 1, String.valueOf(inspection.getId()), null);
+            createCell(row, 2, inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : "", null);
+            createCell(row, 3, safe(inspection.getSysUserId()), null);
+            createCell(row, 4, safe(inspection.getInspectorName()), null);
+            createCell(row, 5, inspection.getBioSample() != null ? String.valueOf(inspection.getBioSample().getId()) : "", null);
+            createCell(row, 6, getAccessionNumber(inspection), null);
+            createCell(row, 7, buildExpectedCoordinate(inspection), null);
+            createCell(row, 8, buildObservedStatus(inspection), null);
+            createCell(row, 9, inspection.getQcResult() != null ? inspection.getQcResult().name() : "", null);
+            createCell(row, 10, safe(inspection.getRemarks()), null);
+        }
+        for (int i = 0; i <= 10; i++) {
+            sheet.autoSizeColumn(i);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        workbook.write(baos);
+        workbook.close();
+        return baos.toByteArray();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public byte[] exportQcBatchToJSON(String qcBatchId) throws IOException {
+        List<BiorepositoryQCInspection> inspections = qcInspectionService.getByQcBatchId(qcBatchId);
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (BiorepositoryQCInspection inspection : inspections) {
+            Map<String, Object> row = new HashMap<>();
+            row.put("qcBatchId", inspection.getQcBatchId());
+            row.put("inspectionId", inspection.getId());
+            row.put("inspectionDateTime", inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
+            row.put("technicianId", inspection.getSysUserId());
+            row.put("inspectorName", inspection.getInspectorName());
+            row.put("bioSampleId", inspection.getBioSample() != null ? inspection.getBioSample().getId() : null);
+            row.put("accessionNumber", getAccessionNumber(inspection));
+            row.put("expectedCoordinate", buildExpectedCoordinate(inspection));
+            row.put("observedStatus", buildObservedStatus(inspection));
+            row.put("qcOutcome", inspection.getQcResult() != null ? inspection.getQcResult().name() : null);
+            row.put("comment", inspection.getRemarks());
+            rows.add(row);
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("qcBatchId", qcBatchId);
+        payload.put("recordCount", rows.size());
+        payload.put("records", rows);
+        return mapper.writeValueAsBytes(payload);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public byte[] exportQcBatchToPDF(String qcBatchId) throws IOException {
+        List<BiorepositoryQCInspection> inspections = qcInspectionService.getByQcBatchId(qcBatchId);
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4.rotate(), 24, 24, 24, 24);
+            PdfWriter.getInstance(document, baos);
+            document.open();
+            Font titleFont = new Font(Font.FontFamily.HELVETICA, 14, Font.BOLD);
+            Font headerFont = new Font(Font.FontFamily.HELVETICA, 8, Font.BOLD);
+            Font bodyFont = new Font(Font.FontFamily.HELVETICA, 7, Font.NORMAL);
+            Paragraph title = new Paragraph("Biorepository QC Batch Report: " + qcBatchId, titleFont);
+            title.setAlignment(Element.ALIGN_CENTER);
+            title.setSpacingAfter(8f);
+            document.add(title);
+            document.add(new Paragraph("Records: " + inspections.size(), bodyFont));
+            document.add(new Paragraph("Generated: " + Timestamp.valueOf(java.time.LocalDateTime.now()), bodyFont));
+            document.add(new Paragraph(" ", bodyFont));
+            PdfPTable table = new PdfPTable(new float[] { 1.3f, 1.8f, 1.8f, 1.1f, 1.2f, 2.4f, 1.6f, 1.6f, 2.0f });
+            table.setWidthPercentage(100f);
+            addHeaderCell(table, "Inspection ID", headerFont);
+            addHeaderCell(table, "Date Time", headerFont);
+            addHeaderCell(table, "Technician", headerFont);
+            addHeaderCell(table, "BioSample", headerFont);
+            addHeaderCell(table, "Accession", headerFont);
+            addHeaderCell(table, "Expected Coordinate", headerFont);
+            addHeaderCell(table, "Observed Status", headerFont);
+            addHeaderCell(table, "QC Outcome", headerFont);
+            addHeaderCell(table, "Comment", headerFont);
+            for (BiorepositoryQCInspection inspection : inspections) {
+                addBodyCell(table, String.valueOf(inspection.getId()), bodyFont);
+                addBodyCell(table, inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : "", bodyFont);
+                addBodyCell(table, safe(inspection.getSysUserId()), bodyFont);
+                addBodyCell(table, inspection.getBioSample() != null ? String.valueOf(inspection.getBioSample().getId()) : "", bodyFont);
+                addBodyCell(table, getAccessionNumber(inspection), bodyFont);
+                addBodyCell(table, buildExpectedCoordinate(inspection), bodyFont);
+                addBodyCell(table, buildObservedStatus(inspection), bodyFont);
+                addBodyCell(table, inspection.getQcResult() != null ? inspection.getQcResult().name() : "", bodyFont);
+                addBodyCell(table, safe(inspection.getRemarks()), bodyFont);
+            }
+            document.add(table);
+            document.close();
+            return baos.toByteArray();
+        } catch (DocumentException e) {
+            throw new IOException("Failed to generate QC batch PDF export", e);
+        }
+    }
+
     // ==================== Helper Methods ====================
+
+    private String safe(String value) {
+        return value != null ? value : "";
+    }
+
+    private String getAccessionNumber(BiorepositoryQCInspection inspection) {
+        if (inspection == null || inspection.getBioSample() == null || inspection.getBioSample().getSampleItem() == null
+                || inspection.getBioSample().getSampleItem().getSample() == null
+                || inspection.getBioSample().getSampleItem().getSample().getAccessionNumber() == null) {
+            return "";
+        }
+        return inspection.getBioSample().getSampleItem().getSample().getAccessionNumber();
+    }
+
+    private String buildExpectedCoordinate(BiorepositoryQCInspection inspection) {
+        if (inspection == null) {
+            return "";
+        }
+        String path = safe(inspection.getExpectedLocationPath());
+        String position = safe(inspection.getExpectedPositionCoordinate());
+        if (!path.isEmpty() && !position.isEmpty()) {
+            return path + " > " + position;
+        }
+        return !path.isEmpty() ? path : position;
+    }
+
+    private String buildObservedStatus(BiorepositoryQCInspection inspection) {
+        if (inspection == null) {
+            return "";
+        }
+        if (inspection.getQcResult() == null) {
+            return "";
+        }
+        if (inspection.getQcResult() == BiorepositoryQCInspection.QCResult.VERIFIED) {
+            return "PASS";
+        }
+        return "FAIL" + (inspection.getDiscrepancyType() != null ? " - " + inspection.getDiscrepancyType().name() : "");
+    }
 
     /**
      * Aggregate dashboard metrics from dashboard service.

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionService.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionService.java
@@ -66,6 +66,11 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
     List<BiorepositoryQCInspection> getByInspectorName(String inspectorName);
 
     /**
+     * Find all inspections in a generated QC batch.
+     */
+    List<BiorepositoryQCInspection> getByQcBatchId(String qcBatchId);
+
+    /**
      * Count inspections by QC result.
      *
      * @param qcResult the QC result
@@ -80,6 +85,12 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
      * @return true if at least one inspection exists
      */
     boolean existsByBioSampleId(Integer bioSampleId);
+
+    /**
+     * Check if a biosample has at least one inspection with inspection time in
+     * {@code [start, end]} (inclusive).
+     */
+    boolean hasInspectionBetween(Integer bioSampleId, java.sql.Timestamp start, java.sql.Timestamp end);
 
     /**
      * Get all inspections within a date range.
@@ -139,20 +150,20 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
      * @param sysUserId                  system user ID
      * @return list of created inspection records
      */
-    List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
-            Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
-            boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String sysUserId);
-
     default List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
-            String sysUserId) {
+            String correctiveAction, String remarks, String sysUserId) {
         return createBulkInspections(bioSampleIds, inspectorName, inspectionDate, samplePresent, labelIntegrity,
                 containerIntegrity, volumeAppearanceAcceptable, correctPosition, discrepancyType, correctiveAction,
-                remarks, sysUserId);
+                remarks, null, null, sysUserId);
     }
+
+    List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
+            Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
+            boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId);
 
     /**
      * Generate a randomized QC round from currently stored samples.
@@ -211,7 +222,11 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
      *
      * @return correction details suitable for API response
      */
-    Map<String, Object> applyCorrectionWorkflow(BiorepositoryQCInspection inspection, String correctionActionType,
-            String correctionLocationId, String correctionLocationType, String correctionPositionCoordinate,
-            String correctionReason, String correctiveAction, String remarks, String correctedByUserId);
+        default Map<String, Object> applyCorrectionWorkflow(BiorepositoryQCInspection inspection,
+            String correctionActionType, String correctionLocationId, String correctionLocationType,
+            String correctionPositionCoordinate, String correctionReason, String correctiveAction, String remarks,
+            String correctedByUserId) {
+        throw new UnsupportedOperationException(
+            "Correction workflow is handled at controller/service integration level in this branch");
+        }
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionService.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionService.java
@@ -29,14 +29,25 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
      */
     BiorepositoryQCInspection getMostRecentByBioSampleId(Integer bioSampleId);
 
-        /**
-         * Find the most recent QC inspections for multiple biosamples in a single
-         * call.
-         *
-         * @param bioSampleIds list of biosample IDs
-         * @return map keyed by biosample ID containing the latest inspection
-         */
-        Map<Integer, BiorepositoryQCInspection> getMostRecentByBioSampleIds(List<Integer> bioSampleIds);
+    /**
+     * Find the most recent QC inspections for multiple biosamples in a single
+     * call.
+     *
+     * @param bioSampleIds list of biosample IDs
+     * @return map keyed by biosample ID containing the latest inspection
+     */
+    default Map<Integer, BiorepositoryQCInspection> getMostRecentByBioSampleIds(List<Integer> bioSampleIds) {
+        java.util.HashMap<Integer, BiorepositoryQCInspection> results = new java.util.HashMap<>();
+        if (bioSampleIds == null) {
+            return results;
+        }
+        for (Integer bioSampleId : bioSampleIds) {
+            if (bioSampleId != null) {
+                results.put(bioSampleId, getMostRecentByBioSampleId(bioSampleId));
+            }
+        }
+        return results;
+    }
 
     /**
      * Find all inspections by QC result.
@@ -99,16 +110,16 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
     BiorepositoryQCInspection createInspection(Integer bioSampleId, String inspectorName, Timestamp inspectionDate,
             boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
-            String sysUserId);
+            String correctiveAction, String remarks, String sysUserId);
 
     default BiorepositoryQCInspection createInspection(Integer bioSampleId, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String sysUserId) {
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId) {
         return createInspection(bioSampleId, inspectorName, inspectionDate, samplePresent, labelIntegrity,
                 containerIntegrity, volumeAppearanceAcceptable, correctPosition, discrepancyType, correctiveAction,
-                remarks, null, null, sysUserId);
+                remarks, sysUserId);
     }
 
     /**
@@ -131,16 +142,16 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
     List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
-            String sysUserId);
+            String correctiveAction, String remarks, String sysUserId);
 
     default List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String sysUserId) {
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId) {
         return createBulkInspections(bioSampleIds, inspectorName, inspectionDate, samplePresent, labelIntegrity,
                 containerIntegrity, volumeAppearanceAcceptable, correctPosition, discrepancyType, correctiveAction,
-                remarks, null, null, sysUserId);
+                remarks, sysUserId);
     }
 
     /**
@@ -152,24 +163,29 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
      * @param sysUserId     request user ID
      * @return round metadata and selected samples
      */
-    Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed, String sysUserId);
+    default Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed,
+            String sysUserId) {
+        throw new UnsupportedOperationException("Random QC round generation is not implemented by this service");
+    }
 
-        /**
-         * Generate a randomized QC round scoped by optional location filters.
-         *
-         * Supported filter keys: freezer, shelf, rack, box
-         */
-        default Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed,
-                        String sysUserId, Map<String, String> locationFilters) {
-                return generateRandomQCRound(boxesPerRound, samplesPerBox, randomSeed, sysUserId);
-        }
+    /**
+     * Generate a randomized QC round scoped by optional location filters.
+     *
+     * Supported filter keys: freezer, shelf, rack, box
+     */
+    default Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed,
+            String sysUserId, Map<String, String> locationFilters) {
+        return generateRandomQCRound(boxesPerRound, samplesPerBox, randomSeed, sysUserId);
+    }
 
-        /**
-         * Build a storage location overview for QC planning UI.
-         *
-         * @return summary counts and location breakdowns by freezer/shelf/rack/box
-         */
-        Map<String, Object> getLocationOverview();
+    /**
+     * Build a storage location overview for QC planning UI.
+     *
+     * @return summary counts and location breakdowns by freezer/shelf/rack/box
+     */
+    default Map<String, Object> getLocationOverview() {
+        throw new UnsupportedOperationException("Location overview is not implemented by this service");
+    }
 
     /**
      * Record a corrective action for a failed QC inspection and keep an auditable
@@ -182,6 +198,20 @@ public interface BiorepositoryQCInspectionService extends BaseObjectService<Bior
      * @param sysUserId           user making the change
      * @return operation summary
      */
-    Map<String, Object> applyCorrectiveAction(Integer inspectionId, String observedCoordinate,
-            String correctedCoordinate, String correctiveReason, String sysUserId);
+    default Map<String, Object> applyCorrectiveAction(Integer inspectionId, String observedCoordinate,
+            String correctedCoordinate, String correctiveReason, String sysUserId) {
+        throw new UnsupportedOperationException("Legacy corrective action endpoint is not implemented by this service");
+    }
+
+    /**
+     * Apply mandatory correction workflow for a failed QC inspection.
+     *
+     * Supports UPDATE_LOCATION, REASSIGN_POSITION, and MARK_MISSING.
+     * Persists correction audit details onto the inspection record.
+     *
+     * @return correction details suitable for API response
+     */
+    Map<String, Object> applyCorrectionWorkflow(BiorepositoryQCInspection inspection, String correctionActionType,
+            String correctionLocationId, String correctionLocationType, String correctionPositionCoordinate,
+            String correctionReason, String correctiveAction, String remarks, String correctedByUserId);
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionServiceImpl.java
@@ -2,7 +2,6 @@ package org.openelisglobal.biorepository.service;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.biorepository.dao.BiorepositoryQCInspectionDAO;
@@ -68,6 +67,12 @@ public class BiorepositoryQCInspectionServiceImpl extends
 
     @Override
     @Transactional(readOnly = true)
+    public List<BiorepositoryQCInspection> getByQcBatchId(String qcBatchId) {
+        return baseObjectDAO.getByQcBatchId(qcBatchId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public long countByQCResult(QCResult qcResult) {
         return baseObjectDAO.countByQCResult(qcResult);
     }
@@ -76,6 +81,15 @@ public class BiorepositoryQCInspectionServiceImpl extends
     @Transactional(readOnly = true)
     public boolean existsByBioSampleId(Integer bioSampleId) {
         return baseObjectDAO.existsByBioSampleId(bioSampleId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasInspectionBetween(Integer bioSampleId, java.sql.Timestamp start, java.sql.Timestamp end) {
+        if (bioSampleId == null) {
+            return false;
+        }
+        return baseObjectDAO.hasInspectionBetween(bioSampleId, start, end);
     }
 
     @Override
@@ -90,6 +104,18 @@ public class BiorepositoryQCInspectionServiceImpl extends
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
             String correctiveAction, String remarks, String sysUserId) {
+        return createInspection(bioSampleId, inspectorName, inspectionDate, samplePresent, labelIntegrity,
+                containerIntegrity, volumeAppearanceAcceptable, correctPosition, discrepancyType, correctiveAction,
+                remarks, null, null, sysUserId);
+    }
+
+    @Override
+    @Transactional
+    public BiorepositoryQCInspection createInspection(Integer bioSampleId, String inspectorName,
+            Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
+            boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId) {
 
         BioSample bioSample = bioSampleService.get(bioSampleId);
         if (bioSample == null) {
@@ -113,6 +139,7 @@ public class BiorepositoryQCInspectionServiceImpl extends
             inspection.setExpectedLocationPath(trimToNull(asString(currentLocation.get("hierarchicalPath"))));
             inspection.setExpectedPositionCoordinate(trimToNull(asString(currentLocation.get("positionCoordinate"))));
         }
+        inspection.setExpectedCoordinateSnapshot(trimToNull(expectedCoordinateSnapshot));
 
         // Auto-calculate QC result based on checklist
         inspection.updateQcResult();
@@ -139,6 +166,7 @@ public class BiorepositoryQCInspectionServiceImpl extends
         }
 
         inspection.setSysUserId(sysUserId);
+        inspection.setQcBatchId(trimToNull(qcBatchId));
 
         return save(inspection);
     }
@@ -164,182 +192,28 @@ public class BiorepositoryQCInspectionServiceImpl extends
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
             String correctiveAction, String remarks, String sysUserId) {
+        return createBulkInspections(bioSampleIds, inspectorName, inspectionDate, samplePresent, labelIntegrity,
+                containerIntegrity, volumeAppearanceAcceptable, correctPosition, discrepancyType, correctiveAction,
+                remarks, null, null, sysUserId);
+    }
+
+    @Override
+    @Transactional
+    public List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
+            Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
+            boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
+            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
+            String sysUserId) {
 
         List<BiorepositoryQCInspection> inspections = new ArrayList<>();
 
         for (Integer bioSampleId : bioSampleIds) {
             BiorepositoryQCInspection inspection = createInspection(bioSampleId, inspectorName, inspectionDate,
                     samplePresent, labelIntegrity, containerIntegrity, volumeAppearanceAcceptable, correctPosition,
-                    discrepancyType, correctiveAction, remarks, sysUserId);
+                    discrepancyType, correctiveAction, remarks, qcBatchId, expectedCoordinateSnapshot, sysUserId);
             inspections.add(inspection);
         }
 
         return inspections;
-    }
-
-    @Override
-    @Transactional
-    public Map<String, Object> applyCorrectionWorkflow(BiorepositoryQCInspection inspection, String correctionActionType,
-            String correctionLocationId, String correctionLocationType, String correctionPositionCoordinate,
-            String correctionReason, String correctiveAction, String remarks, String correctedByUserId) {
-        if (inspection == null) {
-            throw new IllegalArgumentException("Inspection is required for correction workflow");
-        }
-        if (inspection.getQcResult() != BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND) {
-            throw new IllegalArgumentException("Correction workflow requires discrepancy QC result");
-        }
-
-        BioSample bioSample = inspection.getBioSample();
-        if (bioSample == null || bioSample.getSampleItem() == null || bioSample.getSampleItem().getId() == null) {
-            throw new IllegalArgumentException("Sample item is required for correction workflow");
-        }
-
-        String actionType = trimToNull(correctionActionType);
-        if (actionType == null) {
-            throw new IllegalArgumentException("Correction action type is required");
-        }
-
-        String normalizedActionType = actionType.trim().toUpperCase();
-        String sampleItemId = bioSample.getSampleItem().getId();
-
-        String reason = trimToNull(correctionReason);
-        if (reason == null) {
-            reason = trimToNull(correctiveAction);
-        }
-        if (reason == null) {
-            reason = "QC discrepancy correction";
-        }
-
-        String oldCoordinate = composeCoordinate(inspection.getExpectedLocationPath(), inspection.getExpectedPositionCoordinate());
-        Timestamp correctionTimestamp = new Timestamp(System.currentTimeMillis());
-        String normalizedActionReason = normalizedActionType + ": " + reason;
-
-        Map<String, Object> correction = new HashMap<>();
-        correction.put("actionType", normalizedActionType);
-        correction.put("reason", normalizedActionReason);
-        correction.put("correctionTimestamp", correctionTimestamp.toString());
-
-        if ("MARK_MISSING".equals(normalizedActionType)) {
-            if (!isSampleMissingDiscrepancy(inspection)) {
-                throw new IllegalArgumentException("MARK_MISSING requires discrepancy type SAMPLE_MISSING");
-            }
-            if (trimToNull(correctionLocationId) != null || trimToNull(correctionLocationType) != null
-                    || trimToNull(correctionPositionCoordinate) != null) {
-                throw new IllegalArgumentException("MARK_MISSING does not allow correction location/position fields");
-            }
-
-            Map<String, Object> missingUpdate = storageService.markSampleItemMissing(sampleItemId, normalizedActionReason,
-                    trimToNull(remarks));
-            @SuppressWarnings("unchecked")
-            Map<String, Object> updatedLocation = missingUpdate.get("updatedLocation") instanceof Map
-                    ? (Map<String, Object>) missingUpdate.get("updatedLocation")
-                    : Map.of("hierarchicalPath", "Missing (not found during QC)", "positionCoordinate", null,
-                            "status", "MISSING");
-
-            String newCoordinate = composeCoordinate(asString(updatedLocation.get("hierarchicalPath")),
-                    asString(updatedLocation.get("positionCoordinate")));
-
-            inspection.setCorrectiveAction(normalizedActionReason);
-            inspection.setCorrectionActionType(normalizedActionType);
-            inspection.setCorrectionOldCoordinate(oldCoordinate);
-            inspection.setCorrectionNewCoordinate(trimToNull(newCoordinate) != null ? newCoordinate
-                    : "Missing (not found during QC)");
-            inspection.setCorrectionReason(normalizedActionReason);
-            inspection.setCorrectionByUser(trimToNull(correctedByUserId) != null ? trimToNull(correctedByUserId)
-                    : inspection.getSysUserId());
-            inspection.setCorrectionTimestamp(correctionTimestamp);
-            update(inspection);
-
-            correction.put("movementId", asString(missingUpdate.get("movementId")));
-            correction.put("updatedLocation", updatedLocation);
-            correction.put("auditTrail", buildAuditTrail(inspection));
-            return correction;
-        }
-
-        if (!"UPDATE_LOCATION".equals(normalizedActionType) && !"REASSIGN_POSITION".equals(normalizedActionType)) {
-            throw new IllegalArgumentException("Unsupported correction action type: " + correctionActionType);
-        }
-
-        String locationId = trimToNull(correctionLocationId);
-        String locationType = trimToNull(correctionLocationType);
-        if (locationId == null || locationType == null) {
-            throw new IllegalArgumentException(
-                    "Correction locationId and locationType are required for UPDATE_LOCATION/REASSIGN_POSITION");
-        }
-        if ("REASSIGN_POSITION".equals(normalizedActionType) && trimToNull(correctionPositionCoordinate) == null) {
-            throw new IllegalArgumentException("REASSIGN_POSITION requires correctionPositionCoordinate");
-        }
-
-        String movementId = storageService.moveSampleItemWithLocation(sampleItemId, locationId, locationType,
-                trimToNull(correctionPositionCoordinate), normalizedActionReason, trimToNull(remarks));
-
-        Map<String, Object> updatedLocation = storageService.getSampleItemLocation(sampleItemId);
-        String newCoordinate = composeCoordinate(asString(updatedLocation.get("hierarchicalPath")),
-                asString(updatedLocation.get("positionCoordinate")));
-
-        inspection.setCorrectiveAction(normalizedActionReason);
-        inspection.setCorrectionActionType(normalizedActionType);
-        inspection.setCorrectionOldCoordinate(oldCoordinate);
-        inspection.setCorrectionNewCoordinate(newCoordinate);
-        inspection.setCorrectionReason(normalizedActionReason);
-        inspection.setCorrectionByUser(trimToNull(correctedByUserId) != null ? trimToNull(correctedByUserId)
-                : inspection.getSysUserId());
-        inspection.setCorrectionTimestamp(correctionTimestamp);
-        update(inspection);
-
-        correction.put("movementId", movementId);
-        correction.put("updatedLocation", updatedLocation);
-        correction.put("auditTrail", buildAuditTrail(inspection));
-        return correction;
-    }
-
-    private boolean isSampleMissingDiscrepancy(BiorepositoryQCInspection inspection) {
-        if (inspection == null || inspection.getDiscrepancyType() == null) {
-            return false;
-        }
-        return BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.equals(inspection.getDiscrepancyType())
-                || BiorepositoryQCInspection.DiscrepancyType.MISSING_SAMPLE.equals(inspection.getDiscrepancyType());
-    }
-
-    private Map<String, Object> buildAuditTrail(BiorepositoryQCInspection inspection) {
-        Map<String, Object> auditTrail = new HashMap<>();
-        String oldCoordinate = trimToNull(inspection.getCorrectionOldCoordinate()) != null
-                ? inspection.getCorrectionOldCoordinate()
-                : composeCoordinate(inspection.getExpectedLocationPath(), inspection.getExpectedPositionCoordinate());
-        String newCoordinate = trimToNull(inspection.getCorrectionNewCoordinate()) != null
-                ? inspection.getCorrectionNewCoordinate()
-                : oldCoordinate;
-        String timestamp = inspection.getCorrectionTimestamp() != null ? inspection.getCorrectionTimestamp().toString()
-                : (inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
-        String user = trimToNull(inspection.getCorrectionByUser()) != null ? inspection.getCorrectionByUser()
-                : inspection.getSysUserId();
-        String reason = trimToNull(inspection.getCorrectionReason()) != null ? inspection.getCorrectionReason()
-                : inspection.getCorrectiveAction();
-
-        auditTrail.put("oldCoordinate", oldCoordinate);
-        auditTrail.put("newCoordinate", newCoordinate);
-        auditTrail.put("fromCoordinates", oldCoordinate);
-        auditTrail.put("toCoordinates", newCoordinate);
-        auditTrail.put("user", user);
-        auditTrail.put("correctedBy", user);
-        auditTrail.put("timestamp", timestamp);
-        auditTrail.put("correctedAt", timestamp);
-        auditTrail.put("reason", reason);
-        return auditTrail;
-    }
-
-    private String composeCoordinate(String locationPath, String positionCoordinate) {
-        String path = trimToNull(locationPath);
-        String coordinate = trimToNull(positionCoordinate);
-        if (path == null && coordinate == null) {
-            return null;
-        }
-        if (path == null) {
-            return coordinate;
-        }
-        if (coordinate == null) {
-            return path;
-        }
-        return path + " > " + coordinate;
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQCInspectionServiceImpl.java
@@ -2,26 +2,17 @@ package org.openelisglobal.biorepository.service;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
 import org.openelisglobal.biorepository.dao.BiorepositoryQCInspectionDAO;
 import org.openelisglobal.biorepository.valueholder.BioSample;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection.DiscrepancyType;
 import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection.QCResult;
-import org.openelisglobal.biorepository.valueholder.ChainOfCustodyLog.CustodyAction;
 import org.openelisglobal.common.service.AuditableBaseObjectServiceImpl;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.storage.service.SampleStorageService;
-import org.openelisglobal.storage.service.StorageLocationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,13 +31,7 @@ public class BiorepositoryQCInspectionServiceImpl extends
     private BioSampleService bioSampleService;
 
     @Autowired
-    private SampleStorageService sampleStorageService;
-
-    @Autowired
-    private StorageLocationService storageLocationService;
-
-    @Autowired
-    private ChainOfCustodyService chainOfCustodyService;
+    private SampleStorageService storageService;
 
     BiorepositoryQCInspectionServiceImpl() {
         super(BiorepositoryQCInspection.class);
@@ -67,12 +52,6 @@ public class BiorepositoryQCInspectionServiceImpl extends
     @Transactional(readOnly = true)
     public BiorepositoryQCInspection getMostRecentByBioSampleId(Integer bioSampleId) {
         return baseObjectDAO.getMostRecentByBioSampleId(bioSampleId);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Map<Integer, BiorepositoryQCInspection> getMostRecentByBioSampleIds(List<Integer> bioSampleIds) {
-        return baseObjectDAO.getMostRecentByBioSampleIds(bioSampleIds);
     }
 
     @Override
@@ -110,34 +89,30 @@ public class BiorepositoryQCInspectionServiceImpl extends
     public BiorepositoryQCInspection createInspection(Integer bioSampleId, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
-            String sysUserId) {
+            String correctiveAction, String remarks, String sysUserId) {
 
         BioSample bioSample = bioSampleService.get(bioSampleId);
         if (bioSample == null) {
             throw new IllegalArgumentException("BioSample not found: " + bioSampleId);
         }
-        if (!BioSample.WorkflowStatus.STORED.equals(bioSample.getWorkflowStatus())) {
-            throw new IllegalArgumentException("QC inspection can only be recorded for STORED samples. Current "
-                    + "status: " + bioSample.getWorkflowStatus());
-        }
-        if (inspectorName == null || inspectorName.trim().isEmpty()) {
-            throw new IllegalArgumentException("Inspector name is required");
-        }
 
         BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
         inspection.setBioSample(bioSample);
-        inspection.setInspectorName(inspectorName.trim());
-        inspection
-                .setInspectionDate(inspectionDate != null ? inspectionDate : new Timestamp(System.currentTimeMillis()));
+        inspection.setInspectorName(inspectorName);
+        inspection.setInspectionDate(inspectionDate);
         inspection.setSamplePresent(samplePresent);
         inspection.setLabelIntegrity(labelIntegrity);
         inspection.setContainerIntegrity(containerIntegrity);
         inspection.setVolumeAppearanceAcceptable(volumeAppearanceAcceptable);
         inspection.setCorrectPosition(correctPosition);
-        inspection.setQcBatchId(qcBatchId);
-        inspection.setExpectedCoordinateSnapshot(
-                resolveExpectedCoordinateSnapshot(bioSample, expectedCoordinateSnapshot));
+
+        // Snapshot expected location at time of QC record creation.
+        SampleItem sampleItem = bioSample.getSampleItem();
+        if (sampleItem != null && sampleItem.getId() != null) {
+            Map<String, Object> currentLocation = storageService.getSampleItemLocation(sampleItem.getId().toString());
+            inspection.setExpectedLocationPath(trimToNull(asString(currentLocation.get("hierarchicalPath"))));
+            inspection.setExpectedPositionCoordinate(trimToNull(asString(currentLocation.get("positionCoordinate"))));
+        }
 
         // Auto-calculate QC result based on checklist
         inspection.updateQcResult();
@@ -146,25 +121,41 @@ public class BiorepositoryQCInspectionServiceImpl extends
         if (inspection.getQcResult() == QCResult.DISCREPANCY_FOUND) {
             DiscrepancyType type = DiscrepancyType.fromString(discrepancyType);
             if (type == null) {
-                throw new IllegalArgumentException("Discrepancy type is required when QC fails");
+                throw new IllegalArgumentException("Discrepancy type is required when QC result is DISCREPANCY_FOUND");
             }
-            if (correctiveAction == null || correctiveAction.trim().isEmpty()) {
-                throw new IllegalArgumentException("Corrective action is required when QC fails");
+            if (trimToNull(correctiveAction) == null) {
+                throw new IllegalArgumentException("Corrective action is required when QC result is DISCREPANCY_FOUND");
             }
-            if (remarks == null || remarks.trim().isEmpty()) {
-                throw new IllegalArgumentException("Comment/remarks are required when QC fails");
+            if (trimToNull(remarks) == null) {
+                throw new IllegalArgumentException("Comment/remarks is required when QC result is DISCREPANCY_FOUND");
             }
             inspection.setDiscrepancyType(type);
-            inspection.setCorrectiveAction(correctiveAction.trim());
+            inspection.setCorrectiveAction(trimToNull(correctiveAction));
+            inspection.setRemarks(trimToNull(remarks));
         } else {
             inspection.setDiscrepancyType(null);
             inspection.setCorrectiveAction(null);
+            inspection.setRemarks(trimToNull(remarks));
         }
 
-        inspection.setRemarks(remarks);
         inspection.setSysUserId(sysUserId);
 
         return save(inspection);
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return String.valueOf(value);
     }
 
     @Override
@@ -172,15 +163,14 @@ public class BiorepositoryQCInspectionServiceImpl extends
     public List<BiorepositoryQCInspection> createBulkInspections(List<Integer> bioSampleIds, String inspectorName,
             Timestamp inspectionDate, boolean samplePresent, boolean labelIntegrity, boolean containerIntegrity,
             boolean volumeAppearanceAcceptable, boolean correctPosition, String discrepancyType,
-            String correctiveAction, String remarks, String qcBatchId, String expectedCoordinateSnapshot,
-            String sysUserId) {
+            String correctiveAction, String remarks, String sysUserId) {
 
         List<BiorepositoryQCInspection> inspections = new ArrayList<>();
 
         for (Integer bioSampleId : bioSampleIds) {
             BiorepositoryQCInspection inspection = createInspection(bioSampleId, inspectorName, inspectionDate,
                     samplePresent, labelIntegrity, containerIntegrity, volumeAppearanceAcceptable, correctPosition,
-                    discrepancyType, correctiveAction, remarks, qcBatchId, expectedCoordinateSnapshot, sysUserId);
+                    discrepancyType, correctiveAction, remarks, sysUserId);
             inspections.add(inspection);
         }
 
@@ -188,635 +178,159 @@ public class BiorepositoryQCInspectionServiceImpl extends
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed,
-            String sysUserId) {
-        return generateRandomQCRound(boxesPerRound, samplesPerBox, randomSeed, sysUserId, null);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Map<String, Object> generateRandomQCRound(int boxesPerRound, int samplesPerBox, Long randomSeed,
-            String sysUserId, Map<String, String> locationFilters) {
-        int effectiveBoxes = boxesPerRound > 0 ? boxesPerRound : 10;
-        int effectiveSamplesPerBox = samplesPerBox > 0 ? samplesPerBox : 3;
-        Random random = randomSeed != null ? new Random(randomSeed) : new Random();
-        String qcBatchId = "QCBATCH-" + System.currentTimeMillis() + "-"
-                + UUID.randomUUID().toString().substring(0, 8);
-
-        List<Map<String, Object>> candidates = collectStoredSampleCandidates(locationFilters);
-
-        Map<String, List<Map<String, Object>>> candidatesByBox = new HashMap<>();
-        for (Map<String, Object> candidate : candidates) {
-            String boxKey = asString(candidate.get("boxKey"));
-            if (boxKey == null) {
-                continue;
-            }
-            candidatesByBox.computeIfAbsent(boxKey, k -> new ArrayList<>()).add(candidate);
-        }
-
-        List<String> selectedBoxes = selectDistributedBoxesByShelf(candidatesByBox, effectiveBoxes, random);
-
-        List<Map<String, Object>> selectedSamples = new ArrayList<>();
-        for (String boxKey : selectedBoxes) {
-            List<Map<String, Object>> boxCandidates = new ArrayList<>(candidatesByBox.get(boxKey));
-            Collections.shuffle(boxCandidates, random);
-            int limit = Math.min(effectiveSamplesPerBox, boxCandidates.size());
-            for (int i = 0; i < limit; i++) {
-                Map<String, Object> selected = new HashMap<>(boxCandidates.get(i));
-                selected.put("qcBatchId", qcBatchId);
-                selectedSamples.add(selected);
-            }
-        }
-
-        selectedSamples.sort(
-                Comparator.comparing(m -> asString(m.get("boxKey")) + ":" + asString(m.get("expectedCoordinate"))));
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("qcBatchId", qcBatchId);
-        result.put("boxesSelected", selectedBoxes.size());
-        result.put("samplesSelected", selectedSamples.size());
-        result.put("boxesPerRound", effectiveBoxes);
-        result.put("samplesPerBox", effectiveSamplesPerBox);
-        result.put("seed", randomSeed);
-        result.put("filters", locationFilters != null ? locationFilters : Collections.emptyMap());
-        result.put("generatedBy", sysUserId);
-        result.put("samples", selectedSamples);
-        return result;
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Map<String, Object> getLocationOverview() {
-        List<Map<String, Object>> candidates = collectStoredSampleCandidates(null);
-        List<Map<String, Object>> freezerDevices = new ArrayList<>();
-        for (Map<String, Object> device : storageLocationService.getDevicesForAPI(null)) {
-            if (isBiorepositoryFreezer(device)) {
-                freezerDevices.add(device);
-            }
-        }
-
-        Set<String> freezerNames = new HashSet<>();
-        Set<String> configuredShelfKeys = new HashSet<>();
-        Set<String> configuredRackKeys = new HashSet<>();
-        Set<String> configuredBoxKeys = new HashSet<>();
-        List<Map<String, Object>> freezerOptions = new ArrayList<>();
-        List<Map<String, Object>> shelfOptions = new ArrayList<>();
-        List<Map<String, Object>> rackOptions = new ArrayList<>();
-        List<Map<String, Object>> boxOptions = new ArrayList<>();
-
-        for (Map<String, Object> device : freezerDevices) {
-            String freezerName = asString(device.get("name"));
-            Integer deviceId = asInteger(device.get("id"));
-            if (freezerName == null || deviceId == null) {
-                continue;
-            }
-
-            freezerNames.add(freezerName);
-            freezerOptions.add(optionRow(freezerName, freezerName, null, null, null));
-
-            for (Map<String, Object> shelf : storageLocationService.getShelvesForAPI(deviceId)) {
-                if (!Boolean.TRUE.equals(shelf.get("biorepositoryStorage")) || !Boolean.TRUE.equals(shelf.get("active"))) {
-                    continue;
-                }
-                String shelfLabel = asString(shelf.get("label"));
-                if (shelfLabel == null) {
-                    continue;
-                }
-                String shelfKey = freezerName + " > " + shelfLabel;
-                configuredShelfKeys.add(shelfKey);
-                shelfOptions.add(optionRow(shelfLabel, shelfLabel, freezerName, null, null));
-
-                Integer shelfId = asInteger(shelf.get("id"));
-                if (shelfId == null) {
-                    continue;
-                }
-
-                for (Map<String, Object> rack : storageLocationService.getRacksForAPI(shelfId)) {
-                    if (!Boolean.TRUE.equals(rack.get("biorepositoryStorage")) || !Boolean.TRUE.equals(rack.get("active"))) {
-                        continue;
-                    }
-                    String rackLabel = asString(rack.get("rackLabel"));
-                    if (rackLabel == null) {
-                        rackLabel = asString(rack.get("label"));
-                    }
-                    if (rackLabel == null) {
-                        continue;
-                    }
-                    String rackKey = shelfKey + " > " + rackLabel;
-                    configuredRackKeys.add(rackKey);
-                    rackOptions.add(optionRow(rackLabel, rackLabel, freezerName, shelfLabel, null));
-                }
-            }
-        }
-
-        for (Map<String, Object> box : storageLocationService.getBoxesForAPI(null)) {
-            if (!Boolean.TRUE.equals(box.get("biorepositoryStorage")) || !Boolean.TRUE.equals(box.get("active"))) {
-                continue;
-            }
-            String deviceName = asString(box.get("deviceName"));
-            String shelfLabel = asString(box.get("shelfLabel"));
-            String rackLabel = asString(box.get("rackLabel"));
-            String boxLabel = asString(box.get("label"));
-            if (deviceName == null || shelfLabel == null || rackLabel == null || boxLabel == null) {
-                continue;
-            }
-            if (!freezerNames.contains(deviceName)) {
-                continue;
-            }
-            configuredBoxKeys.add(deviceName + " > " + shelfLabel + " > " + rackLabel + " > " + boxLabel);
-            boxOptions.add(optionRow(boxLabel, boxLabel, deviceName, shelfLabel, rackLabel));
-        }
-
-        Map<String, Integer> freezerSampleCount = new HashMap<>();
-        Map<String, Set<String>> freezerShelfSet = new HashMap<>();
-        Map<String, Set<String>> freezerRackSet = new HashMap<>();
-        Map<String, Set<String>> freezerBoxSet = new HashMap<>();
-        Map<String, Integer> shelfSampleCount = new HashMap<>();
-        Map<String, Set<String>> shelfRackSet = new HashMap<>();
-        Map<String, Set<String>> shelfBoxSet = new HashMap<>();
-        Map<String, String> shelfToFreezer = new HashMap<>();
-        Map<String, String> shelfLabelMap = new HashMap<>();
-
-        for (Map<String, Object> candidate : candidates) {
-            String freezer = asString(candidate.get("freezer"));
-            String shelf = asString(candidate.get("shelf"));
-            String shelfKey = asString(candidate.get("shelfKey"));
-            String rackKey = asString(candidate.get("rackKey"));
-            String boxKey = asString(candidate.get("boxKey"));
-            if (freezer == null) {
-                continue;
-            }
-
-            freezerSampleCount.merge(freezer, 1, Integer::sum);
-            freezerShelfSet.computeIfAbsent(freezer, key -> new HashSet<>());
-            freezerRackSet.computeIfAbsent(freezer, key -> new HashSet<>());
-            freezerBoxSet.computeIfAbsent(freezer, key -> new HashSet<>());
-
-            if (shelfKey != null) {
-                freezerShelfSet.get(freezer).add(shelfKey);
-            }
-            if (rackKey != null) {
-                freezerRackSet.get(freezer).add(rackKey);
-            }
-            if (boxKey != null) {
-                freezerBoxSet.get(freezer).add(boxKey);
-            }
-
-            if (shelfKey != null) {
-                shelfToFreezer.putIfAbsent(shelfKey, freezer);
-                shelfLabelMap.putIfAbsent(shelfKey, shelf != null ? shelf : "Unknown Shelf");
-                shelfSampleCount.merge(shelfKey, 1, Integer::sum);
-                shelfRackSet.computeIfAbsent(shelfKey, key -> new HashSet<>());
-                shelfBoxSet.computeIfAbsent(shelfKey, key -> new HashSet<>());
-                if (rackKey != null) {
-                    shelfRackSet.get(shelfKey).add(rackKey);
-                }
-                if (boxKey != null) {
-                    shelfBoxSet.get(shelfKey).add(boxKey);
-                }
-            }
-        }
-
-        List<Map<String, Object>> freezerSummary = new ArrayList<>();
-        for (String freezerName : freezerNames) {
-            Map<String, Object> summaryRow = new HashMap<>();
-            summaryRow.put("freezer", freezerName);
-            summaryRow.put("sampleCount", freezerSampleCount.getOrDefault(freezerName, 0));
-            summaryRow.put("shelfCount", countMatchingPrefix(configuredShelfKeys, freezerName + " > "));
-            summaryRow.put("rackCount", countMatchingPrefix(configuredRackKeys, freezerName + " > "));
-            summaryRow.put("boxCount", countMatchingPrefix(configuredBoxKeys, freezerName + " > "));
-            freezerSummary.add(summaryRow);
-        }
-
-        List<Map<String, Object>> shelfSummary = new ArrayList<>();
-        for (String shelfKey : configuredShelfKeys) {
-            Map<String, Object> summaryRow = new HashMap<>();
-            summaryRow.put("freezer", shelfToFreezer.getOrDefault(shelfKey, prefixBeforeLastSeparator(shelfKey)));
-            summaryRow.put("shelf", shelfLabelMap.getOrDefault(shelfKey, suffixAfterLastSeparator(shelfKey)));
-            summaryRow.put("shelfKey", shelfKey);
-            summaryRow.put("sampleCount", shelfSampleCount.getOrDefault(shelfKey, 0));
-            summaryRow.put("rackCount", countMatchingPrefix(configuredRackKeys, shelfKey + " > "));
-            summaryRow.put("boxCount", countMatchingPrefix(configuredBoxKeys, shelfKey + " > "));
-            shelfSummary.add(summaryRow);
-        }
-
-        freezerSummary.sort(Comparator.comparing(row -> asString(row.get("freezer"))));
-        shelfSummary.sort(Comparator.comparing(row -> asString(row.get("shelfKey"))));
-        freezerOptions.sort(Comparator.comparing(row -> asString(row.get("label"))));
-        shelfOptions.sort(Comparator.comparing(row -> asString(row.get("freezer")) + ":" + asString(row.get("label"))));
-        rackOptions.sort(Comparator.comparing(
-                row -> asString(row.get("freezer")) + ":" + asString(row.get("shelf")) + ":" + asString(row.get("label"))));
-        boxOptions.sort(Comparator.comparing(row -> asString(row.get("freezer")) + ":" + asString(row.get("shelf"))
-                + ":" + asString(row.get("rack")) + ":" + asString(row.get("label"))));
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("totalStoredSamples", candidates.size());
-        result.put("freezerCount", freezerNames.size());
-        result.put("shelfCount", configuredShelfKeys.size());
-        result.put("rackCount", configuredRackKeys.size());
-        result.put("boxCount", configuredBoxKeys.size());
-        result.put("freezerSummary", freezerSummary);
-        result.put("shelfSummary", shelfSummary);
-        result.put("freezerOptions", freezerOptions);
-        result.put("shelfOptions", shelfOptions);
-        result.put("rackOptions", rackOptions);
-        result.put("boxOptions", boxOptions);
-        result.put("generatedAt", System.currentTimeMillis());
-        return result;
-    }
-
-    @Override
     @Transactional
-    public Map<String, Object> applyCorrectiveAction(Integer inspectionId, String observedCoordinate,
-            String correctedCoordinate, String correctiveReason, String sysUserId) {
-        BiorepositoryQCInspection inspection = get(inspectionId);
+    public Map<String, Object> applyCorrectionWorkflow(BiorepositoryQCInspection inspection, String correctionActionType,
+            String correctionLocationId, String correctionLocationType, String correctionPositionCoordinate,
+            String correctionReason, String correctiveAction, String remarks, String correctedByUserId) {
         if (inspection == null) {
-            throw new IllegalArgumentException("QC inspection not found: " + inspectionId);
+            throw new IllegalArgumentException("Inspection is required for correction workflow");
         }
-        if (!QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
-            throw new IllegalStateException("Corrective action is only allowed for failed QC inspections");
-        }
-        if (correctiveReason == null || correctiveReason.trim().isEmpty()) {
-            throw new IllegalArgumentException("Corrective reason is required");
-        }
-        if (correctedCoordinate == null || correctedCoordinate.trim().isEmpty()) {
-            throw new IllegalArgumentException("Corrected coordinate is required");
+        if (inspection.getQcResult() != BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND) {
+            throw new IllegalArgumentException("Correction workflow requires discrepancy QC result");
         }
 
-        SampleItem sampleItem = inspection.getBioSample() != null ? inspection.getBioSample().getSampleItem() : null;
-        if (sampleItem == null || sampleItem.getId() == null) {
-            throw new IllegalStateException("QC inspection sample is missing sample item linkage");
+        BioSample bioSample = inspection.getBioSample();
+        if (bioSample == null || bioSample.getSampleItem() == null || bioSample.getSampleItem().getId() == null) {
+            throw new IllegalArgumentException("Sample item is required for correction workflow");
         }
 
-        Map<String, Object> before = sampleStorageService.getSampleItemLocation(sampleItem.getId());
-        String previousCoordinate = before != null ? asString(before.get("positionCoordinate")) : null;
-        String previousPath = before != null ? asString(before.get("hierarchicalPath")) : null;
+        String actionType = trimToNull(correctionActionType);
+        if (actionType == null) {
+            throw new IllegalArgumentException("Correction action type is required");
+        }
 
-        sampleStorageService.updateAssignmentMetadata(sampleItem.getId(), correctedCoordinate, correctiveReason);
+        String normalizedActionType = actionType.trim().toUpperCase();
+        String sampleItemId = bioSample.getSampleItem().getId();
 
-        Map<String, Object> after = sampleStorageService.getSampleItemLocation(sampleItem.getId());
-        String newCoordinate = after != null ? asString(after.get("positionCoordinate")) : null;
-        String newPath = after != null ? asString(after.get("hierarchicalPath")) : null;
+        String reason = trimToNull(correctionReason);
+        if (reason == null) {
+            reason = trimToNull(correctiveAction);
+        }
+        if (reason == null) {
+            reason = "QC discrepancy correction";
+        }
 
-        String note = "QC corrective action. InspectionId=" + inspectionId + ", batchId="
-                + asString(inspection.getQcBatchId()) + ", observed=" + asString(observedCoordinate) + ", old="
-                + asString(previousCoordinate) + ", new=" + asString(newCoordinate) + ", reason="
-                + correctiveReason.trim();
+        String oldCoordinate = composeCoordinate(inspection.getExpectedLocationPath(), inspection.getExpectedPositionCoordinate());
+        Timestamp correctionTimestamp = new Timestamp(System.currentTimeMillis());
+        String normalizedActionReason = normalizedActionType + ": " + reason;
 
-        chainOfCustodyService.logCustodyAction(sampleItem, CustodyAction.RETURN_INSPECTED, null, null, newCoordinate,
-                null, previousPath, newPath, null, note, sysUserId);
+        Map<String, Object> correction = new HashMap<>();
+        correction.put("actionType", normalizedActionType);
+        correction.put("reason", normalizedActionReason);
+        correction.put("correctionTimestamp", correctionTimestamp.toString());
 
-        inspection.setCorrectiveAction(correctiveReason.trim());
-        inspection.setRemarks((inspection.getRemarks() == null ? "" : inspection.getRemarks() + " | ")
-                + "Corrected coordinate from " + asString(previousCoordinate) + " to " + asString(newCoordinate));
-        inspection.setSysUserId(sysUserId);
+        if ("MARK_MISSING".equals(normalizedActionType)) {
+            if (!isSampleMissingDiscrepancy(inspection)) {
+                throw new IllegalArgumentException("MARK_MISSING requires discrepancy type SAMPLE_MISSING");
+            }
+            if (trimToNull(correctionLocationId) != null || trimToNull(correctionLocationType) != null
+                    || trimToNull(correctionPositionCoordinate) != null) {
+                throw new IllegalArgumentException("MARK_MISSING does not allow correction location/position fields");
+            }
+
+            Map<String, Object> missingUpdate = storageService.markSampleItemMissing(sampleItemId, normalizedActionReason,
+                    trimToNull(remarks));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> updatedLocation = missingUpdate.get("updatedLocation") instanceof Map
+                    ? (Map<String, Object>) missingUpdate.get("updatedLocation")
+                    : Map.of("hierarchicalPath", "Missing (not found during QC)", "positionCoordinate", null,
+                            "status", "MISSING");
+
+            String newCoordinate = composeCoordinate(asString(updatedLocation.get("hierarchicalPath")),
+                    asString(updatedLocation.get("positionCoordinate")));
+
+            inspection.setCorrectiveAction(normalizedActionReason);
+            inspection.setCorrectionActionType(normalizedActionType);
+            inspection.setCorrectionOldCoordinate(oldCoordinate);
+            inspection.setCorrectionNewCoordinate(trimToNull(newCoordinate) != null ? newCoordinate
+                    : "Missing (not found during QC)");
+            inspection.setCorrectionReason(normalizedActionReason);
+            inspection.setCorrectionByUser(trimToNull(correctedByUserId) != null ? trimToNull(correctedByUserId)
+                    : inspection.getSysUserId());
+            inspection.setCorrectionTimestamp(correctionTimestamp);
+            update(inspection);
+
+            correction.put("movementId", asString(missingUpdate.get("movementId")));
+            correction.put("updatedLocation", updatedLocation);
+            correction.put("auditTrail", buildAuditTrail(inspection));
+            return correction;
+        }
+
+        if (!"UPDATE_LOCATION".equals(normalizedActionType) && !"REASSIGN_POSITION".equals(normalizedActionType)) {
+            throw new IllegalArgumentException("Unsupported correction action type: " + correctionActionType);
+        }
+
+        String locationId = trimToNull(correctionLocationId);
+        String locationType = trimToNull(correctionLocationType);
+        if (locationId == null || locationType == null) {
+            throw new IllegalArgumentException(
+                    "Correction locationId and locationType are required for UPDATE_LOCATION/REASSIGN_POSITION");
+        }
+        if ("REASSIGN_POSITION".equals(normalizedActionType) && trimToNull(correctionPositionCoordinate) == null) {
+            throw new IllegalArgumentException("REASSIGN_POSITION requires correctionPositionCoordinate");
+        }
+
+        String movementId = storageService.moveSampleItemWithLocation(sampleItemId, locationId, locationType,
+                trimToNull(correctionPositionCoordinate), normalizedActionReason, trimToNull(remarks));
+
+        Map<String, Object> updatedLocation = storageService.getSampleItemLocation(sampleItemId);
+        String newCoordinate = composeCoordinate(asString(updatedLocation.get("hierarchicalPath")),
+                asString(updatedLocation.get("positionCoordinate")));
+
+        inspection.setCorrectiveAction(normalizedActionReason);
+        inspection.setCorrectionActionType(normalizedActionType);
+        inspection.setCorrectionOldCoordinate(oldCoordinate);
+        inspection.setCorrectionNewCoordinate(newCoordinate);
+        inspection.setCorrectionReason(normalizedActionReason);
+        inspection.setCorrectionByUser(trimToNull(correctedByUserId) != null ? trimToNull(correctedByUserId)
+                : inspection.getSysUserId());
+        inspection.setCorrectionTimestamp(correctionTimestamp);
         update(inspection);
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("inspectionId", inspectionId);
-        result.put("sampleItemId", sampleItem.getId());
-        result.put("oldCoordinate", previousCoordinate);
-        result.put("newCoordinate", newCoordinate);
-        result.put("oldPath", previousPath);
-        result.put("newPath", newPath);
-        result.put("reason", correctiveReason.trim());
-        return result;
+        correction.put("movementId", movementId);
+        correction.put("updatedLocation", updatedLocation);
+        correction.put("auditTrail", buildAuditTrail(inspection));
+        return correction;
     }
 
-    private List<String> selectDistributedBoxesByShelf(Map<String, List<Map<String, Object>>> candidatesByBox,
-            int boxesToSelect, Random random) {
-        Map<String, List<String>> boxesByShelf = new HashMap<>();
-        for (Map.Entry<String, List<Map<String, Object>>> entry : candidatesByBox.entrySet()) {
-            if (entry.getValue() == null || entry.getValue().isEmpty()) {
-                continue;
-            }
-
-            String shelfKey = asString(entry.getValue().get(0).get("shelfKey"));
-            String bucket = shelfKey != null ? shelfKey : "Unknown Shelf";
-            boxesByShelf.computeIfAbsent(bucket, key -> new ArrayList<>()).add(entry.getKey());
-        }
-
-        for (List<String> boxList : boxesByShelf.values()) {
-            Collections.shuffle(boxList, random);
-        }
-
-        List<String> shelfKeys = new ArrayList<>(boxesByShelf.keySet());
-        Collections.shuffle(shelfKeys, random);
-
-        List<String> selected = new ArrayList<>();
-        while (selected.size() < boxesToSelect) {
-            boolean addedInCycle = false;
-            for (String shelfKey : shelfKeys) {
-                List<String> boxes = boxesByShelf.get(shelfKey);
-                if (boxes == null || boxes.isEmpty()) {
-                    continue;
-                }
-                selected.add(boxes.remove(0));
-                addedInCycle = true;
-                if (selected.size() >= boxesToSelect) {
-                    break;
-                }
-            }
-            if (!addedInCycle) {
-                break;
-            }
-        }
-
-        return selected;
-    }
-
-    private List<Map<String, Object>> collectStoredSampleCandidates(Map<String, String> locationFilters) {
-        List<Map<String, Object>> candidates = new ArrayList<>();
-        List<BioSample> storedSamples = bioSampleService.getAllWithRelationships(50000);
-        List<String> sampleItemIds = new ArrayList<>();
-
-        for (BioSample bioSample : storedSamples) {
-            if (!BioSample.WorkflowStatus.STORED.equals(bioSample.getWorkflowStatus())) {
-                continue;
-            }
-            SampleItem sampleItem = bioSample.getSampleItem();
-            if (sampleItem == null || sampleItem.getId() == null || sampleItem.getId().trim().isEmpty()) {
-                continue;
-            }
-            sampleItemIds.add(sampleItem.getId().trim());
-        }
-
-        Map<String, Map<String, Object>> locationsBySampleItemId = sampleStorageService.getSampleItemLocations(sampleItemIds);
-
-        for (BioSample bioSample : storedSamples) {
-            if (!BioSample.WorkflowStatus.STORED.equals(bioSample.getWorkflowStatus())) {
-                continue;
-            }
-            SampleItem sampleItem = bioSample.getSampleItem();
-            if (sampleItem == null || sampleItem.getId() == null || sampleItem.getId().trim().isEmpty()) {
-                continue;
-            }
-
-            Map<String, Object> location = locationsBySampleItemId.get(sampleItem.getId().trim());
-            if (!isBiorepositoryFreezerLocation(location)) {
-                continue;
-            }
-
-            Map<String, String> parsedLocation = normalizeFreezerLocation(location);
-
-            Map<String, Object> candidate = new HashMap<>();
-            candidate.put("bioSampleId", bioSample.getId());
-            candidate.put("sampleItemId", sampleItem.getId());
-            candidate.put("externalId", sampleItem.getExternalId());
-            candidate.put("accessionNumber",
-                    sampleItem.getSample() != null ? sampleItem.getSample().getAccessionNumber() : null);
-            candidate.put("locationPath", asString(location.get("hierarchicalPath")));
-            candidate.put("expectedCoordinate", asString(location.get("positionCoordinate")));
-            candidate.put("freezer", parsedLocation.get("freezer"));
-            candidate.put("shelf", parsedLocation.get("shelf"));
-            candidate.put("rack", parsedLocation.get("rack"));
-            candidate.put("box", parsedLocation.get("box"));
-            candidate.put("shelfKey", parsedLocation.get("shelfKey"));
-            candidate.put("rackKey", parsedLocation.get("rackKey"));
-            candidate.put("boxKey", parsedLocation.get("boxKey"));
-
-            if (matchesLocationFilters(candidate, locationFilters)) {
-                candidates.add(candidate);
-            }
-        }
-
-        return candidates;
-    }
-
-    private boolean isBiorepositoryFreezer(Map<String, Object> device) {
-        return device != null
-                && Boolean.TRUE.equals(device.get("active"))
-                && Boolean.TRUE.equals(device.get("biorepositoryStorage"))
-                && "freezer".equalsIgnoreCase(asString(device.get("deviceType")));
-    }
-
-    private boolean isBiorepositoryFreezerLocation(Map<String, Object> location) {
-        return location != null
-                && !location.isEmpty()
-                && Boolean.TRUE.equals(location.get("deviceBiorepositoryStorage"))
-                && "freezer".equalsIgnoreCase(asString(location.get("deviceType")));
-    }
-
-    private Map<String, String> normalizeFreezerLocation(Map<String, Object> location) {
-        String freezer = asString(location.get("deviceName"));
-        String shelf = asString(location.get("shelfLabel"));
-        String rack = asString(location.get("rackLabel"));
-        String box = asString(location.get("boxLabel"));
-
-        if (freezer != null && shelf != null && rack != null && box != null) {
-            Map<String, String> parsed = new HashMap<>();
-            parsed.put("freezer", freezer);
-            parsed.put("shelf", shelf);
-            parsed.put("rack", rack);
-            parsed.put("box", box);
-            parsed.put("shelfKey", freezer + " > " + shelf);
-            parsed.put("rackKey", freezer + " > " + shelf + " > " + rack);
-            parsed.put("boxKey", freezer + " > " + shelf + " > " + rack + " > " + box);
-            return parsed;
-        }
-
-        return parseLocationParts(asString(location.get("hierarchicalPath")), asString(location.get("positionCoordinate")));
-    }
-
-    private Map<String, String> parseLocationParts(String locationPath, String coordinate) {
-        String freezer = null;
-        String shelf = null;
-        String rack = null;
-        String box = null;
-
-        String[] segments = locationPath != null ? locationPath.split("\\s*>\\s*") : new String[0];
-        List<String> normalizedSegments = new ArrayList<>();
-        for (String segment : segments) {
-            if (segment == null) {
-                continue;
-            }
-            String trimmed = segment.trim();
-            if (trimmed.isEmpty()) {
-                continue;
-            }
-            normalizedSegments.add(trimmed);
-
-            String lower = trimmed.toLowerCase();
-            if (freezer == null && lower.contains("freezer")) {
-                freezer = trimmed;
-                continue;
-            }
-            if (shelf == null && lower.contains("shelf")) {
-                shelf = trimmed;
-                continue;
-            }
-            if (rack == null && lower.contains("rack")) {
-                rack = trimmed;
-                continue;
-            }
-            if (box == null && (lower.contains("box") || lower.startsWith("bx"))) {
-                box = trimmed;
-            }
-        }
-
-        if (freezer == null && !normalizedSegments.isEmpty()) {
-            freezer = normalizedSegments.get(0);
-        }
-        if (shelf == null && normalizedSegments.size() > 1) {
-            shelf = normalizedSegments.get(1);
-        }
-        if (rack == null && normalizedSegments.size() > 2) {
-            rack = normalizedSegments.get(2);
-        }
-        if (box == null) {
-            if (normalizedSegments.size() > 3) {
-                box = normalizedSegments.get(3);
-            } else if (!normalizedSegments.isEmpty()) {
-                box = normalizedSegments.get(normalizedSegments.size() - 1);
-            }
-        }
-
-        String normalizedFreezer = freezer != null ? freezer : "Unknown Freezer";
-        String normalizedShelf = shelf != null ? shelf : "Unknown Shelf";
-        String normalizedRack = rack != null ? rack : "Unknown Rack";
-        String normalizedBox = box != null ? box : "Unknown Box";
-
-        Map<String, String> parsed = new HashMap<>();
-        parsed.put("freezer", normalizedFreezer);
-        parsed.put("shelf", normalizedShelf);
-        parsed.put("rack", normalizedRack);
-        parsed.put("box", normalizedBox);
-        parsed.put("shelfKey", normalizedFreezer + " > " + normalizedShelf);
-        parsed.put("rackKey", normalizedFreezer + " > " + normalizedShelf + " > " + normalizedRack);
-        parsed.put("boxKey", normalizedFreezer + " > " + normalizedShelf + " > " + normalizedRack + " > "
-                + normalizedBox);
-        parsed.put("position", coordinate != null ? coordinate : "");
-        return parsed;
-    }
-
-    private boolean matchesLocationFilters(Map<String, Object> candidate, Map<String, String> filters) {
-        if (filters == null || filters.isEmpty()) {
-            return true;
-        }
-
-        String freezerFilter = normalizeFilter(filters.get("freezer"));
-        String shelfFilter = normalizeFilter(filters.get("shelf"));
-        String rackFilter = normalizeFilter(filters.get("rack"));
-        String boxFilter = normalizeFilter(filters.get("box"));
-
-        if (!matchesSingleFilter(asString(candidate.get("freezer")), freezerFilter)) {
+    private boolean isSampleMissingDiscrepancy(BiorepositoryQCInspection inspection) {
+        if (inspection == null || inspection.getDiscrepancyType() == null) {
             return false;
         }
-        if (!matchesSingleFilter(asString(candidate.get("shelf")), shelfFilter)) {
-            return false;
-        }
-        if (!matchesSingleFilter(asString(candidate.get("rack")), rackFilter)) {
-            return false;
-        }
-
-        if (boxFilter != null) {
-            String box = asString(candidate.get("box"));
-            String boxKey = asString(candidate.get("boxKey"));
-            boolean boxMatches = matchesSingleFilter(box, boxFilter) || matchesSingleFilter(boxKey, boxFilter);
-            if (!boxMatches) {
-                return false;
-            }
-        }
-
-        return true;
+        return BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.equals(inspection.getDiscrepancyType())
+                || BiorepositoryQCInspection.DiscrepancyType.MISSING_SAMPLE.equals(inspection.getDiscrepancyType());
     }
 
-    private boolean matchesSingleFilter(String actual, String normalizedFilter) {
-        if (normalizedFilter == null) {
-            return true;
-        }
-        if (actual == null) {
-            return false;
-        }
-        return actual.toLowerCase().contains(normalizedFilter);
+    private Map<String, Object> buildAuditTrail(BiorepositoryQCInspection inspection) {
+        Map<String, Object> auditTrail = new HashMap<>();
+        String oldCoordinate = trimToNull(inspection.getCorrectionOldCoordinate()) != null
+                ? inspection.getCorrectionOldCoordinate()
+                : composeCoordinate(inspection.getExpectedLocationPath(), inspection.getExpectedPositionCoordinate());
+        String newCoordinate = trimToNull(inspection.getCorrectionNewCoordinate()) != null
+                ? inspection.getCorrectionNewCoordinate()
+                : oldCoordinate;
+        String timestamp = inspection.getCorrectionTimestamp() != null ? inspection.getCorrectionTimestamp().toString()
+                : (inspection.getInspectionDate() != null ? inspection.getInspectionDate().toString() : null);
+        String user = trimToNull(inspection.getCorrectionByUser()) != null ? inspection.getCorrectionByUser()
+                : inspection.getSysUserId();
+        String reason = trimToNull(inspection.getCorrectionReason()) != null ? inspection.getCorrectionReason()
+                : inspection.getCorrectiveAction();
+
+        auditTrail.put("oldCoordinate", oldCoordinate);
+        auditTrail.put("newCoordinate", newCoordinate);
+        auditTrail.put("fromCoordinates", oldCoordinate);
+        auditTrail.put("toCoordinates", newCoordinate);
+        auditTrail.put("user", user);
+        auditTrail.put("correctedBy", user);
+        auditTrail.put("timestamp", timestamp);
+        auditTrail.put("correctedAt", timestamp);
+        auditTrail.put("reason", reason);
+        return auditTrail;
     }
 
-    private String normalizeFilter(String filterValue) {
-        if (filterValue == null || filterValue.trim().isEmpty()) {
-            return null;
-        }
-        return filterValue.trim().toLowerCase();
-    }
-
-    private Map<String, Object> optionRow(String value, String label, String freezer, String shelf, String rack) {
-        Map<String, Object> row = new HashMap<>();
-        row.put("value", value);
-        row.put("label", label);
-        if (freezer != null) {
-            row.put("freezer", freezer);
-        }
-        if (shelf != null) {
-            row.put("shelf", shelf);
-        }
-        if (rack != null) {
-            row.put("rack", rack);
-        }
-        return row;
-    }
-
-    private int countMatchingPrefix(Set<String> values, String prefix) {
-        int count = 0;
-        for (String value : values) {
-            if (value != null && value.startsWith(prefix)) {
-                count++;
-            }
-        }
-        return count;
-    }
-
-    private String prefixBeforeLastSeparator(String value) {
-        if (value == null || !value.contains(" > ")) {
-            return value;
-        }
-        return value.substring(0, value.lastIndexOf(" > "));
-    }
-
-    private String suffixAfterLastSeparator(String value) {
-        if (value == null || !value.contains(" > ")) {
-            return value;
-        }
-        return value.substring(value.lastIndexOf(" > ") + 3);
-    }
-
-    private Integer asInteger(Object value) {
-        if (value == null) {
-            return null;
-        }
-        if (value instanceof Integer) {
-            return (Integer) value;
-        }
-        try {
-            return Integer.valueOf(String.valueOf(value));
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    private String asString(Object value) {
-        if (Objects.isNull(value)) {
-            return null;
-        }
-        String str = String.valueOf(value);
-        return str.isBlank() ? null : str;
-    }
-
-    private String resolveExpectedCoordinateSnapshot(BioSample bioSample, String providedSnapshot) {
-        if (providedSnapshot != null && !providedSnapshot.trim().isEmpty()) {
-            return providedSnapshot.trim();
-        }
-        if (bioSample == null || bioSample.getSampleItem() == null || bioSample.getSampleItem().getId() == null) {
-            return null;
-        }
-
-        Map<String, Object> location = sampleStorageService.getSampleItemLocation(bioSample.getSampleItem().getId());
-        if (location == null || location.isEmpty()) {
-            return null;
-        }
-
-        String path = asString(location.get("hierarchicalPath"));
-        String coordinate = asString(location.get("positionCoordinate"));
-
+    private String composeCoordinate(String locationPath, String positionCoordinate) {
+        String path = trimToNull(locationPath);
+        String coordinate = trimToNull(positionCoordinate);
         if (path == null && coordinate == null) {
             return null;
         }
@@ -826,6 +340,6 @@ public class BiorepositoryQCInspectionServiceImpl extends
         if (coordinate == null) {
             return path;
         }
-        return path + " @ " + coordinate;
+        return path + " > " + coordinate;
     }
 }

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQcOutcomeDerivation.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQcOutcomeDerivation.java
@@ -52,7 +52,7 @@ public final class BiorepositoryQcOutcomeDerivation {
 
     public static boolean isMarkMissingCorrectionApplied(BiorepositoryQCInspection inspection) {
         String correctionActionType = trimToNull(inspection != null ? inspection.getCorrectionActionType() : null);
-        return correctionActionType != null && "MARK_MISSING".equalsIgnoreCase(correctionActionType);
+        return correctionActionType != null && correctionActionType.equalsIgnoreCase("MARK_MISSING");
     }
 
     private static String trimToNull(String value) {

--- a/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQcOutcomeDerivation.java
+++ b/src/main/java/org/openelisglobal/biorepository/service/BiorepositoryQcOutcomeDerivation.java
@@ -1,0 +1,65 @@
+package org.openelisglobal.biorepository.service;
+
+import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
+
+/**
+ * Derives QC status and lifecycle outcome from persisted inspection state.
+ */
+public final class BiorepositoryQcOutcomeDerivation {
+
+    private BiorepositoryQcOutcomeDerivation() {
+    }
+
+    public static String deriveQcStatus(BiorepositoryQCInspection inspection) {
+        if (inspection == null || inspection.getQcResult() == null) {
+            return "UNKNOWN";
+        }
+        if (BiorepositoryQCInspection.QCResult.VERIFIED.equals(inspection.getQcResult())) {
+            return "VALID";
+        }
+        if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+            if (isMarkMissingCorrectionApplied(inspection)) {
+                return "MISSING";
+            }
+            return "QC_FAILED";
+        }
+        return "UNKNOWN";
+    }
+
+    public static String deriveLifecycleOutcome(BiorepositoryQCInspection inspection) {
+        if (inspection == null || inspection.getQcResult() == null) {
+            return "UNKNOWN";
+        }
+        if (BiorepositoryQCInspection.QCResult.VERIFIED.equals(inspection.getQcResult())) {
+            return "PASSED";
+        }
+        if (BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(inspection.getQcResult())) {
+            if (isMarkMissingCorrectionApplied(inspection)) {
+                return "FAILED_MARKED_MISSING";
+            }
+            if (hasAppliedCorrectionWorkflow(inspection)) {
+                return "FAILED_CORRECTED";
+            }
+            return "FAILED_PENDING_CORRECTION";
+        }
+        return "UNKNOWN";
+    }
+
+    public static boolean hasAppliedCorrectionWorkflow(BiorepositoryQCInspection inspection) {
+        String correctionActionType = trimToNull(inspection != null ? inspection.getCorrectionActionType() : null);
+        return correctionActionType != null;
+    }
+
+    public static boolean isMarkMissingCorrectionApplied(BiorepositoryQCInspection inspection) {
+        String correctionActionType = trimToNull(inspection != null ? inspection.getCorrectionActionType() : null);
+        return correctionActionType != null && "MARK_MISSING".equalsIgnoreCase(correctionActionType);
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryQCInspection.java
+++ b/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryQCInspection.java
@@ -54,7 +54,6 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
         WRONG_SAMPLE_IN_POSITION("Wrong sample in position"),
         MISPLACED_SAMPLE_FOUND("Misplaced sample (found elsewhere)"),
         EMPTY_POSITION_REGISTERED("Empty position but registered as occupied"),
-        EMPTY_POSITION_REGISTERED_OCCUPIED("Empty Position But Registered Occupied"),
         LABELING_ERROR("Labeling error"),
         BOX_RACK_MISPLACEMENT("Box/rack misplacement"),
         // Legacy values retained for backward compatibility with existing records
@@ -171,16 +170,6 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
     private String remarks;
 
     // ========================================
-    // QC Round / Coordinate Snapshot
-    // ========================================
-
-    @Column(name = "qc_batch_id", length = 80)
-    private String qcBatchId;
-
-    @Column(name = "expected_coordinate_snapshot", length = 512)
-    private String expectedCoordinateSnapshot;
-
-    // ========================================
     // Expected coordinate snapshot at inspection time
     // ========================================
 
@@ -191,8 +180,22 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
     private String expectedPositionCoordinate;
 
     // ========================================
-    // Correction workflow audit fields
+    // Inspection Metadata
     // ========================================
+
+    @NotNull(message = "Inspector name is required")
+    @Column(name = "inspector_name", nullable = false, length = 100)
+    private String inspectorName;
+
+    @NotNull(message = "Inspection date is required")
+    @Column(name = "inspection_date", nullable = false)
+    private Timestamp inspectionDate;
+
+    @Column(name = "qc_batch_id", length = 80)
+    private String qcBatchId;
+
+    @Column(name = "expected_coordinate_snapshot", length = 512)
+    private String expectedCoordinateSnapshot;
 
     @Column(name = "correction_action_type", length = 50)
     private String correctionActionType;
@@ -211,18 +214,6 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
 
     @Column(name = "correction_timestamp")
     private Timestamp correctionTimestamp;
-
-    // ========================================
-    // Inspection Metadata
-    // ========================================
-
-    @NotNull(message = "Inspector name is required")
-    @Column(name = "inspector_name", nullable = false, length = 100)
-    private String inspectorName;
-
-    @NotNull(message = "Inspection date is required")
-    @Column(name = "inspection_date", nullable = false)
-    private Timestamp inspectionDate;
 
     @Column(name = "sys_user_id", nullable = false, length = 36)
     private String sysUserId;
@@ -344,22 +335,6 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
         this.remarks = remarks;
     }
 
-    public String getQcBatchId() {
-        return qcBatchId;
-    }
-
-    public void setQcBatchId(String qcBatchId) {
-        this.qcBatchId = qcBatchId;
-    }
-
-    public String getExpectedCoordinateSnapshot() {
-        return expectedCoordinateSnapshot;
-    }
-
-    public void setExpectedCoordinateSnapshot(String expectedCoordinateSnapshot) {
-        this.expectedCoordinateSnapshot = expectedCoordinateSnapshot;
-    }
-
     public String getExpectedLocationPath() {
         return expectedLocationPath;
     }
@@ -374,6 +349,38 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
 
     public void setExpectedPositionCoordinate(String expectedPositionCoordinate) {
         this.expectedPositionCoordinate = expectedPositionCoordinate;
+    }
+
+    public String getInspectorName() {
+        return inspectorName;
+    }
+
+    public void setInspectorName(String inspectorName) {
+        this.inspectorName = inspectorName;
+    }
+
+    public Timestamp getInspectionDate() {
+        return inspectionDate;
+    }
+
+    public void setInspectionDate(Timestamp inspectionDate) {
+        this.inspectionDate = inspectionDate;
+    }
+
+    public String getQcBatchId() {
+        return qcBatchId;
+    }
+
+    public void setQcBatchId(String qcBatchId) {
+        this.qcBatchId = qcBatchId;
+    }
+
+    public String getExpectedCoordinateSnapshot() {
+        return expectedCoordinateSnapshot;
+    }
+
+    public void setExpectedCoordinateSnapshot(String expectedCoordinateSnapshot) {
+        this.expectedCoordinateSnapshot = expectedCoordinateSnapshot;
     }
 
     public String getCorrectionActionType() {
@@ -422,22 +429,6 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
 
     public void setCorrectionTimestamp(Timestamp correctionTimestamp) {
         this.correctionTimestamp = correctionTimestamp;
-    }
-
-    public String getInspectorName() {
-        return inspectorName;
-    }
-
-    public void setInspectorName(String inspectorName) {
-        this.inspectorName = inspectorName;
-    }
-
-    public Timestamp getInspectionDate() {
-        return inspectionDate;
-    }
-
-    public void setInspectionDate(Timestamp inspectionDate) {
-        this.inspectionDate = inspectionDate;
     }
 
     /**

--- a/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryQCInspection.java
+++ b/src/main/java/org/openelisglobal/biorepository/valueholder/BiorepositoryQCInspection.java
@@ -49,11 +49,21 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
      * Types of discrepancies that can be found during QC inspection.
      */
     public enum DiscrepancyType {
-        MISSING_SAMPLE("Missing Sample"), WRONG_SAMPLE_IN_POSITION("Wrong Sample In Position"),
-        MISPLACED_ITEM("Misplaced Item (Found Elsewhere)"),
-        EMPTY_POSITION_REGISTERED_OCCUPIED("Empty Position But Registered Occupied"), LABELING_ERROR("Labeling Error"),
-        BOX_RACK_MISPLACEMENT("Box/Rack Misplacement"), DAMAGED_LABEL("Damaged/Illegible Label"),
-        CONTAINER_DAMAGE("Container Damage"), VOLUME_DISCREPANCY("Volume Discrepancy"), OTHER("Other");
+        // Document-aligned core discrepancy classes
+        SAMPLE_MISSING("Sample missing"),
+        WRONG_SAMPLE_IN_POSITION("Wrong sample in position"),
+        MISPLACED_SAMPLE_FOUND("Misplaced sample (found elsewhere)"),
+        EMPTY_POSITION_REGISTERED("Empty position but registered as occupied"),
+        EMPTY_POSITION_REGISTERED_OCCUPIED("Empty Position But Registered Occupied"),
+        LABELING_ERROR("Labeling error"),
+        BOX_RACK_MISPLACEMENT("Box/rack misplacement"),
+        // Legacy values retained for backward compatibility with existing records
+        MISSING_SAMPLE("Missing Sample"),
+        DAMAGED_LABEL("Damaged/Illegible Label"),
+        MISPLACED_ITEM("Misplaced Item (wrong position)"),
+        CONTAINER_DAMAGE("Container Damage"),
+        VOLUME_DISCREPANCY("Volume Discrepancy"),
+        OTHER("Other");
 
         private final String displayValue;
 
@@ -71,6 +81,31 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
         public static DiscrepancyType fromString(String value) {
             if (value == null || value.trim().isEmpty()) {
                 return null;
+            }
+            String normalized = value.trim().toUpperCase();
+            switch (normalized) {
+            case "SAMPLE_MISSING":
+            case "MISSING_SAMPLE":
+                return SAMPLE_MISSING;
+            case "WRONG_SAMPLE_IN_POSITION":
+            case "WRONG_SAMPLE":
+                return WRONG_SAMPLE_IN_POSITION;
+            case "MISPLACED_SAMPLE_FOUND":
+            case "MISPLACED_SAMPLE_FOUND_ELSEWHERE":
+            case "MISPLACED_ITEM":
+                return MISPLACED_SAMPLE_FOUND;
+            case "EMPTY_POSITION_REGISTERED":
+            case "EMPTY_POSITION_BUT_REGISTERED_AS_OCCUPIED":
+                return EMPTY_POSITION_REGISTERED;
+            case "LABELING_ERROR":
+            case "DAMAGED_LABEL":
+                return LABELING_ERROR;
+            case "BOX_RACK_MISPLACEMENT":
+            case "BOX_OR_RACK_MISPLACEMENT":
+            case "CONTAINER_DAMAGE":
+                return BOX_RACK_MISPLACEMENT;
+            default:
+                break;
             }
             for (DiscrepancyType type : values()) {
                 if (type.name().equalsIgnoreCase(value)) {
@@ -144,6 +179,38 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
 
     @Column(name = "expected_coordinate_snapshot", length = 512)
     private String expectedCoordinateSnapshot;
+
+    // ========================================
+    // Expected coordinate snapshot at inspection time
+    // ========================================
+
+    @Column(name = "expected_location_path", columnDefinition = "TEXT")
+    private String expectedLocationPath;
+
+    @Column(name = "expected_position_coordinate", length = 50)
+    private String expectedPositionCoordinate;
+
+    // ========================================
+    // Correction workflow audit fields
+    // ========================================
+
+    @Column(name = "correction_action_type", length = 50)
+    private String correctionActionType;
+
+    @Column(name = "correction_old_coordinate", columnDefinition = "TEXT")
+    private String correctionOldCoordinate;
+
+    @Column(name = "correction_new_coordinate", columnDefinition = "TEXT")
+    private String correctionNewCoordinate;
+
+    @Column(name = "correction_reason", columnDefinition = "TEXT")
+    private String correctionReason;
+
+    @Column(name = "correction_by_user", length = 36)
+    private String correctionByUser;
+
+    @Column(name = "correction_timestamp")
+    private Timestamp correctionTimestamp;
 
     // ========================================
     // Inspection Metadata
@@ -291,6 +358,70 @@ public class BiorepositoryQCInspection extends BaseObject<Integer> {
 
     public void setExpectedCoordinateSnapshot(String expectedCoordinateSnapshot) {
         this.expectedCoordinateSnapshot = expectedCoordinateSnapshot;
+    }
+
+    public String getExpectedLocationPath() {
+        return expectedLocationPath;
+    }
+
+    public void setExpectedLocationPath(String expectedLocationPath) {
+        this.expectedLocationPath = expectedLocationPath;
+    }
+
+    public String getExpectedPositionCoordinate() {
+        return expectedPositionCoordinate;
+    }
+
+    public void setExpectedPositionCoordinate(String expectedPositionCoordinate) {
+        this.expectedPositionCoordinate = expectedPositionCoordinate;
+    }
+
+    public String getCorrectionActionType() {
+        return correctionActionType;
+    }
+
+    public void setCorrectionActionType(String correctionActionType) {
+        this.correctionActionType = correctionActionType;
+    }
+
+    public String getCorrectionOldCoordinate() {
+        return correctionOldCoordinate;
+    }
+
+    public void setCorrectionOldCoordinate(String correctionOldCoordinate) {
+        this.correctionOldCoordinate = correctionOldCoordinate;
+    }
+
+    public String getCorrectionNewCoordinate() {
+        return correctionNewCoordinate;
+    }
+
+    public void setCorrectionNewCoordinate(String correctionNewCoordinate) {
+        this.correctionNewCoordinate = correctionNewCoordinate;
+    }
+
+    public String getCorrectionReason() {
+        return correctionReason;
+    }
+
+    public void setCorrectionReason(String correctionReason) {
+        this.correctionReason = correctionReason;
+    }
+
+    public String getCorrectionByUser() {
+        return correctionByUser;
+    }
+
+    public void setCorrectionByUser(String correctionByUser) {
+        this.correctionByUser = correctionByUser;
+    }
+
+    public Timestamp getCorrectionTimestamp() {
+        return correctionTimestamp;
+    }
+
+    public void setCorrectionTimestamp(Timestamp correctionTimestamp) {
+        this.correctionTimestamp = correctionTimestamp;
     }
 
     public String getInspectorName() {

--- a/src/main/java/org/openelisglobal/storage/service/SampleStorageService.java
+++ b/src/main/java/org/openelisglobal/storage/service/SampleStorageService.java
@@ -56,6 +56,17 @@ public interface SampleStorageService {
     String moveSampleItemWithLocation(String sampleItemId, String locationId, String locationType,
             String positionCoordinate, String reason, String notes);
 
+    /**
+     * Mark a sample item as missing by clearing its current assignment location while
+     * retaining the assignment row for audit/traceability.
+     *
+     * @param sampleItemId SampleItem ID
+     * @param reason       Required reason for missing state
+     * @param notes        Optional notes
+     * @return Map containing movementId, status, and updatedLocation details
+     */
+    java.util.Map<String, Object> markSampleItemMissing(String sampleItemId, String reason, String notes);
+
     java.util.Map<String, Object> updateAssignmentMetadata(String sampleItemId, String positionCoordinate,
             String notes);
 

--- a/src/main/java/org/openelisglobal/storage/service/SampleStorageServiceImpl.java
+++ b/src/main/java/org/openelisglobal/storage/service/SampleStorageServiceImpl.java
@@ -287,6 +287,84 @@ public class SampleStorageServiceImpl implements SampleStorageService {
 
     @Override
     @Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+    public Map<String, Object> markSampleItemMissing(String sampleItemId, String reason, String notes) {
+        try {
+            if (sampleItemId == null || sampleItemId.trim().isEmpty()) {
+                throw new LIMSRuntimeException("SampleItem ID is required");
+            }
+            if (reason == null || reason.trim().isEmpty()) {
+                throw new LIMSRuntimeException("Reason is required when marking sample as missing");
+            }
+
+            SampleItem sampleItem = resolveSampleItem(sampleItemId);
+            SampleStorageAssignment existingAssignment = sampleStorageAssignmentDAO.findBySampleItemId(sampleItem.getId());
+
+            Integer previousLocationId = null;
+            String previousLocationType = null;
+            String previousPositionCoordinate = null;
+            String previousLocationPath = null;
+
+            if (existingAssignment != null) {
+                previousLocationId = existingAssignment.getLocationId();
+                previousLocationType = existingAssignment.getLocationType();
+                previousPositionCoordinate = existingAssignment.getPositionCoordinate();
+                previousLocationPath = buildHierarchicalPathForAssignment(existingAssignment);
+
+                existingAssignment.setLocationId(null);
+                existingAssignment.setLocationType(null);
+                existingAssignment.setPositionCoordinate(null);
+                existingAssignment.setAssignedDate(new Timestamp(System.currentTimeMillis()));
+
+                String trimmedNotes = notes != null ? notes.trim() : null;
+                if (trimmedNotes == null || trimmedNotes.isEmpty()) {
+                    existingAssignment.setNotes("MARK_MISSING: " + reason.trim());
+                } else {
+                    existingAssignment.setNotes(trimmedNotes);
+                }
+
+                sampleStorageAssignmentDAO.update(existingAssignment);
+            }
+
+            Integer movementIdInt = null;
+            if (previousLocationId != null && previousLocationType != null) {
+                SampleStorageMovement movement = new SampleStorageMovement();
+                movement.setSampleItem(sampleItem);
+                movement.setPreviousLocationId(previousLocationId);
+                movement.setPreviousLocationType(previousLocationType);
+                movement.setPreviousPositionCoordinate(previousPositionCoordinate);
+                movement.setNewLocationId(null);
+                movement.setNewLocationType(null);
+                movement.setNewPositionCoordinate(null);
+                movement.setMovementDate(new Timestamp(System.currentTimeMillis()));
+                movement.setReason("MARK_MISSING: " + reason.trim());
+                movement.setMovedByUserId(1);
+                movementIdInt = sampleStorageMovementDAO.insert(movement);
+            }
+
+            Map<String, Object> updatedLocation = new HashMap<>();
+            updatedLocation.put("hierarchicalPath", "Missing (not found during QC)");
+            updatedLocation.put("positionCoordinate", null);
+            updatedLocation.put("status", "MISSING");
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("movementId", movementIdInt != null ? movementIdInt.toString() : null);
+            response.put("sampleItemId", sampleItem.getId());
+            response.put("status", "MISSING");
+            response.put("reason", reason.trim());
+            response.put("updatedLocation", updatedLocation);
+            if (previousLocationPath != null) {
+                response.put("previousLocation", previousLocationPath);
+            }
+
+            return response;
+        } catch (StaleObjectStateException e) {
+            throw new LIMSRuntimeException("Sample was just modified by another user. Please refresh and try again.",
+                    e);
+        }
+    }
+
+    @Override
+    @Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
     public Map<String, Object> disposeSampleItem(String sampleItemId, String reason, String method, String notes) {
         try {
             // Validate inputs

--- a/src/main/resources/liquibase/3.5.x.x/034-qc-core-alignment.xml
+++ b/src/main/resources/liquibase/3.5.x.x/034-qc-core-alignment.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="qc-core-add-expected-coordinate-snapshot" author="openelis-biorepository">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="biorepository_qc_inspection" schemaName="clinlims"/>
+        </preConditions>
+
+        <comment>Add expected coordinate snapshot fields required for QC result traceability</comment>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="expected_location_path" type="TEXT"/>
+        </addColumn>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="expected_position_coordinate" type="VARCHAR(50)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="qc-core-update-discrepancy-constraint" author="openelis-biorepository">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="biorepository_qc_inspection" schemaName="clinlims"/>
+        </preConditions>
+
+        <comment>Align discrepancy values with Periodic QC document while retaining legacy values</comment>
+
+        <sql>
+            ALTER TABLE clinlims.biorepository_qc_inspection
+            DROP CONSTRAINT IF EXISTS check_discrepancy_type;
+        </sql>
+
+        <sql>
+            ALTER TABLE clinlims.biorepository_qc_inspection
+            ADD CONSTRAINT check_discrepancy_type
+            CHECK (
+                discrepancy_type IS NULL OR discrepancy_type IN (
+                    'SAMPLE_MISSING',
+                    'WRONG_SAMPLE_IN_POSITION',
+                    'MISPLACED_SAMPLE_FOUND',
+                    'EMPTY_POSITION_REGISTERED',
+                    'LABELING_ERROR',
+                    'BOX_RACK_MISPLACEMENT',
+                    'MISSING_SAMPLE',
+                    'DAMAGED_LABEL',
+                    'MISPLACED_ITEM',
+                    'CONTAINER_DAMAGE',
+                    'VOLUME_DISCREPANCY',
+                    'OTHER'
+                )
+            );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/035-qc-correction-audit-fields.xml
+++ b/src/main/resources/liquibase/3.5.x.x/035-qc-correction-audit-fields.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="qc-add-correction-audit-columns" author="openelis-biorepository">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="biorepository_qc_inspection" schemaName="clinlims"/>
+        </preConditions>
+
+        <comment>
+            Persist correction workflow audit fields so old/new coordinate, user,
+            timestamp, and reason are durable across UPDATE_LOCATION,
+            REASSIGN_POSITION, and MARK_MISSING actions.
+        </comment>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="correction_action_type" type="VARCHAR(50)"/>
+        </addColumn>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="correction_old_coordinate" type="TEXT"/>
+        </addColumn>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="correction_new_coordinate" type="TEXT"/>
+        </addColumn>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="correction_reason" type="TEXT"/>
+        </addColumn>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="correction_by_user" type="VARCHAR(36)"/>
+        </addColumn>
+
+        <addColumn tableName="biorepository_qc_inspection" schemaName="clinlims">
+            <column name="correction_timestamp" type="TIMESTAMP"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -104,4 +104,9 @@
     <include file="liquibase/3.5.x.x/031-biorepository-qc-round-hardening.xml"/>
     <include file="liquibase/3.5.x.x/034-add-biorepository-storage-flag.xml"/>
 
+    <!-- M14: QC core behavior alignment (required discrepancy + coordinate snapshot) -->
+    <include file="liquibase/3.5.x.x/034-qc-core-alignment.xml"/>
+    <!-- M15: Persist QC correction workflow audit fields -->
+    <include file="liquibase/3.5.x.x/035-qc-correction-audit-fields.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -96,17 +96,12 @@
 
     <include file="liquibase/3.5.x.x/033-add-retrieval-notebook-link.xml"/>
 
-    <!-- ======================================================== -->
-    <!-- Biorepository QC Round hardening                        -->
-    <!-- Add qc_batch_id + expected snapshot + discrepancy check -->
-    <!-- ======================================================== -->
-
+    <!-- M14: QC round hardening (batch id + generated round behavior) -->
     <include file="liquibase/3.5.x.x/031-biorepository-qc-round-hardening.xml"/>
     <include file="liquibase/3.5.x.x/034-add-biorepository-storage-flag.xml"/>
 
     <!-- M14: QC core behavior alignment (required discrepancy + coordinate snapshot) -->
     <include file="liquibase/3.5.x.x/034-qc-core-alignment.xml"/>
-    <!-- M15: Persist QC correction workflow audit fields -->
     <include file="liquibase/3.5.x.x/035-qc-correction-audit-fields.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/biorepository/BiorepositoryQCInspectionServiceIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/BiorepositoryQCInspectionServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
@@ -20,6 +21,12 @@ import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.sampleitem.service.SampleItemService;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.storage.service.SampleStorageService;
+import org.openelisglobal.storage.service.StorageLocationService;
+import org.openelisglobal.storage.valueholder.StorageBox;
+import org.openelisglobal.storage.valueholder.StorageDevice;
+import org.openelisglobal.storage.valueholder.StorageRack;
+import org.openelisglobal.storage.valueholder.StorageShelf;
 import org.openelisglobal.systemuser.service.SystemUserService;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.openelisglobal.typeofsample.service.TypeOfSampleService;
@@ -52,6 +59,12 @@ public class BiorepositoryQCInspectionServiceIntegrationTest extends BaseWebCont
 
     @Autowired
     private SystemUserService systemUserService;
+
+    @Autowired
+    private SampleStorageService sampleStorageService;
+
+    @Autowired
+    private StorageLocationService storageLocationService;
 
     private SystemUser testUser;
     private TypeOfSample serumType;
@@ -479,7 +492,162 @@ public class BiorepositoryQCInspectionServiceIntegrationTest extends BaseWebCont
         assertNull("Should return null for null input", parsed);
     }
 
+    @Test
+    public void testApplyCorrectionWorkflow_UpdateLocation_PersistsAuditFields() {
+        BioSample bioSample = createTestBioSample("QC-CORR-UPDATE-" + System.currentTimeMillis());
+        LocationTarget initialLocation = selectActiveLocation("box");
+        String initialCoordinate = "QA-" + (System.currentTimeMillis() % 10000);
+        sampleStorageService.assignSampleItemWithLocation(bioSample.getSampleItem().getId(), initialLocation.id,
+                initialLocation.type, initialCoordinate, "Initial assignment for QC correction");
+
+        BiorepositoryQCInspection inspection = qcInspectionService.createInspection(bioSample.getId(), "Inspector",
+                new Timestamp(System.currentTimeMillis()), true, true, true, true, false, "MISPLACED_SAMPLE_FOUND",
+                "Sample appears misplaced", "Initial discrepancy", testUser.getId().toString());
+
+        LocationTarget targetLocation = selectActiveLocation("rack");
+        Map<String, Object> correction = qcInspectionService.applyCorrectionWorkflow(inspection, "UPDATE_LOCATION",
+                targetLocation.id, targetLocation.type, "B2", "Moved to correct rack", "Moved to correct rack",
+                "Confirmed during QC", testUser.getId().toString());
+
+        BiorepositoryQCInspection updated = qcInspectionService.get(inspection.getId());
+        assertEquals("UPDATE_LOCATION", updated.getCorrectionActionType());
+        assertNotNull("Correction timestamp should be persisted", updated.getCorrectionTimestamp());
+        assertEquals("Correction user should be persisted", testUser.getId().toString(), updated.getCorrectionByUser());
+        assertNotNull("Correction old coordinate should be persisted", updated.getCorrectionOldCoordinate());
+        assertNotNull("Correction new coordinate should be persisted", updated.getCorrectionNewCoordinate());
+        assertTrue("Correction reason should include action prefix",
+                updated.getCorrectionReason().startsWith("UPDATE_LOCATION:"));
+        assertTrue("Returned correction should include movementId", correction.containsKey("movementId"));
+        assertTrue("Returned correction should include auditTrail", correction.containsKey("auditTrail"));
+    }
+
+    @Test
+    public void testApplyCorrectionWorkflow_ReassignPosition_PersistsAuditFields() {
+        BioSample bioSample = createTestBioSample("QC-CORR-REASSIGN-" + System.currentTimeMillis());
+        LocationTarget initialLocation = selectActiveLocation("box");
+        String initialCoordinate = "QB-" + (System.currentTimeMillis() % 10000);
+        sampleStorageService.assignSampleItemWithLocation(bioSample.getSampleItem().getId(), initialLocation.id,
+                initialLocation.type, initialCoordinate, "Initial assignment for position reassign");
+
+        BiorepositoryQCInspection inspection = qcInspectionService.createInspection(bioSample.getId(), "Inspector",
+                new Timestamp(System.currentTimeMillis()), true, true, true, true, false, "MISPLACED_SAMPLE_FOUND",
+                "Position mismatch", "Detected wrong coordinate", testUser.getId().toString());
+
+        Map<String, Object> correction = qcInspectionService.applyCorrectionWorkflow(inspection, "REASSIGN_POSITION",
+                initialLocation.id, initialLocation.type, "C7", "Reassigned to correct position",
+                "Reassigned to correct position", "Confirmed coordinate update", testUser.getId().toString());
+
+        BiorepositoryQCInspection updated = qcInspectionService.get(inspection.getId());
+        assertEquals("REASSIGN_POSITION", updated.getCorrectionActionType());
+        assertNotNull("Correction timestamp should be persisted", updated.getCorrectionTimestamp());
+        assertEquals("Correction user should be persisted", testUser.getId().toString(), updated.getCorrectionByUser());
+        assertTrue("New coordinate should include updated position",
+                updated.getCorrectionNewCoordinate() != null && updated.getCorrectionNewCoordinate().contains("C7"));
+        assertTrue("Returned correction should include auditTrail", correction.containsKey("auditTrail"));
+    }
+
+    @Test
+    public void testApplyCorrectionWorkflow_MarkMissing_PersistsAuditFields() {
+        BioSample bioSample = createTestBioSample("QC-CORR-MISSING-" + System.currentTimeMillis());
+        LocationTarget initialLocation = selectActiveLocation("box");
+        String initialCoordinate = "QC-" + (System.currentTimeMillis() % 10000);
+        sampleStorageService.assignSampleItemWithLocation(bioSample.getSampleItem().getId(), initialLocation.id,
+                initialLocation.type, initialCoordinate, "Initial assignment before missing mark");
+
+        BiorepositoryQCInspection inspection = qcInspectionService.createInspection(bioSample.getId(), "Inspector",
+                new Timestamp(System.currentTimeMillis()), false, true, true, true, true, "SAMPLE_MISSING",
+                "Sample not found", "Missing during QC", testUser.getId().toString());
+
+        Map<String, Object> correction = qcInspectionService.applyCorrectionWorkflow(inspection, "MARK_MISSING", null,
+                null, null, "Unable to locate sample in expected box", "Unable to locate sample in expected box",
+                "Escalate to inventory review", testUser.getId().toString());
+
+        BiorepositoryQCInspection updated = qcInspectionService.get(inspection.getId());
+        assertEquals("MARK_MISSING", updated.getCorrectionActionType());
+        assertNotNull("Correction timestamp should be persisted", updated.getCorrectionTimestamp());
+        assertEquals("Correction user should be persisted", testUser.getId().toString(), updated.getCorrectionByUser());
+        assertEquals("Missing correction should persist canonical target coordinate", "Missing (not found during QC)",
+                updated.getCorrectionNewCoordinate());
+        assertTrue("Correction reason should include action prefix",
+                updated.getCorrectionReason().startsWith("MARK_MISSING:"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> updatedLocation = (Map<String, Object>) correction.get("updatedLocation");
+        assertEquals("MISSING", updatedLocation.get("status"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testApplyCorrectionWorkflow_MarkMissing_RejectsLocationFields() {
+        BioSample bioSample = createTestBioSample("QC-CORR-MISSING-INVALID-" + System.currentTimeMillis());
+        LocationTarget initialLocation = selectActiveLocation("box");
+        sampleStorageService.assignSampleItemWithLocation(bioSample.getSampleItem().getId(), initialLocation.id,
+                initialLocation.type, "QD-1", "Initial assignment before invalid missing mark");
+
+        BiorepositoryQCInspection inspection = qcInspectionService.createInspection(bioSample.getId(), "Inspector",
+                new Timestamp(System.currentTimeMillis()), false, true, true, true, true, "SAMPLE_MISSING",
+                "Sample not found", "Missing during QC", testUser.getId().toString());
+
+        qcInspectionService.applyCorrectionWorkflow(inspection, "MARK_MISSING", initialLocation.id, initialLocation.type, "B2",
+                "invalid request", "invalid request", "invalid request", testUser.getId().toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testApplyCorrectionWorkflow_ReassignPosition_RequiresPositionCoordinate() {
+        BioSample bioSample = createTestBioSample("QC-CORR-REASSIGN-INVALID-" + System.currentTimeMillis());
+        LocationTarget initialLocation = selectActiveLocation("box");
+        sampleStorageService.assignSampleItemWithLocation(bioSample.getSampleItem().getId(), initialLocation.id,
+                initialLocation.type, "QE-1", "Initial assignment before invalid reassign");
+
+        BiorepositoryQCInspection inspection = qcInspectionService.createInspection(bioSample.getId(), "Inspector",
+                new Timestamp(System.currentTimeMillis()), true, true, true, true, false, "MISPLACED_SAMPLE_FOUND",
+                "Position mismatch", "Detected wrong coordinate", testUser.getId().toString());
+
+        qcInspectionService.applyCorrectionWorkflow(inspection, "REASSIGN_POSITION", initialLocation.id, initialLocation.type,
+                null, "invalid request", "invalid request", "invalid request", testUser.getId().toString());
+    }
+
     // ========== HELPER METHODS ==========
+
+    private LocationTarget selectActiveLocation(String preferredType) {
+        if ("box".equals(preferredType)) {
+            for (StorageBox box : storageLocationService.getAllBoxes()) {
+                if (box != null && Boolean.TRUE.equals(box.getActive()) && box.getId() != null) {
+                    return new LocationTarget(box.getId().toString(), "box");
+                }
+            }
+        }
+
+        if ("rack".equals(preferredType)) {
+            for (StorageRack rack : storageLocationService.getAllRacks()) {
+                if (rack != null && Boolean.TRUE.equals(rack.getActive()) && rack.getId() != null) {
+                    return new LocationTarget(rack.getId().toString(), "rack");
+                }
+            }
+        }
+
+        for (StorageShelf shelf : storageLocationService.getAllShelves()) {
+            if (shelf != null && Boolean.TRUE.equals(shelf.getActive()) && shelf.getId() != null) {
+                return new LocationTarget(shelf.getId().toString(), "shelf");
+            }
+        }
+
+        for (StorageDevice device : storageLocationService.getAllDevices()) {
+            if (device != null && Boolean.TRUE.equals(device.getActive()) && device.getId() != null) {
+                return new LocationTarget(device.getId().toString(), "device");
+            }
+        }
+
+        throw new IllegalStateException("No active storage location available for correction workflow test");
+    }
+
+    private static class LocationTarget {
+        private final String id;
+        private final String type;
+
+        private LocationTarget(String id, String type) {
+            this.id = id;
+            this.type = type;
+        }
+    }
 
     /**
      * Create a test BioSample with STORED workflow status.

--- a/src/test/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryDashboardRestControllerDateValidationTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryDashboardRestControllerDateValidationTest.java
@@ -1,0 +1,43 @@
+package org.openelisglobal.biorepository.controller.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.biorepository.service.BiorepositoryDashboardService;
+import org.springframework.http.ResponseEntity;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BiorepositoryDashboardRestControllerDateValidationTest {
+
+    @Mock
+    private BiorepositoryDashboardService dashboardService;
+
+    @InjectMocks
+    private BiorepositoryDashboardRestController controller;
+
+    @Test
+    public void retrievalStats_InvalidStartDate_ReturnsBadRequest() {
+        ResponseEntity<Map<String, Object>> response = controller.getRetrievalStats("2026/04/21", null);
+        assertEquals(400, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertTrue(String.valueOf(response.getBody().get("error")).contains("Expected YYYY-MM-DD"));
+        verifyZeroInteractions(dashboardService);
+    }
+
+    @Test
+    public void disposalStats_InvalidEndDate_ReturnsBadRequest() {
+        ResponseEntity<Map<String, Object>> response = controller.getDisposalStats(null, "21-04-2026");
+        assertEquals(400, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertTrue(String.valueOf(response.getBody().get("error")).contains("Expected YYYY-MM-DD"));
+        verifyZeroInteractions(dashboardService);
+    }
+}

--- a/src/test/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestControllerFlowTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestControllerFlowTest.java
@@ -1,0 +1,278 @@
+package org.openelisglobal.biorepository.controller.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.biorepository.service.BioSampleService;
+import org.openelisglobal.biorepository.service.BiorepositoryQCInspectionService;
+import org.openelisglobal.biorepository.valueholder.BioSample;
+import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.storage.service.SampleStorageService;
+import org.openelisglobal.storage.service.StorageLocationService;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.http.ResponseEntity;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BiorepositoryQCInspectionRestControllerFlowTest {
+
+    @Mock
+    private BiorepositoryQCInspectionService qcInspectionService;
+    @Mock
+    private BioSampleService bioSampleService;
+    @Mock
+    private SampleStorageService storageService;
+    @Mock
+    private StorageLocationService storageLocationService;
+
+    @InjectMocks
+    private BiorepositoryQCInspectionRestController controller;
+
+    private HttpServletRequest requestWithUser;
+
+    @Before
+    public void setUp() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        UserSessionData usd = new UserSessionData();
+        usd.setSytemUserId(7);
+        request.getSession().setAttribute("userSessionData", usd);
+        requestWithUser = request;
+    }
+
+    @Test
+    public void bulkApply_UpdateLocation_ReturnsCorrectedOutcomeAndAuditFields() {
+        runCorrectionFlowAssertion("UPDATE_LOCATION", BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND,
+                "FAILED_CORRECTED", "QC_FAILED");
+    }
+
+    @Test
+    public void bulkApply_ReassignPosition_ReturnsCorrectedOutcomeAndAuditFields() {
+        runCorrectionFlowAssertion("REASSIGN_POSITION", BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND,
+                "FAILED_CORRECTED", "QC_FAILED");
+    }
+
+    @Test
+    public void bulkApply_MarkMissing_ReturnsMissingOutcomeAndAuditFields() {
+        runCorrectionFlowAssertion("MARK_MISSING", BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING,
+                "FAILED_MARKED_MISSING", "MISSING");
+    }
+
+    @Test
+    public void bulkApply_DiscrepancyWithoutCorrection_UsesCurrentLocationAsAuditFallback() {
+        BiorepositoryQCInspection inspection = buildInspection(
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, null, "QC_FAILED");
+        BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = buildRequest(null,
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND.name());
+
+        when(qcInspectionService.createBulkInspections(any(), any(), any(), any(Boolean.class), any(Boolean.class),
+                any(Boolean.class), any(Boolean.class), any(Boolean.class), any(), any(), any(), eq("7")))
+                        .thenReturn(List.of(inspection));
+        when(storageService.getSampleItemLocation("101")).thenReturn(Map.of("hierarchicalPath",
+                "Freezer-A > Shelf-1 > Rack-1 > Box-9", "positionCoordinate", "D2"));
+
+        ResponseEntity<?> response = controller.bulkApplyQC(request, requestWithUser);
+        assertEquals(200, response.getStatusCode().value());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> inspections = (List<Map<String, Object>>) body.get("inspections");
+        Map<String, Object> mapped = inspections.get(0);
+
+        assertEquals("FAILED_PENDING_CORRECTION", mapped.get("lifecycleOutcome"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> auditTrail = (Map<String, Object>) mapped.get("auditTrail");
+        assertEquals("Freezer-A > Shelf-1 > Rack-1 > Box-9 > D2", auditTrail.get("newCoordinate"));
+        verify(storageService).getSampleItemLocation("101");
+    }
+
+    private void runCorrectionFlowAssertion(String correctionActionType,
+            BiorepositoryQCInspection.DiscrepancyType discrepancyType, String expectedLifecycle, String expectedStatus) {
+        BiorepositoryQCInspection inspection = buildInspection(discrepancyType, correctionActionType, expectedStatus);
+        BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = buildRequest(correctionActionType,
+                discrepancyType.name());
+
+        when(qcInspectionService.createBulkInspections(any(), any(), any(), any(Boolean.class), any(Boolean.class),
+                any(Boolean.class), any(Boolean.class), any(Boolean.class), any(), any(), any(), eq("7")))
+                        .thenReturn(List.of(inspection));
+        when(qcInspectionService.applyCorrectionWorkflow(eq(inspection), eq(correctionActionType), any(), any(), any(),
+                any(), any(), any(), eq("7"))).thenReturn(Map.of(
+                        "actionType", correctionActionType,
+                        "reason", correctionActionType + ": operator correction",
+                        "correctionTimestamp", inspection.getCorrectionTimestamp().toString(),
+                        "updatedLocation", Map.of("hierarchicalPath", "Freezer-A > Shelf-1 > Rack-1 > Box-2",
+                                "positionCoordinate", "B5")));
+
+        ResponseEntity<?> response = controller.bulkApplyQC(request, requestWithUser);
+        assertEquals(200, response.getStatusCode().value());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> inspections = (List<Map<String, Object>>) body.get("inspections");
+        assertEquals(1, inspections.size());
+        Map<String, Object> mapped = inspections.get(0);
+
+        assertEquals(expectedLifecycle, mapped.get("lifecycleOutcome"));
+        assertEquals(expectedStatus, mapped.get("qcStatus"));
+        assertEquals(correctionActionType, mapped.get("correctionActionType"));
+        assertEquals("7", mapped.get("correctionByUser"));
+        assertNotNull(mapped.get("correctionTimestamp"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> auditTrail = (Map<String, Object>) mapped.get("auditTrail");
+        assertNotNull(auditTrail);
+        assertNotNull(auditTrail.get("oldCoordinate"));
+        assertNotNull(auditTrail.get("newCoordinate"));
+        assertEquals("7", auditTrail.get("correctedBy"));
+        assertTrue(String.valueOf(auditTrail.get("reason")).startsWith(correctionActionType + ":"));
+    }
+
+    @Test
+    public void bulkApply_MarkMissingWithNonMissingDiscrepancy_ReturnsBadRequest() {
+        BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = buildRequest("MARK_MISSING",
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND.name());
+
+        ResponseEntity<?> response = controller.bulkApplyQC(request, requestWithUser);
+        assertEquals(400, response.getStatusCode().value());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> errorBody = (Map<String, Object>) response.getBody();
+        assertNotNull(errorBody);
+        assertTrue(String.valueOf(errorBody.get("error")).contains("MARK_MISSING requires discrepancy type SAMPLE_MISSING"));
+        verifyZeroInteractions(qcInspectionService);
+    }
+
+    @Test
+    public void bulkApply_MarkMissingWithLocationFields_ReturnsBadRequest() {
+        BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = buildRequest("MARK_MISSING",
+                BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING.name());
+        request.setCorrectionLocationType("box");
+        request.setCorrectionLocationId("301");
+        request.setCorrectionPositionCoordinate("B5");
+
+        ResponseEntity<?> response = controller.bulkApplyQC(request, requestWithUser);
+        assertEquals(400, response.getStatusCode().value());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> errorBody = (Map<String, Object>) response.getBody();
+        assertNotNull(errorBody);
+        assertTrue(String.valueOf(errorBody.get("error"))
+                .contains("MARK_MISSING does not allow correction location/position fields"));
+        verifyZeroInteractions(qcInspectionService);
+    }
+
+    @Test
+    public void bulkApply_UpdateLocationWithoutLocationFields_ReturnsBadRequest() {
+        BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = buildRequest("UPDATE_LOCATION",
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND.name());
+        request.setCorrectionLocationId(null);
+        request.setCorrectionLocationType(null);
+
+        ResponseEntity<?> response = controller.bulkApplyQC(request, requestWithUser);
+        assertEquals(400, response.getStatusCode().value());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> errorBody = (Map<String, Object>) response.getBody();
+        assertNotNull(errorBody);
+        assertTrue(String.valueOf(errorBody.get("error"))
+                .contains("UPDATE_LOCATION/REASSIGN_POSITION require correctionLocationId and correctionLocationType"));
+        verifyZeroInteractions(qcInspectionService);
+    }
+
+    @Test
+    public void bulkApply_ReassignPositionWithoutPositionCoordinate_ReturnsBadRequest() {
+        BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = buildRequest("REASSIGN_POSITION",
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND.name());
+        request.setCorrectionPositionCoordinate(null);
+
+        ResponseEntity<?> response = controller.bulkApplyQC(request, requestWithUser);
+        assertEquals(400, response.getStatusCode().value());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> errorBody = (Map<String, Object>) response.getBody();
+        assertNotNull(errorBody);
+        assertTrue(String.valueOf(errorBody.get("error")).contains("REASSIGN_POSITION requires correctionPositionCoordinate"));
+        verifyZeroInteractions(qcInspectionService);
+    }
+
+    private BiorepositoryQCInspectionRestController.BulkQCInspectionRequest buildRequest(String correctionActionType,
+            String discrepancyType) {
+        BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = new BiorepositoryQCInspectionRestController.BulkQCInspectionRequest();
+        request.setBioSampleIds(List.of(99));
+        request.setInspectorName("Operator");
+        request.setInspectionDate(new Timestamp(System.currentTimeMillis()));
+        request.setSamplePresent(false);
+        request.setLabelIntegrity(true);
+        request.setContainerIntegrity(true);
+        request.setVolumeAppearanceAcceptable(true);
+        request.setCorrectPosition(false);
+        request.setDiscrepancyType(discrepancyType);
+        request.setCorrectiveAction("Operator identified discrepancy");
+        request.setRemarks("Operator discrepancy remarks");
+        request.setCorrectionActionType(correctionActionType);
+        if (correctionActionType != null) {
+            request.setCorrectionLocationType("rack");
+            request.setCorrectionLocationId("301");
+            request.setCorrectionPositionCoordinate("B5");
+            request.setCorrectionReason("operator correction");
+        }
+        if ("MARK_MISSING".equals(correctionActionType) || correctionActionType == null) {
+            request.setCorrectionLocationType(null);
+            request.setCorrectionLocationId(null);
+            request.setCorrectionPositionCoordinate(null);
+        }
+        return request;
+    }
+
+    private BiorepositoryQCInspection buildInspection(BiorepositoryQCInspection.DiscrepancyType discrepancyType,
+            String correctionActionType, String expectedStatus) {
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId("101");
+
+        BioSample bioSample = new BioSample();
+        bioSample.setId(99);
+        bioSample.setSampleItem(sampleItem);
+
+        BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
+        inspection.setId(501);
+        inspection.setBioSample(bioSample);
+        inspection.setInspectorName("Operator");
+        inspection.setSysUserId("7");
+        inspection.setInspectionDate(new Timestamp(System.currentTimeMillis()));
+        inspection.setQcResult(BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND);
+        inspection.setDiscrepancyType(discrepancyType);
+        inspection.setCorrectiveAction((correctionActionType != null ? correctionActionType : "PENDING")
+                + ": Operator identified discrepancy");
+        inspection.setRemarks("Operator discrepancy remarks");
+        inspection.setExpectedLocationPath("Freezer-A > Shelf-1 > Rack-1 > Box-2");
+        inspection.setExpectedPositionCoordinate("A1");
+        inspection.setCorrectionActionType(correctionActionType);
+        inspection.setCorrectionOldCoordinate("Freezer-A > Shelf-1 > Rack-1 > Box-2 > A1");
+        if (correctionActionType != null) {
+            inspection.setCorrectionNewCoordinate("MISSING".equals(expectedStatus) ? "Missing (not found during QC)"
+                    : "Freezer-A > Shelf-1 > Rack-1 > Box-2 > B5");
+            inspection.setCorrectionReason(correctionActionType + ": operator correction");
+            inspection.setCorrectionByUser("7");
+            inspection.setCorrectionTimestamp(new Timestamp(System.currentTimeMillis()));
+        }
+        return inspection;
+    }
+}

--- a/src/test/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestControllerFlowTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/controller/rest/BiorepositoryQCInspectionRestControllerFlowTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -27,6 +28,10 @@ import org.openelisglobal.login.valueholder.UserSessionData;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.storage.service.SampleStorageService;
 import org.openelisglobal.storage.service.StorageLocationService;
+import org.openelisglobal.storage.valueholder.StorageBox;
+import org.openelisglobal.storage.valueholder.StorageDevice;
+import org.openelisglobal.storage.valueholder.StorageRack;
+import org.openelisglobal.storage.valueholder.StorageShelf;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.http.ResponseEntity;
 
@@ -81,8 +86,8 @@ public class BiorepositoryQCInspectionRestControllerFlowTest {
         BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = buildRequest(null,
                 BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND.name());
 
-        when(qcInspectionService.createBulkInspections(any(), any(), any(), any(Boolean.class), any(Boolean.class),
-                any(Boolean.class), any(Boolean.class), any(Boolean.class), any(), any(), any(), eq("7")))
+        when(qcInspectionService.createBulkInspections(any(), any(), any(), anyBoolean(), anyBoolean(),
+                anyBoolean(), anyBoolean(), anyBoolean(), any(), any(), any(), any(), any(), eq("7")))
                         .thenReturn(List.of(inspection));
         when(storageService.getSampleItemLocation("101")).thenReturn(Map.of("hierarchicalPath",
                 "Freezer-A > Shelf-1 > Rack-1 > Box-9", "positionCoordinate", "D2"));
@@ -109,16 +114,26 @@ public class BiorepositoryQCInspectionRestControllerFlowTest {
         BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = buildRequest(correctionActionType,
                 discrepancyType.name());
 
-        when(qcInspectionService.createBulkInspections(any(), any(), any(), any(Boolean.class), any(Boolean.class),
-                any(Boolean.class), any(Boolean.class), any(Boolean.class), any(), any(), any(), eq("7")))
+        when(qcInspectionService.createBulkInspections(any(), any(), any(), anyBoolean(), anyBoolean(),
+                anyBoolean(), anyBoolean(), anyBoolean(), any(), any(), any(), any(), any(), eq("7")))
                         .thenReturn(List.of(inspection));
-        when(qcInspectionService.applyCorrectionWorkflow(eq(inspection), eq(correctionActionType), any(), any(), any(),
-                any(), any(), any(), eq("7"))).thenReturn(Map.of(
-                        "actionType", correctionActionType,
-                        "reason", correctionActionType + ": operator correction",
-                        "correctionTimestamp", inspection.getCorrectionTimestamp().toString(),
-                        "updatedLocation", Map.of("hierarchicalPath", "Freezer-A > Shelf-1 > Rack-1 > Box-2",
-                                "positionCoordinate", "B5")));
+        if ("MARK_MISSING".equals(correctionActionType)) {
+            java.util.HashMap<String, Object> missingLocation = new java.util.HashMap<>();
+            missingLocation.put("hierarchicalPath", "Missing (not found during QC)");
+            missingLocation.put("positionCoordinate", null);
+            missingLocation.put("status", "MISSING");
+
+            java.util.HashMap<String, Object> missingResult = new java.util.HashMap<>();
+            missingResult.put("movementId", "mv-1");
+            missingResult.put("updatedLocation", missingLocation);
+            when(storageService.markSampleItemMissing(eq("101"), any(), any())).thenReturn(missingResult);
+        } else {
+            when(storageService.moveSampleItemWithLocation(eq("101"), eq("301"), eq("rack"), eq("B5"), any(), any()))
+                    .thenReturn("mv-1");
+            when(storageService.getSampleItemLocation("101")).thenReturn(Map.of(
+                    "hierarchicalPath", "Freezer-A > Shelf-1 > Rack-1 > Box-2",
+                    "positionCoordinate", "B5"));
+        }
 
         ResponseEntity<?> response = controller.bulkApplyQC(request, requestWithUser);
         assertEquals(200, response.getStatusCode().value());
@@ -213,6 +228,76 @@ public class BiorepositoryQCInspectionRestControllerFlowTest {
         verifyZeroInteractions(qcInspectionService);
     }
 
+    @Test
+    public void getQCStorageOverview_ExcludesAlreadyInspectedSamplesByDefault() {
+        BioSample pendingSample = buildStoredBioSample(100, "101");
+        BioSample inspectedSample = buildStoredBioSample(101, "102");
+        java.util.HashMap<Integer, BiorepositoryQCInspection> mostRecentInspections = new java.util.HashMap<>();
+        mostRecentInspections.put(100, null);
+        mostRecentInspections.put(101,
+                buildInspection(BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, "UPDATE_LOCATION",
+                        "QC_FAILED"));
+
+        when(bioSampleService.getAll()).thenReturn(List.of(pendingSample, inspectedSample));
+        when(qcInspectionService.existsByBioSampleId(100)).thenReturn(false);
+        when(qcInspectionService.existsByBioSampleId(101)).thenReturn(true);
+        when(qcInspectionService.hasInspectionBetween(eq(100), any(), any())).thenReturn(false);
+        when(qcInspectionService.hasInspectionBetween(eq(101), any(), any())).thenReturn(true);
+        stubActiveStorageHierarchy();
+        when(storageService.getSampleItemLocation("101"))
+                .thenReturn(Map.of("hierarchicalPath", "Freezer-A > Shelf-1 > Rack-1 > Box-1", "positionCoordinate",
+                        "A1"));
+
+        ResponseEntity<Map<String, Object>> response = controller.getQCStorageOverview(null, null, null, null, false);
+        assertEquals(200, response.getStatusCode().value());
+
+        Map<String, Object> body = response.getBody();
+        assertNotNull(body);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> eligibleSamples = (List<Map<String, Object>>) body.get("eligibleSamples");
+        assertEquals(1, eligibleSamples.size());
+        assertEquals(100, eligibleSamples.get(0).get("bioSampleId"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> counts = (Map<String, Object>) body.get("counts");
+        assertEquals(1, counts.get("eligibleSamples"));
+    }
+
+    @Test
+    public void getQCStorageOverview_IncludeInspectedTrue_ReturnsCompletedSamplesInPool() {
+        BioSample pendingSample = buildStoredBioSample(100, "101");
+        BioSample inspectedSample = buildStoredBioSample(101, "102");
+        java.util.HashMap<Integer, BiorepositoryQCInspection> mostRecentInspections = new java.util.HashMap<>();
+        mostRecentInspections.put(100, null);
+        mostRecentInspections.put(101,
+                buildInspection(BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, "UPDATE_LOCATION",
+                        "QC_FAILED"));
+
+        when(bioSampleService.getAll()).thenReturn(List.of(pendingSample, inspectedSample));
+        when(qcInspectionService.existsByBioSampleId(100)).thenReturn(false);
+        when(qcInspectionService.existsByBioSampleId(101)).thenReturn(true);
+        when(qcInspectionService.hasInspectionBetween(eq(100), any(), any())).thenReturn(false);
+        when(qcInspectionService.hasInspectionBetween(eq(101), any(), any())).thenReturn(true);
+        stubActiveStorageHierarchy();
+        when(storageService.getSampleItemLocation("101"))
+                .thenReturn(Map.of("hierarchicalPath", "Freezer-A > Shelf-1 > Rack-1 > Box-1", "positionCoordinate",
+                        "A1"));
+        when(storageService.getSampleItemLocation("102"))
+                .thenReturn(Map.of("hierarchicalPath", "Freezer-A > Shelf-1 > Rack-1 > Box-1", "positionCoordinate",
+                        "A2"));
+
+        ResponseEntity<Map<String, Object>> response = controller.getQCStorageOverview(null, null, null, null, true);
+        assertEquals(200, response.getStatusCode().value());
+
+        Map<String, Object> body = response.getBody();
+        assertNotNull(body);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> eligibleSamples = (List<Map<String, Object>>) body.get("eligibleSamples");
+        assertEquals(2, eligibleSamples.size());
+        assertTrue(eligibleSamples.stream().anyMatch(sample -> Integer.valueOf(101).equals(sample.get("bioSampleId"))
+                && Boolean.TRUE.equals(sample.get("hasInspectionHistory"))));
+    }
+
     private BiorepositoryQCInspectionRestController.BulkQCInspectionRequest buildRequest(String correctionActionType,
             String discrepancyType) {
         BiorepositoryQCInspectionRestController.BulkQCInspectionRequest request = new BiorepositoryQCInspectionRestController.BulkQCInspectionRequest();
@@ -240,6 +325,48 @@ public class BiorepositoryQCInspectionRestControllerFlowTest {
             request.setCorrectionPositionCoordinate(null);
         }
         return request;
+    }
+
+    private BioSample buildStoredBioSample(Integer bioSampleId, String sampleItemId) {
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId(sampleItemId);
+
+        BioSample bioSample = new BioSample();
+        bioSample.setId(bioSampleId);
+        bioSample.setWorkflowStatus(BioSample.WorkflowStatus.STORED);
+        bioSample.setSampleItem(sampleItem);
+        return bioSample;
+    }
+
+    private void stubActiveStorageHierarchy() {
+        StorageDevice device = new StorageDevice();
+        device.setId(1);
+        device.setName("Freezer-A");
+        device.setType(StorageDevice.DeviceType.FREEZER.getValue());
+        device.setActive(true);
+
+        StorageShelf shelf = new StorageShelf();
+        shelf.setId(11);
+        shelf.setLabel("Shelf-1");
+        shelf.setActive(true);
+        shelf.setParentDevice(device);
+
+        StorageRack rack = new StorageRack();
+        rack.setId(21);
+        rack.setLabel("Rack-1");
+        rack.setActive(true);
+        rack.setParentShelf(shelf);
+
+        StorageBox box = new StorageBox();
+        box.setId(31);
+        box.setLabel("Box-1");
+        box.setActive(true);
+        box.setParentRack(rack);
+
+        when(storageLocationService.getAllDevices()).thenReturn(List.of(device));
+        when(storageLocationService.getAllShelves()).thenReturn(List.of(shelf));
+        when(storageLocationService.getAllRacks()).thenReturn(List.of(rack));
+        when(storageLocationService.getAllBoxes()).thenReturn(List.of(box));
     }
 
     private BiorepositoryQCInspection buildInspection(BiorepositoryQCInspection.DiscrepancyType discrepancyType,

--- a/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardEscalationAndResolutionTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardEscalationAndResolutionTest.java
@@ -1,0 +1,224 @@
+package org.openelisglobal.biorepository.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.biorepository.valueholder.BioSample;
+import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.storage.service.SampleStorageService;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BiorepositoryDashboardEscalationAndResolutionTest {
+
+    @Mock
+    private BioSampleService bioSampleService;
+    @Mock
+    private BiorepositoryQCInspectionService qcInspectionService;
+    @Mock
+    private SampleRetrievalService retrievalService;
+    @Mock
+    private org.openelisglobal.notebook.service.NotebookEntryTemperatureLogService temperatureLogService;
+    @Mock
+    private org.openelisglobal.notebook.service.NotebookEntryRoomEnvironmentLogService roomEnvironmentLogService;
+    @Mock
+    private SampleStorageService storageService;
+
+    @InjectMocks
+    private BiorepositoryDashboardServiceImpl dashboardService;
+
+    @Test
+    public void qcMetrics_ExposeEscalationAndResolutionSummaries() {
+        List<BiorepositoryQCInspection> inspections = new ArrayList<>();
+        inspections.add(buildInspection(1, BiorepositoryQCInspection.QCResult.VERIFIED, null, null,
+                "Freezer-A > Shelf-1 > Rack-1 > Box-1", "A1"));
+        inspections.add(buildInspection(2, BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND,
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, null,
+                "Freezer-A > Shelf-1 > Rack-1 > Box-1", "A2"));
+        inspections.add(buildInspection(3, BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND,
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, "UPDATE_LOCATION",
+                "Freezer-A > Shelf-1 > Rack-1 > Box-1", "A3"));
+        inspections.add(buildInspection(4, BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND,
+                BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING, "MARK_MISSING",
+                "Freezer-A > Shelf-1 > Rack-2 > Box-4", "B4"));
+
+        when(qcInspectionService.getAll()).thenReturn(inspections);
+
+        Map<String, Object> metrics = dashboardService.getQCComplianceMetrics();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resolution = (Map<String, Object>) metrics.get("failureResolutionSummary");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> correctedVsUnresolved = (Map<String, Object>) resolution.get("correctedVsUnresolved");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> escalationSignals = (Map<String, Object>) metrics.get("escalationSignals");
+
+        assertNotNull(resolution);
+        assertEquals(1L, ((Number) resolution.get("failedPendingCorrection")).longValue());
+        assertEquals(1L, ((Number) resolution.get("failedCorrected")).longValue());
+        assertEquals(1L, ((Number) resolution.get("failedMarkedMissing")).longValue());
+        assertEquals(2L, ((Number) correctedVsUnresolved.get("corrected")).longValue());
+        assertEquals(1L, ((Number) correctedVsUnresolved.get("unresolved")).longValue());
+
+        assertNotNull(escalationSignals);
+        assertTrue(Boolean.TRUE.equals(escalationSignals.get("batchFailRateExceeded")));
+        assertTrue(Boolean.TRUE.equals(escalationSignals.get("repeatedFailureInSameBoxOrRack")));
+        assertTrue(Boolean.TRUE.equals(escalationSignals.get("criticalSamplesMissing")));
+    }
+
+    @Test
+    public void qcHistory_ExposesPerRecordFlagsAndFailureResolutionStatus() {
+        List<BiorepositoryQCInspection> inspections = new ArrayList<>();
+        inspections.add(buildInspection(10, BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND,
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, null,
+                "Freezer-B > Shelf-2 > Rack-3 > Box-8", "A1"));
+        inspections.add(buildInspection(11, BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND,
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, "UPDATE_LOCATION",
+                "Freezer-B > Shelf-2 > Rack-3 > Box-8", "A2"));
+
+        when(qcInspectionService.getAll()).thenReturn(inspections);
+
+        Map<String, Object> history = dashboardService.getQCHistory(10);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = (List<Map<String, Object>>) history.get("items");
+        assertEquals(2, items.size());
+
+        Map<String, Object> pending = items.stream()
+                .filter(item -> "FAILED_PENDING_CORRECTION".equals(item.get("lifecycleOutcome"))).findFirst()
+                .orElseThrow(() -> new AssertionError("Missing pending correction item"));
+        Map<String, Object> corrected = items.stream()
+                .filter(item -> "FAILED_CORRECTED".equals(item.get("lifecycleOutcome"))).findFirst()
+                .orElseThrow(() -> new AssertionError("Missing corrected item"));
+
+        assertEquals("UNDER_INVESTIGATION", pending.get("boxFlag"));
+        assertEquals("UNDER_INVESTIGATION", corrected.get("boxFlag"));
+        assertEquals("UNRESOLVED", pending.get("failureResolution"));
+        assertEquals("RESOLVED", corrected.get("failureResolution"));
+        assertTrue(Boolean.TRUE.equals(pending.get("escalationTriggered")));
+        assertTrue(Boolean.TRUE.equals(corrected.get("escalationTriggered")));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> summary = (Map<String, Object>) history.get("failureResolutionSummary");
+        assertNotNull(summary);
+        assertEquals(1L, ((Number) summary.get("failedPendingCorrection")).longValue());
+        assertEquals(1L, ((Number) summary.get("failedCorrected")).longValue());
+        assertFalse(items.isEmpty());
+    }
+
+    @Test
+    public void qcMetrics_BatchFailRateExactlyFivePercent_DoesNotTriggerOverFiveRule() {
+        List<BiorepositoryQCInspection> inspections = new ArrayList<>();
+        // 20 total, 1 failed => exactly 5.0%
+        for (int i = 1; i <= 19; i++) {
+            inspections.add(buildInspection(100 + i, BiorepositoryQCInspection.QCResult.VERIFIED, null, null,
+                    "Freezer-C > Shelf-1 > Rack-1 > Box-1", "A" + i));
+        }
+        inspections.add(buildInspection(200, BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND,
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, null,
+                "Freezer-C > Shelf-1 > Rack-1 > Box-1", "Z1"));
+
+        when(qcInspectionService.getAll()).thenReturn(inspections);
+
+        Map<String, Object> metrics = dashboardService.getQCComplianceMetrics();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> escalationSignals = (Map<String, Object>) metrics.get("escalationSignals");
+
+        assertNotNull(escalationSignals);
+        assertEquals(5.0, ((Number) escalationSignals.get("batchFailRatePercent")).doubleValue(), 0.0001);
+        assertFalse(Boolean.TRUE.equals(escalationSignals.get("batchFailRateExceeded")));
+
+        @SuppressWarnings("unchecked")
+        List<String> triggeredRules = (List<String>) escalationSignals.get("triggeredRules");
+        assertFalse(triggeredRules.contains("BATCH_FAIL_RATE_OVER_5_PERCENT"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> flaggedFreezers = (List<Map<String, Object>>) escalationSignals.get("flaggedFreezers");
+        assertTrue("Freezer should not be flagged at exactly 5.0%", flaggedFreezers.isEmpty());
+    }
+
+    @Test
+    public void qcMetrics_BatchFailRateAboveFivePercent_TriggersOverFiveRuleAndFlagsFreezer() {
+        List<BiorepositoryQCInspection> inspections = new ArrayList<>();
+        // 20 total, 2 failed => 10.0%
+        for (int i = 1; i <= 18; i++) {
+            inspections.add(buildInspection(300 + i, BiorepositoryQCInspection.QCResult.VERIFIED, null, null,
+                    "Freezer-D > Shelf-1 > Rack-1 > Box-1", "A" + i));
+        }
+        inspections.add(buildInspection(400, BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND,
+                BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND, null,
+                "Freezer-D > Shelf-1 > Rack-1 > Box-1", "Z1"));
+        inspections.add(buildInspection(401, BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND,
+                BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING, "MARK_MISSING",
+                "Freezer-D > Shelf-1 > Rack-1 > Box-1", "Z2"));
+
+        when(qcInspectionService.getAll()).thenReturn(inspections);
+
+        Map<String, Object> metrics = dashboardService.getQCComplianceMetrics();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> escalationSignals = (Map<String, Object>) metrics.get("escalationSignals");
+
+        assertNotNull(escalationSignals);
+        assertTrue(((Number) escalationSignals.get("batchFailRatePercent")).doubleValue() > 5.0);
+        assertTrue(Boolean.TRUE.equals(escalationSignals.get("batchFailRateExceeded")));
+
+        @SuppressWarnings("unchecked")
+        List<String> triggeredRules = (List<String>) escalationSignals.get("triggeredRules");
+        assertTrue(triggeredRules.contains("BATCH_FAIL_RATE_OVER_5_PERCENT"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> flaggedFreezers = (List<Map<String, Object>>) escalationSignals.get("flaggedFreezers");
+        assertFalse("Freezer should be flagged above 5.0% fail rate", flaggedFreezers.isEmpty());
+        assertEquals("Freezer-D", flaggedFreezers.get(0).get("key"));
+    }
+
+    private BiorepositoryQCInspection buildInspection(int id, BiorepositoryQCInspection.QCResult qcResult,
+            BiorepositoryQCInspection.DiscrepancyType discrepancyType, String correctionActionType, String locationPath,
+            String position) {
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId(String.valueOf(1000 + id));
+
+        BioSample bioSample = new BioSample();
+        bioSample.setId(id);
+        bioSample.setSampleItem(sampleItem);
+
+        BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
+        inspection.setId(id);
+        inspection.setBioSample(bioSample);
+        inspection.setInspectorName("Inspector-" + id);
+        inspection.setSysUserId("7");
+        inspection.setInspectionDate(new Timestamp(System.currentTimeMillis() - id * 1000L));
+        inspection.setQcResult(qcResult);
+        inspection.setDiscrepancyType(discrepancyType);
+        inspection.setCorrectiveAction("QC note " + id);
+        inspection.setRemarks("QC remark " + id);
+        inspection.setExpectedLocationPath(locationPath);
+        inspection.setExpectedPositionCoordinate(position);
+        inspection.setSamplePresent(!BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(qcResult));
+        inspection.setLabelIntegrity(true);
+        inspection.setContainerIntegrity(true);
+        inspection.setVolumeAppearanceAcceptable(true);
+        inspection.setCorrectPosition(!BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND.equals(qcResult));
+        inspection.setCorrectionActionType(correctionActionType);
+        if (correctionActionType != null) {
+            inspection.setCorrectionOldCoordinate(locationPath + " > " + position);
+            inspection.setCorrectionNewCoordinate("MARK_MISSING".equals(correctionActionType)
+                    ? "Missing (not found during QC)"
+                    : locationPath + " > Z9");
+            inspection.setCorrectionReason(correctionActionType + ": corrected");
+            inspection.setCorrectionByUser("7");
+            inspection.setCorrectionTimestamp(new Timestamp(System.currentTimeMillis()));
+        }
+        return inspection;
+    }
+}

--- a/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardEscalationAndResolutionTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardEscalationAndResolutionTest.java
@@ -117,7 +117,7 @@ public class BiorepositoryDashboardEscalationAndResolutionTest {
     }
 
     @Test
-    public void qcMetrics_BatchFailRateExactlyFivePercent_DoesNotTriggerOverFiveRule() {
+    public void qcMetrics_BatchFailRateExactlyFivePercent_TriggersFivePercentRule() {
         List<BiorepositoryQCInspection> inspections = new ArrayList<>();
         // 20 total, 1 failed => exactly 5.0%
         for (int i = 1; i <= 19; i++) {
@@ -136,15 +136,15 @@ public class BiorepositoryDashboardEscalationAndResolutionTest {
 
         assertNotNull(escalationSignals);
         assertEquals(5.0, ((Number) escalationSignals.get("batchFailRatePercent")).doubleValue(), 0.0001);
-        assertFalse(Boolean.TRUE.equals(escalationSignals.get("batchFailRateExceeded")));
+        assertTrue(Boolean.TRUE.equals(escalationSignals.get("batchFailRateExceeded")));
 
         @SuppressWarnings("unchecked")
         List<String> triggeredRules = (List<String>) escalationSignals.get("triggeredRules");
-        assertFalse(triggeredRules.contains("BATCH_FAIL_RATE_OVER_5_PERCENT"));
+        assertTrue(triggeredRules.contains("BATCH_FAIL_RATE_OVER_5_PERCENT"));
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> flaggedFreezers = (List<Map<String, Object>>) escalationSignals.get("flaggedFreezers");
-        assertTrue("Freezer should not be flagged at exactly 5.0%", flaggedFreezers.isEmpty());
+        assertFalse("Freezer should be flagged at exactly 5.0%", flaggedFreezers.isEmpty());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardQCHistoryAuditMappingTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardQCHistoryAuditMappingTest.java
@@ -1,0 +1,105 @@
+package org.openelisglobal.biorepository.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.biorepository.valueholder.BioSample;
+import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.storage.service.SampleStorageService;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BiorepositoryDashboardQCHistoryAuditMappingTest {
+
+    @Mock
+    private BioSampleService bioSampleService;
+    @Mock
+    private BiorepositoryQCInspectionService qcInspectionService;
+    @Mock
+    private SampleRetrievalService retrievalService;
+    @Mock
+    private org.openelisglobal.notebook.service.NotebookEntryTemperatureLogService temperatureLogService;
+    @Mock
+    private org.openelisglobal.notebook.service.NotebookEntryRoomEnvironmentLogService roomEnvironmentLogService;
+    @Mock
+    private SampleStorageService storageService;
+
+    @InjectMocks
+    private BiorepositoryDashboardServiceImpl dashboardService;
+
+    @Test
+    public void qcHistory_UsesPersistedCorrectionCoordinatesWhenCorrectionApplied() {
+        BiorepositoryQCInspection inspection = buildInspection("UPDATE_LOCATION", "Freezer-A > Shelf-1 > Rack-2 > Box-3 > B7");
+
+        // Simulate current location drift after correction; history should still show persisted correction coordinate.
+        when(storageService.getSampleItemLocation(anyString()))
+                .thenReturn(Map.of("hierarchicalPath", "Freezer-Z > Shelf-9 > Rack-9 > Box-9", "positionCoordinate", "Z1"));
+        when(qcInspectionService.getAll()).thenReturn(new ArrayList<>(List.of(inspection)));
+
+        Map<String, Object> history = dashboardService.getQCHistory(10);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = (List<Map<String, Object>>) history.get("items");
+
+        assertEquals(1, items.size());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> auditTrail = (Map<String, Object>) items.get(0).get("auditTrail");
+        assertNotNull(auditTrail);
+        assertEquals("Freezer-A > Shelf-1 > Rack-2 > Box-3 > B7", auditTrail.get("newCoordinate"));
+    }
+
+    @Test
+    public void qcHistory_UsesCurrentLocationFallbackWhenNoCorrectionApplied() {
+        BiorepositoryQCInspection inspection = buildInspection(null, null);
+
+        when(storageService.getSampleItemLocation(anyString()))
+                .thenReturn(Map.of("hierarchicalPath", "Freezer-B > Shelf-2 > Rack-1 > Box-4", "positionCoordinate", "C2"));
+        when(qcInspectionService.getAll()).thenReturn(new ArrayList<>(List.of(inspection)));
+
+        Map<String, Object> history = dashboardService.getQCHistory(10);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = (List<Map<String, Object>>) history.get("items");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> auditTrail = (Map<String, Object>) items.get(0).get("auditTrail");
+        assertEquals("Freezer-B > Shelf-2 > Rack-1 > Box-4 > C2", auditTrail.get("newCoordinate"));
+    }
+
+    private BiorepositoryQCInspection buildInspection(String correctionActionType, String correctionNewCoordinate) {
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId("101");
+
+        BioSample bioSample = new BioSample();
+        bioSample.setId(77);
+        bioSample.setSampleItem(sampleItem);
+
+        BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
+        inspection.setId(11);
+        inspection.setBioSample(bioSample);
+        inspection.setInspectorName("Inspector");
+        inspection.setSysUserId("7");
+        inspection.setInspectionDate(new Timestamp(System.currentTimeMillis()));
+        inspection.setQcResult(BiorepositoryQCInspection.QCResult.DISCREPANCY_FOUND);
+        inspection.setDiscrepancyType(BiorepositoryQCInspection.DiscrepancyType.MISPLACED_SAMPLE_FOUND);
+        inspection.setCorrectiveAction("Discrepancy note");
+        inspection.setExpectedLocationPath("Freezer-A > Shelf-1 > Rack-2 > Box-3");
+        inspection.setExpectedPositionCoordinate("A1");
+        inspection.setCorrectionActionType(correctionActionType);
+        inspection.setCorrectionOldCoordinate("Freezer-A > Shelf-1 > Rack-2 > Box-3 > A1");
+        inspection.setCorrectionNewCoordinate(correctionNewCoordinate);
+        inspection.setCorrectionReason(correctionActionType != null ? correctionActionType + ": corrected" : null);
+        inspection.setCorrectionByUser(correctionActionType != null ? "7" : null);
+        inspection.setCorrectionTimestamp(correctionActionType != null ? new Timestamp(System.currentTimeMillis()) : null);
+        return inspection;
+    }
+}

--- a/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardSampleAgingUnitTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardSampleAgingUnitTest.java
@@ -1,0 +1,71 @@
+package org.openelisglobal.biorepository.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.biorepository.valueholder.BioSample;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.storage.service.SampleStorageService;
+import org.openelisglobal.storage.service.StorageLocationService;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BiorepositoryDashboardSampleAgingUnitTest {
+
+    @Mock
+    private BioSampleService bioSampleService;
+    @Mock
+    private BiorepositoryQCInspectionService qcInspectionService;
+    @Mock
+    private SampleRetrievalService retrievalService;
+    @Mock
+    private org.openelisglobal.notebook.service.NotebookEntryTemperatureLogService temperatureLogService;
+    @Mock
+    private org.openelisglobal.notebook.service.NotebookEntryRoomEnvironmentLogService roomEnvironmentLogService;
+    @Mock
+    private SampleStorageService storageService;
+    @Mock
+    private StorageLocationService storageLocationService;
+
+    @InjectMocks
+    private BiorepositoryDashboardServiceImpl dashboardService;
+
+    @Test
+    public void sampleAgingMetrics_ComputesAverageAgeYearsFromCollectionAndReceivedDates() {
+        BioSample fromCollectionDate = buildStoredSample(
+                Timestamp.valueOf(LocalDate.now().minusDays(365).atStartOfDay()),
+                Timestamp.valueOf(LocalDate.now().minusDays(20).atStartOfDay()));
+        BioSample fromReceivedDate = buildStoredSample(
+                null,
+                Timestamp.valueOf(LocalDate.now().minusDays(730).atStartOfDay()));
+
+        when(bioSampleService.getAll()).thenReturn(List.of(fromCollectionDate, fromReceivedDate));
+
+        Map<String, Object> metrics = dashboardService.getSampleAgingMetrics();
+        double averageAgeYears = ((Number) metrics.get("averageAgeYears")).doubleValue();
+        assertEquals(1.5, averageAgeYears, 0.05);
+    }
+
+    private BioSample buildStoredSample(Timestamp collectionDate, Timestamp receivedTimestamp) {
+        Sample sample = new Sample();
+        sample.setReceivedTimestamp(receivedTimestamp);
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId(String.valueOf(System.nanoTime()));
+        sampleItem.setCollectionDate(collectionDate);
+        sampleItem.setSample(sample);
+
+        BioSample bioSample = new BioSample();
+        bioSample.setSampleItem(sampleItem);
+        bioSample.setWorkflowStatus(BioSample.WorkflowStatus.STORED);
+        return bioSample;
+    }
+}

--- a/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardStorageUtilizationTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryDashboardStorageUtilizationTest.java
@@ -1,0 +1,156 @@
+package org.openelisglobal.biorepository.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.biorepository.valueholder.BioSample;
+import org.openelisglobal.storage.service.SampleStorageService;
+import org.openelisglobal.storage.service.StorageLocationService;
+import org.openelisglobal.storage.valueholder.StorageBox;
+import org.openelisglobal.storage.valueholder.StorageDevice;
+import org.openelisglobal.storage.valueholder.StorageRack;
+import org.openelisglobal.storage.valueholder.StorageShelf;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BiorepositoryDashboardStorageUtilizationTest {
+
+    @Mock
+    private BioSampleService bioSampleService;
+    @Mock
+    private BiorepositoryQCInspectionService qcInspectionService;
+    @Mock
+    private SampleRetrievalService retrievalService;
+    @Mock
+    private org.openelisglobal.notebook.service.NotebookEntryTemperatureLogService temperatureLogService;
+    @Mock
+    private org.openelisglobal.notebook.service.NotebookEntryRoomEnvironmentLogService roomEnvironmentLogService;
+    @Mock
+    private SampleStorageService storageService;
+    @Mock
+    private StorageLocationService storageLocationService;
+
+    @InjectMocks
+    private BiorepositoryDashboardServiceImpl dashboardService;
+
+    @Test
+    public void storageCapacityMetrics_ExposeComputedDeviceSummary() {
+        StorageDevice freezerA = buildDevice(1, "Freezer-A", "FRA", true, 100);
+        StorageDevice freezerB = buildDevice(2, "Freezer-B", "FRB", true, null);
+        StorageDevice inactive = buildDevice(3, "Freezer-C", "FRC", false, 200);
+        StorageShelf shelfB = buildShelf(21, freezerB, true);
+        StorageRack rackB = buildRack(31, shelfB, true);
+        StorageBox boxB = buildBox(41, rackB, true, 4, 10); // derived capacity = 40
+
+        when(bioSampleService.getAll()).thenReturn(List.of(
+                buildBioSample(101, BioSample.WorkflowStatus.STORED),
+                buildBioSample(102, BioSample.WorkflowStatus.STORED),
+                buildBioSample(103, BioSample.WorkflowStatus.PENDING_STORAGE)));
+        when(storageLocationService.getAllDevices()).thenReturn(List.of(freezerA, freezerB, inactive));
+        when(storageLocationService.getAllShelves()).thenReturn(List.of(shelfB));
+        when(storageLocationService.getAllRacks()).thenReturn(List.of(rackB));
+        when(storageLocationService.getAllBoxes()).thenReturn(List.of(boxB));
+        when(storageLocationService.countOccupiedInDevice(1)).thenReturn(20);
+        when(storageLocationService.countOccupiedInDevice(2)).thenReturn(10);
+
+        Map<String, Object> metrics = dashboardService.getStorageCapacityMetrics();
+
+        assertEquals(2L, ((Number) metrics.get("totalSamplesStored")).longValue());
+        assertEquals(1L, ((Number) metrics.get("pendingStorage")).longValue());
+        assertEquals(2, ((Number) metrics.get("totalDevices")).intValue());
+        assertEquals(2, ((Number) metrics.get("capacityDefinedDevices")).intValue());
+        assertEquals(0, ((Number) metrics.get("capacityUndefinedDevices")).intValue());
+        assertEquals(140L, ((Number) metrics.get("totalConfiguredCapacity")).longValue());
+        assertEquals(30L, ((Number) metrics.get("totalCurrentUsage")).longValue());
+        assertEquals(21.4285, ((Number) metrics.get("averageUtilization")).doubleValue(), 0.001);
+    }
+
+    @Test
+    public void storageUtilizationByDevice_UsesConfiguredOrDerivedCapacitySources() {
+        StorageDevice freezerA = buildDevice(1, "Freezer-A", "FRA", true, 100);
+        StorageDevice freezerB = buildDevice(2, "Freezer-B", "FRB", true, null);
+        StorageShelf shelfB = buildShelf(21, freezerB, true);
+        StorageRack rackB = buildRack(31, shelfB, true);
+        StorageBox boxB = buildBox(41, rackB, true, 4, 10);
+
+        when(storageLocationService.getAllDevices()).thenReturn(List.of(freezerA, freezerB));
+        when(storageLocationService.getAllShelves()).thenReturn(List.of(shelfB));
+        when(storageLocationService.getAllRacks()).thenReturn(List.of(rackB));
+        when(storageLocationService.getAllBoxes()).thenReturn(List.of(boxB));
+        when(storageLocationService.countOccupiedInDevice(1)).thenReturn(20);
+        when(storageLocationService.countOccupiedInDevice(2)).thenReturn(10);
+
+        Map<String, Object> utilization = dashboardService.getStorageUtilizationByDevice();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> devices = (List<Map<String, Object>>) utilization.get("devices");
+
+        assertNotNull(devices);
+        assertEquals(2, devices.size());
+        Map<String, Object> first = devices.get(0);
+        Map<String, Object> second = devices.get(1);
+
+        assertEquals("Freezer-A", first.get("deviceName"));
+        assertEquals("DEVICE_CAPACITY_LIMIT", first.get("capacitySource"));
+        assertEquals(20.0, ((Number) first.get("utilizationPercent")).doubleValue(), 0.001);
+
+        assertEquals("Freezer-B", second.get("deviceName"));
+        assertEquals("BOX_GRID_SUM", second.get("capacitySource"));
+        assertEquals(40L, ((Number) second.get("totalCapacity")).longValue());
+        assertEquals(25.0, ((Number) second.get("utilizationPercent")).doubleValue(), 0.001);
+    }
+
+    private BioSample buildBioSample(int id, BioSample.WorkflowStatus status) {
+        BioSample sample = new BioSample();
+        sample.setId(id);
+        sample.setWorkflowStatus(status);
+        return sample;
+    }
+
+    private StorageDevice buildDevice(int id, String name, String code, boolean active, Integer capacityLimit) {
+        StorageDevice device = new StorageDevice();
+        device.setId(id);
+        device.setName(name);
+        device.setCode(code);
+        device.setType(StorageDevice.DeviceType.FREEZER.getValue());
+        device.setActive(active);
+        device.setCapacityLimit(capacityLimit);
+        return device;
+    }
+
+    private StorageShelf buildShelf(int id, StorageDevice parentDevice, boolean active) {
+        StorageShelf shelf = new StorageShelf();
+        shelf.setId(id);
+        shelf.setParentDevice(parentDevice);
+        shelf.setActive(active);
+        shelf.setLabel("Shelf-" + id);
+        return shelf;
+    }
+
+    private StorageRack buildRack(int id, StorageShelf parentShelf, boolean active) {
+        StorageRack rack = new StorageRack();
+        rack.setId(id);
+        rack.setParentShelf(parentShelf);
+        rack.setActive(active);
+        rack.setLabel("Rack-" + id);
+        return rack;
+    }
+
+    private StorageBox buildBox(int id, StorageRack parentRack, boolean active, int rows, int columns) {
+        StorageBox box = new StorageBox();
+        box.setId(id);
+        box.setParentRack(parentRack);
+        box.setActive(active);
+        box.setRows(rows);
+        box.setColumns(columns);
+        box.setLabel("Box-" + id);
+        box.setCode("B" + id);
+        return box;
+    }
+}

--- a/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryExportServicePdfTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryExportServicePdfTest.java
@@ -1,0 +1,88 @@
+package org.openelisglobal.biorepository.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.biorepository.valueholder.ChainOfCustodyLog;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BiorepositoryExportServicePdfTest {
+
+    @Mock
+    private BiorepositoryDashboardService dashboardService;
+
+    @Mock
+    private ChainOfCustodyService custodyService;
+
+    @InjectMocks
+    private BiorepositoryExportServiceImpl exportService;
+
+    @Test
+    public void exportDashboardToPDF_ReturnsPdfDocumentBytes() throws Exception {
+        when(dashboardService.getStorageCapacityMetrics()).thenReturn(
+                Map.of("totalDevices", 2, "totalSamplesStored", 20, "pendingStorage", 3, "averageUtilization", 45.5));
+        when(dashboardService.getSampleAgingMetrics())
+                .thenReturn(Map.of("total", 20, "expiring30Days", 2, "expiring60Days", 1, "expiring90Days", 0, "expired", 1));
+        when(dashboardService.getQCComplianceMetrics())
+                .thenReturn(Map.of("totalInspections", 10, "passedInspections", 9, "failedInspections", 1, "complianceRate", 90.0));
+        when(dashboardService.getRetrievalStatistics(any(), any()))
+                .thenReturn(Map.of("totalRequests", 5, "pendingRequests", 1, "rejectedRequests", 0, "completedRequests", 4));
+
+        byte[] bytes = exportService.exportDashboardToPDF();
+        assertNotNull(bytes);
+        assertTrue(bytes.length > 32);
+        String prefix = new String(bytes, 0, 5, StandardCharsets.ISO_8859_1);
+        assertEqualsPdfSignature(prefix);
+    }
+
+    @Test
+    public void exportAuditTrailToPDF_ReturnsPdfDocumentBytes() throws Exception {
+        ChainOfCustodyLog log = new ChainOfCustodyLog();
+        log.setActionTimestamp(new Timestamp(System.currentTimeMillis()));
+        log.setCustodyAction(ChainOfCustodyLog.CustodyAction.CHECKOUT_RETRIEVED);
+        log.setFromLocation("Freezer-A > Shelf-1");
+        log.setToLocation("Bench-1");
+        log.setTemperature(new BigDecimal("-70.5"));
+        log.setNotes("Operator transfer");
+
+        Sample sample = new Sample();
+        sample.setAccessionNumber("ACC-123");
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId("1001");
+        sampleItem.setExternalId("BAR-001");
+        sampleItem.setSample(sample);
+        log.setSampleItem(sampleItem);
+
+        when(custodyService.searchCustodyLogs(anyString(), any(), anyInt(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(List.of(log));
+
+        byte[] bytes = exportService.exportAuditTrailToPDF("BAR-001", null, null, null, null);
+        assertNotNull(bytes);
+        assertTrue(bytes.length > 32);
+        String prefix = new String(bytes, 0, 5, StandardCharsets.ISO_8859_1);
+        assertEqualsPdfSignature(prefix);
+        String contentProbe = new String(bytes, StandardCharsets.ISO_8859_1);
+        assertFalse(contentProbe.trim().startsWith("{"));
+    }
+
+    private void assertEqualsPdfSignature(String prefix) {
+        assertTrue("Expected PDF signature but got: " + prefix, "%PDF-".equals(prefix));
+    }
+}

--- a/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryQcOutcomeDerivationTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryQcOutcomeDerivationTest.java
@@ -45,6 +45,7 @@ public class BiorepositoryQcOutcomeDerivationTest {
     public void markMissingCorrection_IsMissingAndFailedMarkedMissing() {
         BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
         inspection.setQcResult(QCResult.DISCREPANCY_FOUND);
+        inspection.setDiscrepancyType(BiorepositoryQCInspection.DiscrepancyType.SAMPLE_MISSING);
         inspection.setCorrectiveAction("MARK_MISSING: unable to locate sample");
         inspection.setCorrectionActionType("MARK_MISSING");
 

--- a/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryQcOutcomeDerivationTest.java
+++ b/src/test/java/org/openelisglobal/biorepository/service/BiorepositoryQcOutcomeDerivationTest.java
@@ -1,0 +1,54 @@
+package org.openelisglobal.biorepository.service;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection;
+import org.openelisglobal.biorepository.valueholder.BiorepositoryQCInspection.QCResult;
+
+public class BiorepositoryQcOutcomeDerivationTest {
+
+    @Test
+    public void discrepancyWithCorrectiveActionButNoCorrectionWorkflow_IsPendingCorrection() {
+        BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
+        inspection.setQcResult(QCResult.DISCREPANCY_FOUND);
+        inspection.setCorrectiveAction("Investigate discrepancy and locate sample");
+        inspection.setCorrectionActionType(null);
+
+        assertEquals("QC_FAILED", BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection));
+        assertEquals("FAILED_PENDING_CORRECTION", BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection));
+    }
+
+    @Test
+    public void updateLocationCorrection_IsFailedCorrected() {
+        BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
+        inspection.setQcResult(QCResult.DISCREPANCY_FOUND);
+        inspection.setCorrectiveAction("UPDATE_LOCATION: moved to expected rack");
+        inspection.setCorrectionActionType("UPDATE_LOCATION");
+
+        assertEquals("QC_FAILED", BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection));
+        assertEquals("FAILED_CORRECTED", BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection));
+    }
+
+    @Test
+    public void reassignPositionCorrection_IsFailedCorrected() {
+        BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
+        inspection.setQcResult(QCResult.DISCREPANCY_FOUND);
+        inspection.setCorrectiveAction("REASSIGN_POSITION: set to B4");
+        inspection.setCorrectionActionType("REASSIGN_POSITION");
+
+        assertEquals("QC_FAILED", BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection));
+        assertEquals("FAILED_CORRECTED", BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection));
+    }
+
+    @Test
+    public void markMissingCorrection_IsMissingAndFailedMarkedMissing() {
+        BiorepositoryQCInspection inspection = new BiorepositoryQCInspection();
+        inspection.setQcResult(QCResult.DISCREPANCY_FOUND);
+        inspection.setCorrectiveAction("MARK_MISSING: unable to locate sample");
+        inspection.setCorrectionActionType("MARK_MISSING");
+
+        assertEquals("MISSING", BiorepositoryQcOutcomeDerivation.deriveQcStatus(inspection));
+        assertEquals("FAILED_MARKED_MISSING", BiorepositoryQcOutcomeDerivation.deriveLifecycleOutcome(inspection));
+    }
+}


### PR DESCRIPTION
## What this solves
- completes the biorepository QC validation workflow on top of `demo/ethiopia`
- adds dashboard storage-capacity/utilization coverage, weighted utilization summary, and per-device reporting
- includes QC history, corrective action audit fields, escalation/reporting hardening, export support, and manifest import error handling for the biorepository flow
- keeps the PR scoped to product/test code only with no `.md` files in the diff

## Requirement coverage
- QC rounds and inspection recording
- randomized sampling / batch handling / QC history
- discrepancy tracking and corrective action audit fields
- dashboard metrics, escalation indicators, and reporting/export paths
- manifest import validation messages for the QC workflow

## Explicitly not included
- automated supervisor email/SMS/in-app notification delivery
- automatic creation of follow-up freezer-wide audits or scheduler-driven rounds

## Validation run on this branch
- `mvn -Dtest=BiorepositoryDashboardRestControllerDateValidationTest,BiorepositoryQCInspectionRestControllerFlowTest,BiorepositoryDashboardEscalationAndResolutionTest,BiorepositoryDashboardQCHistoryAuditMappingTest,BiorepositoryDashboardSampleAgingUnitTest,BiorepositoryDashboardStorageUtilizationTest,BiorepositoryExportServicePdfTest,BiorepositoryQcOutcomeDerivationTest test`
- `CI=true npm test -- --runInBand --watchAll=false manifestImportErrorMessages.test.js qcCorrectionGuardrails.test.js ReportingStorageConfidence.test.js`

## Notes
- branch rebuilt cleanly from current `origin/demo/ethiopia`
- previous wrong-base PR can stay closed; this PR replaces it against the correct base
- `BiorepositoryQCInspectionServiceIntegrationTest` was not included in the passing set here because this environment's Testcontainers/Docker client is currently incompatible
