### PR TITLE
fix(e2e): Fix incorrect E2E test selectors

### DIFF
--- a/frontend/Dockerfile.certs
+++ b/frontend/Dockerfile.certs
@@ -1,7 +1,7 @@
 ##
 # Build Stage
 #
-FROM ubuntu:focal as build
+FROM ubuntu:focal AS build
 
 ENV KEYSTORE_PW="kspass"
 ENV TRUSTSTORE_PW="tspass"
@@ -28,7 +28,7 @@ RUN sed -i 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g; s|htt
 #
 
 # Self-signed Certs
-RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/apache-selfsigned.key -out /etc/ssl/certs/apache-selfsigned.crt \ 
+RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/apache-selfsigned.key -out /etc/ssl/certs/apache-selfsigned.crt \
     -subj "/C=US/ST=WA/L=Seattle/O=DIGI-UW/OU=DIGI/CN=localhost" \
     -addext "subjectAltName=DNS:*.openelis.org"
 

--- a/frontend/playwright/tests/demo/core/ogc-62-shipment-workflow.spec.ts
+++ b/frontend/playwright/tests/demo/core/ogc-62-shipment-workflow.spec.ts
@@ -44,7 +44,7 @@ async function gotoCreateBox(page: Page) {
           .getByText(/create.*box|new.*box/i)
           .first(),
       )
-      .or(page.locator('[role="combobox"]').first())
+      .or(page.locator("#destination"))
       .first(),
   ).toBeVisible({ timeout: LONG_TIMEOUT });
 }
@@ -200,11 +200,9 @@ test("US2 — Create a new shipment box", async ({ page }, testInfo) => {
   );
   await showSceneLabel(page, "US2 · Select Destination", testInfo);
 
-  // Look for a dropdown/combobox for facility selection
-  const facilityDropdown = page
-    .locator('[role="combobox"]')
-    .or(page.locator("select"))
-    .first();
+  // Carbon Dropdown with id="destination" in BoxCreation.jsx. The id is
+  // applied to the list-box root; clicking it opens the listbox.
+  const facilityDropdown = page.locator("#destination");
   await expect(facilityDropdown).toBeVisible({ timeout: UI_TIMEOUT });
   await scrollToAndPause(page, facilityDropdown, pause, 1200);
 
@@ -212,16 +210,18 @@ test("US2 — Create a new shipment box", async ({ page }, testInfo) => {
   const isSelect =
     (await facilityDropdown.evaluate((el) => el.tagName)) === "SELECT";
   if (isSelect) {
-    const options = await facilityDropdown.locator("option").count();
+    const options = await facilityDropdown.locator('[role="option"]').count();
     if (options > 1) {
       await facilityDropdown.selectOption({ index: 1 });
     }
   } else {
     await facilityDropdown.click();
-    await expect(page.locator('[role="option"]').first()).toBeVisible({
+    await expect(
+      facilityDropdown.locator('[role="option"]').first(),
+    ).toBeVisible({
       timeout: UI_TIMEOUT,
     });
-    await page.locator('[role="option"]').first().click();
+    await facilityDropdown.locator('[role="option"]').first().click();
   }
   await pause(800);
 
@@ -338,11 +338,8 @@ test("US3 — View shipment boxes on dashboard", async ({ page }, testInfo) => {
     await scrollToAndPause(page, searchInput, pause, 1200);
   }
 
-  // State filter dropdown
-  const stateFilter = page
-    .getByText(/filter.*state/i)
-    .or(page.locator('[role="combobox"]').first())
-    .first();
+  // State filter Carbon Dropdown has id="state-filter" in ShipmentDashboard.jsx.
+  const stateFilter = page.locator("#state-filter");
   if (await stateFilter.isVisible()) {
     await scrollToAndPause(page, stateFilter, pause, 1200);
   }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

The test in the core 2 batch seem to be consistently failing on PR because the locators are either non-specific enough (i.e. `page.locator('[role="combox"]')` selects the first drop-down in the DOM, which doesn't match the intention of the first drop-down on the form) or wrong (i.e. `page.locator('option').first()` tries to select the first `option` DOM element, but Carbon for w/e reason uses `li` elements with `role="option"`. This PR scopes the selections to the right element by relying on the fact that we're already using `id` elements to control form element names.

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
