### PR TITLE
fix(frontend): correct help text typo in Result Reporting Configuration

### DIFF
--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -4446,7 +4446,7 @@
   "testnotification.patient.email": "Patient Email",
   "testnotification.patient.sms": "Patient SMS",
   "testnotification.patiententry.header": "Result Reporting",
-  "testnotification.patiententry.info": "If OpenELIS is not able to connect to the recipient of the transmitted results it will queue them up. A large and growing queue is a sign that troubling shootingshould be done including contacting the receiving party.",
+  "testnotification.patiententry.info": "If OpenELIS is not able to connect to the recipient of the transmitted results it will queue them up. A large and growing queue is a sign that troubleshooting should be done including contacting the receiving party.",
   "testnotification.provider.email": "Provider Email",
   "testnotification.provider.sms": "Provider SMS",
   "testnotification.subjecttemplate": "Subject",

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -1234,7 +1234,7 @@
   "configuration.testUnit.order.explain": "Sort lab units by clicking a unit and dragging it into the proper order.",
   "configuration.testUnit.order.explain.limits": "Only test sections with tests assigned may be ordered.  For new sections please assign tests before ordering.",
   "configuration.type.rename": "Rename Existing Sample Types",
-  "configuration.type.rename.explain": "Use to correct the name of existing panels.",
+  "configuration.type.rename.explain": "Use to correct the name of existing sample types.",
   "configuration.uom.create": "Create New Units of Measure",
   "configuration.uom.manage": "Manage Units of Measure",
   "configuration.uom.manage.explain": "Use to create Units of Measure",


### PR DESCRIPTION
Fix typo in testnotification.patiententry.info:
- "troubling shooting" → "troubleshooting"
- "shootingshould" → "shooting should" (add missing space)


