### PR TITLE
feat(qc): receive lot+level metadata from FHIR Observation extensions

### DIFF
--- a/src/main/java/org/openelisglobal/analyzer/service/BridgeRegistrationService.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/BridgeRegistrationService.java
@@ -6,6 +6,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import org.openelisglobal.common.log.LogEvent;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,12 @@ public class BridgeRegistrationService {
     private String bridgeBaseUrl;
 
     private final HttpClient httpClient;
+
+    // Optional — null in older deployments without QC rule support; service
+    // exists in current codebase. Autowired to avoid threading qcRules through
+    // every registerFile caller.
+    @Autowired(required = false)
+    private AnalyzerQcRuleService analyzerQcRuleService;
 
     public BridgeRegistrationService() {
         HttpClient client;
@@ -98,6 +105,30 @@ public class BridgeRegistrationService {
             }
             if (testMappings != null && !testMappings.isEmpty()) {
                 payload.put("testMappings", testMappings);
+            }
+            // Pull QC identification rules from the analyzer's profile and
+            // include them in the registration payload. The bridge's
+            // FileResultParser routes through these to classify QC samples
+            // (e.g. SPECIMEN_ID_PREFIX matches like CNEG/CPOS/LPC/HPC).
+            // Without this the bridge falls back to its hardcoded prefix
+            // list and silently mis-classifies any sample that uses a
+            // non-default prefix as a patient sample.
+            if (analyzerQcRuleService != null) {
+                java.util.List<QcRuleDto> qcRules = analyzerQcRuleService.getActiveRuleDtosForAnalyzer(oeAnalyzerId);
+                if (qcRules != null && !qcRules.isEmpty()) {
+                    java.util.List<java.util.Map<String, Object>> qcRulesPayload = new java.util.ArrayList<>(
+                            qcRules.size());
+                    for (QcRuleDto r : qcRules) {
+                        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+                        m.put("ruleType", r.ruleType());
+                        if (r.targetField() != null) {
+                            m.put("targetField", r.targetField());
+                        }
+                        m.put("operand", r.operand());
+                        qcRulesPayload.add(m);
+                    }
+                    payload.put("qcRules", qcRulesPayload);
+                }
             }
             String json = objectMapper.writeValueAsString(payload);
             return callRegister(json, oeAnalyzerId);

--- a/src/main/java/org/openelisglobal/analyzer/service/QCResultProcessingService.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/QCResultProcessingService.java
@@ -32,12 +32,20 @@ public interface QCResultProcessingService {
      *
      * @param analyzerId      Analyzer ID (from X-Analyzer-Id header)
      * @param testId          Mapped OE test ID (from AnalyzerTestNameCache)
-     * @param accessionNumber Specimen accession number (used to look up control lot
-     *                        by lot number)
+     * @param accessionNumber Specimen accession number (specimen identifier)
+     * @param lotNumber       Canonical {@code qc_control_lot.lot_number} when the
+     *                        bridge could extract it (ASTM Q-segment field 3
+     *                        component 2). Pass {@code null} when not available —
+     *                        resolver falls through to level-based or single-lot
+     *                        fallback.
+     * @param controlLevel    Clinical level identifier (LPC/HPC/CNEG/CPOS etc.) —
+     *                        ASTM Q-segment field 3 component 3, OR the matched
+     *                        FILE qcRule SPECIMEN_ID_PREFIX operand. Pass
+     *                        {@code null} when not available.
      * @param resultValue     Numeric result value
      * @param unit            Unit of measure
      * @param timestamp       Run date/time from Observation.effectiveDateTime
      */
-    void processQCResult(String analyzerId, String testId, String accessionNumber, BigDecimal resultValue, String unit,
-            LocalDateTime timestamp);
+    void processQCResult(String analyzerId, String testId, String accessionNumber, String lotNumber,
+            String controlLevel, BigDecimal resultValue, String unit, LocalDateTime timestamp);
 }

--- a/src/main/java/org/openelisglobal/analyzer/service/QCResultProcessingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/QCResultProcessingServiceImpl.java
@@ -47,8 +47,8 @@ public class QCResultProcessingServiceImpl implements QCResultProcessingService 
 
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
-    public void processQCResult(String analyzerId, String testId, String accessionNumber, BigDecimal resultValue,
-            String unit, LocalDateTime timestamp) {
+    public void processQCResult(String analyzerId, String testId, String accessionNumber, String lotNumber,
+            String controlLevel, BigDecimal resultValue, String unit, LocalDateTime timestamp) {
 
         if (testId == null || analyzerId == null || accessionNumber == null) {
             LogEvent.logWarn(CLASS_NAME, "processQCResult", "Skipping QC processing — missing required field: testId="
@@ -67,11 +67,11 @@ public class QCResultProcessingServiceImpl implements QCResultProcessingService 
             return;
         }
 
-        QCControlLot lot = findMatchingControlLot(accessionNumber, testIdInt, instrumentId);
+        QCControlLot lot = findMatchingControlLot(accessionNumber, lotNumber, controlLevel, testIdInt, instrumentId);
         if (lot == null) {
             LogEvent.logError(CLASS_NAME, "processQCResult",
-                    "No matching QC control lot for accession=" + accessionNumber + " testId=" + testId
-                            + " instrumentId=" + analyzerId
+                    "No matching QC control lot for accession=" + accessionNumber + " lotNumber=" + lotNumber
+                            + " controlLevel=" + controlLevel + " testId=" + testId + " instrumentId=" + analyzerId
                             + " — create an ACTIVE control lot for this test+instrument via the QC dashboard");
             return;
         }
@@ -94,42 +94,70 @@ public class QCResultProcessingServiceImpl implements QCResultProcessingService 
      * Find a control lot for the given QC observation.
      *
      * <p>
-     * Two-tier resolution strategy per the design spec
-     * ({@code getActiveControlLot(testId, instrumentId, level)}):
+     * Three-tier resolution. Each tier consumes metadata that the bridge propagated
+     * upstream — no guessing, no substring heuristics:
      *
      * <ol>
-     * <li><b>Strict match</b>: specimen accession equals a lot's {@code lotNumber}.
-     * Supports labs that encode the lot number in the specimen ID (e.g.,
-     * "BioRad-Lot-12345").</li>
-     * <li><b>Fallback</b>: if no strict match, and exactly one ACTIVE lot exists
-     * for {@code (testId, instrumentId)}, use it. This covers FILE analyzers where
-     * the specimen ID is a per-run identifier (CNEG001, NTC001) unrelated to the
-     * lot number.</li>
+     * <li><b>Tier 1 — explicit lot match</b>: bridge extracted a canonical lot
+     * identifier (ASTM Q-segment field 3 component 2, or future FILE profile
+     * mappings). Equality match on {@code lotNumber}.</li>
+     * <li><b>Tier 2 — level match</b>: bridge surfaced a control level (ASTM
+     * Q-segment field 3 component 3, or matched FILE qcRule SPECIMEN_ID_PREFIX
+     * operand like "LPC"/"HPC"/"CNEG"). Equality match on {@code controlLevel} for
+     * the (test, instrument). Handles the normal multi-level QC case where labs run
+     * LPC + HPC simultaneously.</li>
+     * <li><b>Tier 3 — single-lot fallback</b>: backwards-compat for pre-extension
+     * bundles or ad-hoc registrations with exactly one ACTIVE lot on (test,
+     * instrument).</li>
      * </ol>
      *
      * <p>
-     * Returns {@code null} if zero or multiple ACTIVE lots exist without a strict
-     * match (ambiguous — requires manual lot selection or level-based
-     * disambiguation in a future milestone).
+     * Returns {@code null} when no tier matches. Caller logs the error including
+     * all metadata so a clinician can identify which lot was expected.
      */
-    private QCControlLot findMatchingControlLot(String accessionNumber, Integer testId, Integer instrumentId) {
+    private QCControlLot findMatchingControlLot(String accessionNumber, String lotNumber, String controlLevel,
+            Integer testId, Integer instrumentId) {
         List<QCControlLot> lots = controlLotDAO.getByTestAndInstrument(testId, instrumentId);
 
-        // Tier 1: strict match — accession number equals lot number
+        // Tier 1: explicit lot_number from FHIR extension OR from accession
+        // when operator encoded it in specimen ID (BioRad-Lot-12345 pattern)
+        if (lotNumber != null && !lotNumber.isEmpty()) {
+            for (QCControlLot lot : lots) {
+                if (isUsable(lot) && lotNumber.equals(lot.getLotNumber())) {
+                    LogEvent.logInfo(CLASS_NAME, "findMatchingControlLot", "Tier 1: explicit lot match '" + lotNumber
+                            + "' for testId=" + testId + " instrumentId=" + instrumentId);
+                    return lot;
+                }
+            }
+        }
         for (QCControlLot lot : lots) {
-            String status = lot.getStatus();
-            if (("ACTIVE".equals(status) || "ESTABLISHMENT".equals(status))
-                    && accessionNumber.equals(lot.getLotNumber())) {
+            if (isUsable(lot) && accessionNumber.equals(lot.getLotNumber())) {
+                LogEvent.logInfo(CLASS_NAME, "findMatchingControlLot", "Tier 1: accession-as-lot match '"
+                        + accessionNumber + "' for testId=" + testId + " instrumentId=" + instrumentId);
                 return lot;
             }
         }
 
-        // Tier 2: fallback — single ACTIVE lot for (test, instrument)
+        // Tier 2: level match — controlLevel from FHIR extension picks the
+        // right lot when (testId, instrumentId) has multiple ACTIVE lots
+        // (the normal multi-level QC case: LPC + HPC simultaneously).
+        if (controlLevel != null && !controlLevel.isEmpty()) {
+            for (QCControlLot lot : lots) {
+                if ("ACTIVE".equals(lot.getStatus()) && controlLevel.equalsIgnoreCase(lot.getControlLevel())) {
+                    LogEvent.logInfo(CLASS_NAME, "findMatchingControlLot",
+                            "Tier 2: level match controlLevel='" + controlLevel + "' → lot '" + lot.getLotNumber()
+                                    + "' for testId=" + testId + " instrumentId=" + instrumentId);
+                    return lot;
+                }
+            }
+        }
+
+        // Tier 3: single-ACTIVE-lot fallback (backwards-compat / pre-extension bundles)
         List<QCControlLot> activeLots = lots.stream().filter(l -> "ACTIVE".equals(l.getStatus())).toList();
         if (activeLots.size() == 1) {
             LogEvent.logInfo(CLASS_NAME, "findMatchingControlLot",
-                    "No strict lot-number match for accession=" + accessionNumber + "; using single ACTIVE lot '"
-                            + activeLots.get(0).getLotNumber() + "' for testId=" + testId + " instrumentId="
+                    "Tier 3: single-ACTIVE-lot fallback — using '" + activeLots.get(0).getLotNumber()
+                            + "' for accession=" + accessionNumber + " testId=" + testId + " instrumentId="
                             + instrumentId);
             return activeLots.get(0);
         }
@@ -146,10 +174,16 @@ public class QCResultProcessingServiceImpl implements QCResultProcessingService 
 
         if (activeLots.size() > 1) {
             LogEvent.logWarn(CLASS_NAME, "findMatchingControlLot",
-                    "Multiple ACTIVE lots for testId=" + testId + " instrumentId=" + instrumentId
-                            + " — cannot resolve without level-based matching. Lot count: " + activeLots.size());
+                    "Multiple ACTIVE lots for testId=" + testId + " instrumentId=" + instrumentId + " (count="
+                            + activeLots.size() + "); bridge did not propagate lotNumber/"
+                            + "controlLevel — cannot disambiguate.");
         }
 
         return null;
+    }
+
+    private static boolean isUsable(QCControlLot lot) {
+        String status = lot.getStatus();
+        return "ACTIVE".equals(status) || "ESTABLISHMENT".equals(status);
     }
 }

--- a/src/main/java/org/openelisglobal/analyzerimport/action/AnalyzerFhirImportController.java
+++ b/src/main/java/org/openelisglobal/analyzerimport/action/AnalyzerFhirImportController.java
@@ -366,6 +366,27 @@ public class AnalyzerFhirImportController extends org.openelisglobal.common.rest
             ar.setIsControl(isQc);
         }
 
+        // QC metadata from bridge extensions — used by
+        // QCResultProcessingService.findMatchingControlLot to resolve to
+        // the right qc_control_lot row directly. Populated by the bridge
+        // when it could extract them (ASTM Q-segment OR matched FILE
+        // qcRule operand). Carried in-memory only (transient on AR), so
+        // no schema migration required.
+        if (obs.hasExtension("http://openelis-global.org/fhir/qc/lot-number")) {
+            org.hl7.fhir.r4.model.Extension lotExt = obs
+                    .getExtensionByUrl("http://openelis-global.org/fhir/qc/lot-number");
+            if (lotExt != null && lotExt.getValue() instanceof org.hl7.fhir.r4.model.StringType) {
+                ar.setLotNumber(((org.hl7.fhir.r4.model.StringType) lotExt.getValue()).getValue());
+            }
+        }
+        if (obs.hasExtension("http://openelis-global.org/fhir/qc/control-level")) {
+            org.hl7.fhir.r4.model.Extension levelExt = obs
+                    .getExtensionByUrl("http://openelis-global.org/fhir/qc/control-level");
+            if (levelExt != null && levelExt.getValue() instanceof org.hl7.fhir.r4.model.StringType) {
+                ar.setControlLevel(((org.hl7.fhir.r4.model.StringType) levelExt.getValue()).getValue());
+            }
+        }
+
         // Completion timestamp from effectiveDateTime
         if (obs.hasEffectiveDateTimeType()) {
             try {
@@ -645,7 +666,7 @@ public class AnalyzerFhirImportController extends org.openelisglobal.common.rest
                     : LocalDateTime.now();
 
             qcResultProcessingService.processQCResult(analyzer.getId(), ar.getTestId(), ar.getAccessionNumber(),
-                    resultValue, ar.getUnits(), timestamp);
+                    ar.getLotNumber(), ar.getControlLevel(), resultValue, ar.getUnits(), timestamp);
         } catch (NumberFormatException e) {
             LogEvent.logWarn(CLASS_NAME, "processQCAnalyzerResult",
                     "QC result value is not numeric — skipping QC processing: " + ar.getResult());

--- a/src/main/java/org/openelisglobal/analyzerresults/valueholder/AnalyzerResults.java
+++ b/src/main/java/org/openelisglobal/analyzerresults/valueholder/AnalyzerResults.java
@@ -84,12 +84,44 @@ public class AnalyzerResults extends BaseObject<String> implements Cloneable {
     @Column(name = "import_issue_reason", length = 200)
     private String importIssueReason;
 
+    // QC metadata propagated from the analyzer-bridge for control samples.
+    // Transient — only carried in-memory from FHIR ingest
+    // (AnalyzerFhirImportController) through to QCResultProcessingService.
+    // Not persisted on analyzer_results because the matched lot is
+    // already recorded on the qc_result row (control_lot_id FK).
+    // - lotNumber: canonical qc_control_lot.lot_number when the bridge
+    // extracted it (ASTM Q-segment field 3 component 2)
+    // - controlLevel: clinical level identifier (LPC/HPC/CNEG/CPOS/etc.)
+    // — ASTM Q-segment field 3 component 3, OR matched FILE qcRule's
+    // SPECIMEN_ID_PREFIX operand
+    @jakarta.persistence.Transient
+    private String lotNumber;
+
+    @jakarta.persistence.Transient
+    private String controlLevel;
+
     public String getImportIssueReason() {
         return importIssueReason;
     }
 
     public void setImportIssueReason(String importIssueReason) {
         this.importIssueReason = importIssueReason;
+    }
+
+    public String getLotNumber() {
+        return lotNumber;
+    }
+
+    public void setLotNumber(String lotNumber) {
+        this.lotNumber = lotNumber;
+    }
+
+    public String getControlLevel() {
+        return controlLevel;
+    }
+
+    public void setControlLevel(String controlLevel) {
+        this.controlLevel = controlLevel;
     }
 
     public Object clone() throws CloneNotSupportedException {


### PR DESCRIPTION
## Summary

OE side of the QC metadata propagation pipeline. Replaces the
substring-match disambiguation hack in \`QCResultProcessingService\`
with explicit metadata flowing from analyzer → bridge → FHIR
extensions → OE.

Paired bridge PR: [openelis-analyzer-bridge#37](https://github.com/DIGI-UW/openelis-analyzer-bridge/pull/37).

## Pipeline

\`\`\`
Bridge bundles Observation with extensions:
  http://openelis-global.org/fhir/qc/lot-number    (StringType)
  http://openelis-global.org/fhir/qc/control-level (StringType)
        ↓ POST /fhir
AnalyzerFhirImportController reads the extensions and sets
  ar.lotNumber / ar.controlLevel (@Transient — in-memory only)
        ↓
QCResultProcessingService.processQCResult(..., lotNumber, controlLevel, ...)
        ↓
findMatchingControlLot:
  Tier 1: explicit lotNumber match (also accepts accession-as-lotNumber for
          labs that encode lot in specimen ID)
  Tier 2: case-insensitive controlLevel equality on ACTIVE lots
          (LPC, HPC, CNEG, CPOS) — disambiguates multi-level QC
  Tier 3: single-ACTIVE-lot fallback
  Backstop: single-ESTABLISHMENT-lot fallback for new lots accumulating data
\`\`\`

## Why \`@Transient\`, not a schema change

The lot/level metadata flows from FHIR ingest (\`AnalyzerFhirImportController\`)
to the QC service inside one request. It is recorded canonically on
\`qc_result.control_lot_id\` (FK). Nothing queries
\`analyzer_results.lot_number\` later, no audit needs the column,
no cross-request workflow depends on it. \`@Transient\` is the right tool.

## BridgeRegistrationService change

\`BridgeRegistrationService.registerFile\` now pushes the OE-side
\`AnalyzerQcRules\` rows in the registration payload as
\`{ ruleType, targetField, operand }\`. The bridge uses these to
classify samples and surface the matched-rule operand as
\`controlLevel\` before bundling — completing the round-trip.

## Test plan

- [ ] Upload \`qadocs/QuantStudio Failing QC Samples.zip/qc-only_01_1-3s.csv\`
      via bridge UI against a profile that has both LPC + HPC ACTIVE lots
      seeded for QuantStudio. Webapp log emits
      \`Tier 2: level match controlLevel='LPC' → lot 'LOT-LPC-26B'\`.
- [ ] Verify \`qc_alert\` row created with rule \`1₃ₛ\` (Westgard 1-3s violation).
- [ ] ASTM Q-segment with \`Q|1|TEST^LOT-12345^HPC|...\` resolves via Tier 1.
- [ ] No-metadata + single-ACTIVE-lot still works (Tier 3, backwards compat).