### PR TITLE
fix(nav): SPA-route internal URLs + collapse Admin overlay drawer

### DIFF
--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -464,7 +464,11 @@ function OEHeader({
       }
 
       if (menuItem.menu.actionURL) {
-        if (menuItem.menu.openInNewWindow) {
+        // Internal SPA routes (path starts with "/") always use history.push,
+        // even when the menu row was seeded with new_window=true. The flag
+        // only fires window.open() for true external URLs (http(s)://, mailto:, etc.).
+        const isInternalUrl = menuItem.menu.actionURL.startsWith("/");
+        if (menuItem.menu.openInNewWindow && !isInternalUrl) {
           window.open(menuItem.menu.actionURL);
         } else {
           history.push(menuItem.menu.actionURL);
@@ -497,6 +501,15 @@ function OEHeader({
             isActive={carbonIsActive}
             onToggle={(expanded) => {
               setMenuItemExpanded(menuItem, path);
+              // TEMP: Admin's child page renders its own admin sub-nav,
+              // which the overlay drawer covers in SHOW mode. Collapse the
+              // drawer so the page underneath is visible.
+              if (
+                menuItem.menu.elementId === "menu_administration" &&
+                mode === SIDENAV_MODES.SHOW
+              ) {
+                setMode(SIDENAV_MODES.CLOSE);
+              }
             }}
             className={
               level === 0
@@ -541,8 +554,18 @@ function OEHeader({
           }
           isActive={isLeafActive}
           href={menuItem.menu.actionURL || undefined}
-          target={menuItem.menu.openInNewWindow ? "_blank" : undefined}
-          rel={menuItem.menu.openInNewWindow ? "noreferrer" : undefined}
+          target={
+            menuItem.menu.openInNewWindow &&
+            !menuItem.menu.actionURL?.startsWith("/")
+              ? "_blank"
+              : undefined
+          }
+          rel={
+            menuItem.menu.openInNewWindow &&
+            !menuItem.menu.actionURL?.startsWith("/")
+              ? "noreferrer"
+              : undefined
+          }
           onClick={handleLabelClick}
           aria-current={isLeafActive ? "page" : undefined}
           style={level === 0 ? undefined : { width: "100%" }}


### PR DESCRIPTION
## Summary

Two side-nav issues surfaced from Madagascar distro testing.

### 1. Aliquot opens in a new tab

The upstream menu seed (\`liquibase/3.2.x.x/sample_item.xml\`,
\`menu_aliquot\`) has \`new_window=true\` on a route that is internal
to the SPA (\`/Aliquot\`). \`Header.jsx\` honored the flag and called
\`window.open()\`, breaking SPA routing.

**Fix:** any \`actionURL\` starting with \`/\` is an internal SPA route
— route via \`history.push()\` regardless of the flag. External URLs
(http(s)://, mailto:, etc.) keep their new-tab behavior. Mirror the
same guard on the leaf-render \`target\`/\`rel\` attributes so
right/middle-click matches the click-handler intent.

This is a general fix that applies fleet-wide. Any menu row with
\`new_window=true\` AND an internal \`/\`-route is effectively
miscoded; the new behavior matches what those rows were trying to
express.

### 2. Admin overlay drawer covers admin sub-nav (TEMP)

The Admin parent renders its own admin-landing sub-nav, which the
overlay drawer covers in \`SHOW\` mode. Temp fix: collapse the
drawer to rail when the user toggles Admin in \`SHOW\` mode.

- Element-id gated (\`menu_administration\` only)
- Mode-gated (only in \`SHOW\` overlay mode; no effect on \`LOCK\`)
- Comment-tagged \`// TEMP:\` for trivial removal once the proper
  Admin layout fix lands.

## Test plan

- [ ] Aliquot top-level: click → URL is \`/Aliquot\` in the same tab,
      React Aliquot page renders. Right-click → no "Open in new tab"
      prompt for \`_blank\`.
- [ ] TAT in Reports (whitelisted via distro \`menu_config.json\`):
      click → \`/TATReport\` renders inline.
- [ ] Admin temp fix: cycle to \`SHOW\` (overlay) → expand Admin →
      drawer collapses to rail; admin landing page sub-nav uncovered.
      Cycle to \`LOCK\` and repeat → drawer stays pinned (mode gating
      works).