### PR TITLE
fix(modify-order): show Patient ID and Unique Health ID in header

### DIFF
--- a/frontend/src/components/common/PatientHeader.jsx
+++ b/frontend/src/components/common/PatientHeader.jsx
@@ -12,6 +12,7 @@ const PatientHeader = (props) => {
     dob,
     age = null,
     patientName = null,
+    patientId = null,
     subjectNumber = null,
     nationalId = null,
     accesionNumber = null,
@@ -72,8 +73,14 @@ const PatientHeader = (props) => {
                           : dob}
                       </span>
                     </div>
-                    {/* <br/> */}
+                    <br />
                     <div className="patient-id">
+                      {patientId && (
+                        <Tag size="lg" type="blue" style={tagStyle}>
+                          <FormattedMessage id="patient.id" /> :{" "}
+                          <strong>{patientId}</strong>
+                        </Tag>
+                      )}
                       {nationalId && (
                         <Tag size="lg" type="blue" style={tagStyle}>
                           <FormattedMessage id="patient.natioanalid" /> :{" "}

--- a/frontend/src/components/modifyOrder/ModifyOrder.jsx
+++ b/frontend/src/components/modifyOrder/ModifyOrder.jsx
@@ -55,6 +55,8 @@ const ModifyOrder = () => {
     gender: "",
     dob: "",
     nationalId: "",
+    patientId: "",
+    subjectNumber: "",
     accessionNumber: "",
   });
   const [changed, setChanged] = useState({
@@ -124,6 +126,8 @@ const ModifyOrder = () => {
           gender: data.gender || "",
           dob: data.dob || "",
           nationalId: data.nationalId || "",
+          patientId: data.patientId || "",
+          subjectNumber: data.subjectNumber || "",
           accessionNumber: data.accessionNumber || "",
         });
       }
@@ -296,6 +300,7 @@ const ModifyOrder = () => {
   return (
     <>
       <PageBreadCrumb breadcrumbs={breadcrumbs} />
+      <br />
 
       <PatientHeader
         id={patientId}
@@ -303,8 +308,10 @@ const ModifyOrder = () => {
         gender={patientHeaderInfo.gender}
         dob={patientHeaderInfo.dob}
         nationalId={patientHeaderInfo.nationalId}
+        patientId={patientHeaderInfo.patientId}
+        subjectNumber={patientHeaderInfo.subjectNumber}
         accesionNumber={patientHeaderInfo.accessionNumber}
-        className="patient-header3"
+        className="patient-header2"
         isOrderPage={true}
       >
         {" "}

--- a/src/main/java/org/openelisglobal/sample/controller/rest/SampleEditRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/SampleEditRestController.java
@@ -317,6 +317,8 @@ public class SampleEditRestController extends BaseSampleEntryController {
         form.setDob(patientPatientService.getEnteredDOB(patient));
         form.setGender(patientPatientService.getGender(patient));
         form.setNationalId(patientPatientService.getNationalId(patient));
+        form.setPatientId(patientPatientService.getPatientId(patient));
+        form.setSubjectNumber(patientPatientService.getSubjectNumber(patient));
     }
 
     private List<SampleEditItem> getCurrentTestInfo(List<SampleItem> sampleItemList, String accessionNumber,

--- a/src/main/java/org/openelisglobal/sample/form/SampleEditForm.java
+++ b/src/main/java/org/openelisglobal/sample/form/SampleEditForm.java
@@ -45,6 +45,10 @@ public class SampleEditForm extends BaseForm {
     @Pattern(regexp = ValidationHelper.PATIENT_ID_REGEX, groups = { SampleEdit.class })
     private String nationalId = "";
 
+    private String patientId = "";
+
+    private String subjectNumber = "";
+
     @ValidAccessionNumber(groups = { SampleEdit.class }, searchValue = true)
     private String accessionNumber;
 
@@ -175,6 +179,22 @@ public class SampleEditForm extends BaseForm {
 
     public void setNationalId(String nationalId) {
         this.nationalId = nationalId;
+    }
+
+    public String getPatientId() {
+        return patientId;
+    }
+
+    public void setPatientId(String patientId) {
+        this.patientId = patientId;
+    }
+
+    public String getSubjectNumber() {
+        return subjectNumber;
+    }
+
+    public void setSubjectNumber(String subjectNumber) {
+        this.subjectNumber = subjectNumber;
     }
 
     public String getAccessionNumber() {


### PR DESCRIPTION
The Edit Order patient header only displayed name, gender, DOB, National ID, and accession number, leaving reviewers without a quick way to see the system patient identifier or the configured subject/unique number without leaving the screen.

# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
