### PR TITLE
fix(tat-report): populate date inputs and dropdown options (OGC-644, OGC-645)

### DIFF
--- a/frontend/playwright/tests/demo/core/ogc-307-tat-report.spec.ts
+++ b/frontend/playwright/tests/demo/core/ogc-307-tat-report.spec.ts
@@ -212,3 +212,47 @@ test.describe("OGC-307: TAT Report (US2-US5)", () => {
     });
   });
 });
+
+// Regression coverage for OGC-644 / OGC-645. Independent of the demo
+// presentation flow above — does not need seeded accessions, only inspects
+// the filter bar UI itself.
+test.describe("OGC-644/645: TAT filter-bar UI regression", () => {
+  test("priority + segment dropdowns render visible options; presets populate date inputs", async ({
+    page,
+  }) => {
+    await page.goto("/TATReport");
+    await expect(
+      page.getByRole("heading", { name: "Turn Around Time Report" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // OGC-645 — Priority dropdown was rendering empty options.
+    await page.locator("#tat-priority button.cds--list-box__field").click();
+    await expect(page.getByRole("option", { name: "All" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "Routine" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "STAT" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "ASAP" })).toBeVisible();
+    await page.getByRole("option", { name: "STAT" }).click();
+    await expect(
+      page.locator("#tat-priority button.cds--list-box__field"),
+    ).toContainText("STAT");
+
+    // Sibling latent bug — same itemToString omission on segment dropdown.
+    await page.locator("#tat-segment button.cds--list-box__field").click();
+    await expect(
+      page.getByRole("option", { name: "Receipt to Validation" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "Overall TAT" }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    // OGC-644 — preset click must populate the visible date inputs, not just state.
+    await page.getByRole("button", { name: "Last 7 Days" }).click();
+    await expect(page.locator("#tat-from-date")).toHaveValue(
+      /^\d{4}-\d{2}-\d{2}$/,
+    );
+    await expect(page.locator("#tat-to-date")).toHaveValue(
+      /^\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+});

--- a/frontend/src/components/reports/tat/TATFilterBar.jsx
+++ b/frontend/src/components/reports/tat/TATFilterBar.jsx
@@ -184,10 +184,9 @@ function TATFilterBar({ onGenerate }) {
       >
         <DatePicker
           datePickerType="single"
+          dateFormat="Y-m-d"
           value={fromDate}
-          onChange={([date]) =>
-            date && setFromDate(date.toISOString().split("T")[0])
-          }
+          onChange={(_dates, dateStr) => setFromDate(dateStr)}
         >
           <DatePickerInput
             id="tat-from-date"
@@ -199,10 +198,9 @@ function TATFilterBar({ onGenerate }) {
 
         <DatePicker
           datePickerType="single"
+          dateFormat="Y-m-d"
           value={toDate}
-          onChange={([date]) =>
-            date && setToDate(date.toISOString().split("T")[0])
-          }
+          onChange={(_dates, dateStr) => setToDate(dateStr)}
         >
           <DatePickerInput
             id="tat-to-date"
@@ -219,6 +217,7 @@ function TATFilterBar({ onGenerate }) {
             id: s.id,
             text: intl.formatMessage({ id: s.labelKey }),
           }))}
+          itemToString={(item) => item?.text || ""}
           selectedItem={{
             id: segment,
             text: intl.formatMessage({
@@ -335,6 +334,7 @@ function TATFilterBar({ onGenerate }) {
             { id: "STAT", text: intl.formatMessage({ id: "reports.tat.priority.stat" }) },
             { id: "ASAP", text: intl.formatMessage({ id: "reports.tat.priority.asap" }) },
           ]}
+          itemToString={(item) => item?.text || ""}
           selectedItem={{
             id: priority,
             text: priority

--- a/frontend/src/components/reports/tat/__tests__/TATFilterBar.test.jsx
+++ b/frontend/src/components/reports/tat/__tests__/TATFilterBar.test.jsx
@@ -112,29 +112,45 @@ describe("TATFilterBar", () => {
     expect(checkbox).not.toBeChecked();
   });
 
-  test("onGenerate callback includes priority when selected", () => {
+  test("priority dropdown shows all options by visible text and selects STAT", () => {
     renderWithIntl(<TATFilterBar onGenerate={mockOnGenerate} />);
 
-    // Open the priority dropdown — Carbon Dropdown uses Downshift
-    const priorityWrapper = document.getElementById("tat-priority");
-    const trigger = priorityWrapper.querySelector(
-      "button.cds--list-box__field",
-    );
+    const trigger = document
+      .getElementById("tat-priority")
+      .querySelector("button.cds--list-box__field");
     fireEvent.click(trigger);
 
-    // Select the STAT option (index 2: All=0, Routine=1, STAT=2, ASAP=3)
-    // Carbon renders items as role="option" but without visible text in JSDOM
-    // because itemToString defaults to String(item) for object items
-    const options = priorityWrapper.querySelectorAll('[role="option"]');
-    expect(options.length).toBe(4);
-    fireEvent.click(options[2]); // STAT
+    expect(screen.getByRole("option", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Routine" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "STAT" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "ASAP" })).toBeInTheDocument();
 
-    // Click Generate and verify the priority is passed through
+    fireEvent.click(screen.getByRole("option", { name: "STAT" }));
     fireEvent.click(screen.getByTestId("generate-report-button"));
 
     expect(mockOnGenerate).toHaveBeenCalledTimes(1);
-    const filters = mockOnGenerate.mock.calls[0][0];
-    expect(filters).toHaveProperty("priority", "STAT");
+    expect(mockOnGenerate.mock.calls[0][0]).toHaveProperty("priority", "STAT");
+  });
+
+  test("segment dropdown shows all 7 segments by visible text", () => {
+    renderWithIntl(<TATFilterBar onGenerate={mockOnGenerate} />);
+
+    const trigger = document
+      .getElementById("tat-segment")
+      .querySelector("button.cds--list-box__field");
+    fireEvent.click(trigger);
+
+    for (const name of [
+      "Receipt to Validation",
+      "Order to Collection",
+      "Collection to Receipt",
+      "Receipt to Testing Started",
+      "Receipt to Result Entry",
+      "Result Entry to Validation",
+      "Overall TAT",
+    ]) {
+      expect(screen.getByRole("option", { name })).toBeInTheDocument();
+    }
   });
 
   test("renders new filter controls (lab unit, test, sample type, ordering site)", () => {
@@ -148,28 +164,31 @@ describe("TATFilterBar", () => {
     expect(comboboxes.length).toBeGreaterThanOrEqual(2);
   });
 
-  test("date preset 'Last 7 Days' sets correct date range", () => {
+  test("date preset 'Last 7 Days' populates visible inputs and filter state", () => {
     act(() => {
       renderWithIntl(<TATFilterBar onGenerate={mockOnGenerate} />);
     });
 
-    // Click the "Last 7 Days" preset tag
     const presetTag = screen.getByText(
       messages["reports.tat.preset.7days"] || "Last 7 Days",
     );
     fireEvent.click(presetTag);
 
-    // Click Generate to capture the filter state
-    fireEvent.click(screen.getByTestId("generate-report-button"));
+    const fromInput = screen.getByLabelText(/Date Range \(From\)/);
+    const toInput = screen.getByLabelText(/Date Range \(To\)/);
+    expect(fromInput.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(toInput.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
+    const visibleDiffDays = Math.round(
+      (new Date(toInput.value) - new Date(fromInput.value)) / 86400000,
+    );
+    expect(visibleDiffDays).toBe(7);
+
+    fireEvent.click(screen.getByTestId("generate-report-button"));
     expect(mockOnGenerate).toHaveBeenCalledTimes(1);
     const filters = mockOnGenerate.mock.calls[0][0];
-
-    // Verify the date range is approximately 7 days
-    const from = new Date(filters.fromDate);
-    const to = new Date(filters.toDate);
-    const diffDays = Math.round((to - from) / (1000 * 60 * 60 * 24));
-    expect(diffDays).toBe(7);
+    expect(filters.fromDate).toBe(fromInput.value);
+    expect(filters.toDate).toBe(toInput.value);
   });
 
   test("onGenerate includes new filter fields", () => {


### PR DESCRIPTION
## Summary

Two **Highest**-priority bugs Casey filed after testing TAT Report on `mgtest`:

- **[OGC-644](https://uwdigi.atlassian.net/browse/OGC-644)** — DatePicker on `/TATReport` did not populate the input after a single-date pick or preset click ("Last 7 Days", etc.).
- **[OGC-645](https://uwdigi.atlassian.net/browse/OGC-645)** — Priority dropdown opened but rendered no selectable options.

Both were single-prop omissions in `frontend/src/components/reports/tat/TATFilterBar.jsx` from the recent feature 310 (TAT Report) implementation.

### Fixes

| Bug | Component | Missing prop | Fix |
|---|---|---|---|
| OGC-644 | DatePicker (from / to) | `dateFormat` | Add `dateFormat="Y-m-d"`; switch onChange to use Flatpickr's pre-formatted `dateStr` arg. Mirrors working pattern in [SystemAuditEvents.jsx:243-269](https://github.com/DIGI-UW/OpenELIS-Global-2/blob/develop/frontend/src/components/reports/auditTrailReport/SystemAuditEvents.jsx#L243-L269). |
| OGC-645 | Priority Dropdown | `itemToString` | Add `itemToString={(item) => item?.text \|\| ""}`. Carbon's default `itemToString` reads `.label`; items use `.text`, so default returned `""` for every option. Mirrors sibling dropdowns in the same file. |
| (sibling, not filed) | Segment Dropdown | `itemToString` | Same one-line fix; same latent bug pattern that Casey didn't open. |

### Why the existing tests didn't catch this

The unit test for the priority dropdown had observed the empty-text rendering and **worked around it** with index-based option selection plus a comment rationalizing the empty text as "a JSDOM quirk where itemToString defaults to String(item) for object items." That was the production bug, sitting in source.

The date-preset test asserted only the *filter state* passed to `onGenerate`, never the visible input value. State was correctly set even when the input rendered blank.

The Playwright spec is a demo-presentation walkthrough — it never opened the priority dropdown and never asserted a `DatePickerInput` value.

### Test hardening (in this PR)

- Removed the rationalizing comment + index-selection workaround.
- Priority dropdown test now uses `getByRole("option", { name: "STAT" })` — fails if visible text is empty.
- Added analogous segment-dropdown test asserting all 7 segment labels by visible text.
- Date-preset test now asserts `fromInput.value` and `toInput.value` match `^\d{4}-\d{2}-\d{2}$` and the visible 7-day delta — fails if Flatpickr doesn't write the input.
- New Playwright regression block (independent of the demo's `serial`/seed flow) opens both dropdowns, asserts options, clicks a preset, asserts visible input values.

### Red → Green verification (observed)

Against the **unfixed** code the new assertions fail with the right reasons:
1. Priority test: `getByRole("option", { name: "All" })` not found (empty accessible names).
2. Segment test: same.
3. Date-preset test: `fromInput.value === ""` (Flatpickr never wrote the input).

After the prop additions all 12 unit tests pass.

## Test plan

- [x] `cd frontend && npm test -- --run TATFilterBar` → 12/12 green
- [x] `mvn spotless:apply` and `cd frontend && npm run format` clean
- [ ] Playwright regression block runs in CI (`OGC-644/645: TAT filter-bar UI regression`)
- [ ] Manual verification on dev / mgtest after merge: open Priority + Segment dropdowns, click preset buttons, confirm visible date values

## Out of scope

- Wiring the missing `/TATReport` nav-menu link (separate ticket — feature 310 T064 silently skipped the menu).
- Auditing other 310-era components for the same `itemToString` / `dateFormat` omissions.

[OGC-644]: https://uwdigi.atlassian.net/browse/OGC-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OGC-645]: https://uwdigi.atlassian.net/browse/OGC-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ