### PR TITLE
OGC-654: persist Notes column entries on /AccessionValidation save (LO-05-05)

### DIFF
--- a/frontend/src/components/validation/SearchForm.jsx
+++ b/frontend/src/components/validation/SearchForm.jsx
@@ -100,6 +100,16 @@ const SearchForm = (props) => {
   };
 
   useEffect(() => {
+    // OGC-654: server's GET response omits a `note` key on each row.
+    // jpSet (utils/JsonPath.js) silently no-ops when the JSONPath query
+    // returns 0 matches, so handleChange's `jpSet(form, "resultList[N].note", value)`
+    // never reaches the form state when typing into the Notes column. Pre-init
+    // each row's note to "" so the path exists and the mutation succeeds.
+    if (searchResults?.resultList) {
+      for (const row of searchResults.resultList) {
+        if (row && row.note === undefined) row.note = "";
+      }
+    }
     props.setResults(searchResults);
   }, [searchResults]);
 


### PR DESCRIPTION
## What

Validation by Order's Notes column was silently dropping user-typed text on Save: result validation succeeded (status_id 4 → 6) but the typed note never reached `clinlims.note` (verified live on mgtest 2026-05-04 with 0 rows written despite multiple successful validations).

## Why it matters

Blocks **LO-05-05** Madagascar UAT requirement (amendments to results: "the reason for the change is recorded **and included in the revised report**"). Patient-report data integrity issue — amended values reach the report stripped of the explanation.

Reported in Jira as [OGC-654](https://uwdigi.atlassian.net/browse/OGC-654) by Casey Iiams-Hauser; reproduced independently end-to-end on mgtest.

## Root cause

`form/AccessionValidationForm.java` populates `resultList` with `AnalysisItem`s that have `isAccepted/isRejected/result/...` but no `note` key. `Validation.jsx`'s `handleChange` calls:

```js
jpSet(form, "resultList[N].note", value);
```

`jpSet` (in `frontend/src/components/utils/JsonPath.js`) is documented to "resolve the parent via resultType:'all' and assigns through it." When the JSONPath query returns 0 matches — which it does whenever the leaf field doesn't already exist — jpSet silently no-ops. The checkbox bound to `isAccepted` worked because the server returns `isAccepted: false` on every row; the textarea bound to `note` did not.

## Fix

In `SearchForm.jsx`, pre-init each row's `note` to `""` before passing the form into the parent state via `setResults`. jpSet's path-resolution then succeeds and the in-place mutation persists through to the POST. **One useEffect block, ~5 lines.**

The fix is **minimal and bounded to Validation flow**. Per pre-existing convention, jpSet's docstring is honest about its semantics — the caller (Validation.jsx) was making assumptions jpSet doesn't promise. Hardening jpSet to silently create missing paths is a footgun for unrelated forms (e.g., conditional-field patterns where silent-no-op is intentional) and is intentionally out of scope; will be filed as a separate utility-hardening issue.

## Verification (live, end-to-end on mgtest)

Captured POST body before fix (note field absent):
```json
"resultList": [{
  "isAccepted": true, "analysisId": "6", "id": 0,
  ... // NO `note` field
}]
```

After fix — Playwright drives the actual UI on `https://mgtest.openelis-global.org/AccessionValidation`:
```
notes_total: 0 → 1     ✅
POST.resultList[0].note: "OGC-654-pwt-1777863727663"  ✅
POST status: 200       ✅
```

DB row in `clinlims.note` after save:
```
note_type='E' (External)   subject='Result Note'
text='OGC-654-pwt-1777863727663'   reference_id=7   reference_table=4
sys_user_id=1   lastupdated=2026-05-04 06:02:13
```

## Test coverage

Regression test added in the sibling **openelis-madagascar-test-harness** repo at `playwright/tests/foundational/harness/ogc-654-validation-note-persistence.spec.ts` — drives /AccessionValidation end-to-end, asserts both the POST body contains the note AND `clinlims.note` row count increments by 1. (Separate PR there per "1 PR per repo" convention.)

## Out of scope (separate follow-ups)

- **OE2 GH issue [#3541](https://github.com/DIGI-UW/OpenELIS-Global-2/issues/3541)** — Validation Save UX cluster (page-reload-on-no-rows-selected, no per-row save feedback, no confirmation toast on success). Already filed during OGC-654 reproduction; not bundled.
- **jpSet silent-no-op on missing paths** — utility-level footgun that could affect any future form that adds new fields not present on initial load. Worth filing as a separate hardening issue, not bundled per scope discipline.

## Files changed

- `frontend/src/components/validation/SearchForm.jsx` (+10/-0)

[OGC-654]: https://uwdigi.atlassian.net/browse/OGC-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ