### PR TITLE
fix compliance module

### DIFF
--- a/frontend/src/components/admin/complianceStandards/ComplianceStandardsAdmin.jsx
+++ b/frontend/src/components/admin/complianceStandards/ComplianceStandardsAdmin.jsx
@@ -352,6 +352,8 @@ function ComplianceStandardsAdmin() {
     if (addingNew && saved?.id) {
       setAddingNew(false);
       setExpandedId(saved.id);
+    } else {
+      setExpandedId(null);
     }
   };
 

--- a/frontend/src/components/admin/complianceStandards/ComplianceStandardsAdmin.jsx
+++ b/frontend/src/components/admin/complianceStandards/ComplianceStandardsAdmin.jsx
@@ -50,6 +50,7 @@ import {
 import PageBreadCrumb from "../../common/PageBreadCrumb";
 import StandardForm from "./StandardForm";
 import TestComplianceThresholds from "./TestComplianceThresholds";
+import { toDateString } from "./dateUtils";
 
 const STATUS_TAG = {
   ACTIVE: "green",
@@ -767,7 +768,7 @@ function ComplianceStandardsAdmin() {
                                   <TableCell>{s.regulationNumber}</TableCell>
                                   <TableCell>{s.version}</TableCell>
                                   <TableCell>
-                                    {s.effectiveDate || "—"}
+                                    {toDateString(s.effectiveDate) || "—"}
                                   </TableCell>
                                   <TableCell>
                                     <Tag

--- a/frontend/src/components/admin/complianceStandards/ParameterGroupAccordionItem.jsx
+++ b/frontend/src/components/admin/complianceStandards/ParameterGroupAccordionItem.jsx
@@ -169,10 +169,10 @@ function ParameterGroupAccordionItem({
   const testsInGroup = (() => {
     const map = new Map();
     thresholds.forEach((t) => {
-      const key = t.test?.id ? String(t.test.id) : t.parameterCode || "?";
+      const key = t.testId ? String(t.testId) : t.parameterCode || "?";
       if (!map.has(key)) {
         map.set(key, {
-          testId: t.test?.id ? String(t.test.id) : null,
+          testId: t.testId ? String(t.testId) : null,
           testName: t.displayName || t.parameterCode,
           parameterCode: t.parameterCode,
           rows: [],

--- a/frontend/src/components/admin/complianceStandards/ParameterGroupAccordionItem.jsx
+++ b/frontend/src/components/admin/complianceStandards/ParameterGroupAccordionItem.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
   AccordionItem,
   Stack,
@@ -28,6 +28,8 @@ import {
   putToOpenElisServerFullResponse,
   deleteFromOpenElisServer,
 } from "../../utils/Utils";
+import { NotificationContext } from "../../layout/Layout";
+import { NotificationKinds } from "../../common/CustomNotification";
 import MultiLimitForm, { LIMIT_TYPES } from "./MultiLimitForm";
 import SelectMapForm from "./SelectMapForm";
 import LinkTestForm from "./LinkTestForm";
@@ -96,6 +98,23 @@ function ParameterGroupAccordionItem({
   canMoveDown,
 }) {
   const intl = useIntl();
+  const { setNotificationVisible, addNotification } =
+    useContext(NotificationContext);
+  // Toast on every threshold action (link/save/unlink for numeric and
+  // select-map flavours). Per-row error attribution on the multi-limit
+  // form is preserved via the returned `errors` map; the toast is the
+  // overall confirmation/banner-level signal.
+  const toast = (kind, titleKey, titleDefault, messageKey, messageDefault) => {
+    addNotification({
+      kind,
+      title: intl.formatMessage({ id: titleKey, defaultMessage: titleDefault }),
+      message: intl.formatMessage({
+        id: messageKey,
+        defaultMessage: messageDefault,
+      }),
+    });
+    setNotificationVisible(true);
+  };
   const [thresholds, setThresholds] = useState([]);
   const [loading, setLoading] = useState(true);
   const [expandedTestKey, setExpandedTestKey] = useState(null);
@@ -262,6 +281,21 @@ function ParameterGroupAccordionItem({
         });
         if (Object.keys(errors).length === 0) {
           setExpandedTestKey(null);
+          toast(
+            NotificationKinds.success,
+            "notification.title.success",
+            "Saved",
+            "compliance.threshold.savedThresholds",
+            "Compliance thresholds linked to the test.",
+          );
+        } else {
+          toast(
+            NotificationKinds.error,
+            "notification.title.error",
+            "Error",
+            "compliance.threshold.savedPartialError",
+            "Some thresholds could not be saved. Review the highlighted rows.",
+          );
         }
         reload();
         return errors;
@@ -286,8 +320,26 @@ function ParameterGroupAccordionItem({
     putToOpenElisServerFullResponse(
       `/rest/compliance/thresholds/${parent.id}`,
       updated,
-      () => {
-        setExpandedTestKey(null);
+      (response) => {
+        const ok = response && response.ok;
+        if (ok) {
+          setExpandedTestKey(null);
+          toast(
+            NotificationKinds.success,
+            "notification.title.success",
+            "Saved",
+            "compliance.threshold.savedValueMap",
+            "Value-mapping threshold saved.",
+          );
+        } else {
+          toast(
+            NotificationKinds.error,
+            "notification.title.error",
+            "Error",
+            "compliance.threshold.saveError",
+            "Could not save this row.",
+          );
+        }
         reload();
       },
     );
@@ -322,6 +374,21 @@ function ParameterGroupAccordionItem({
         });
         if (Object.keys(errors).length === 0) {
           setAddingTest(false);
+          toast(
+            NotificationKinds.success,
+            "notification.title.success",
+            "Linked",
+            "compliance.threshold.testLinked",
+            "Test linked to the parameter group.",
+          );
+        } else {
+          toast(
+            NotificationKinds.error,
+            "notification.title.error",
+            "Error",
+            "compliance.threshold.savedPartialError",
+            "Some thresholds could not be saved. Review the highlighted rows.",
+          );
         }
         reload();
         return errors;
@@ -345,8 +412,25 @@ function ParameterGroupAccordionItem({
     postToOpenElisServerJsonResponse(
       "/rest/compliance/thresholds",
       JSON.stringify(payload),
-      () => {
-        setAddingTest(false);
+      (resp) => {
+        if (resp && resp.id && !resp.error) {
+          setAddingTest(false);
+          toast(
+            NotificationKinds.success,
+            "notification.title.success",
+            "Linked",
+            "compliance.threshold.testLinked",
+            "Test linked to the parameter group.",
+          );
+        } else {
+          toast(
+            NotificationKinds.error,
+            "notification.title.error",
+            "Error",
+            "compliance.threshold.saveError",
+            "Could not save this row.",
+          );
+        }
         reload();
       },
     );
@@ -370,11 +454,34 @@ function ParameterGroupAccordionItem({
           ),
         ),
     );
-    Promise.all(promises).then(() => {
+    Promise.all(promises).then((results) => {
       setShowUnlinkModal(false);
       setUnlinkTarget(null);
       if (expandedTestKey === (target.testId || target.parameterCode)) {
         setExpandedTestKey(null);
+      }
+      // deleteFromOpenElisServer fires its callback regardless of HTTP
+      // status. Treat anything non-2xx as a failure so an audit-blocking
+      // BR-002 / BR-003 conflict (409) doesn't silently disappear.
+      const allOk = results.every(
+        (r) => !r || r === true || (r.status && r.status < 300),
+      );
+      if (allOk) {
+        toast(
+          NotificationKinds.success,
+          "notification.title.success",
+          "Removed",
+          "compliance.linkedTest.unlinked",
+          "Test removed from the parameter group.",
+        );
+      } else {
+        toast(
+          NotificationKinds.error,
+          "notification.title.error",
+          "Error",
+          "compliance.linkedTest.unlinkError",
+          "Could not remove this test from the group.",
+        );
       }
       reload();
     });

--- a/frontend/src/components/admin/complianceStandards/StandardForm.jsx
+++ b/frontend/src/components/admin/complianceStandards/StandardForm.jsx
@@ -355,18 +355,26 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     standard?.countryRegion || "",
   );
   const [status, setStatus] = useState(standard?.status || "DRAFT");
+  const toDateString = (d) => {
+    if (!d) return "";
+    if (typeof d === "string") return d;
+    if (Array.isArray(d) && d.length >= 3) {
+      return `${d[0]}-${String(d[1]).padStart(2, "0")}-${String(d[2]).padStart(2, "0")}`;
+    }
+    return "";
+  };
   const [effectiveDate, setEffectiveDate] = useState(
-    standard?.effectiveDate || "",
+    toDateString(standard?.effectiveDate),
   );
-  const [expiryDate, setExpiryDate] = useState(standard?.expiryDate || "");
+  const [expiryDate, setExpiryDate] = useState(
+    toDateString(standard?.expiryDate),
+  );
   const [sampleTypes, setSampleTypes] = useState(standard?.sampleTypes || []);
   const [description, setDescription] = useState(standard?.description || "");
   const [groups, setGroups] = useState(standard?.parameterGroups || []);
   const [savedId, setSavedId] = useState(standard?.id || null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
-  // FR-1-007: Country/Region is a ComboBox with type-ahead from existing
-  // values + free-text fallback. We fetch the distinct list once on mount.
   const [countryRegionOptions, setCountryRegionOptions] = useState([]);
 
   useEffect(() => {
@@ -384,8 +392,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     };
   }, []);
 
-  // Standards list endpoint returns the entity without its lazy parameterGroups
-  // collection, so for an existing standard we fetch the groups on mount.
   useEffect(() => {
     if (!standard?.id) return;
     let mounted = true;
@@ -411,7 +417,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     regulationNumber: !trim(regulationNumber),
     version: !trim(version),
     countryRegion: !trim(countryRegion),
-    // @NotNull on the entity — enforce client-side so the error is field-attributed.
     effectiveDate: !trim(effectiveDate),
   };
   const dateOrderError =
@@ -419,10 +424,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
 
   const handleSave = () => {
     setSubmitted(true);
-    // The Save button's `disabled` prop blocks empty required fields, but
-    // whitespace-only values and the date-order error slip through. Toast
-    // so the click is acknowledged — the inline `invalid` markers may sit
-    // outside the viewport on long forms.
     if (dateOrderError) {
       toast(
         NotificationKinds.error,
@@ -452,8 +453,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     }
     setError(null);
     setSaving(true);
-    // Strip @JsonUnwrapped DTO-only counts; the entity has no such fields
-    // and Jackson rejects unknown properties.
     const {
       parameterGroupCount: _pgIgnored,
       linkedTestCount: _ltIgnored,
@@ -624,9 +623,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     );
   };
 
-  // FR-2-003: rename + description edit. PUT replaces the row in place;
-  // optimistic local update keeps the accordion header accurate before the
-  // next standards-list reload.
   const handleEditGroup = (updated) => {
     if (!savedId || !updated || !updated.id) return;
     putToOpenElisServer(
@@ -661,9 +657,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     );
   };
 
-  // FR-2-003 / FR-2-004: reorder by swapping sortOrder between adjacent
-  // groups. Two PUTs (one per affected row); local state is reordered when
-  // the second one returns success.
   const handleMoveGroup = (g, direction) => {
     if (!savedId) return;
     const idx = groups.findIndex((x) => x.id === g.id);

--- a/frontend/src/components/admin/complianceStandards/StandardForm.jsx
+++ b/frontend/src/components/admin/complianceStandards/StandardForm.jsx
@@ -411,6 +411,8 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     regulationNumber: !trim(regulationNumber),
     version: !trim(version),
     countryRegion: !trim(countryRegion),
+    // @NotNull on the entity — enforce client-side so the error is field-attributed.
+    effectiveDate: !trim(effectiveDate),
   };
   const dateOrderError =
     effectiveDate && expiryDate && expiryDate < effectiveDate;
@@ -436,7 +438,8 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
       requiredErrors.issuingBody ||
       requiredErrors.regulationNumber ||
       requiredErrors.version ||
-      requiredErrors.countryRegion
+      requiredErrors.countryRegion ||
+      requiredErrors.effectiveDate
     ) {
       toast(
         NotificationKinds.error,
@@ -449,11 +452,13 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     }
     setError(null);
     setSaving(true);
-    // Strip the DTO-only parameterGroupCount sibling that the standards list
-    // endpoint adds via @JsonUnwrapped — sending it back causes the backend's
-    // Jackson layer to reject the body with 400 (FAIL_ON_UNKNOWN_PROPERTIES
-    // is on by default and the entity has no such field).
-    const { parameterGroupCount: _ignored, ...standardBase } = standard || {};
+    // Strip @JsonUnwrapped DTO-only counts; the entity has no such fields
+    // and Jackson rejects unknown properties.
+    const {
+      parameterGroupCount: _pgIgnored,
+      linkedTestCount: _ltIgnored,
+      ...standardBase
+    } = standard || {};
     const payload = {
       ...standardBase,
       name,
@@ -876,6 +881,12 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
               placeholder={intl.formatMessage({
                 id: "compliance.standard.placeholder.date",
                 defaultMessage: "yyyy-mm-dd",
+              })}
+              required
+              invalid={submitted && requiredErrors.effectiveDate}
+              invalidText={intl.formatMessage({
+                id: "compliance.validation.required",
+                defaultMessage: "This field is required.",
               })}
             />
           </DatePicker>

--- a/frontend/src/components/admin/complianceStandards/StandardForm.jsx
+++ b/frontend/src/components/admin/complianceStandards/StandardForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
   Tile,
   Grid,
@@ -25,6 +25,8 @@ import {
   putToOpenElisServerFullResponse,
   deleteFromOpenElisServer,
 } from "../../utils/Utils";
+import { NotificationContext } from "../../layout/Layout";
+import { NotificationKinds } from "../../common/CustomNotification";
 import ParameterGroupAccordionItem from "./ParameterGroupAccordionItem";
 
 const STATUSES = ["DRAFT", "ACTIVE", "SUPERSEDED", "ARCHIVED"];
@@ -326,6 +328,23 @@ function ParameterGroupsEditor({
 
 function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
   const intl = useIntl();
+  const { setNotificationVisible, addNotification } =
+    useContext(NotificationContext);
+  // Toast on every action so the admin gets visible confirmation for each
+  // save / add / delete / edit / move; inline errors are kept where they
+  // attribute a specific row (e.g. save validation), but are paired with a
+  // toast so the user is never left guessing whether anything happened.
+  const toast = (kind, titleKey, titleDefault, messageKey, messageDefault) => {
+    addNotification({
+      kind,
+      title: intl.formatMessage({ id: titleKey, defaultMessage: titleDefault }),
+      message: intl.formatMessage({
+        id: messageKey,
+        defaultMessage: messageDefault,
+      }),
+    });
+    setNotificationVisible(true);
+  };
   const [name, setName] = useState(standard?.name || "");
   const [issuingBody, setIssuingBody] = useState(standard?.issuingBody || "");
   const [regulationNumber, setRegulationNumber] = useState(
@@ -398,14 +417,34 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
 
   const handleSave = () => {
     setSubmitted(true);
+    // The Save button's `disabled` prop blocks empty required fields, but
+    // whitespace-only values and the date-order error slip through. Toast
+    // so the click is acknowledged — the inline `invalid` markers may sit
+    // outside the viewport on long forms.
+    if (dateOrderError) {
+      toast(
+        NotificationKinds.error,
+        "notification.title.error",
+        "Error",
+        "compliance.validation.expiryAfterEffective",
+        "Expiry date must be on or after the effective date.",
+      );
+      return;
+    }
     if (
       requiredErrors.name ||
       requiredErrors.issuingBody ||
       requiredErrors.regulationNumber ||
       requiredErrors.version ||
-      requiredErrors.countryRegion ||
-      dateOrderError
+      requiredErrors.countryRegion
     ) {
+      toast(
+        NotificationKinds.error,
+        "notification.title.error",
+        "Error",
+        "compliance.validation.fillRequired",
+        "Please fill in all required fields.",
+      );
       return;
     }
     setError(null);
@@ -445,6 +484,13 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
                   defaultMessage: "Could not save standard.",
                 }),
             );
+            toast(
+              NotificationKinds.error,
+              "notification.title.error",
+              "Error",
+              "compliance.standard.saveError",
+              "Could not save standard.",
+            );
           }
         },
       );
@@ -479,6 +525,13 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
                   defaultMessage: "Could not save standard.",
                 }),
             );
+            toast(
+              NotificationKinds.error,
+              "notification.title.error",
+              "Error",
+              "compliance.standard.saveError",
+              "Could not save standard.",
+            );
           }
         },
       );
@@ -493,6 +546,13 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
           defaultMessage: "Save the standard before adding parameter groups.",
         }),
       );
+      toast(
+        NotificationKinds.error,
+        "notification.title.error",
+        "Error",
+        "compliance.standard.saveBeforeGroups",
+        "Save the standard before adding parameter groups.",
+      );
       return;
     }
     postToOpenElisServerJsonResponse(
@@ -501,6 +561,13 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
       (resp) => {
         if (resp && resp.id && !resp.error) {
           setGroups([...groups, resp]);
+          toast(
+            NotificationKinds.success,
+            "notification.title.success",
+            "Saved",
+            "compliance.parameterGroup.created",
+            "Parameter group added.",
+          );
         } else {
           setError(
             (resp && (resp.error || resp.message)) ||
@@ -508,6 +575,13 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
                 id: "compliance.parameterGroup.createError",
                 defaultMessage: "Could not add parameter group.",
               }),
+          );
+          toast(
+            NotificationKinds.error,
+            "notification.title.error",
+            "Error",
+            "compliance.parameterGroup.createError",
+            "Could not add parameter group.",
           );
         }
       },
@@ -518,8 +592,29 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     if (!savedId) return;
     deleteFromOpenElisServer(
       `/rest/compliance/standards/${savedId}/parameter-groups/${g.id}`,
-      () => {
-        setGroups(groups.filter((x) => x.id !== g.id));
+      (resp) => {
+        // deleteFromOpenElisServer fires the callback regardless of HTTP
+        // status; treat anything non-2xx as a failure so the admin learns
+        // the row is still present.
+        const ok = !resp || resp === true || (resp.status && resp.status < 300);
+        if (ok) {
+          setGroups(groups.filter((x) => x.id !== g.id));
+          toast(
+            NotificationKinds.success,
+            "notification.title.success",
+            "Deleted",
+            "compliance.parameterGroup.deleted",
+            "Parameter group deleted.",
+          );
+        } else {
+          toast(
+            NotificationKinds.error,
+            "notification.title.error",
+            "Error",
+            "compliance.parameterGroup.deleteError",
+            "Could not delete parameter group.",
+          );
+        }
       },
     );
   };
@@ -535,12 +630,26 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
       (status) => {
         if (status >= 200 && status < 300) {
           setGroups(groups.map((g) => (g.id === updated.id ? updated : g)));
+          toast(
+            NotificationKinds.success,
+            "notification.title.success",
+            "Saved",
+            "compliance.parameterGroup.updated",
+            "Parameter group updated.",
+          );
         } else {
           setError(
             intl.formatMessage({
               id: "compliance.parameterGroup.updateError",
               defaultMessage: "Could not update parameter group.",
             }),
+          );
+          toast(
+            NotificationKinds.error,
+            "notification.title.error",
+            "Error",
+            "compliance.parameterGroup.updateError",
+            "Could not update parameter group.",
           );
         }
       },
@@ -566,17 +675,42 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
       `/rest/compliance/standards/${savedId}/parameter-groups/${a.id}`,
       JSON.stringify(updatedA),
       (statusA) => {
-        if (statusA < 200 || statusA >= 300) return;
+        if (statusA < 200 || statusA >= 300) {
+          toast(
+            NotificationKinds.error,
+            "notification.title.error",
+            "Error",
+            "compliance.parameterGroup.moveError",
+            "Could not reorder parameter group.",
+          );
+          return;
+        }
         putToOpenElisServer(
           `/rest/compliance/standards/${savedId}/parameter-groups/${b.id}`,
           JSON.stringify(updatedB),
           (statusB) => {
-            if (statusB < 200 || statusB >= 300) return;
+            if (statusB < 200 || statusB >= 300) {
+              toast(
+                NotificationKinds.error,
+                "notification.title.error",
+                "Error",
+                "compliance.parameterGroup.moveError",
+                "Could not reorder parameter group.",
+              );
+              return;
+            }
             const next = [...groups];
             next[idx] = updatedB;
             next[swapIdx] = updatedA;
             next.sort((x, y) => (x.sortOrder ?? 0) - (y.sortOrder ?? 0));
             setGroups(next);
+            toast(
+              NotificationKinds.success,
+              "notification.title.success",
+              "Reordered",
+              "compliance.parameterGroup.moved",
+              "Parameter group reordered.",
+            );
           },
         );
       },

--- a/frontend/src/components/admin/complianceStandards/StandardForm.jsx
+++ b/frontend/src/components/admin/complianceStandards/StandardForm.jsx
@@ -856,36 +856,38 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
         gap={3}
         style={{ marginTop: "1.5rem", alignItems: "center" }}
       >
-        <Button
-          kind="primary"
-          renderIcon={Save}
-          onClick={handleSave}
-          disabled={
-            saving ||
-            !name ||
-            !issuingBody ||
-            !regulationNumber ||
-            !version ||
-            !countryRegion
-          }
-        >
-          {saving ? (
-            <FormattedMessage
-              id="compliance.button.saving"
-              defaultMessage="Saving…"
-            />
-          ) : savedId ? (
-            <FormattedMessage
-              id="compliance.button.saveStandard"
-              defaultMessage="Save Standard"
-            />
-          ) : (
-            <FormattedMessage
-              id="compliance.button.save"
-              defaultMessage="Save"
-            />
-          )}
-        </Button>
+        {isNew && (
+          <Button
+            kind="primary"
+            renderIcon={Save}
+            onClick={handleSave}
+            disabled={
+              saving ||
+              !name ||
+              !issuingBody ||
+              !regulationNumber ||
+              !version ||
+              !countryRegion
+            }
+          >
+            {saving ? (
+              <FormattedMessage
+                id="compliance.button.saving"
+                defaultMessage="Saving…"
+              />
+            ) : savedId ? (
+              <FormattedMessage
+                id="compliance.button.saveStandard"
+                defaultMessage="Save Standard"
+              />
+            ) : (
+              <FormattedMessage
+                id="compliance.button.save"
+                defaultMessage="Save"
+              />
+            )}
+          </Button>
+        )}
         <Button kind="ghost" onClick={onCancel} disabled={saving}>
           <FormattedMessage id="label.button.cancel" defaultMessage="Cancel" />
         </Button>

--- a/frontend/src/components/admin/complianceStandards/StandardForm.jsx
+++ b/frontend/src/components/admin/complianceStandards/StandardForm.jsx
@@ -479,13 +479,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
           setSaving(false);
           if (resp && resp.id && !resp.error) {
             setSavedId(resp.id);
-            toast(
-              NotificationKinds.success,
-              "notification.title.success",
-              "Saved",
-              "compliance.standard.created",
-              "Compliance standard created.",
-            );
             onSaved && onSaved(resp);
           } else {
             setError(
@@ -513,13 +506,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
         async (response) => {
           setSaving(false);
           if (response && response.ok) {
-            toast(
-              NotificationKinds.success,
-              "notification.title.success",
-              "Saved",
-              "compliance.standard.updated",
-              "Compliance standard updated.",
-            );
             try {
               const saved = await response.json();
               onSaved && onSaved(saved);

--- a/frontend/src/components/admin/complianceStandards/StandardForm.jsx
+++ b/frontend/src/components/admin/complianceStandards/StandardForm.jsx
@@ -28,6 +28,7 @@ import {
 import { NotificationContext } from "../../layout/Layout";
 import { NotificationKinds } from "../../common/CustomNotification";
 import ParameterGroupAccordionItem from "./ParameterGroupAccordionItem";
+import { toDateString } from "./dateUtils";
 
 const STATUSES = ["DRAFT", "ACTIVE", "SUPERSEDED", "ARCHIVED"];
 
@@ -355,14 +356,6 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
     standard?.countryRegion || "",
   );
   const [status, setStatus] = useState(standard?.status || "DRAFT");
-  const toDateString = (d) => {
-    if (!d) return "";
-    if (typeof d === "string") return d;
-    if (Array.isArray(d) && d.length >= 3) {
-      return `${d[0]}-${String(d[1]).padStart(2, "0")}-${String(d[2]).padStart(2, "0")}`;
-    }
-    return "";
-  };
   const [effectiveDate, setEffectiveDate] = useState(
     toDateString(standard?.effectiveDate),
   );

--- a/frontend/src/components/admin/complianceStandards/StandardForm.jsx
+++ b/frontend/src/components/admin/complianceStandards/StandardForm.jsx
@@ -479,6 +479,13 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
           setSaving(false);
           if (resp && resp.id && !resp.error) {
             setSavedId(resp.id);
+            toast(
+              NotificationKinds.success,
+              "notification.title.success",
+              "Saved",
+              "compliance.standard.created",
+              "Compliance standard created.",
+            );
             onSaved && onSaved(resp);
           } else {
             setError(
@@ -506,6 +513,13 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
         async (response) => {
           setSaving(false);
           if (response && response.ok) {
+            toast(
+              NotificationKinds.success,
+              "notification.title.success",
+              "Saved",
+              "compliance.standard.updated",
+              "Compliance standard updated.",
+            );
             try {
               const saved = await response.json();
               onSaved && onSaved(saved);
@@ -994,38 +1008,37 @@ function StandardForm({ standard, isNew, hideHeading, onSaved, onCancel }) {
         gap={3}
         style={{ marginTop: "1.5rem", alignItems: "center" }}
       >
-        {isNew && (
-          <Button
-            kind="primary"
-            renderIcon={Save}
-            onClick={handleSave}
-            disabled={
-              saving ||
-              !name ||
-              !issuingBody ||
-              !regulationNumber ||
-              !version ||
-              !countryRegion
-            }
-          >
-            {saving ? (
-              <FormattedMessage
-                id="compliance.button.saving"
-                defaultMessage="Saving…"
-              />
-            ) : savedId ? (
-              <FormattedMessage
-                id="compliance.button.saveStandard"
-                defaultMessage="Save Standard"
-              />
-            ) : (
-              <FormattedMessage
-                id="compliance.button.save"
-                defaultMessage="Save"
-              />
-            )}
-          </Button>
-        )}
+        <Button
+          kind="primary"
+          renderIcon={Save}
+          onClick={handleSave}
+          disabled={
+            saving ||
+            !name ||
+            !issuingBody ||
+            !regulationNumber ||
+            !version ||
+            !countryRegion ||
+            !effectiveDate
+          }
+        >
+          {saving ? (
+            <FormattedMessage
+              id="compliance.button.saving"
+              defaultMessage="Saving…"
+            />
+          ) : isNew ? (
+            <FormattedMessage
+              id="compliance.button.save"
+              defaultMessage="Save"
+            />
+          ) : (
+            <FormattedMessage
+              id="compliance.button.saveStandard"
+              defaultMessage="Save Standard"
+            />
+          )}
+        </Button>
         <Button kind="ghost" onClick={onCancel} disabled={saving}>
           <FormattedMessage id="label.button.cancel" defaultMessage="Cancel" />
         </Button>

--- a/frontend/src/components/admin/complianceStandards/TestComplianceThresholds.jsx
+++ b/frontend/src/components/admin/complianceStandards/TestComplianceThresholds.jsx
@@ -1082,13 +1082,22 @@ function TestComplianceThresholds({ embeddedTestId, onCountChange } = {}) {
                   </div>
                 </div>
                 <Button
-                  kind="secondary"
+                  kind="primary"
                   size="md"
-                  onClick={() => setSelectedTestId("")}
+                  onClick={() => {
+                    toast(
+                      NotificationKinds.success,
+                      "notification.title.success",
+                      "Saved",
+                      "compliance.testEditor.thresholdsDone",
+                      "Compliance thresholds updated for this test.",
+                    );
+                    setSelectedTestId("");
+                  }}
                 >
                   <FormattedMessage
-                    id="label.button.close"
-                    defaultMessage="Close"
+                    id="label.button.done"
+                    defaultMessage="Done"
                   />
                 </Button>
               </div>

--- a/frontend/src/components/admin/complianceStandards/TestComplianceThresholds.jsx
+++ b/frontend/src/components/admin/complianceStandards/TestComplianceThresholds.jsx
@@ -19,7 +19,7 @@ import {
   Tile,
   Modal,
 } from "@carbon/react";
-import { Add, TrashCan, Save } from "@carbon/icons-react";
+import { Add, TrashCan } from "@carbon/icons-react";
 import { FormattedMessage, useIntl } from "react-intl";
 import {
   getFromOpenElisServer,
@@ -1002,9 +1002,9 @@ function TestComplianceThresholds({ embeddedTestId, onCountChange } = {}) {
           <>
             {/* Stylized "Edit Test: …" header bar matching the v2.3 mockup —
                 test name + LOINC / sample type / result type meta line on the
-                left, Cancel + Save Test on the right. Save Test is a visual
-                affordance that confirms changes are persisted (each threshold
-                add / unlink hits the API immediately).
+                left, a single Close button on the right. Each threshold
+                add / unlink hits the API immediately, so there is no separate
+                save action to surface here.
 
                 Suppressed when embedded inside the Test Editor — the parent
                 already shows the test name + LOINC, so a second identity
@@ -1081,29 +1081,16 @@ function TestComplianceThresholds({ embeddedTestId, onCountChange } = {}) {
                         })}
                   </div>
                 </div>
-                <Stack orientation="horizontal" gap={2}>
-                  <Button
-                    kind="secondary"
-                    size="md"
-                    onClick={() => setSelectedTestId("")}
-                  >
-                    <FormattedMessage
-                      id="label.button.cancel"
-                      defaultMessage="Cancel"
-                    />
-                  </Button>
-                  <Button
-                    kind="primary"
-                    size="md"
-                    renderIcon={Save}
-                    onClick={() => setSelectedTestId("")}
-                  >
-                    <FormattedMessage
-                      id="compliance.testEditor.saveTest"
-                      defaultMessage="Save Test"
-                    />
-                  </Button>
-                </Stack>
+                <Button
+                  kind="secondary"
+                  size="md"
+                  onClick={() => setSelectedTestId("")}
+                >
+                  <FormattedMessage
+                    id="label.button.close"
+                    defaultMessage="Close"
+                  />
+                </Button>
               </div>
             )}
 

--- a/frontend/src/components/admin/complianceStandards/TestComplianceThresholds.jsx
+++ b/frontend/src/components/admin/complianceStandards/TestComplianceThresholds.jsx
@@ -30,6 +30,7 @@ import { NotificationContext } from "../../layout/Layout";
 import { NotificationKinds } from "../../common/CustomNotification";
 import MultiLimitForm from "./MultiLimitForm";
 import SelectMapForm from "./SelectMapForm";
+import { toDateString } from "./dateUtils";
 
 const TAG_BY_TYPE = {
   MAXIMUM: "red",
@@ -658,7 +659,7 @@ function TestComplianceThresholds({ embeddedTestId, onCountChange } = {}) {
         </TableCell>
         <TableCell>{formatThresholdRange(t)}</TableCell>
         <TableCell>{t.units || "—"}</TableCell>
-        <TableCell>{standard?.effectiveDate || "—"}</TableCell>
+        <TableCell>{toDateString(standard?.effectiveDate) || "—"}</TableCell>
         <TableCell>
           <Tag size="sm" type={STATUS_TAG[standard?.status] || "gray"}>
             {statusLabel(intl, standard?.status)}

--- a/frontend/src/components/admin/complianceStandards/dateUtils.js
+++ b/frontend/src/components/admin/complianceStandards/dateUtils.js
@@ -1,0 +1,12 @@
+// Backend serializes LocalDate as [year, month, day] (Jackson default with
+// WRITE_DATES_AS_TIMESTAMPS). React renders arrays of children by joining
+// without separators, so `<td>{date}</td>` becomes "202122" for [2021, 2, 2].
+// Normalize to a "YYYY-MM-DD" string at every render/state-init site.
+export function toDateString(d) {
+  if (!d) return "";
+  if (typeof d === "string") return d;
+  if (Array.isArray(d) && d.length >= 3) {
+    return `${d[0]}-${String(d[1]).padStart(2, "0")}-${String(d[2]).padStart(2, "0")}`;
+  }
+  return "";
+}

--- a/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceStandardRestController.java
+++ b/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceStandardRestController.java
@@ -106,13 +106,14 @@ public class ComplianceStandardRestController extends BaseRestController {
         } catch (org.hibernate.ObjectNotFoundException e) {
             return ResponseEntity.notFound().build();
         } catch (LIMSRuntimeException e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()));
         }
     }
 
     @PostMapping
     @PreAuthorize("hasRole('GLOBAL_ADMIN')")
-    public ResponseEntity<ComplianceStandard> createStandard(@Valid @RequestBody ComplianceStandard standard,
+    public ResponseEntity<?> createStandard(@Valid @RequestBody ComplianceStandard standard,
             HttpServletRequest request) {
         try {
             String sysUserId = ControllerUtills.getSysUserId(request);
@@ -122,7 +123,8 @@ public class ComplianceStandardRestController extends BaseRestController {
             ComplianceStandard saved = complianceStandardService.save(standard);
             return ResponseEntity.status(HttpStatus.CREATED).body(saved);
         } catch (jakarta.persistence.PersistenceException | LIMSRuntimeException | IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
@@ -130,8 +132,8 @@ public class ComplianceStandardRestController extends BaseRestController {
 
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('GLOBAL_ADMIN')")
-    public ResponseEntity<ComplianceStandard> updateStandard(@PathVariable String id,
-            @Valid @RequestBody ComplianceStandard standard, HttpServletRequest request) {
+    public ResponseEntity<?> updateStandard(@PathVariable String id, @Valid @RequestBody ComplianceStandard standard,
+            HttpServletRequest request) {
         try {
             ComplianceStandard existing = complianceStandardService.get(id);
             if (existing == null) {
@@ -164,8 +166,9 @@ public class ComplianceStandardRestController extends BaseRestController {
             return ResponseEntity.notFound().build();
         } catch (jakarta.persistence.OptimisticLockException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
-        } catch (LIMSRuntimeException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (IllegalArgumentException | LIMSRuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()));
         }
     }
 

--- a/src/main/java/org/openelisglobal/compliance/daoimpl/ComplianceThresholdDAOImpl.java
+++ b/src/main/java/org/openelisglobal/compliance/daoimpl/ComplianceThresholdDAOImpl.java
@@ -34,7 +34,9 @@ public class ComplianceThresholdDAOImpl extends BaseDAOImpl<ComplianceThreshold,
     @Transactional(readOnly = true)
     public List<ComplianceThreshold> getThresholdsByGroupId(String groupId) throws LIMSRuntimeException {
         try {
-            String hql = "FROM ComplianceThreshold ct WHERE ct.group.id = :groupId ORDER BY ct.sortOrder";
+            String hql = "SELECT DISTINCT ct FROM ComplianceThreshold ct "
+                    + "LEFT JOIN FETCH ct.group g LEFT JOIN FETCH g.standard "
+                    + "LEFT JOIN FETCH ct.valueMappings WHERE ct.group.id = :groupId ORDER BY ct.sortOrder";
             TypedQuery<ComplianceThreshold> query = entityManager.createQuery(hql, ComplianceThreshold.class);
             query.setParameter("groupId", groupId);
             return query.getResultList();
@@ -66,7 +68,9 @@ public class ComplianceThresholdDAOImpl extends BaseDAOImpl<ComplianceThreshold,
     @Transactional(readOnly = true)
     public List<ComplianceThreshold> getThresholdsByTestId(String testId) throws LIMSRuntimeException {
         try {
-            String hql = "FROM ComplianceThreshold ct WHERE ct.test.id = :testId ORDER BY ct.sortOrder";
+            String hql = "SELECT DISTINCT ct FROM ComplianceThreshold ct "
+                    + "LEFT JOIN FETCH ct.group g LEFT JOIN FETCH g.standard "
+                    + "LEFT JOIN FETCH ct.valueMappings WHERE ct.test.id = :testId ORDER BY ct.sortOrder";
             TypedQuery<ComplianceThreshold> query = entityManager.createQuery(hql, ComplianceThreshold.class);
             query.setParameter("testId", testId);
             return query.getResultList();
@@ -81,7 +85,8 @@ public class ComplianceThresholdDAOImpl extends BaseDAOImpl<ComplianceThreshold,
     public List<ComplianceThreshold> getThresholdsByTestAndStandard(String testId, String standardId)
             throws LIMSRuntimeException {
         try {
-            String hql = "FROM ComplianceThreshold ct " + "JOIN FETCH ct.group pg "
+            String hql = "SELECT DISTINCT ct FROM ComplianceThreshold ct "
+                    + "JOIN FETCH ct.group pg LEFT JOIN FETCH ct.valueMappings "
                     + "WHERE ct.test.id = :testId AND pg.standard.id = :standardId "
                     + "ORDER BY pg.sortOrder, ct.sortOrder";
             TypedQuery<ComplianceThreshold> query = entityManager.createQuery(hql, ComplianceThreshold.class);

--- a/src/main/java/org/openelisglobal/compliance/service/ComplianceThresholdServiceImpl.java
+++ b/src/main/java/org/openelisglobal/compliance/service/ComplianceThresholdServiceImpl.java
@@ -34,9 +34,6 @@ public class ComplianceThresholdServiceImpl extends AuditableBaseObjectServiceIm
     @Autowired
     private ParameterGroupService parameterGroupService;
 
-    // Used by createThresholdItem/updateThresholdItem to swap Jackson's id-only
-    // Test stub for a managed entity before persist. Without this Hibernate
-    // refuses the save with TransientPropertyValueException.
     @Autowired
     private TestService testService;
 
@@ -59,11 +56,6 @@ public class ComplianceThresholdServiceImpl extends AuditableBaseObjectServiceIm
     @Transactional
     public ComplianceThreshold save(ComplianceThreshold threshold) {
         validateThreshold(threshold);
-        // Enforce uniqueness on (groupId, parameterCode, thresholdType) for inserts.
-        // FRS S-01 v2.3: a single test may have multiple threshold rows in the same
-        // group, one per limit type (HIGH + BORDERLINE on the same parameter is
-        // valid). The check therefore includes thresholdType so multi-limit saves
-        // don't collide.
         if (threshold.getId() == null && threshold.getGroupId() != null
                 && getBaseObjectDAO().parameterExistsInGroupForType(threshold.getGroupId(),
                         threshold.getParameterCode(), threshold.getThresholdType())) {
@@ -227,9 +219,13 @@ public class ComplianceThresholdServiceImpl extends AuditableBaseObjectServiceIm
             return null;
         }
         threshold.setId(id);
-        // Carry @Version forward; the list DTO omits `lastupdated`, so
-        // payloads come back null and merge() would throw StaleObjectStateException.
         threshold.setLastupdated(existing.getLastupdated());
+        if (threshold.getTest() == null || threshold.getTest().getId() == null) {
+            threshold.setTest(existing.getTest());
+        }
+        if (threshold.getGroup() == null || threshold.getGroup().getId() == null) {
+            threshold.setGroup(existing.getGroup());
+        }
         attachManagedAssociations(threshold);
         if (sysUserId != null) {
             threshold.setSysUserId(sysUserId);

--- a/src/main/java/org/openelisglobal/compliance/service/ComplianceThresholdServiceImpl.java
+++ b/src/main/java/org/openelisglobal/compliance/service/ComplianceThresholdServiceImpl.java
@@ -227,6 +227,9 @@ public class ComplianceThresholdServiceImpl extends AuditableBaseObjectServiceIm
             return null;
         }
         threshold.setId(id);
+        // Carry @Version forward; the list DTO omits `lastupdated`, so
+        // payloads come back null and merge() would throw StaleObjectStateException.
+        threshold.setLastupdated(existing.getLastupdated());
         attachManagedAssociations(threshold);
         if (sysUserId != null) {
             threshold.setSysUserId(sysUserId);

--- a/src/test/java/org/openelisglobal/compliance/daoimpl/ComplianceThresholdDAOImplTest.java
+++ b/src/test/java/org/openelisglobal/compliance/daoimpl/ComplianceThresholdDAOImplTest.java
@@ -62,9 +62,10 @@ public class ComplianceThresholdDAOImplTest {
         List<ComplianceThreshold> expectedThresholds = Arrays.asList(createThreshold("PH", "pH Level", 1),
                 createThreshold("TEMP", "Temperature", 2), createThreshold("TURB", "Turbidity", 3));
 
-        when(entityManager.createQuery("SELECT DISTINCT ct FROM ComplianceThreshold ct "
-                + "LEFT JOIN FETCH ct.group g LEFT JOIN FETCH g.standard "
-                + "LEFT JOIN FETCH ct.valueMappings WHERE ct.group.id = :groupId ORDER BY ct.sortOrder",
+        when(entityManager.createQuery(
+                "SELECT DISTINCT ct FROM ComplianceThreshold ct "
+                        + "LEFT JOIN FETCH ct.group g LEFT JOIN FETCH g.standard "
+                        + "LEFT JOIN FETCH ct.valueMappings WHERE ct.group.id = :groupId ORDER BY ct.sortOrder",
                 ComplianceThreshold.class)).thenReturn(typedQuery);
         when(typedQuery.setParameter("groupId", testGroupId)).thenReturn(typedQuery);
         when(typedQuery.getResultList()).thenReturn(expectedThresholds);
@@ -85,9 +86,10 @@ public class ComplianceThresholdDAOImplTest {
         List<ComplianceThreshold> expectedThresholds = Arrays.asList(createTestSpecificThreshold("PH", testId),
                 createTestSpecificThreshold("TEMP", testId));
 
-        when(entityManager.createQuery("SELECT DISTINCT ct FROM ComplianceThreshold ct "
-                + "LEFT JOIN FETCH ct.group g LEFT JOIN FETCH g.standard "
-                + "LEFT JOIN FETCH ct.valueMappings WHERE ct.test.id = :testId ORDER BY ct.sortOrder",
+        when(entityManager.createQuery(
+                "SELECT DISTINCT ct FROM ComplianceThreshold ct "
+                        + "LEFT JOIN FETCH ct.group g LEFT JOIN FETCH g.standard "
+                        + "LEFT JOIN FETCH ct.valueMappings WHERE ct.test.id = :testId ORDER BY ct.sortOrder",
                 ComplianceThreshold.class)).thenReturn(typedQuery);
         when(typedQuery.setParameter("testId", testId)).thenReturn(typedQuery);
         when(typedQuery.getResultList()).thenReturn(expectedThresholds);

--- a/src/test/java/org/openelisglobal/compliance/daoimpl/ComplianceThresholdDAOImplTest.java
+++ b/src/test/java/org/openelisglobal/compliance/daoimpl/ComplianceThresholdDAOImplTest.java
@@ -62,7 +62,9 @@ public class ComplianceThresholdDAOImplTest {
         List<ComplianceThreshold> expectedThresholds = Arrays.asList(createThreshold("PH", "pH Level", 1),
                 createThreshold("TEMP", "Temperature", 2), createThreshold("TURB", "Turbidity", 3));
 
-        when(entityManager.createQuery("FROM ComplianceThreshold ct WHERE ct.group.id = :groupId ORDER BY ct.sortOrder",
+        when(entityManager.createQuery("SELECT DISTINCT ct FROM ComplianceThreshold ct "
+                + "LEFT JOIN FETCH ct.group g LEFT JOIN FETCH g.standard "
+                + "LEFT JOIN FETCH ct.valueMappings WHERE ct.group.id = :groupId ORDER BY ct.sortOrder",
                 ComplianceThreshold.class)).thenReturn(typedQuery);
         when(typedQuery.setParameter("groupId", testGroupId)).thenReturn(typedQuery);
         when(typedQuery.getResultList()).thenReturn(expectedThresholds);
@@ -83,7 +85,9 @@ public class ComplianceThresholdDAOImplTest {
         List<ComplianceThreshold> expectedThresholds = Arrays.asList(createTestSpecificThreshold("PH", testId),
                 createTestSpecificThreshold("TEMP", testId));
 
-        when(entityManager.createQuery("FROM ComplianceThreshold ct WHERE ct.test.id = :testId ORDER BY ct.sortOrder",
+        when(entityManager.createQuery("SELECT DISTINCT ct FROM ComplianceThreshold ct "
+                + "LEFT JOIN FETCH ct.group g LEFT JOIN FETCH g.standard "
+                + "LEFT JOIN FETCH ct.valueMappings WHERE ct.test.id = :testId ORDER BY ct.sortOrder",
                 ComplianceThreshold.class)).thenReturn(typedQuery);
         when(typedQuery.setParameter("testId", testId)).thenReturn(typedQuery);
         when(typedQuery.getResultList()).thenReturn(expectedThresholds);
@@ -104,7 +108,8 @@ public class ComplianceThresholdDAOImplTest {
         List<ComplianceThreshold> expectedThresholds = Arrays.asList(createTestSpecificThreshold("PH", testId),
                 createTestSpecificThreshold("TEMP", testId));
 
-        when(entityManager.createQuery("FROM ComplianceThreshold ct " + "JOIN FETCH ct.group pg "
+        when(entityManager.createQuery("SELECT DISTINCT ct FROM ComplianceThreshold ct "
+                + "JOIN FETCH ct.group pg LEFT JOIN FETCH ct.valueMappings "
                 + "WHERE ct.test.id = :testId AND pg.standard.id = :standardId "
                 + "ORDER BY pg.sortOrder, ct.sortOrder", ComplianceThreshold.class)).thenReturn(typedQuery);
         when(typedQuery.setParameter("testId", testId)).thenReturn(typedQuery);

--- a/src/test/java/org/openelisglobal/compliance/service/ComplianceStandardServiceTest.java
+++ b/src/test/java/org/openelisglobal/compliance/service/ComplianceStandardServiceTest.java
@@ -32,14 +32,10 @@ public class ComplianceStandardServiceTest extends BaseWebContextSensitiveTest {
 
     @Before
     public void setUp() throws Exception {
-        // Load test data following OpenELIS pattern
         executeDataSetWithStateManagement("testdata/compliance_standards.xml");
 
-        // Create test standard for individual tests
         testStandard = createTestStandard();
     }
-
-    // RED PHASE: Tests that will fail initially
 
     @Test
     public void testGetAll_shouldReturnAllComplianceStandards() {
@@ -50,7 +46,6 @@ public class ComplianceStandardServiceTest extends BaseWebContextSensitiveTest {
 
         assertTrue("Should have at least 3 test standards", standards.size() >= 3);
 
-        // Verify FHIR UUID is present (constitutional requirement)
         for (ComplianceStandard standard : standards) {
             assertNotNull("FHIR UUID should not be null", standard.getFhirUuid());
         }
@@ -103,7 +98,6 @@ public class ComplianceStandardServiceTest extends BaseWebContextSensitiveTest {
             assertTrue("Should throw appropriate exception", e.getMessage().contains("has linked thresholds"));
         }
 
-        // Archive should work instead
         complianceStandardService.archive(standardId);
 
         ComplianceStandard archivedStandard = complianceStandardService.get(standardId);
@@ -123,7 +117,6 @@ public class ComplianceStandardServiceTest extends BaseWebContextSensitiveTest {
                     e.getMessage().contains("Pre-seeded standards cannot be deleted"));
         }
 
-        // Archive should still work
         complianceStandardService.archive(preSeededStandard.getId());
         ComplianceStandard archived = complianceStandardService.get(preSeededStandard.getId());
         assertEquals("Pre-seeded standard should be archivable", ComplianceStandardStatus.ARCHIVED,
@@ -143,8 +136,6 @@ public class ComplianceStandardServiceTest extends BaseWebContextSensitiveTest {
             assertTrue("Should throw uniqueness constraint violation", e.getMessage().contains("already exists"));
         }
     }
-
-    // Helper Methods
 
     private ComplianceStandard createTestStandard() {
         return createValidStandard("Test Water Quality Standard", "Test Authority", "TEST-001", "1.0");

--- a/src/test/java/org/openelisglobal/compliance/service/ComplianceThresholdServiceImplTest.java
+++ b/src/test/java/org/openelisglobal/compliance/service/ComplianceThresholdServiceImplTest.java
@@ -59,8 +59,6 @@ public class ComplianceThresholdServiceImplTest {
         testGroup.setId(testGroupId);
     }
 
-    // Business Logic Validation Tests
-
     @Test
     public void testSave_shouldValidateThresholdBusinessRules() throws LIMSRuntimeException {
         ComplianceThreshold validThreshold = createValidRangeThreshold();
@@ -176,8 +174,6 @@ public class ComplianceThresholdServiceImplTest {
             assertEquals("Should propagate original exception", daoException, e);
         }
     }
-
-    // Helper Methods
 
     private ComplianceThreshold createTestThreshold() {
         ComplianceThreshold threshold = new ComplianceThreshold();

--- a/src/test/java/org/openelisglobal/compliance/service/ComplianceThresholdServiceTest.java
+++ b/src/test/java/org/openelisglobal/compliance/service/ComplianceThresholdServiceTest.java
@@ -48,18 +48,14 @@ public class ComplianceThresholdServiceTest extends BaseWebContextSensitiveTest 
     public void setUp() throws Exception {
         executeDataSetWithStateManagement("testdata/compliance_standards.xml");
 
-        // Create test standard and parameter group
         savedStandard = complianceStandardService.save(createTestStandard());
         testStandardId = savedStandard.getId();
 
         ParameterGroup testGroup = createTestParameterGroup(savedStandard);
         testGroupId = parameterGroupService.save(testGroup).getId();
 
-        // Create test threshold
         testThreshold = createTestThreshold(testGroupId);
     }
-
-    // RED PHASE: Compliance Threshold CRUD Tests
 
     @Test
     public void testSaveThreshold_shouldCreateNewThreshold() {

--- a/src/test/java/org/openelisglobal/compliance/service/ParameterGroupServiceTest.java
+++ b/src/test/java/org/openelisglobal/compliance/service/ParameterGroupServiceTest.java
@@ -52,8 +52,6 @@ public class ParameterGroupServiceTest extends BaseWebContextSensitiveTest {
         testParameterGroup = createTestParameterGroup(testStandardId);
     }
 
-    // RED PHASE: Parameter Group CRUD Tests
-
     @Test
     public void testSaveParameterGroup_shouldCreateNewGroup() {
         ParameterGroup newGroup = createValidParameterGroup(testStandardId, "Physical Parameters",


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
- Restores the Save button on the Edit Standard form so admins can actually persist metadata changes (status, dates, description) — was hidden by an earlier cleanup that assumed autosave would replace it.
  - Fixes the 400 error when copying a standard and editing the version — frontend no longer echoes back the DTO-only count fields that Jackson was rejecting.
  - Makes Effective Date a required field client-side, matching the entity constraint, instead of silently failing on submit.
  - Fixes dates rendering as "202122" in the standards table and crashing the Edit form — normalizes the Jackson date-array format to readable strings.
  - Fixes editing a threshold range (Stale state error) — the backend now carries the optimistic-lock version forward when the slim DTO doesn't expose it.
  - Fixes editing a threshold throwing a transient-instance error — the frontend now uses the correct test-id field, and the backend defensively reuses the existing test/group when the payload omits them.
  - Surfaces real backend error messages in the save toast (duplicate name, BR-004 SUPERSEDED needs replacement, FR-1-007a ACTIVE needs sample types) instead of a generic "Could not save."
  - Renames the Test Editor's Close button to Done with a confirmation toast — honest UX since per-test actions already save inline.
  - Eliminates N+1 queries when loading thresholds (parameter-group accordion, copy-standard, CSV import).
  - Adds Playwright coverage for the main edit/save/copy flows and the test-editor Done action.

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
