### PR TITLE
fix(frontend): clear scroll-restore setTimeout on FieldMapping unmount

### DIFF
--- a/frontend/src/components/analyzers/FieldMapping/FieldMapping.jsx
+++ b/frontend/src/components/analyzers/FieldMapping/FieldMapping.jsx
@@ -75,10 +75,13 @@ const FieldMapping = () => {
 
     const storageKey = `fieldMapping.${analyzerId}.scrollY`;
     const storedScrollY = sessionStorage.getItem(storageKey);
+    let scrollRestoreTimer = null;
     if (storedScrollY) {
       try {
-        setTimeout(() => {
-          window.scrollTo(0, parseInt(storedScrollY, 10));
+        scrollRestoreTimer = setTimeout(() => {
+          if (typeof window !== "undefined") {
+            window.scrollTo(0, parseInt(storedScrollY, 10));
+          }
         }, 100);
       } catch (_) {
         // ignore
@@ -143,6 +146,9 @@ const FieldMapping = () => {
     };
     window.addEventListener("beforeunload", onBeforeUnload);
     return () => {
+      if (scrollRestoreTimer) {
+        clearTimeout(scrollRestoreTimer);
+      }
       window.removeEventListener("beforeunload", onBeforeUnload);
       sessionStorage.setItem(
         `fieldMapping.${analyzerId}.scrollY`,


### PR DESCRIPTION
## Summary

Develop's \`02 - Frontend / Static\` job has been red since translations PR #3572 merged at \`b95ff8164\` (2026-05-08). Every test passes (587 / 600), but Vitest reports a single \`ReferenceError: window is not defined\` unhandled error originating from \`FieldMapping.jsx:81\`:

\`\`\`
ReferenceError: window is not defined
 ❯ Timeout._onTimeout src/components/analyzers/FieldMapping/FieldMapping.jsx:81:11
\`\`\`

The original failing run: [25579578004](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/25579578004).

## Root cause

\`FieldMapping\`'s mount effect schedules a 100 ms \`setTimeout\` to restore scroll position, but the timer ID is never captured — so the existing \`useEffect\` cleanup can't \`clearTimeout\` it. When the test finishes before the timer fires, the callback runs against a torn-down JSDOM \`window\` and throws.

Race-flaky: the same code passed on PR #3572's \`Static\` run ([job 75092241068](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/25578729652/job/75092241068)) and failed on the post-merge develop push. Whether the unhandled error surfaces depends on Vitest's parallel scheduling and JSDOM teardown timing.

This is also why this failure looks like \"Transifex breaks CI\" — Transifex bot is just the highest-frequency merger, so it statistically lands on the dice-roll more often than other PRs. The actual bug is pre-existing.

## Fix

Two-part minimal fix in \`FieldMapping.jsx\`:

1. Capture the \`setTimeout\` return value (\`scrollRestoreTimer\`) so the existing \`useEffect\` cleanup can \`clearTimeout\` it on unmount or effect re-run.
2. Guard \`window\` inside the timer callback (\`typeof window !== \"undefined\"\`) as defense-in-depth.

8-line diff, one file.

## Test plan

- [x] \`npx vitest run src/components/analyzers/FieldMapping/FieldMapping.test.jsx\` — 6 tests pass, no unhandled errors
- [x] \`npx vitest run\` (full suite) — 87 files / 587 pass / 13 skip, no \`Errors\` line and no \`Unhandled Errors\` block (the only stderr is the intentional throw in \`RouteErrorBoundary.test.jsx\`)
- [x] \`npm run format\` — clean
- [ ] CI: \`02 - Frontend / Static\` should turn green; once develop's next push runs, the chronic flake disappears