### PR TITLE
backport(test): protect reference_tables seed from fixture-load wipes (#3603)

### DIFF
--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -14,7 +14,9 @@ import org.dbunit.DatabaseUnitException;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseConnection;
 import org.dbunit.database.IDatabaseConnection;
+import org.dbunit.dataset.FilteredDataSet;
 import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.filter.ExcludeTableFilter;
 import org.dbunit.dataset.xml.FlatXmlDataSet;
 import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
@@ -50,6 +52,21 @@ import org.springframework.web.context.WebApplicationContext;
 public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJUnit4SpringContextTests {
 
     Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Tables that are static seeds — fixture loads must never truncate or replace
+     * them. {@code reference_tables} is populated by Liquibase at DB init with ~136
+     * rows (PATIENT, PERSON, DICTIONARY, BARCODE_LABEL_INFO, ANALYSIS, NCE_EVENT,
+     * etc.). Every audit-emitting service (post PR #3591) does an
+     * {@code AuditTrailServiceImpl.saveNewHistory} lookup keyed on its
+     * ref_table_name; if a fixture loader truncates the seed and re-inserts only
+     * the fixture's handful of rows, every downstream test that audits an entity
+     * blows up with "Reference Table is null". The bug is surefire-order-dependent
+     * and was masked until PR #3591 (2026-05-13) opted 14 P0 services into
+     * audit-emit. Filter at the loader so the seed is untouchable regardless of
+     * which fixture declares which rows.
+     */
+    private static final String[] PROTECTED_SEED_TABLES = { "reference_tables" };
 
     @Autowired
     protected WebApplicationContext webApplicationContext;
@@ -147,7 +164,13 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
                 throw new IllegalArgumentException("Dataset file '" + datasetFileName + "' not found in classpath");
             }
 
-            IDataSet dataset = new FlatXmlDataSet(inputStream);
+            // Strip PROTECTED_SEED_TABLES from the loaded dataset BEFORE truncating
+            // or refreshing. This makes the static seed (reference_tables, etc.)
+            // immune to fixture-load wipes — see PROTECTED_SEED_TABLES javadoc.
+            // Any <reference_tables> rows declared by a fixture are silently
+            // ignored; the SQL-seeded row stays in place.
+            IDataSet dataset = new FilteredDataSet(new ExcludeTableFilter(PROTECTED_SEED_TABLES),
+                    new FlatXmlDataSet(inputStream));
             String[] tableNames = dataset.getTableNames();
             cleanRowsInCurrentConnection(tableNames);
 

--- a/src/test/java/org/openelisglobal/FixtureLoaderProtectedSeedsTest.java
+++ b/src/test/java/org/openelisglobal/FixtureLoaderProtectedSeedsTest.java
@@ -1,0 +1,89 @@
+package org.openelisglobal;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import javax.sql.DataSource;
+import org.junit.Test;
+import org.openelisglobal.referencetables.service.ReferenceTablesService;
+import org.openelisglobal.referencetables.valueholder.ReferenceTables;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Locks the base-test invariant:
+ * {@link BaseWebContextSensitiveTest#executeDataSetWithStateManagement} must
+ * NOT truncate or replace static-seed tables (currently
+ * {@code reference_tables}) even when a fixture XML declares rows in those
+ * tables.
+ *
+ * <p>
+ * Background. Pre-fix, the DBUnit loader called {@code TRUNCATE ...
+ * RESTART IDENTITY CASCADE} on every table named in the fixture before
+ * REFRESHing the rows. {@code reference_tables} is populated by Liquibase at DB
+ * init with ~246 rows that every audit-emitting service (post PR #3591) looks
+ * up by name in {@code AuditTrailServiceImpl.saveNewHistory}. When a fixture
+ * incidentally declared a {@code <reference_tables>} row (10+ fixtures had
+ * this), the truncate wiped the seed, leaving every downstream audit-emitting
+ * test surefire-order-dependently red with "Reference Table is null".
+ *
+ * <p>
+ * This test loads a fixture that ASSERTIVELY declares a rogue
+ * {@code <reference_tables>} row and verifies the SQL seed survives. Regression
+ * of the filter would make this test go red.
+ */
+public class FixtureLoaderProtectedSeedsTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private ReferenceTablesService referenceTablesService;
+
+    @Autowired
+    private DataSource dataSource;
+
+    /**
+     * Seed tables that should survive any fixture load. Mirrors the constant on
+     * {@link BaseWebContextSensitiveTest} but is duplicated here so a future change
+     * that drops a name from PROTECTED_SEED_TABLES still gets caught by an explicit
+     * assertion.
+     */
+    private static final String[] CANARY_SEED_NAMES = { "PATIENT", "PERSON", "DICTIONARY", "SAMPLE", "ANALYSIS",
+            "site_information", "BARCODE_LABEL_INFO" };
+
+    @Test
+    public void loadingFixtureWithRogueReferenceTablesRow_doesNotWipeSeed() throws Exception {
+        int seedSizeBefore = countReferenceTables();
+        assertTrue("seed should be populated before test (got " + seedSizeBefore + ")", seedSizeBefore >= 50);
+
+        for (String name : CANARY_SEED_NAMES) {
+            ReferenceTables row = referenceTablesService.getReferenceTableByName(name);
+            assertNotNull("Canary seed row missing before fixture load: " + name, row);
+        }
+
+        // Load any existing fixture that declares <reference_tables> rows. Use
+        // result.xml because it's a small fixture with id=9999 (no PK conflict
+        // with seed) so the test focuses purely on the truncate-survival
+        // invariant, not on REFRESH side-effects.
+        executeDataSetWithStateManagement("testdata/result.xml");
+
+        for (String name : CANARY_SEED_NAMES) {
+            ReferenceTables row = referenceTablesService.getReferenceTableByName(name);
+            assertNotNull("Canary seed row wiped by fixture load: " + name, row);
+        }
+
+        int seedSizeAfter = countReferenceTables();
+        assertTrue("Seed shrank from " + seedSizeBefore + " to " + seedSizeAfter + " — fixture loader truncated "
+                + "reference_tables despite the PROTECTED_SEED_TABLES filter. Did someone drop reference_tables "
+                + "from BaseWebContextSensitiveTest.PROTECTED_SEED_TABLES?", seedSizeAfter >= seedSizeBefore);
+    }
+
+    private int countReferenceTables() throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement("SELECT COUNT(*) FROM clinlims.reference_tables");
+                ResultSet rs = stmt.executeQuery()) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+}

--- a/src/test/java/org/openelisglobal/barcode/BarcodeConfigurationRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/barcode/BarcodeConfigurationRestControllerTest.java
@@ -33,6 +33,7 @@ public class BarcodeConfigurationRestControllerTest extends BaseWebContextSensit
     public void setUp() throws Exception {
         super.setUp();
         ensureBarcodeLabelDomainExists();
+        ensureBarcodeLabelQuantityRowsExist();
     }
 
     private void ensureBarcodeLabelDomainExists() {
@@ -45,6 +46,35 @@ public class BarcodeConfigurationRestControllerTest extends BaseWebContextSensit
         domain.setName("labels");
         domain.setDescription("items that pertain to barcodes/labels");
         siteInformationDomainService.insert(domain);
+    }
+
+    // Liquibase changeset 2.5.x.x/barcode_additional_info.xml installs the
+    // numMax*/numDefault* site_information rows on context startup, but sibling
+    // tests (BarcodeConfigServiceTest, SiteInformationServiceTest) load fixtures
+    // whose <site_information> elements cause cleanRowsInCurrentConnection to
+    // TRUNCATE site_information RESTART IDENTITY CASCADE, wiping those rows.
+    // Re-seed defensively here so this test class is order-independent.
+    private void ensureBarcodeLabelQuantityRowsExist() {
+        SiteInformationDomain labelsDomain = siteInformationDomainService.getByName("labels");
+        ensureSiteInformationRow("numMaxOrderLabels", "5000", labelsDomain);
+        ensureSiteInformationRow("numMaxSpecimenLabels", "5000", labelsDomain);
+        ensureSiteInformationRow("numMaxAliquotLabels", "5000", labelsDomain);
+        ensureSiteInformationRow("numDefaultOrderLabels", "1", labelsDomain);
+        ensureSiteInformationRow("numDefaultSpecimenLabels", "1", labelsDomain);
+        ensureSiteInformationRow("numDefaultAliquotLabels", "1", labelsDomain);
+    }
+
+    private void ensureSiteInformationRow(String name, String defaultValue, SiteInformationDomain domain) {
+        if (siteInformationService.getSiteInformationByName(name) != null) {
+            return;
+        }
+        SiteInformation row = new SiteInformation();
+        row.setName(name);
+        row.setValue(defaultValue);
+        row.setValueType("text");
+        row.setDomain(domain);
+        row.setSysUserId("1");
+        siteInformationService.insert(row);
     }
 
     private void applyValidDimensions(BarcodeConfigurationForm form) {

--- a/src/test/java/org/openelisglobal/referencetables/ReferenceTablesServiceTest.java
+++ b/src/test/java/org/openelisglobal/referencetables/ReferenceTablesServiceTest.java
@@ -6,7 +6,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.util.List;
+import javax.sql.DataSource;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,19 +20,69 @@ import org.openelisglobal.referencetables.service.ReferenceTablesService;
 import org.openelisglobal.referencetables.valueholder.ReferenceTables;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Service-level tests for {@link ReferenceTablesService}.
+ *
+ * <p>
+ * Seeds 8 deterministic test rows directly via JDBC at high IDs (9001-9008) to
+ * avoid PK collisions with the SQL-seeded {@code reference_tables} rows (~246
+ * entries spanning SAMPLE, PERSON, DICTIONARY, etc.). Pre-fix this class loaded
+ * {@code
+ * testdata/referencetables.xml} via
+ * {@link BaseWebContextSensitiveTest#executeDataSetWithStateManagement}, which
+ * TRUNCATEd the table and re-inserted only the 8 fixture rows — that broke
+ * every downstream audit-emitting test (see {@code PROTECTED_SEED_TABLES}
+ * javadoc on the base class) and made the assertion
+ * {@code getTotalReferenceTableCount() == 8} accidentally pass.
+ *
+ * <p>
+ * The fixture-loader now skips {@code reference_tables}, so the seed survives
+ * and this test owns its data explicitly.
+ */
 public class ReferenceTablesServiceTest extends BaseWebContextSensitiveTest {
 
     @Autowired
     ReferenceTablesService referenceTablesService;
 
+    @Autowired
+    private DataSource dataSource;
+
+    private static final long TEST_ID_BASE = 9000L;
+
+    private static final String[][] TEST_ROWS = {
+            // {id-offset, name, is_hl7_encoded}
+            { "1", "TestTable", "N" }, { "2", "DuplicateTable", "N" }, { "3", "Table1", "N" }, { "4", "Table2", "N" },
+            { "5", "CountTable1", "N" }, { "6", "CountTable2", "N" }, { "7", "Hl7Table", "Y" },
+            { "8", "NonHl7Table", "N" }, };
+
     @Before
-    public void init() throws Exception {
-        executeDataSetWithStateManagement("testdata/referencetables.xml");
+    public void seedTestRows() throws Exception {
+        deleteTestRows();
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement insert = conn.prepareStatement("INSERT INTO clinlims.reference_tables "
+                        + "(id, name, keep_history, is_hl7_encoded, lastupdated) VALUES (?, ?, 'Y', ?, NOW())")) {
+            for (String[] row : TEST_ROWS) {
+                long id = TEST_ID_BASE + Long.parseLong(row[0]);
+                insert.setLong(1, id);
+                insert.setString(2, row[1]);
+                insert.setString(3, row[2]);
+                insert.executeUpdate();
+            }
+        }
     }
 
     @After
-    public void tearDown() {
+    public void cleanupTestRows() throws Exception {
+        deleteTestRows();
+    }
 
+    private void deleteTestRows() throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement del = conn.prepareStatement("DELETE FROM clinlims.reference_tables "
+                        + "WHERE name IN ('TestTable','DuplicateTable','Table1','Table2',"
+                        + "'CountTable1','CountTable2','Hl7Table','NonHl7Table','NewInsertTestTable')")) {
+            del.executeUpdate();
+        }
     }
 
     @Test
@@ -78,10 +131,13 @@ public class ReferenceTablesServiceTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void getTotalReferenceTableCount_shouldReturnCorrectCount() throws Exception {
-        int expectedCount = 8;
+    public void getTotalReferenceTableCount_shouldIncludeAllTestSeededRows() throws Exception {
+        // Pre-fix this asserted exactly-8 because the fixture loader truncated
+        // reference_tables. Post-fix the SQL seed (~246 rows) survives, so the
+        // contract is "at least our 8 test rows are present alongside the seed."
         int count = referenceTablesService.getTotalReferenceTableCount();
-        assertEquals(expectedCount, count);
+        assertTrue("Expected at least 8 reference_tables rows (the 8 seeded by this test); got " + count,
+                count >= TEST_ROWS.length);
     }
 
     @Test
@@ -128,5 +184,4 @@ public class ReferenceTablesServiceTest extends BaseWebContextSensitiveTest {
         refTable.setId(null);
         referenceTablesService.update(refTable);
     }
-
 }

--- a/src/test/resources/testdata/dictionary.xml
+++ b/src/test/resources/testdata/dictionary.xml
@@ -8,9 +8,12 @@
     * the License. * * The Original Code is OpenELIS code. * * Copyright (C)
     ITECH, University of Washington, Seattle WA. All Rights Reserved. -->
 <dataset>
-    <!-- Reference table entry for DICTIONARY (needed for audit trail) -->
-    <reference_tables id="9999" name="DICTIONARY"
-        keep_history="Y" is_hl7_encoded="N" lastupdated="2023-10-01 12:00:00" />
+    <!-- DICTIONARY reference_tables row is provided by the SQL seed (id=9).
+        Do NOT declare it here: executeDataSetWithStateManagement TRUNCATEs every
+        table named in the dataset with RESTART IDENTITY CASCADE, so including <reference_tables>
+        here wipes the ~228 other seeded rows (PERSON, site_information, BARCODE_LABEL_INFO,
+        nc_event, etc.) and leaves whichever test class runs next failing with "Reference
+        Table is null in AuditTrailDAOImpl saveNewHistory()". -->
 
     <!-- Dictionary Category Entries -->
     <dictionary_category id="1"


### PR DESCRIPTION
## Summary

- Backport of upstream/develop commit [`768b6a23e`](https://github.com/DIGI-UW/OpenELIS-Global-2/commit/768b6a23e01199706671961606078f930e452b56) (originally landed in #3603 by Piotr Mankowski)
- `demo-silnas` is currently behind `develop` and is missing this fix — every PR targeting `demo-silnas` is failing the same CI test (`DictionaryMenuRestControllerTest.showDeleteDictionary_shouldSuccessfullyDeleteDictionary` → `expected:<200> but was:<500>`)
- This unblocks all open PRs against `demo-silnas` (vector V-03, OGC-547, OGC-384, issue-2891-add-method-uom, Refactor-GenericSampleOrderTest, ...)

## What the fix does

- Adds a `PROTECTED_SEED_TABLES = { "reference_tables" }` allowlist in `BaseWebContextSensitiveTest`
- Wraps loaded fixtures with `FilteredDataSet + ExcludeTableFilter` so any `<reference_tables>` rows declared inside a fixture are silently dropped before the truncate step
- Removes the stray `<reference_tables id="9999" name="DICTIONARY"/>` row from `testdata/dictionary.xml` (defense-in-depth)
- Defensively re-seeds `site_information` in `BarcodeConfigurationRestControllerTest.setUp()` for one fixture-pollution case the allowlist doesn't reach
- Adds `FixtureLoaderProtectedSeedsTest` to lock the invariant in place

## Why it was broken on demo-silnas only

Surefire `runOrder` defaults to filesystem order on the CI runner, so the failure is order-sensitive — develop hit it first (run [25882538522](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/25882538522)) and got fixed two days later. demo-silnas hasn't pulled the fix in.

## Test plan

- [ ] CI: backend job passes on this branch
- [ ] Verify with a follow-up rebase on any open demo-silnas PR (e.g. #3607) that the same test now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)