### PR TITLE
(fix) Enable text wrapping for long select list results on result screens

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11587,7 +11587,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -364,6 +364,25 @@ button {
   padding: 0.5%;
 }
 
+/* Text wrapping for select list result values */
+.resultCellText {
+  white-space: normal;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  line-height: 1.4;
+}
+
+.cds--form-item.result .cds--select-input {
+  white-space: normal;
+  text-overflow: ellipsis;
+  height: auto;
+  min-height: 2.5rem;
+}
+
+.cds--form-item.result {
+  width: 100%;
+}
+
 .inlineDiv {
   display: flex;
   margin-top: 2%;

--- a/frontend/src/components/resultPage/SearchResultForm.jsx
+++ b/frontend/src/components/resultPage/SearchResultForm.jsx
@@ -1060,7 +1060,8 @@ export function SearchResults(props) {
       cell: (row, index, column, id) => {
         return renderCell(row, index, column, id);
       },
-      width: "20rem",
+      minWidth: "20rem",
+      grow: 2,
     },
     {
       id: "currentResult",
@@ -1068,7 +1069,8 @@ export function SearchResults(props) {
       cell: (row, index, column, id) => {
         return renderCell(row, index, column, id);
       },
-      width: "10rem",
+      minWidth: "15rem",
+      grow: 1,
     },
     {
       id: "notes",
@@ -1243,6 +1245,10 @@ export function SearchResults(props) {
                 noLabel={true}
                 onChange={(e) => validateResults(e, row.id)}
                 value={row.resultValue}
+                title={
+                  row.dictionaryResults.find((r) => r.id == row.resultValue)
+                    ?.value || ""
+                }
               >
                 {/* {...updateShadowResult(e, this, param.rowId)} */}
                 <SelectItem text="" value="" />
@@ -1365,16 +1371,16 @@ export function SearchResults(props) {
         switch (row.resultType) {
           case "M":
           case "C":
-          case "D":
+          case "D": {
+            const currentResultText = row.dictionaryResults.find(
+              (result) => result.id == row.shadowResultValue,
+            )?.value;
             return (
-              <>
-                {
-                  row.dictionaryResults.find(
-                    (result) => result.id == row.shadowResultValue,
-                  )?.value
-                }
-              </>
+              <span className="resultCellText" title={currentResultText}>
+                {currentResultText}
+              </span>
             );
+          }
 
           default:
             return row.shadowResultValue;
@@ -1454,8 +1460,8 @@ export function SearchResults(props) {
       Boolean(locationData?.currentLocationPath) ||
       Boolean(
         sampleLocations[analysisId] &&
-        typeof sampleLocations[analysisId] === "object" &&
-        sampleLocations[analysisId].locationPath,
+          typeof sampleLocations[analysisId] === "object" &&
+          sampleLocations[analysisId].locationPath,
       );
 
     try {

--- a/frontend/src/components/resultPage/SearchResultForm.jsx
+++ b/frontend/src/components/resultPage/SearchResultForm.jsx
@@ -1458,8 +1458,8 @@ export function SearchResults(props) {
       Boolean(locationData?.currentLocationPath) ||
       Boolean(
         sampleLocations[analysisId] &&
-          typeof sampleLocations[analysisId] === "object" &&
-          sampleLocations[analysisId].locationPath,
+        typeof sampleLocations[analysisId] === "object" &&
+        sampleLocations[analysisId].locationPath,
       );
 
     try {

--- a/frontend/src/components/resultPage/SearchResultForm.jsx
+++ b/frontend/src/components/resultPage/SearchResultForm.jsx
@@ -1061,7 +1061,6 @@ export function SearchResults(props) {
         return renderCell(row, index, column, id);
       },
       minWidth: "20rem",
-      grow: 2,
     },
     {
       id: "currentResult",
@@ -1070,7 +1069,6 @@ export function SearchResults(props) {
         return renderCell(row, index, column, id);
       },
       minWidth: "15rem",
-      grow: 1,
     },
     {
       id: "notes",

--- a/frontend/src/components/validation/Validation.jsx
+++ b/frontend/src/components/validation/Validation.jsx
@@ -83,7 +83,6 @@ const Validation = (props) => {
         return renderCell(row, index, column, id);
       },
       minWidth: "15rem",
-      grow: 2,
     },
     {
       id: "save",

--- a/frontend/src/components/validation/Validation.jsx
+++ b/frontend/src/components/validation/Validation.jsx
@@ -82,7 +82,8 @@ const Validation = (props) => {
       cell: (row, index, column, id) => {
         return renderCell(row, index, column, id);
       },
-      width: "8rem",
+      minWidth: "15rem",
+      grow: 2,
     },
     {
       id: "save",
@@ -359,16 +360,16 @@ const Validation = (props) => {
         switch (row.resultType) {
           case "M":
           case "C":
-          case "D":
+          case "D": {
+            const resultText = row.dictionaryResults.find(
+              (result) => result.id == row.result,
+            )?.value;
             return (
-              <>
-                {
-                  row.dictionaryResults.find(
-                    (result) => result.id == row.result,
-                  )?.value
-                }
-              </>
+              <span className="resultCellText" title={resultText}>
+                {resultText}
+              </span>
             );
+          }
           default:
             return row.result;
         }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Long dictionary result values (e.g. "Bacillus species (not anthracis) - Further identification pending") were truncated with ellipsis in the Result Entry and Validation screens. 
Override Carbon Select CSS to allow text wrapping, widen result columns with flexible growth, wrap plain-text result displays, and add title tooltips as a fallback.

## Screenshots

Before:
<img width="1280" height="720" alt="results-long-value" src="https://github.com/user-attachments/assets/334a9704-bba9-4133-b960-c2068220d58e" />


After:
<img width="1492" height="629" alt="Screenshot 2026-05-21 at 15 39 00" src="https://github.com/user-attachments/assets/b2f53441-8bd5-40f3-bef2-50418c8e7593" />



## Related Issue
https://uwdigi.atlassian.net/browse/OGC-271

## Other

[Add any additional information or notes here]
