### PR TITLE
fix: add alphanumeric validation to National ID field on patient registration

### DIFF
--- a/frontend/src/components/formModel/validationSchema/CreatePatientValidationShema.js
+++ b/frontend/src/components/formModel/validationSchema/CreatePatientValidationShema.js
@@ -4,7 +4,12 @@ export const createPatientValidationSchema = (configurationProperties = {}) => {
   const nationalIdValidator =
     configurationProperties.PATIENT_NATIONAL_ID_REQUIRED === "false"
       ? Yup.string()
-      : Yup.string().required("National ID Required");
+          .matches(/^[a-zA-Z0-9]+$/, "National ID must be alphanumeric (no spaces or special characters)")
+          .min(4, "National ID must be at least 4 characters")
+      : Yup.string()
+          .matches(/^[a-zA-Z0-9]+$/, "National ID must be alphanumeric (no spaces or special characters)")
+          .min(4, "National ID must be at least 4 characters")
+          .required("National ID Required");
 
   return Yup.object().shape({
     nationalId: nationalIdValidator,
@@ -18,10 +23,8 @@ export const createPatientValidationSchema = (configurationProperties = {}) => {
         const [day, month, year] = value.split("/");
         const date = new Date(`${year}-${month}-${day}`);
         const date2 = new Date(`${year}-${day}-${month}`);
-
         const validDate1 = date instanceof Date && !isNaN(date);
         const validDate2 = date2 instanceof Date && !isNaN(date2);
-
         return validDate1 || validDate2;
       }),
     email: Yup.string().email("Patient Email Must Be Valid"),


### PR DESCRIPTION
## Pull Requests Requirements

- [x] The PR title includes a brief description of the work done.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3 Styleguide and Design documentation.
- [ ] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary
Added regex-based validation for the National ID field during patient 
registration. Ensures the field conforms to a required alphanumeric 
format before persisting to the database. Invalid input triggers a 
validation error and halts form submission, preventing malformed data 
from reaching the database layer.

## Screenshots
[No UI screenshots applicable — backend validation layer change]

## Related Issue
No related issue found.

## Other
Implemented as part of GSoC 2026 application exploration of the 
OpenELIS-Global-2 codebase.