### PR TITLE
refactor: extract emergency contact into separate domain entity

### DIFF
--- a/frontend/src/components/patient/sections/EmergencyContactSection.js
+++ b/frontend/src/components/patient/sections/EmergencyContactSection.js
@@ -1,0 +1,91 @@
+import React from "react";
+import { Field, ErrorMessage } from "formik";
+import { Grid, Column, TextInput } from "@carbon/react";
+import { useIntl } from "react-intl";
+
+const EmergencyContactSection = ({
+  values,
+  phoneValidation,
+  handlePhoneValidation,
+  handleFirstContactNameChange,
+  handleLastContactNameChange,
+  configurationProperties,
+}) => {
+  const intl = useIntl();
+
+  return (
+    <Grid>
+      <Column lg={16} md={8} sm={4}><br /></Column>
+      {/* Last Name */}
+      <Column lg={8} md={4} sm={4}>
+        <Field name="patientContact.person.lastName">
+          {({ field }) => (
+            <TextInput
+              {...field}
+              value={values.patientContact?.person?.lastName || ""}
+              labelText={intl.formatMessage({ id: "patientcontact.person.lastname" })}
+              id={field.name}
+              onChange={handleLastContactNameChange}
+              placeholder={intl.formatMessage({ id: "patient.emergency.lastname" })}
+            />
+          )}
+        </Field>
+      </Column>
+      {/* First Name */}
+      <Column lg={8} md={4} sm={4}>
+        <Field name="patientContact.person.firstName">
+          {({ field }) => (
+            <TextInput
+              {...field}
+              value={values.patientContact?.person?.firstName || ""}
+              labelText={intl.formatMessage({ id: "patientcontact.person.firstname" })}
+              id={field.name}
+              onChange={handleFirstContactNameChange}
+              placeholder={intl.formatMessage({ id: "patient.emergency.firstname" })}
+            />
+          )}
+        </Field>
+      </Column>
+      {/* Email */}
+      <Column lg={8} md={4} sm={4}>
+        <Field name="patientContact.person.email">
+          {({ field }) => (
+            <TextInput
+              {...field}
+              value={values.patientContact?.person?.email || ""}
+              labelText={intl.formatMessage({ id: "patientcontact.person.email" })}
+              id={field.name}
+              placeholder={intl.formatMessage({ id: "patient.emergency.email" })}
+            />
+          )}
+        </Field>
+        <div className="error">
+          <ErrorMessage name="patientContact.person.email" />
+        </div>
+      </Column>
+      {/* Primary Phone */}
+      <Column lg={8} md={4} sm={4}>
+        <Field name="patientContact.person.primaryPhone">
+          {({ field }) => (
+            <TextInput
+              {...field}
+              value={values.patientContact?.person?.primaryPhone || ""}
+              id="contactPhone"
+              onBlur={handlePhoneValidation}
+              labelText={intl.formatMessage(
+                { id: "patient.label.contactphone", defaultMessage: "Contact Phone: {PHONE_FORMAT}" },
+                { PHONE_FORMAT: configurationProperties.PHONE_FORMAT }
+              )}
+              invalid={!phoneValidation.contactPhone.status}
+              invalidText={phoneValidation.contactPhone.status ? "" : phoneValidation.contactPhone.body}
+              placeholder={intl.formatMessage({ id: "patient.emergency.phone" })}
+            />
+          )}
+        </Field>
+      </Column>
+      <Column lg={16} md={8} sm={4}><br /></Column>
+    </Grid>
+  );
+};
+
+export default EmergencyContactSection;


### PR DESCRIPTION
## Pull Requests Requirements

- [x] The PR title includes a brief description of the work done.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3 Styleguide and Design documentation.
- [ ] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary
Refactored emergency contact information from flat columns on the 
patient table into a dedicated EmergencyContact domain entity with 
a proper one-to-one relationship. Changes include:
- New EmergencyContact entity with JPA/Hibernate mapping
- Foreign key constraint linking emergency_contact to patient table
- Updated Patient.java to replace flat string fields with object 
  relationship mapping
- DTOs updated to handle nested emergency contact form payload

## Screenshots
[No UI screenshots applicable]

## Related Issue
No related issue found.

## Other
Implemented as part of GSoC 2026 application exploration of the 
OpenELIS-Global-2 codebase.