### PR TITLE
fix(sso): show report logos and Logging Configuration under SSO login

### DIFF
--- a/src/main/java/org/openelisglobal/interceptor/ModuleAuthenticationInterceptor.java
+++ b/src/main/java/org/openelisglobal/interceptor/ModuleAuthenticationInterceptor.java
@@ -167,7 +167,8 @@ public class ModuleAuthenticationInterceptor implements HandlerInterceptor {
     }
 
     private boolean isRestFullPath() {
-        if (path.startsWith("/rest") || path.startsWith("/Provider")) {
+        if (path.startsWith("/rest") || path.startsWith("/Provider") || path.startsWith("/dbImage")
+                || path.startsWith("/logging")) {
             return true;
         }
         return false;


### PR DESCRIPTION
## Summary

Under SSO (Keycloak) login, the legacy module-permission interceptor was rejecting requests for the report-header / lab-director-signature images and for the Logging Configuration endpoints, causing the images to fail to load and the live-log screen to be inaccessible.

Whitelists `/dbImage` and `/logging` in the interceptor so SSO admins can use these features. Authorization is still enforced — images require an authenticated session, and the Logging controller is class-level `@PreAuthorize` admin-only.