### PR TITLE
fix: change getReferralsBySampleItemId parameter type from Integer to String

### DIFF
--- a/src/main/java/org/openelisglobal/referral/dao/ReferralDAO.java
+++ b/src/main/java/org/openelisglobal/referral/dao/ReferralDAO.java
@@ -71,7 +71,7 @@ public interface ReferralDAO extends BaseDAO<Referral, String> {
      * @param sampleItemId - the PK of a SampleItem
      * @return list of referrals for this sample item
      */
-    public List<Referral> getReferralsBySampleItemId(Integer sampleItemId);
+    public List<Referral> getReferralsBySampleItemId(String sampleItemId);
 
     /**
      * Get all unassigned referrals grouped by sample item. Returns distinct sample

--- a/src/main/java/org/openelisglobal/referral/daoimpl/ReferralDAOImpl.java
+++ b/src/main/java/org/openelisglobal/referral/daoimpl/ReferralDAOImpl.java
@@ -238,7 +238,7 @@ public class ReferralDAOImpl extends BaseDAOImpl<Referral, String> implements Re
 
     @Transactional(readOnly = true)
     @Override
-    public List<Referral> getReferralsBySampleItemId(Integer sampleItemId) {
+    public List<Referral> getReferralsBySampleItemId(String sampleItemId) {
         String hql = "SELECT DISTINCT r" + " FROM Referral r" + " JOIN FETCH r.analysis a"
                 + " JOIN FETCH a.sampleItem si" + " LEFT JOIN FETCH a.test t" + " LEFT JOIN FETCH r.organization org"
                 + " WHERE si.id = :sampleItemId" + "   AND r.status != 'CANCELED'"

--- a/src/main/java/org/openelisglobal/shipment/service/BoxSampleItemServiceImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/service/BoxSampleItemServiceImpl.java
@@ -209,8 +209,7 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
             shippingBoxDAO.update(box);
 
             // Assign all referrals for this sample item to this box
-            Integer sampleItemIdInt = Integer.parseInt(sampleItemId);
-            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemIdInt);
+            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemId);
             for (Referral referral : referrals) {
                 if (referral.getAssignedBox() == null) {
                     referral.setAssignedBox(box);
@@ -249,7 +248,7 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
 
             // Unassign all referrals for this sample item that are assigned to this box
             if (sampleItem != null && shippingBox != null) {
-                List<Referral> referrals = referralDAO.getReferralsBySampleItemId(Integer.parseInt(sampleItem.getId()));
+                List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItem.getId());
 
                 for (Referral referral : referrals) {
                     // Check if this referral is assigned to this box

--- a/src/main/java/org/openelisglobal/shipment/service/UnassignedSampleItemServiceImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/service/UnassignedSampleItemServiceImpl.java
@@ -77,9 +77,7 @@ public class UnassignedSampleItemServiceImpl implements UnassignedSampleItemServ
     public SampleItemDTO getSampleItemById(String sampleItemId) {
         try {
             // Get all referrals for this sample item
-            Integer sampleItemIdInt = Integer.parseInt(sampleItemId);
-
-            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemIdInt);
+            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemId);
 
             if (referrals.isEmpty()) {
                 logger.warn("No referrals found for sample item: {}", sampleItemId);
@@ -174,8 +172,7 @@ public class UnassignedSampleItemServiceImpl implements UnassignedSampleItemServ
                     collectionDate);
 
             // Get all referrals for this sample item
-            Integer sampleItemIdInt = Integer.parseInt(sampleItemId);
-            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemIdInt);
+            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemId);
 
             List<ReferralTestDTO> referralTests = new ArrayList<>();
             for (Referral referral : referrals) {

--- a/src/test/java/org/openelisglobal/shipment/service/BoxSampleItemServiceTest.java
+++ b/src/test/java/org/openelisglobal/shipment/service/BoxSampleItemServiceTest.java
@@ -5,6 +5,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.referral.dao.ReferralDAO;
+import org.openelisglobal.referral.valueholder.Referral;
 import org.openelisglobal.shipment.dto.SampleItemDTO;
 import org.openelisglobal.shipment.valueholder.BoxSampleItem;
 import org.openelisglobal.shipment.valueholder.ReceptionStatus;
@@ -14,6 +16,9 @@ public class BoxSampleItemServiceTest extends BaseWebContextSensitiveTest {
 
     @Autowired
     private BoxSampleItemService boxSampleItemService;
+
+    @Autowired
+    private ReferralDAO referralDAO;
 
     @Before
     public void init() throws Exception {
@@ -151,5 +156,35 @@ public class BoxSampleItemServiceTest extends BaseWebContextSensitiveTest {
         Assert.assertEquals("1", fetched.getSampleItem().getId());
         Assert.assertEquals(ReceptionStatus.RECEIVED_GOOD, fetched.getReceptionStatus());
         Assert.assertEquals("Verified OK", fetched.getReceptionNotes());
+    }
+
+    @Test
+    public void removeSampleItemFromBox_shouldSucceedAndUnassignReferralFromBox() {
+        Referral referralBefore = referralDAO.getReferralById("1");
+        Assert.assertNotNull(referralBefore.getAssignedBox());
+        Assert.assertEquals(Integer.valueOf(1), referralBefore.getAssignedBox().getId());
+
+        boxSampleItemService.removeSampleItemFromBox(100, 1);
+
+        BoxSampleItem removed = boxSampleItemService.getBoxSampleItemById(100);
+        Assert.assertNull(removed);
+
+        Referral referralAfter = referralDAO.getReferralById("1");
+        Assert.assertNull(referralAfter.getAssignedBox());
+
+        int remainingInBox = boxSampleItemService.countSampleItemsInBox(1);
+        Assert.assertEquals(1, remainingInBox);
+    }
+
+    @Test
+    public void removeSampleItemFromBox_shouldNotAffectReferralsAssignedToOtherBoxes() {
+        boxSampleItemService.removeSampleItemFromBox(101, 1);
+
+        BoxSampleItem removed = boxSampleItemService.getBoxSampleItemById(101);
+        Assert.assertNull(removed);
+
+        Referral referralUnaffected = referralDAO.getReferralById("1");
+        Assert.assertNotNull(referralUnaffected.getAssignedBox());
+        Assert.assertEquals(Integer.valueOf(1), referralUnaffected.getAssignedBox().getId());
     }
 }

--- a/src/test/resources/testdata/box_sample_item_service.xml
+++ b/src/test/resources/testdata/box_sample_item_service.xml
@@ -113,6 +113,10 @@
         description="Confirmation requested"
         display_key="referral.reason.confirmation"
         lastupdated="2024-01-01 10:00:00" />
+    <referral_reason id="2" name="New Case"
+        description="Initial consultation"
+        display_key="referral.reason.newcase"
+        lastupdated="2024-07-02 09:15:00" />
 
     <!-- Referral for sample_item 1, already assigned to shipping_box 1 (mirrors
         the state that removeSampleItemFromBox must correctly unassign) -->

--- a/src/test/resources/testdata/box_sample_item_service.xml
+++ b/src/test/resources/testdata/box_sample_item_service.xml
@@ -92,4 +92,35 @@
         reception_notes="Arrived in good condition" sys_user_id="1"
         lastupdated="2024-01-01 11:00:00" />
 
+    <!-- Referral fixtures: sample_item 1 (already in BOX-001 via box_sample_item
+        100) has a referral assigned to that same box, for remove/unassign testing -->
+    <test_section id="1" name="Chemistry"
+        description="Chemistry Section" name_localization_id="1"
+        lastupdated="2024-01-01 10:00:00" />
+    <test id="1" description="Blood Chemistry Test" name="Blood Chem"
+        guid="TEST-BLOOD-CHEM-001" test_section_id="1"
+        lastupdated="2024-01-01 10:00:00" />
+    <analysis id="1" sampitem_id="1" test_sect_id="1" test_id="1"
+        revision="1" status="1" status_id="1" is_reportable="Y"
+        entry_date="2024-01-01 10:00:00" analysis_type="ROUTINE"
+        lastupdated="2024-01-01 10:00:00" />
+
+    <referral_type id="1" name="Confirmation"
+        description="Sent out to confirm result"
+        display_key="referral.type.confirmation"
+        lastupdated="2024-01-01 10:00:00" />
+    <referral_reason id="1" name="Confirmation requested"
+        description="Confirmation requested"
+        display_key="referral.reason.confirmation"
+        lastupdated="2024-01-01 10:00:00" />
+
+    <!-- Referral for sample_item 1, already assigned to shipping_box 1 (mirrors
+        the state that removeSampleItemFromBox must correctly unassign) -->
+    <referral id="1" analysis_id="1" organization_id="1"
+        organization_name="Test Facility" referral_reason_id="1"
+        referral_type_id="1" requester_name="Doctor" status="SENT"
+        assigned_to_box_id="1" referral_request_date="2024-01-01 10:00:00"
+        lastUpdated="2024-01-01 10:00:00" canceled="false"
+        fhir_uuid="c3d4e5f6-a7b8-9012-cdef-123456789012" />
+
 </dataset>


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
## Problem
`BoxSampleItemService.removeSampleItemFromBox` was crashing with `IllegalArgumentException` under Hibernate 6 due to a type mismatch.

`SampleItem` extends `BaseObject<String>` so its ID is a `String`, but `ReferralDAOImpl.getReferralsBySampleItemId` accepted an `Integer` and bound it to `si.id` which is a `String` field.

Hibernate 6 strictly validates parameter types and throws:
`IllegalArgumentException: Parameter value [X] did not match expected type [java.lang.String]`

## Changes
- `ReferralDAO.java` — updated interface signature from `Integer` to `String`
- `ReferralDAOImpl.java` — updated implementation signature from `Integer` to `String`
- `BoxSampleItemServiceImpl.java` — removed unnecessary `Integer.parseInt()` and pass `sampleItemId`/`sampleItem.getId()` directly

## Related Issue
Fixes #3660

