### PR TITLE
UAT: admin dashboard shortcuts, dictionary loader fix, urine pregnancy typo

### DIFF
--- a/frontend/src/components/admin/Admin.test.jsx
+++ b/frontend/src/components/admin/Admin.test.jsx
@@ -52,13 +52,13 @@ describe("Admin", () => {
       expect(
         screen.getByText(messages["master.lists.page.test.management"]),
       ).toBeInTheDocument();
-      expect(screen.getAllByTestId("admin-dashboard-tile")).toHaveLength(6);
+      expect(screen.getAllByTestId("admin-dashboard-tile")).toHaveLength(12);
       expect(
         container.querySelectorAll(".admin-dashboard__tile-icon"),
-      ).toHaveLength(6);
+      ).toHaveLength(12);
       expect(
         container.querySelectorAll(".admin-dashboard__tile-arrow"),
-      ).toHaveLength(6);
+      ).toHaveLength(12);
       expect(document.querySelector(".cds--side-nav")).not.toBeInTheDocument();
     },
   );

--- a/frontend/src/components/admin/AdminDashboard.jsx
+++ b/frontend/src/components/admin/AdminDashboard.jsx
@@ -4,8 +4,13 @@ import { useHistory } from "react-router-dom";
 import { ClickableTile, Column, Grid } from "@carbon/react";
 import {
   ArrowRight,
+  CharacterWholeNumber,
+  ChartBubble,
   ConnectionSignal,
   ContainerSoftware,
+  ListDropdown,
+  Microscope,
+  QrCode,
   ResultNew,
   Settings,
   TableOfContents,
@@ -42,6 +47,36 @@ const ADMIN_DASHBOARD_LINKS = [
     messageId: "externalconnections.browse.title",
     path: "externalConnections",
     icon: ConnectionSignal,
+  },
+  {
+    messageId: "dictionary.label.modify",
+    path: "DictionaryMenu",
+    icon: CharacterWholeNumber,
+  },
+  {
+    messageId: "admin.formEntryConfig",
+    path: "SiteInformationMenu",
+    icon: ListDropdown,
+  },
+  {
+    messageId: "sidenav.label.admin.program",
+    path: "program",
+    icon: ChartBubble,
+  },
+  {
+    messageId: "sidenav.label.admin.testmgt.reflex",
+    path: "reflex",
+    icon: Microscope,
+  },
+  {
+    messageId: "sidenav.label.admin.labNumber",
+    path: "labNumber",
+    icon: CharacterWholeNumber,
+  },
+  {
+    messageId: "sidenav.label.admin.barcodeconfiguration",
+    path: "barcodeConfiguration",
+    icon: QrCode,
   },
 ];
 

--- a/frontend/src/components/admin/testManagement/ViewTestCatalog.jsx
+++ b/frontend/src/components/admin/testManagement/ViewTestCatalog.jsx
@@ -357,7 +357,7 @@ const TestCatalog = () => {
       <br />
       <PageBreadCrumb breadcrumbs={breadcrumbs} />
       <br />
-      <div className="orderLegendBody">
+      <div className="orderLegendBody" style={{ minHeight: "80vh" }}>
         <Grid fullWidth={true}>
           <Column lg={12} md={6} sm={3}>
             <h1>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <minor.version>2</minor.version>
         <state.version>1</state.version>
         <!-- 0 = alpha, 1 = beta, 2 = rc, 3 = deployable -->
-        <fix.version>9</fix.version>
+        <fix.version>10</fix.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <liquibase.propertyFile>${project.basedir}/liquibase/liquibase.properties</liquibase.propertyFile>
         <castor.version>1.4.1</castor.version>

--- a/src/main/java/org/openelisglobal/testresult/service/TestResultConfigurationHandler.java
+++ b/src/main/java/org/openelisglobal/testresult/service/TestResultConfigurationHandler.java
@@ -255,20 +255,21 @@ public class TestResultConfigurationHandler implements DomainConfigurationHandle
                 return 0;
             }
 
-            // Find dictionary entry, optionally by category
             Dictionary dictionary = null;
             if (!dictionaryCategory.isEmpty()) {
-                // Look up by entry name and category
-                dictionary = dictionaryService.getDictionaryEntrysByNameAndCategoryDescription(resultValue,
-                        dictionaryCategory);
+                dictionary = dictionaryService.getDictionaryEntryByNameAndCategoryName(resultValue, dictionaryCategory);
                 if (dictionary == null) {
                     LogEvent.logDebug(this.getClass().getSimpleName(), "processCsvLine",
                             "Dictionary entry '" + resultValue + "' not found in category '" + dictionaryCategory
-                                    + "'. Trying fallback lookup by entry name only.");
+                                    + "' (by name). Trying legacy description match.");
+                    dictionary = dictionaryService.getDictionaryEntrysByNameAndCategoryDescription(resultValue,
+                            dictionaryCategory);
                 }
             }
             if (dictionary == null) {
-                // Fall back to lookup by entry name only
+                // Last-resort fallback: name-only. Note this fails silently if duplicate
+                // dict_entry rows exist (getMatch returns empty on >1 match); see
+                // BaseObjectServiceImpl.getMatch.
                 dictionary = dictionaryService.getDictionaryByDictEntry(resultValue);
             }
             if (dictionary == null) {

--- a/src/main/resources/liquibase/3.5.x.x/030-fix-urine-pregnancy-test-typo.xml
+++ b/src/main/resources/liquibase/3.5.x.x/030-fix-urine-pregnancy-test-typo.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+      Fix legacy typo "Urine prenancy test" → "Urine pregnancy test" on the
+      test row and on its name + report-name localization rows. Each
+      changeset is independent and idempotent (fires only when the stale
+      value is still present).
+    -->
+
+    <changeSet author="openelis" id="fix-urine-pregnancy-test-name">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">SELECT count(*) FROM clinlims.test WHERE name = 'Urine prenancy test-Urine'</sqlCheck>
+        </preConditions>
+        <update schemaName="clinlims" tableName="test">
+            <column name="name" value="Urine pregnancy test-Urine" />
+            <column name="lastupdated" valueComputed="${now}" />
+            <where>name = 'Urine prenancy test-Urine'</where>
+        </update>
+    </changeSet>
+
+    <changeSet author="openelis" id="fix-urine-pregnancy-test-description">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">SELECT count(*) FROM clinlims.test WHERE description = 'Urine prenancy test'</sqlCheck>
+        </preConditions>
+        <update schemaName="clinlims" tableName="test">
+            <column name="description" value="Urine pregnancy test" />
+            <column name="lastupdated" valueComputed="${now}" />
+            <where>description = 'Urine prenancy test'</where>
+        </update>
+    </changeSet>
+
+    <changeSet author="openelis" id="fix-urine-pregnancy-localization-value">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists schemaName="clinlims" tableName="localization_value"/>
+                <sqlCheck expectedResult="1">SELECT count(*) FROM clinlims.localization_value WHERE locale = 'en' AND value = 'Urine prenancy test'</sqlCheck>
+            </and>
+        </preConditions>
+        <update schemaName="clinlims" tableName="localization_value">
+            <column name="value" value="Urine pregnancy test" />
+            <column name="last_updated" valueComputed="${now}" />
+            <where>locale = 'en' AND value = 'Urine prenancy test'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -94,4 +94,7 @@
 
   <include relativeToChangelogFile="true" file="026-register-audit-ref-tables-for-p0-services.xml"/>
 
+  <!-- Fix typo on the legacy "Urine prenancy test" -->
+  <include relativeToChangelogFile="true" file="030-fix-urine-pregnancy-test-typo.xml"/>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

A small UAT batch of admin-side polish and reliability fixes:

- **Admin dashboard** — adds shortcut tiles for Dictionary Menu, General Configurations, Program Entry, Reflex Management, Lab Number Management, and Barcode Configuration so admins can reach the most-used config pages without going through the side nav.
- **View Test Catalog** — fixes the Test Section dropdown being hidden behind an empty area on first page load.
- **Dictionary config loader** — test-results CSVs now reliably find dictionary entries even when a category's name and description don't match, preventing silent "entry not found" errors during config loads.
- **Test name typo** — Liquibase fix to rename the legacy "Urine prenancy test" to "Urine pregnancy test" wherever it appears.
- Version bump to 3.2.1.10.