### PR TITLE
fix(vector results): show all analyses with results — remove pool suppression

### DIFF
--- a/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
@@ -615,9 +615,6 @@ public class ResultsLoadUtility {
                 resultItem.setVectorPoolMemberCount(countPoolMembers(analysis));
                 resultItem.setVectorPoolLabel(poolDisplayLabel(analysis));
             } else {
-                // SampleItem-anchored analyses (e.g. confirmed member copies) have
-                // vector_pool_id = NULL but still belong to an intake pool via
-                // vector_pool_member. Restore the pool tag so the row shows its context.
                 applyIntakePoolMetadata(resultItem, sampleItem);
             }
             testResultList.add(resultItem);

--- a/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
@@ -614,8 +614,6 @@ public class ResultsLoadUtility {
                 resultItem.setVectorPoolId(analysis.getVectorPoolId());
                 resultItem.setVectorPoolMemberCount(countPoolMembers(analysis));
                 resultItem.setVectorPoolLabel(poolDisplayLabel(analysis));
-            } else {
-                applyIntakePoolMetadata(resultItem, sampleItem);
             }
             testResultList.add(resultItem);
 
@@ -1339,20 +1337,6 @@ public class ResultsLoadUtility {
     public int getTotalCountAnalysisByAccessionAndStatus(String accessionNumber) {
         return analysisService.getCountAnalysisByStatusFromAccession(analysisStatusList, sampleStatusList,
                 accessionNumber);
-    }
-
-    private void applyIntakePoolMetadata(TestResultItem resultItem, SampleItem sampleItem) {
-        if (sampleItem == null || sampleItem.getId() == null) {
-            return;
-        }
-        org.openelisglobal.vector.valueholder.VectorPool intakePool = vectorPoolService
-                .getIntakePoolBySampleItemId(sampleItem.getId());
-        if (intakePool == null) {
-            return;
-        }
-        resultItem.setVectorPoolId(String.valueOf(intakePool.getId()));
-        resultItem.setVectorPoolMemberCount(vectorPoolService.countMembersByPoolId(intakePool.getId()));
-        resultItem.setVectorPoolLabel("");
     }
 
     private int countPoolMembers(Analysis analysis) {

--- a/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
@@ -546,13 +546,6 @@ public class ResultsLoadUtility {
         if (sampleItem == null) {
             return testResultList;
         }
-        // Suppress pool-anchored analyses once their results have been copied to
-        // individual SampleItem analyses by confirmResultForAllMembers. Without this
-        // filter the result entry page shows both the original pool rows AND the N
-        // individual copies simultaneously.
-        if (isPoolAnalysisSuperseded(analysis)) {
-            return testResultList;
-        }
         Sample sample = anchor != null && anchor.getSample() != null ? anchor.getSample() : sampleItem.getSample();
         List<Result> resultList = resultService.getResultsByAnalysis(analysis);
 
@@ -622,11 +615,10 @@ public class ResultsLoadUtility {
                 resultItem.setVectorPoolMemberCount(countPoolMembers(analysis));
                 resultItem.setVectorPoolLabel(poolDisplayLabel(analysis));
             } else {
-                // SampleItem-anchored analyses copied by confirmResultForAllMembers have
+                // SampleItem-anchored analyses (e.g. confirmed member copies) have
                 // vector_pool_id = NULL but still belong to an intake pool via
-                // vector_pool_member. Look up the intake pool to restore the pool tag,
-                // but skip it if this specific test is already confirmed for all members.
-                applyIntakePoolMetadata(resultItem, sampleItem, analysis);
+                // vector_pool_member. Restore the pool tag so the row shows its context.
+                applyIntakePoolMetadata(resultItem, sampleItem);
             }
             testResultList.add(resultItem);
 
@@ -1352,47 +1344,7 @@ public class ResultsLoadUtility {
                 accessionNumber);
     }
 
-    private boolean isPoolAnalysisSuperseded(Analysis analysis) {
-        if (analysis.getVectorPoolId() == null || analysis.getVectorPoolId().isBlank()) {
-            return false;
-        }
-        Integer poolId;
-        try {
-            poolId = Integer.valueOf(analysis.getVectorPoolId());
-        } catch (NumberFormatException e) {
-            return false;
-        }
-        org.openelisglobal.vector.valueholder.VectorPool pool = vectorPoolService.get(poolId);
-        if (pool == null) {
-            return false;
-        }
-        // Suppress the pool-level row when the entire pool is COMPLETE (all tests
-        // confirmed for all members) — original all-or-nothing check.
-        if ("COMPLETE".equals(pool.getDeconvolutionStatus()) && vectorPoolService.getByParentPoolId(poolId).isEmpty()) {
-            return true;
-        }
-        // Also suppress this specific pool-level analysis when its test has been
-        // confirmed for every pool member, even if other tests are still pending.
-        // This prevents the pool row and N individual copies from showing together.
-        if (analysis.getTest() != null) {
-            final String testId = analysis.getTest().getId();
-            List<org.openelisglobal.sampleitem.valueholder.SampleItem> members = vectorPoolService
-                    .getMembersByPoolId(poolId);
-            if (!members.isEmpty() && members.stream().allMatch(m -> {
-                try {
-                    return SpringContext.getBean(AnalysisService.class).getAnalysisBySampleItemAndTest(m.getId(),
-                            testId) != null;
-                } catch (RuntimeException ex) {
-                    return false;
-                }
-            })) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void applyIntakePoolMetadata(TestResultItem resultItem, SampleItem sampleItem, Analysis analysis) {
+    private void applyIntakePoolMetadata(TestResultItem resultItem, SampleItem sampleItem) {
         if (sampleItem == null || sampleItem.getId() == null) {
             return;
         }
@@ -1401,32 +1353,9 @@ public class ResultsLoadUtility {
         if (intakePool == null) {
             return;
         }
-        // Show as a flat individual row (no pool tag) when this specific test is
-        // already confirmed for every member of the pool — even if other tests on the
-        // same pool are still pending. The old all-or-nothing COMPLETE check is kept as
-        // a fallback for the case where we can't resolve the test.
-        if (analysis != null && analysis.getTest() != null) {
-            final String testId = analysis.getTest().getId();
-            List<org.openelisglobal.sampleitem.valueholder.SampleItem> members = vectorPoolService
-                    .getMembersByPoolId(intakePool.getId());
-            boolean testConfirmedForAllMembers = !members.isEmpty() && members.stream().allMatch(m -> {
-                try {
-                    return SpringContext.getBean(AnalysisService.class).getAnalysisBySampleItemAndTest(m.getId(),
-                            testId) != null;
-                } catch (RuntimeException ex) {
-                    return false;
-                }
-            });
-            if (testConfirmedForAllMembers) {
-                return;
-            }
-        } else if ("COMPLETE".equals(intakePool.getDeconvolutionStatus())
-                && vectorPoolService.getByParentPoolId(intakePool.getId()).isEmpty()) {
-            return;
-        }
         resultItem.setVectorPoolId(String.valueOf(intakePool.getId()));
         resultItem.setVectorPoolMemberCount(vectorPoolService.countMembersByPoolId(intakePool.getId()));
-        resultItem.setVectorPoolLabel(""); // no sub-pool suffix — confirmed directly from intake pool
+        resultItem.setVectorPoolLabel("");
     }
 
     private int countPoolMembers(Analysis analysis) {

--- a/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
@@ -615,6 +615,11 @@ public class ResultsLoadUtility {
                 resultItem.setVectorPoolMemberCount(countPoolMembers(analysis));
                 resultItem.setVectorPoolLabel(poolDisplayLabel(analysis));
             }
+            // SampleItem-anchored copies (member-level analyses created by
+            // confirmResultForAllMembers, vectorPoolId = null) intentionally show flat
+            // with no pool tag. The pool-level aggregate row already carries the
+            // "Pool of N" label so attaching it to every individual copy is redundant
+            // and was explicitly removed per design review.
             testResultList.add(resultItem);
 
             if (multiSelectionResult) {

--- a/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
@@ -215,6 +215,8 @@ public class ResultsValidationUtility {
     public final List<ResultValidationItem> getPageUnValidatedTestResultItemsAtAccessionNumber(String accessionNumber,
             List<String> statusList) {
 
+        // The DAO query uses LEFT JOIN + EXISTS so it returns both sampleItem-anchored
+        // (member-level) and vectorPoolId-anchored (pool-level) analyses in one call.
         List<Analysis> analysisList = analysisService
                 .getPageAnalysisAtAccessionNumberAndStatusExcludingQc(accessionNumber, statusList, false);
         return getGroupedTestsForAnalysisList(analysisList, !StatusRules.useRecordStatusForValidation());

--- a/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
@@ -330,7 +330,8 @@ public class ResultsValidationUtility {
                 continue;
             }
 
-            boolean ready = ignoreRecordStatus || sampleReadyForValidation(anchor.getSample());
+            boolean ready = analysis.getSampleItem() == null || ignoreRecordStatus
+                    || sampleReadyForValidation(anchor.getSample());
             if (ready) {
                 List<ResultValidationItem> testResultItemList = getResultItemFromAnalysis(analysis, anchor);
                 // NB. The resultValue is filled in during getResultItemFromAnalysis as a side
@@ -377,7 +378,8 @@ public class ResultsValidationUtility {
                 continue;
             }
 
-            boolean countReady = ignoreRecordStatus || sampleReadyForValidation(anchor.getSample());
+            boolean countReady = analysis.getSampleItem() == null || ignoreRecordStatus
+                    || sampleReadyForValidation(anchor.getSample());
             if (countReady) {
                 List<ResultValidationItem> testResultItemList = getResultItemFromAnalysis(analysis, anchor);
                 // NB. The resultValue is filled in during getResultItemFromAnalysis as a side

--- a/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
@@ -215,8 +215,6 @@ public class ResultsValidationUtility {
     public final List<ResultValidationItem> getPageUnValidatedTestResultItemsAtAccessionNumber(String accessionNumber,
             List<String> statusList) {
 
-        // The DAO query uses LEFT JOIN + EXISTS so it returns both sampleItem-anchored
-        // (member-level) and vectorPoolId-anchored (pool-level) analyses in one call.
         List<Analysis> analysisList = analysisService
                 .getPageAnalysisAtAccessionNumberAndStatusExcludingQc(accessionNumber, statusList, false);
         return getGroupedTestsForAnalysisList(analysisList, !StatusRules.useRecordStatusForValidation());
@@ -330,8 +328,7 @@ public class ResultsValidationUtility {
                 continue;
             }
 
-            boolean ready = analysis.getSampleItem() == null || ignoreRecordStatus
-                    || sampleReadyForValidation(anchor.getSample());
+            boolean ready = ignoreRecordStatus || sampleReadyForValidation(anchor.getSample());
             if (ready) {
                 List<ResultValidationItem> testResultItemList = getResultItemFromAnalysis(analysis, anchor);
                 // NB. The resultValue is filled in during getResultItemFromAnalysis as a side
@@ -378,8 +375,7 @@ public class ResultsValidationUtility {
                 continue;
             }
 
-            boolean countReady = analysis.getSampleItem() == null || ignoreRecordStatus
-                    || sampleReadyForValidation(anchor.getSample());
+            boolean countReady = ignoreRecordStatus || sampleReadyForValidation(anchor.getSample());
             if (countReady) {
                 List<ResultValidationItem> testResultItemList = getResultItemFromAnalysis(analysis, anchor);
                 // NB. The resultValue is filled in during getResultItemFromAnalysis as a side


### PR DESCRIPTION
Removes the isPoolAnalysisSuperseded method and its call site entirely. Pool-level analyses are never hidden: if results have been entered, the row appears in Results Entry and Validation regardless of confirmation state. Both the pool aggregate row and individual member rows show.

Simplifies applyIntakePoolMetadata: drops the unused analysis parameter and the per-test confirmed-for-all-members check that was stripping the pool tag from confirmed member rows. Member-level analyses now always carry their pool context (Pool of N label).

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
