### PR TITLE
feat(analyzer): push identifier_pattern to the bridge for identity corroboration

### DIFF
--- a/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerQcRuleRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerQcRuleRestController.java
@@ -124,7 +124,7 @@ public class AnalyzerQcRuleRestController extends BaseRestController {
                 String protocol = analyzer.getProtocolVersion() != null && analyzer.getProtocolVersion().isHl7() ? "HL7"
                         : "ASTM";
                 bridgeRegistrationService.registerTcp(analyzer.getId(), analyzer.getName(), analyzer.getIpAddress(),
-                        analyzer.getPort(), protocol);
+                        analyzer.getPort(), protocol, analyzer.getIdentifierPattern());
             }
             if (analyzer.getImportDirectory() != null && !analyzer.getImportDirectory().isBlank()) {
                 List<String> testMappings = analyzerTestMappingService.getAllForAnalyzer(analyzer.getId()).stream()

--- a/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
+++ b/src/main/java/org/openelisglobal/analyzer/controller/AnalyzerRestController.java
@@ -1103,7 +1103,7 @@ public class AnalyzerRestController extends BaseRestController {
                 String protocol = analyzer.getProtocolVersion() != null && analyzer.getProtocolVersion().isHl7() ? "HL7"
                         : "ASTM";
                 registered = bridgeRegistrationService.registerTcp(id, name, analyzer.getIpAddress(),
-                        analyzer.getPort(), protocol);
+                        analyzer.getPort(), protocol, analyzer.getIdentifierPattern());
             }
 
             // FILE analyzers: register by watch directory (unified fields on Analyzer)

--- a/src/main/java/org/openelisglobal/analyzer/service/AnalyzerBridgeStartupRegistrar.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/AnalyzerBridgeStartupRegistrar.java
@@ -110,7 +110,7 @@ public class AnalyzerBridgeStartupRegistrar {
                             ? "HL7"
                             : "ASTM";
                     if (bridgeRegistrationService.registerTcp(analyzerId, analyzerName, analyzer.getIpAddress(),
-                            analyzer.getPort(), protocol)) {
+                            analyzer.getPort(), protocol, analyzer.getIdentifierPattern())) {
                         registered++;
                         bridgeReachable = true;
                     }

--- a/src/main/java/org/openelisglobal/analyzer/service/BridgeRegistrationService.java
+++ b/src/main/java/org/openelisglobal/analyzer/service/BridgeRegistrationService.java
@@ -45,7 +45,8 @@ public class BridgeRegistrationService {
     private org.openelisglobal.test.service.TestService testService;
 
     /** Register a TCP analyzer (ASTM/HL7) with the bridge. */
-    public boolean registerTcp(String oeAnalyzerId, String name, String ip, Integer port, String protocol) {
+    public boolean registerTcp(String oeAnalyzerId, String name, String ip, Integer port, String protocol,
+            String identifierPattern) {
         if (!isBridgeConfigured()) {
             return false;
         }
@@ -56,6 +57,14 @@ public class BridgeRegistrationService {
             payload.put("sourceId", ip);
             payload.put("name", name);
             payload.put("protocol", protocol != null ? protocol : "ASTM");
+            // The same regex OE uses to identify an inbound message by its sender
+            // (Analyzer.identifierPattern). Letting the bridge corroborate the
+            // connection-source-IP identity against this authoritative pattern —
+            // rather than a name-substring heuristic — keeps the two identity
+            // signals consistent (e.g. ASTM sender "GENEXPERT^GeneXpert^4.6.0").
+            if (identifierPattern != null && !identifierPattern.isBlank()) {
+                payload.put("identifierPattern", identifierPattern);
+            }
             attachQcRules(payload, oeAnalyzerId);
             attachControlLots(payload, oeAnalyzerId);
             attachTestCodeLoinc(payload, oeAnalyzerId);

--- a/src/test/java/org/openelisglobal/analyzer/service/AnalyzerBridgeStartupRegistrarTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/service/AnalyzerBridgeStartupRegistrarTest.java
@@ -105,6 +105,6 @@ public class AnalyzerBridgeStartupRegistrarTest {
         verify(bridgeRegistrationService, timeout(ASYNC_TIMEOUT_MS).times(0)).registerFile(any(), any(), any(), any(),
                 any(), any(), any(), any(), any());
         verify(bridgeRegistrationService, timeout(ASYNC_TIMEOUT_MS).times(0)).registerTcp(any(), any(), any(), any(),
-                any());
+                any(), any());
     }
 }


### PR DESCRIPTION
## Why
The bridge corroborates an inbound message's two identity signals (connection source IP × in-message sender). To do that authoritatively it needs the same regex OE identifies senders with — `Analyzer.identifierPattern`. Without it the bridge falls back to a display-name substring, which false-mismatches ASTM caret-delimited senders.

## What
Pass `Analyzer.getIdentifierPattern()` through `registerTcp` into the bridge registration payload — all three callers (create, startup re-registration, QC-rule registration). No behaviour change in OE itself.

> Stacked on #3629 (`feat/analyzer-order-dispatch`). Pairs with the bridge PR that consumes the pattern. OE2 compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)