### PR TITLE
fix: BaseWebContextSensitiveTest — Phase 1 bug fixes (#3699)

### DIFF
--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import javax.sql.DataSource;
+import org.dbunit.DatabaseUnitException;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseConnection;
 import org.dbunit.database.IDatabaseConnection;
@@ -160,16 +161,10 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
             throw new NullPointerException("Please provide test dataset file to execute!");
         }
 
-        IDatabaseConnection connection = null;
+        IDatabaseConnection connection = buildDbUnitConnection();
         InputStream inputStream = null;
 
         try {
-            connection = new DatabaseConnection(dataSource.getConnection());
-            DatabaseConfig config = connection.getConfig();
-            config.setProperty(DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS, true);
-            config.setProperty(DatabaseConfig.FEATURE_CASE_SENSITIVE_TABLE_NAMES, true);
-            config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
-
             inputStream = getClass().getClassLoader().getResourceAsStream(datasetFileName);
 
             if (inputStream == null) {
@@ -204,6 +199,15 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
                 connection.close();
             }
         }
+    }
+
+    private IDatabaseConnection buildDbUnitConnection() throws DatabaseUnitException, SQLException {
+        IDatabaseConnection connection = new DatabaseConnection(dataSource.getConnection());
+        DatabaseConfig config = connection.getConfig();
+        config.setProperty(DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS, true);
+        config.setProperty(DatabaseConfig.FEATURE_CASE_SENSITIVE_TABLE_NAMES, true);
+        config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
+        return connection;
     }
 
     /**

--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -81,6 +81,9 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
      */
     protected static final String TEST_SYS_USER_ID = "1";
 
+    private static final ObjectMapper OBJECT_MAPPER = new MappingJackson2HttpMessageConverter().getObjectMapper()
+            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+
     @Autowired
     protected WebApplicationContext webApplicationContext;
 
@@ -138,16 +141,11 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
     }
 
     protected String mapToJson(Object obj) throws JsonProcessingException {
-        MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
-        ObjectMapper objectMapper = jsonConverter.getObjectMapper();
-        return objectMapper.writeValueAsString(obj);
+        return OBJECT_MAPPER.writeValueAsString(obj);
     }
 
     public <T> T mapFromJson(String json, Class<T> clazz) throws IOException {
-        MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
-        ObjectMapper objectMapper = jsonConverter.getObjectMapper();
-        objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
-        return objectMapper.readValue(json, clazz);
+        return OBJECT_MAPPER.readValue(json, clazz);
     }
 
     /**

--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -10,7 +10,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import javax.sql.DataSource;
-import org.dbunit.DatabaseUnitException;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseConnection;
 import org.dbunit.database.IDatabaseConnection;
@@ -216,9 +215,9 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
      * @param tableNames The names of the tables to truncate.
      * @throws SQLException If an error occurs during truncation.
      */
-    protected void cleanRowsInCurrentConnection(String[] tableNames) throws SQLException, DatabaseUnitException {
-        IDatabaseConnection connection = new DatabaseConnection(dataSource.getConnection());
-        try (Connection conn = connection.getConnection(); Statement stmt = conn.createStatement()) {
+
+    protected void cleanRowsInCurrentConnection(String[] tableNames) throws SQLException {
+        try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
             for (String tableName : tableNames) {
                 String truncateQuery = "TRUNCATE TABLE " + tableName + " RESTART IDENTITY CASCADE";
                 logger.info("Truncating table: {}", tableName);

--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -134,7 +134,7 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
         request.addHeader("Accept", "application/fhir+json");
 
         UserSessionData sessionData = new UserSessionData();
-        sessionData.setSytemUserId(1);
+        sessionData.setSytemUserId(Integer.parseInt(TEST_SYS_USER_ID));
 
         request.getSession().setAttribute(IActionConstants.USER_SESSION_DATA, sessionData);
         return request;

--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -107,6 +107,7 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
         SecurityContextHolder.clearContext();
     }
 
+    @Before
     protected void setUp() throws Exception {
         mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
     }


### PR DESCRIPTION
Closes #3699

Applies all five self-contained fixes to `BaseWebContextSensitiveTest` 
as described in the issue. No existing subclass changes its extends declaration.

### Changes
- Add `@Before` to `setUp()` so MockMvc is guaranteed to initialise automatically
- Remove DBUnit wrapper leak in `cleanRowsInCurrentConnection` — plain JDBC with a single try-with-resources is sufficient
- Cache `ObjectMapper` as a `private static final` field instead of recreating it on every `mapToJson`/`mapFromJson` call
- Replace magic literal `1` with `Integer.parseInt(TEST_SYS_USER_ID)` in `buildFhirRequest`
- Extract `buildDbUnitConnection()` as a private helper to avoid duplicating DBUnit config if a second caller ever needs it

### Testing
- `mvn spotless:apply` produces no changes
- `mvn test-compile` exits with BUILD SUCCESS