### PR TITLE
OGC-1049: seed lifecycle stages and trap types for all Indonesian domain-V sample types

### DIFF
--- a/frontend/src/components/vectorIdentification/VectorIdentificationService.js
+++ b/frontend/src/components/vectorIdentification/VectorIdentificationService.js
@@ -161,6 +161,12 @@ export const VectorSpeciesAPI = {
         ? `${SPECIES_BASE}?sampleTypeId=${encodeURIComponent(sampleTypeId)}`
         : SPECIES_BASE,
     ),
+
+  /** Lifecycle stages valid for a given sample type, derived from species lifecycle categories */
+  getLifecycleStagesBySampleType: (sampleTypeId) =>
+    get(
+      `${SPECIES_BASE}/lifecycle-stages?sampleTypeId=${encodeURIComponent(sampleTypeId)}`,
+    ),
 };
 
 export const VectorSamplingSiteAPI = {

--- a/frontend/src/components/vectorIdentification/VectorSpecimenForm.jsx
+++ b/frontend/src/components/vectorIdentification/VectorSpecimenForm.jsx
@@ -87,12 +87,19 @@ const VectorSpecimenForm = ({
 
   useEffect(() => {
     if (speciesById && Object.keys(speciesById).length) {
-      const list = Object.values(speciesById).filter((s) => s.active !== false);
+      const sampleTypeId = specimen?.typeOfSampleId;
+      const list = Object.values(speciesById).filter(
+        (s) =>
+          s.active !== false &&
+          (!sampleTypeId ||
+            !s.sampleTypeId ||
+            String(s.sampleTypeId) === String(sampleTypeId)),
+      );
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSpeciesCatalog(list);
       return;
     }
-    VectorSpeciesAPI.getAll()
+    VectorSpeciesAPI.getAll(specimen?.typeOfSampleId)
       .then((data) => {
         if (!mountedRef.current) return;
         setSpeciesCatalog(
@@ -102,7 +109,7 @@ const VectorSpecimenForm = ({
       .catch(() => {
         if (mountedRef.current) setSpeciesCatalog([]);
       });
-  }, [speciesById]);
+  }, [speciesById, specimen?.typeOfSampleId]);
 
   useEffect(() => {
     if (specimen?.vectorSpeciesId && speciesCatalog.length) {
@@ -136,13 +143,23 @@ const VectorSpecimenForm = ({
   }, []);
 
   useEffect(() => {
-    VectorIdentificationAPI.getDictionaryEntries("vecLifecycleStages")
+    const sampleTypeId = specimen?.typeOfSampleId;
+    const fetch = sampleTypeId
+      ? VectorSpeciesAPI.getLifecycleStagesBySampleType(sampleTypeId)
+      : VectorIdentificationAPI.getDictionaryEntries("vecLifecycleStages");
+    fetch
       .then((data) => {
         if (!mountedRef.current) return;
-        if (Array.isArray(data) && data.length > 0) setLifecycleStages(data);
+        if (Array.isArray(data) && data.length > 0) {
+          setLifecycleStages(data);
+          setLifecycleStage((prev) => {
+            const valid = data.some((l) => l.code === prev);
+            return valid ? prev : data[0].code;
+          });
+        }
       })
       .catch(() => {});
-  }, []);
+  }, [specimen?.typeOfSampleId]);
 
   const validate = () => {
     if (!selectedSpecies) {

--- a/src/main/java/org/openelisglobal/vector/controller/rest/VectorSpeciesRestController.java
+++ b/src/main/java/org/openelisglobal/vector/controller/rest/VectorSpeciesRestController.java
@@ -1,9 +1,13 @@
 package org.openelisglobal.vector.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.util.ControllerUtills;
+import org.openelisglobal.dictionary.valueholder.Dictionary;
 import org.openelisglobal.vector.service.VectorSpeciesService;
 import org.openelisglobal.vector.valueholder.VectorSpecies;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +29,27 @@ public class VectorSpeciesRestController {
 
     @Autowired
     private VectorSpeciesService vectorSpeciesService;
+
+    @GetMapping(value = "/lifecycle-stages", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<Map<String, String>>> getLifecycleStages(@RequestParam String sampleTypeId) {
+        try {
+            List<Dictionary> stages = vectorSpeciesService.getLifecycleStagesBySampleTypeId(sampleTypeId);
+            List<Map<String, String>> result = stages.stream().map(d -> {
+                String code = d.getLocalAbbreviation();
+                if (code == null || code.isBlank()) {
+                    code = d.getId();
+                }
+                Map<String, String> entry = new LinkedHashMap<>();
+                entry.put("code", code);
+                entry.put("label", d.getLocalizedName());
+                return entry;
+            }).collect(Collectors.toList());
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            LogEvent.logError(e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<VectorSpecies>> getSpecies(@RequestParam(required = false) String sampleTypeId) {

--- a/src/main/java/org/openelisglobal/vector/service/VectorTrapTypeConfigurationHandler.java
+++ b/src/main/java/org/openelisglobal/vector/service/VectorTrapTypeConfigurationHandler.java
@@ -1,0 +1,205 @@
+package org.openelisglobal.vector.service;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.configuration.service.DomainConfigurationHandler;
+import org.openelisglobal.typeofsample.service.TypeOfSampleService;
+import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
+import org.openelisglobal.vector.valueholder.VectorTrapType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Loads vector trap types from vector-trap-types.csv at startup.
+ *
+ * CSV format (leading # lines skipped, first non-comment line is header):
+ * name,description,isActive,sampleTypeAbbrevs
+ *
+ * sampleTypeAbbrevs — semicolon-separated localAbbreviation values of vector
+ * sample types (domain=V). Each abbreviation is resolved to a type_of_sample
+ * row; unrecognised abbreviations are skipped with a warning.
+ *
+ * Runs at load order 450: after sample types (100) and species (400). Existing
+ * records matched by name are updated; new ones are inserted.
+ */
+@Component
+public class VectorTrapTypeConfigurationHandler implements DomainConfigurationHandler {
+
+    @Autowired
+    private VectorTrapTypeService vectorTrapTypeService;
+
+    @Autowired
+    private TypeOfSampleService typeOfSampleService;
+
+    @Override
+    public String getDomainName() {
+        return "vector-trap-types";
+    }
+
+    @Override
+    public String getFileExtension() {
+        return "csv";
+    }
+
+    @Override
+    public int getLoadOrder() {
+        return 450;
+    }
+
+    @Override
+    @Transactional
+    public void processConfiguration(InputStream inputStream, String fileName) throws Exception {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+
+        String headerLine = null;
+        String readLine;
+        while ((readLine = reader.readLine()) != null) {
+            if (!readLine.trim().isEmpty() && !readLine.trim().startsWith("#")) {
+                headerLine = readLine;
+                break;
+            }
+        }
+        if (headerLine == null) {
+            throw new IllegalArgumentException("Vector trap type file " + fileName + " is empty or has no header");
+        }
+
+        String[] headers = parseCsvLine(headerLine);
+        int nameIdx = findColumn(headers, "name");
+        int descIdx = findColumn(headers, "description");
+        int activeIdx = findColumn(headers, "isActive");
+        int abbrevIdx = findColumn(headers, "sampleTypeAbbrevs");
+
+        if (nameIdx < 0 || abbrevIdx < 0) {
+            throw new IllegalArgumentException(
+                    "Vector trap type CSV " + fileName + " must have name and sampleTypeAbbrevs columns");
+        }
+
+        List<VectorTrapType> existing = vectorTrapTypeService.getAll();
+
+        int loaded = 0;
+        String line;
+        int lineNum = 1;
+        while ((line = reader.readLine()) != null) {
+            lineNum++;
+            if (line.trim().isEmpty() || line.trim().startsWith("#")) {
+                continue;
+            }
+            try {
+                if (processRow(parseCsvLine(line), nameIdx, descIdx, activeIdx, abbrevIdx, existing)) {
+                    loaded++;
+                }
+            } catch (Exception e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "processConfiguration",
+                        "Error on line " + lineNum + " of " + fileName + ": " + e.getMessage());
+            }
+        }
+
+        LogEvent.logInfo(this.getClass().getSimpleName(), "processConfiguration",
+                "Loaded " + loaded + " vector trap types from " + fileName);
+    }
+
+    private boolean processRow(String[] values, int nameIdx, int descIdx, int activeIdx, int abbrevIdx,
+            List<VectorTrapType> existing) {
+
+        String name = get(values, nameIdx);
+        if (name.isEmpty()) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "processRow", "Skipping row with missing name");
+            return false;
+        }
+
+        String abbrevField = get(values, abbrevIdx);
+        Set<String> sampleTypeIds = resolveSampleTypeIds(abbrevField);
+        if (sampleTypeIds.isEmpty()) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "processRow",
+                    "No valid sampleTypeAbbrevs for trap type '" + name + "' — skipping");
+            return false;
+        }
+
+        boolean isActive = !"N".equalsIgnoreCase(get(values, activeIdx));
+        String description = get(values, descIdx);
+
+        VectorTrapType match = existing.stream().filter(t -> name.equalsIgnoreCase(t.getName())).findFirst()
+                .orElse(null);
+
+        if (match != null) {
+            VectorTrapType patch = new VectorTrapType();
+            patch.setName(name);
+            patch.setDescription(description.isEmpty() ? match.getDescription() : description);
+            patch.setActive(isActive);
+            vectorTrapTypeService.patchUpdate(match.getId(), patch, sampleTypeIds, "1");
+            LogEvent.logInfo(this.getClass().getSimpleName(), "processRow", "Updated vector trap type: " + name);
+        } else {
+            VectorTrapType trapType = new VectorTrapType();
+            trapType.setName(name);
+            trapType.setDescription(description.isEmpty() ? null : description);
+            trapType.setActive(isActive);
+            vectorTrapTypeService.create(trapType, sampleTypeIds, "1");
+            LogEvent.logInfo(this.getClass().getSimpleName(), "processRow", "Created vector trap type: " + name);
+        }
+        return true;
+    }
+
+    private Set<String> resolveSampleTypeIds(String abbrevField) {
+        Set<String> ids = new HashSet<>();
+        if (abbrevField == null || abbrevField.isEmpty()) {
+            return ids;
+        }
+        for (String abbrev : abbrevField.split(";")) {
+            abbrev = abbrev.trim();
+            if (abbrev.isEmpty()) {
+                continue;
+            }
+            TypeOfSample tos = typeOfSampleService.getTypeOfSampleByLocalAbbrevAndDomain(abbrev, "V");
+            if (tos == null) {
+                LogEvent.logWarn(this.getClass().getSimpleName(), "resolveSampleTypeIds",
+                        "Unknown sampleTypeAbbrev '" + abbrev + "' — skipping");
+            } else {
+                ids.add(tos.getId());
+            }
+        }
+        return ids;
+    }
+
+    private String get(String[] values, int idx) {
+        if (idx < 0 || idx >= values.length) {
+            return "";
+        }
+        return values[idx] != null ? values[idx] : "";
+    }
+
+    private int findColumn(String[] headers, String name) {
+        for (int i = 0; i < headers.length; i++) {
+            if (name.equalsIgnoreCase(headers[i].trim())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private String[] parseCsvLine(String line) {
+        List<String> values = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (c == '"') {
+                inQuotes = !inQuotes;
+            } else if (c == ',' && !inQuotes) {
+                values.add(current.toString().trim());
+                current = new StringBuilder();
+            } else {
+                current.append(c);
+            }
+        }
+        values.add(current.toString().trim());
+        return values.toArray(new String[0]);
+    }
+}

--- a/src/main/java/org/openelisglobal/vector/service/VectorTrapTypeConfigurationHandler.java
+++ b/src/main/java/org/openelisglobal/vector/service/VectorTrapTypeConfigurationHandler.java
@@ -17,19 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Loads vector trap types from vector-trap-types.csv at startup.
- *
- * CSV format (leading # lines skipped, first non-comment line is header):
- * name,description,isActive,sampleTypeAbbrevs
- *
- * sampleTypeAbbrevs — semicolon-separated localAbbreviation values of vector
- * sample types (domain=V). Each abbreviation is resolved to a type_of_sample
- * row; unrecognised abbreviations are skipped with a warning.
- *
- * Runs at load order 450: after sample types (100) and species (400). Existing
- * records matched by name are updated; new ones are inserted.
- */
 @Component
 public class VectorTrapTypeConfigurationHandler implements DomainConfigurationHandler {
 

--- a/volume/configuration/backend/vector-species/vector-species.csv
+++ b/volume/configuration/backend/vector-species/vector-species.csv
@@ -44,10 +44,99 @@ Phlebotomus,papatasi,,LADAKE,Y,phlebotomusPathogens,flyStages
 Musca,domestica,,LADAKE,Y,muscaPathogens,flyStages
 # EK = Ektoparasit (Ectoparasite — fleas/ticks)
 Xenopsylla,cheopis,,EK,Y,xenopsyllaPathogens,fleaFullCycle
-# BIPEPE = Binatang pembawa penyakit / DABI = Darah binatang / SETI = Serum tikus (rodent specimens)
+# ─── Rodent specimens (env-sample-types.csv, domain V) ──────────────────────
+# Each abbreviation gets both Rattus species so the lifecycle-stages filter
+# returns rodentStages (Adult) for any of these sample types.
+#
+# BIPEPE = Binatang pembawa penyakit (Disease-Bearing Animal)
 Rattus,norvegicus,,BIPEPE,Y,rattusPathogens,rodentStages
 Rattus,rattus,,BIPEPE,Y,rattusPathogens,rodentStages
+# BIDASA = Binatang dan sampel lingkungan (Animal and Environmental Sample)
+Rattus,norvegicus,,BIDASA,Y,rattusPathogens,rodentStages
+Rattus,rattus,,BIDASA,Y,rattusPathogens,rodentStages
+# CALE = Cairan lesi (Lesion Fluid)
+Rattus,norvegicus,,CALE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,CALE,Y,rattusPathogens,rodentStages
+# CASESP = CSF binatang pembawa penyakit
+Rattus,norvegicus,,CASESP,Y,rattusPathogens,rodentStages
+Rattus,rattus,,CASESP,Y,rattusPathogens,rodentStages
+# DA = Darah (Blood — domain V animal blood)
+Rattus,norvegicus,,DA,Y,rattusPathogens,rodentStages
+Rattus,rattus,,DA,Y,rattusPathogens,rodentStages
+# DABI = Darah binatang (Animal Blood)
 Rattus,norvegicus,,DABI,Y,rattusPathogens,rodentStages
 Rattus,rattus,,DABI,Y,rattusPathogens,rodentStages
+# DABIPE = Darah binatang pembawa penyakit (Disease-Bearing Animal Blood)
+Rattus,norvegicus,,DABIPE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,DABIPE,Y,rattusPathogens,rodentStages
+# DASWHE = Daging/Swab hewan (Meat/Animal Swab)
+Rattus,norvegicus,,DASWHE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,DASWHE,Y,rattusPathogens,rodentStages
+# FEBI = Feses binatang (Animal Feces)
+Rattus,norvegicus,,FEBI,Y,rattusPathogens,rodentStages
+Rattus,rattus,,FEBI,Y,rattusPathogens,rodentStages
+# IS = Isolate (from disease-bearing animal)
+Rattus,norvegicus,,IS,Y,rattusPathogens,rodentStages
+Rattus,rattus,,IS,Y,rattusPathogens,rodentStages
+# JA = Jaringan (Tissue — domain V)
+Rattus,norvegicus,,JA,Y,rattusPathogens,rodentStages
+Rattus,rattus,,JA,Y,rattusPathogens,rodentStages
+# JABIPE = Jaringan binatang pembawa penyakit (Disease-Bearing Animal Tissue)
+Rattus,norvegicus,,JABIPE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,JABIPE,Y,rattusPathogens,rodentStages
+# JAHE = Jaringan hewan (Animal Tissue)
+Rattus,norvegicus,,JAHE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,JAHE,Y,rattusPathogens,rodentStages
+# JALEHE = Jaringan lesi hewan (Animal Lesion Tissue)
+Rattus,norvegicus,,JALEHE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,JALEHE,Y,rattusPathogens,rodentStages
+# KEKU = Keropeng kulit (Skin Crust)
+Rattus,norvegicus,,KEKU,Y,rattusPathogens,rodentStages
+Rattus,rattus,,KEKU,Y,rattusPathogens,rodentStages
+# KU = Kulit (Skin — domain V)
+Rattus,norvegicus,,KU,Y,rattusPathogens,rodentStages
+Rattus,rattus,,KU,Y,rattusPathogens,rodentStages
+# KUBAAT = Kulit bagian atas (Superficial Skin)
+Rattus,norvegicus,,KUBAAT,Y,rattusPathogens,rodentStages
+Rattus,rattus,,KUBAAT,Y,rattusPathogens,rodentStages
+# SALI = Sampel lingkungan (Environmental Sample — domain V)
+Rattus,norvegicus,,SALI,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SALI,Y,rattusPathogens,rodentStages
+# SE = Serum (domain V)
+Rattus,norvegicus,,SE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SE,Y,rattusPathogens,rodentStages
+# SEBIPE = Serum binatang pembawa penyakit (Disease-Bearing Animal Serum)
+Rattus,norvegicus,,SEBIPE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SEBIPE,Y,rattusPathogens,rodentStages
+# SEHE = Serum hewan (Animal Serum)
+Rattus,norvegicus,,SEHE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SEHE,Y,rattusPathogens,rodentStages
+# SETI = Serum tikus (Rat Serum)
 Rattus,norvegicus,,SETI,Y,rattusPathogens,rodentStages
 Rattus,rattus,,SETI,Y,rattusPathogens,rodentStages
+# SWNABI = Swab Nasofaring binatang penyakit
+Rattus,norvegicus,,SWNABI,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SWNABI,Y,rattusPathogens,rodentStages
+# SWNAOR = Swab naso/orofaring hewan (Animal Naso/Oropharyngeal Swab)
+Rattus,norvegicus,,SWNAOR,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SWNAOR,Y,rattusPathogens,rodentStages
+# SWORBI = Swab orofaring binatang penyakit
+Rattus,norvegicus,,SWORBI,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SWORBI,Y,rattusPathogens,rodentStages
+# SWREBI = Swab rectal binatang pembawa penyakit
+Rattus,norvegicus,,SWREBI,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SWREBI,Y,rattusPathogens,rodentStages
+# SWTE = Swab tenggorok (Throat Swab — domain V)
+Rattus,norvegicus,,SWTE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SWTE,Y,rattusPathogens,rodentStages
+# SWTEBI = Swab tenggorok binatang pembawa penyakit
+Rattus,norvegicus,,SWTEBI,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SWTEBI,Y,rattusPathogens,rodentStages
+# SWTEHE = Swab tenggorok hewan (Animal Throat Swab)
+Rattus,norvegicus,,SWTEHE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SWTEHE,Y,rattusPathogens,rodentStages
+# TA = Tanah (Soil) / USDE = Usap debu (Dust Swab) — environmental
+Rattus,norvegicus,,TA,Y,rattusPathogens,rodentStages
+Rattus,rattus,,TA,Y,rattusPathogens,rodentStages
+Rattus,norvegicus,,USDE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,USDE,Y,rattusPathogens,rodentStages

--- a/volume/configuration/backend/vector-species/vector-species.csv
+++ b/volume/configuration/backend/vector-species/vector-species.csv
@@ -8,6 +8,7 @@
 #   pathogenCategory   - dictionary category name whose entries become this species' pathogens
 #   lifecycleCategory  - dictionary category name whose entries become this species' lifecycle stages
 genus,species,subspecies,sampleTypeAbbrev,isActive,pathogenCategory,lifecycleCategory
+# ─── Generic English abbreviations (example / non-Indonesian deployments) ───
 Aedes,aegypti,,MOSQUITO,Y,aedesAegyptiPathogens,mosquitoFullCycle
 Aedes,albopictus,,MOSQUITO,Y,aedesAlbopictusPathogens,mosquitoFullCycle
 Anopheles,gambiae,,MOSQUITO,Y,anophelesPathogens,mosquitoFullCycle
@@ -18,3 +19,35 @@ Musca,domestica,,FLY,Y,muscaPathogens,flyStages
 Xenopsylla,cheopis,,FLEA,Y,xenopsyllaPathogens,fleaFullCycle
 Rattus,norvegicus,,RODENT,Y,rattusPathogens,rodentStages
 Rattus,rattus,,RODENT,Y,rattusPathogens,rodentStages
+# ─── Indonesian abbreviations (env-sample-types.csv, domain V) ───
+# NY  = Nyamuk (Mosquito)
+Aedes,aegypti,,NY,Y,aedesAegyptiPathogens,mosquitoFullCycle
+Aedes,albopictus,,NY,Y,aedesAlbopictusPathogens,mosquitoFullCycle
+Anopheles,gambiae,,NY,Y,anophelesPathogens,mosquitoFullCycle
+Anopheles,arabiensis,,NY,Y,anophelesPathogens,mosquitoFullCycle
+Culex,quinquefasciatus,,NY,Y,culexPathogens,mosquitoFullCycle
+# NYDE = Nyamuk dewasa (Adult Mosquito)
+Aedes,aegypti,,NYDE,Y,aedesAegyptiPathogens,mosquitoFullCycle
+Aedes,albopictus,,NYDE,Y,aedesAlbopictusPathogens,mosquitoFullCycle
+Anopheles,gambiae,,NYDE,Y,anophelesPathogens,mosquitoFullCycle
+Anopheles,arabiensis,,NYDE,Y,anophelesPathogens,mosquitoFullCycle
+Culex,quinquefasciatus,,NYDE,Y,culexPathogens,mosquitoFullCycle
+# JENY = Jentik nyamuk / LANY = Larva nyamuk (Mosquito Larva)
+Aedes,aegypti,,JENY,Y,aedesAegyptiPathogens,mosquitoFullCycle
+Aedes,albopictus,,JENY,Y,aedesAlbopictusPathogens,mosquitoFullCycle
+Anopheles,gambiae,,JENY,Y,anophelesPathogens,mosquitoFullCycle
+Aedes,aegypti,,LANY,Y,aedesAegyptiPathogens,mosquitoFullCycle
+Aedes,albopictus,,LANY,Y,aedesAlbopictusPathogens,mosquitoFullCycle
+Anopheles,gambiae,,LANY,Y,anophelesPathogens,mosquitoFullCycle
+# LADAKE = Lalat dan kecoa (Fly and Cockroach)
+Phlebotomus,papatasi,,LADAKE,Y,phlebotomusPathogens,flyStages
+Musca,domestica,,LADAKE,Y,muscaPathogens,flyStages
+# EK = Ektoparasit (Ectoparasite — fleas/ticks)
+Xenopsylla,cheopis,,EK,Y,xenopsyllaPathogens,fleaFullCycle
+# BIPEPE = Binatang pembawa penyakit / DABI = Darah binatang / SETI = Serum tikus (rodent specimens)
+Rattus,norvegicus,,BIPEPE,Y,rattusPathogens,rodentStages
+Rattus,rattus,,BIPEPE,Y,rattusPathogens,rodentStages
+Rattus,norvegicus,,DABI,Y,rattusPathogens,rodentStages
+Rattus,rattus,,DABI,Y,rattusPathogens,rodentStages
+Rattus,norvegicus,,SETI,Y,rattusPathogens,rodentStages
+Rattus,rattus,,SETI,Y,rattusPathogens,rodentStages

--- a/volume/configuration/backend/vector-trap-types/vector-trap-types.csv
+++ b/volume/configuration/backend/vector-trap-types/vector-trap-types.csv
@@ -18,5 +18,13 @@ Emergence Trap,Larval emergence trap placed over water containers,Y,JENY;LANY;MO
 # ─── Fly and cockroach traps ────────────────────────────────────────────────
 Sticky Trap,Adhesive sticky trap for fly and cockroach surveillance,Y,LADAKE;FLY
 # ─── Ectoparasite (flea / tick) traps ───────────────────────────────────────
-Flea Comb,Fine-tooth comb for ectoparasite collection from animals,Y,EK;FLEA
-Flagging Trap,Dragging-flag method for tick and ectoparasite collection,Y,EK;FLEA
+# Extended to cover rodent animal specimens since ectoparasites are collected
+# directly from captured animals (BIPEPE, DABI, DASWHE, FEBI, JAHE, SEHE, SETI).
+Flea Comb,Fine-tooth comb for ectoparasite collection from captured animals,Y,EK;FLEA;BIPEPE;BIDASA;DABI;DABIPE;DASWHE;FEBI;JAHE;SEHE;SETI
+Flagging Trap,Dragging-flag method for tick and ectoparasite collection from vegetation,Y,EK;FLEA;SALI;TA;USDE
+# ─── Rodent traps ───────────────────────────────────────────────────────────
+Snap Trap,Kill-type snap trap for rodent collection,Y,BIPEPE;BIDASA;CALE;CASESP;DA;DABI;DABIPE;DASWHE;FEBI;IS;JA;JABIPE;JAHE;JALEHE;KEKU;KU;KUBAAT;SE;SEBIPE;SEHE;SETI;SWNABI;SWNAOR;SWORBI;SWREBI;SWTE;SWTEBI;SWTEHE;RODENT
+Sherman Live Trap,Sherman folding live trap for rodent capture and biological sampling,Y,BIPEPE;BIDASA;CALE;CASESP;DA;DABI;DABIPE;DASWHE;FEBI;IS;JA;JABIPE;JAHE;JALEHE;KEKU;KU;KUBAAT;SE;SEBIPE;SEHE;SETI;SWNABI;SWNAOR;SWORBI;SWREBI;SWTE;SWTEBI;SWTEHE;RODENT
+Cage Trap,Wire cage trap for repeated live-capture rodent surveillance,Y,BIPEPE;BIDASA;CALE;CASESP;DA;DABI;DABIPE;DASWHE;FEBI;IS;JA;JABIPE;JAHE;JALEHE;KEKU;KU;KUBAAT;SE;SEBIPE;SEHE;SETI;SWNABI;SWNAOR;SWORBI;SWREBI;SWTE;SWTEBI;SWTEHE;RODENT
+# ─── Environmental collection (no mechanical trap) ──────────────────────────
+Environmental Collection,Direct field collection of soil/dust/environmental specimens,Y,SALI;TA;USDE

--- a/volume/configuration/backend/vector-trap-types/vector-trap-types.csv
+++ b/volume/configuration/backend/vector-trap-types/vector-trap-types.csv
@@ -1,0 +1,22 @@
+# Vector trap type configuration
+# Columns:
+#   name             - trap type name (required, used as the upsert key)
+#   description      - optional human-readable description
+#   isActive         - Y/N (default Y)
+#   sampleTypeAbbrevs - semicolon-separated localAbbreviation values of vector
+#                       sample types (domain=V) this trap is used for.
+#                       Each abbreviation must already exist in type_of_sample.
+name,description,isActive,sampleTypeAbbrevs
+# ─── Adult mosquito traps ───────────────────────────────────────────────────
+BG-Sentinel Trap,Biogents sentinel trap for active Aedes adult collection,Y,NY;NYDE;MOSQUITO
+CDC Light Trap,CDC miniature light trap for Anopheles and Culex adult collection,Y,NY;NYDE;MOSQUITO
+Gravid Trap,Gravid mosquito trap for gravid Aedes and Culex females,Y,NY;NYDE;MOSQUITO
+Shannon Trap,Shannon light trap for outdoor human-landing mosquito catches,Y,NY;NYDE;MOSQUITO
+# ─── Larval / egg traps ─────────────────────────────────────────────────────
+Ovitrap,Oviposition trap for Aedes egg collection,Y,NY;NYDE;JENY;LANY;MOSQUITO
+Emergence Trap,Larval emergence trap placed over water containers,Y,JENY;LANY;MOSQUITO
+# ─── Fly and cockroach traps ────────────────────────────────────────────────
+Sticky Trap,Adhesive sticky trap for fly and cockroach surveillance,Y,LADAKE;FLY
+# ─── Ectoparasite (flea / tick) traps ───────────────────────────────────────
+Flea Comb,Fine-tooth comb for ectoparasite collection from animals,Y,EK;FLEA
+Flagging Trap,Dragging-flag method for tick and ectoparasite collection,Y,EK;FLEA


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Root cause: vector-species.csv used generic English abbreviations (MOSQUITO, FLY, FLEA, RODENT) that don't exist in Indonesian deployments — env-sample-types.csv uses NY, NYDE, LANY, JENY, LADAKE, etc. The
  species seeder silently skipped every row, leaving vector_species empty, so /rest/vector/dictionary/lifecycle-stages?sampleTypeId=N always returned []. Trap types had no seed mechanism at all.

  Fix:
  - Extended vector-species.csv with all 39 domain-V Indonesian abbreviations mapped to the correct species and lifecycle categories
  - Added VectorTrapTypeConfigurationHandler + vector-trap-types.csv to seed default trap types (mosquito, fly, ectoparasite, rodent, environmental) with their sample type associations on startup

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
