### PR TITLE
fix(OGC-1051): prevent false unsaved-changes guard on fresh vector/environmental order entry

### DIFF
--- a/frontend/src/components/order/OrderContext.jsx
+++ b/frontend/src/components/order/OrderContext.jsx
@@ -284,6 +284,14 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
     setSaveStatus(SaveStatus.UNSAVED);
   }, []);
 
+  const setOrderDataSilent = useCallback((newData) => {
+    setOrderDataState(newData);
+  }, []);
+
+  const setSamplesSilent = useCallback((newSamples) => {
+    setSamplesState(newSamples);
+  }, []);
+
   /**
    * Wrapper for setSamples that marks form as dirty
    */
@@ -1357,7 +1365,9 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
     saveOrderEntry, // Step 1: saves order + creates sample_type_requests (no sample_items)
     setCurrentStep,
     setOrderData,
+    setOrderDataSilent,
     setSamples,
+    setSamplesSilent,
     resetOrder,
     enableEditMode,
     markStepComplete,

--- a/frontend/src/components/order/steps/EnvironmentalOrderEnter.jsx
+++ b/frontend/src/components/order/steps/EnvironmentalOrderEnter.jsx
@@ -40,6 +40,7 @@ const EnvironmentalOrderEnter = () => {
   const {
     orderData,
     setOrderData,
+    setOrderDataSilent,
     samples,
     setSamples,
     labNumber,
@@ -78,7 +79,7 @@ const EnvironmentalOrderEnter = () => {
     const current =
       orderData?.sampleOrderItems?.environmentalFields?.workflowType;
     if (current !== WORKFLOW_TYPE) {
-      setOrderData((prev) => ({
+      setOrderDataSilent((prev) => ({
         ...prev,
         patientUpdateStatus: "NO_ACTION",
         patientProperties: {

--- a/frontend/src/components/order/steps/VectorOrderEnter.jsx
+++ b/frontend/src/components/order/steps/VectorOrderEnter.jsx
@@ -38,6 +38,7 @@ const VectorOrderEnter = () => {
   const {
     orderData,
     setOrderData,
+    setOrderDataSilent,
     samples,
     setSamples,
     labNumber,
@@ -69,11 +70,12 @@ const VectorOrderEnter = () => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Seed workflowType + clear patient status on mount.
+  // Uses setOrderDataSilent so initialization does not arm the unsaved-changes guard.
   useEffect(() => {
     const current =
       orderData?.sampleOrderItems?.environmentalFields?.workflowType;
     if (current !== WORKFLOW_TYPE) {
-      setOrderData((prev) => ({
+      setOrderDataSilent((prev) => ({
         ...prev,
         patientUpdateStatus: "NO_ACTION",
         patientProperties: {

--- a/frontend/src/components/order/steps/sections/VectorSection.jsx
+++ b/frontend/src/components/order/steps/sections/VectorSection.jsx
@@ -113,7 +113,7 @@ function SelectedCard({ onClear, children }) {
 
 function VectorSection({ orderData, setOrderData, isReadOnly, workflowType }) {
   const intl = useIntl();
-  const { samples, setSamples } = useOrderContext();
+  const { samples, setSamples, setSamplesSilent } = useOrderContext();
 
   const isEnv = workflowType === "environmental";
 
@@ -172,7 +172,7 @@ function VectorSection({ orderData, setOrderData, isReadOnly, workflowType }) {
   useEffect(() => {
     if (!samples || samples.length === 0) return;
     if (samples.every((s) => s.collectionDate)) return;
-    setSamples(
+    setSamplesSilent(
       samples.map((s) =>
         s.collectionDate ? s : { ...s, collectionDate: collectionDate },
       ),


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
fixes https://uwdigi.atlassian.net/browse/OGC-1051?actionerId=557058%3A99fa116c-0d0d-4dd2-aa5c-a335a4160851&sourceType=assign

## Screenshots
### before any change
https://github.com/user-attachments/assets/cac09224-c55b-4989-9af2-5ce57463776e

### after changes in this PR

https://github.com/user-attachments/assets/756d8941-adb7-4962-a61c-d0f92275ba1a

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
