### PR TITLE
feat(order): enhance order loading and navigation with URL parameters

### DIFF
--- a/frontend/src/components/order/OrderContext.jsx
+++ b/frontend/src/components/order/OrderContext.jsx
@@ -222,6 +222,7 @@ const getInitialOrderData = (workflowType = "clinical") => {
 export const OrderProvider = ({ children, workflowType = "clinical" }) => {
   const { configurationProperties } = useContext(ConfigurationContext);
   const isDayFirst = configurationProperties?.DEFAULT_DATE_LOCALE === "fr-FR";
+  const location = useLocation();
 
   const [orderId, setOrderId] = useState(null);
   const [labNumber, setLabNumber] = useState(null);
@@ -789,7 +790,9 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
       setError(null);
 
       // For Step 1, we send empty sampleXML - sample types will be saved as requests
-      const envFields = orderData?.sampleOrderItems?.environmentalFields || {};
+      const envFields = {
+        ...(orderData?.sampleOrderItems?.environmentalFields || {}),
+      };
       const workflowType = envFields.workflowType || "clinical";
 
       // For vector orders, stamp today's date/time on each sample and map
@@ -1222,6 +1225,28 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
       }
     });
   }, []);
+
+  // On mount (and on refresh), if ?order=<labNumber> is in the URL and the
+  // path prefix matches this provider's workflowType, auto-load the order.
+  // After load, if the order's workflowType doesn't match this provider's
+  // (e.g. a clinical ?order= carried into the environmental provider), strip
+  // the param and reset so the form starts clean.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const orderParam = params.get("order");
+    if (!orderParam || orderId) return;
+
+    const path = location.pathname;
+    const pathWorkflow = path.startsWith("/order/vector")
+      ? "vector"
+      : path.startsWith("/order/environmental")
+        ? "environmental"
+        : "clinical";
+
+    if (pathWorkflow !== workflowType) return;
+
+    loadOrder(orderParam, false); // eslint-disable-line react-hooks/set-state-in-effect
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
    * Auto-save effect - saves every 30 seconds if form is dirty and has minimum required data.

--- a/frontend/src/components/order/OrderDashboard.jsx
+++ b/frontend/src/components/order/OrderDashboard.jsx
@@ -139,11 +139,14 @@ const OrderDashboardContent = () => {
   };
 
   const handleContinueOrder = async (order) => {
-    // Load the order into context, then navigate to the appropriate step
+    // Load the order into context, then navigate to the appropriate step.
+    // Include ?order= so a refresh reloads the order automatically.
     try {
       await loadOrder(order.labNumber, false); // false = editable
       const nextStep = getNextStep(order);
-      history.push(`${workflowPrefix}/${nextStep}`);
+      history.push(
+        `${workflowPrefix}/${nextStep}?order=${encodeURIComponent(order.labNumber)}`,
+      );
     } catch (error) {
       console.error("handleContinueOrder: Error loading order", error);
       addNotification({
@@ -161,7 +164,9 @@ const OrderDashboardContent = () => {
   const handleAcceptExternal = async (order) => {
     try {
       await loadOrder(order.labNumber, false);
-      history.push(`${workflowPrefix}/enter`);
+      history.push(
+        `${workflowPrefix}/enter?order=${encodeURIComponent(order.labNumber)}`,
+      );
     } catch (error) {
       addNotification({
         kind: NotificationKinds.error,
@@ -176,11 +181,13 @@ const OrderDashboardContent = () => {
   };
 
   const handleFixIssue = async (order) => {
-    // Load the order into context, then navigate to the step that needs fixing
+    // Load the order into context, then navigate to the step that needs fixing.
     try {
       await loadOrder(order.labNumber, false); // false = editable
       const returnedStep = order.returnedToStep || "enter";
-      history.push(`${workflowPrefix}/${returnedStep}`);
+      history.push(
+        `${workflowPrefix}/${returnedStep}?order=${encodeURIComponent(order.labNumber)}`,
+      );
     } catch (error) {
       addNotification({
         kind: NotificationKinds.error,

--- a/frontend/src/components/order/OrderStepper.jsx
+++ b/frontend/src/components/order/OrderStepper.jsx
@@ -115,7 +115,10 @@ const OrderStepper = ({ currentStep, steps, onStepClick, className = "" }) => {
     if (onStepClick) {
       onStepClick(stepIndex);
     } else {
-      history.push(resolvedSteps[stepIndex].path);
+      const path = resolvedSteps[stepIndex].path;
+      history.push(
+        labNumber ? `${path}?order=${encodeURIComponent(labNumber)}` : path,
+      );
     }
   };
 

--- a/frontend/src/components/order/SaveNavigationButtons.jsx
+++ b/frontend/src/components/order/SaveNavigationButtons.jsx
@@ -3,6 +3,7 @@ import { Button } from "@carbon/react";
 import { FormattedMessage } from "react-intl";
 import { useHistory, useLocation } from "react-router-dom";
 import { useOrderContext } from "./OrderContext";
+
 import {
   CLINICAL_ORDER_STEPS,
   ENVIRONMENTAL_ORDER_STEPS,
@@ -29,7 +30,8 @@ const SaveNavigationButtons = ({
 }) => {
   const history = useHistory();
   const location = useLocation();
-  const { isSubmitting, isReadOnly, isEditMode, saveOrder } = useOrderContext();
+  const { isSubmitting, isReadOnly, isEditMode, saveOrder, labNumber } =
+    useOrderContext();
 
   // Infer step set from URL prefix — no workflowType context read needed.
   const steps = (() => {
@@ -42,6 +44,14 @@ const SaveNavigationButtons = ({
 
   const isLastStep = currentStep >= steps.length - 1;
   const isFirstStep = currentStep <= 0;
+
+  // Always carry ?order= when an order is loaded, regardless of how we arrived.
+  // Derived from context labNumber so it survives regardless of URL history.
+  const navigateTo = (path) => {
+    history.push(
+      labNumber ? `${path}?order=${encodeURIComponent(labNumber)}` : path,
+    );
+  };
 
   const handleSave = async () => {
     if (onSave) {
@@ -57,14 +67,14 @@ const SaveNavigationButtons = ({
     } else {
       await saveOrder();
       if (currentStep < steps.length - 1) {
-        history.push(steps[currentStep + 1].path);
+        navigateTo(steps[currentStep + 1].path);
       }
     }
   };
 
   const handleBack = () => {
     if (!isFirstStep) {
-      history.push(steps[currentStep - 1].path);
+      navigateTo(steps[currentStep - 1].path);
     }
   };
 
@@ -81,7 +91,7 @@ const SaveNavigationButtons = ({
           <Button
             kind="primary"
             className="forward-button"
-            onClick={() => history.push(steps[currentStep + 1].path)}
+            onClick={() => navigateTo(steps[currentStep + 1].path)}
           >
             <FormattedMessage id="next.action.button" />
           </Button>

--- a/frontend/src/components/order/steps/ClinicalOrderEnter.jsx
+++ b/frontend/src/components/order/steps/ClinicalOrderEnter.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect, useRef } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { useIntl, FormattedMessage } from "react-intl";
 import {
   Grid,
@@ -33,6 +33,7 @@ const WORKFLOW_TYPE = "clinical";
 const ClinicalOrderEnter = () => {
   const intl = useIntl();
   const history = useHistory();
+  const location = useLocation();
   const componentMounted = useRef(true);
   const {
     orderData,
@@ -44,13 +45,14 @@ const ClinicalOrderEnter = () => {
     markStepComplete,
     isReadOnly,
     isEditMode,
+    resetOrder,
   } = useOrderContext();
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
 
-  const [localLabNumber, setLocalLabNumber] = useState(
-    labNumber || orderData?.sampleOrderItems?.labNo || "",
-  );
+  // Initialise empty — populated by the sync effect below after the mount
+  // reset guard runs, preventing stale cross-domain lab numbers from bleeding in.
+  const [localLabNumber, setLocalLabNumber] = useState("");
   const [isGeneratingLabNo, setIsGeneratingLabNo] = useState(false);
   const [printLabelsExpanded, setPrintLabelsExpanded] = useState(false);
   const [errors, setErrors] = useState({});
@@ -58,6 +60,17 @@ const ClinicalOrderEnter = () => {
     primaryPhone: { body: "", status: true },
     contactPhone: { body: "", status: true },
   });
+
+  // Reset on mount for new orders. Only skip reset when ?order= is present
+  // AND the URL path belongs to this workflow — prevents a stale ?order= from
+  // a different domain blocking the reset when switching between workflows.
+  useEffect(() => {
+    const orderParam = new URLSearchParams(location.search).get("order");
+    const pathMatchesWorkflow = location.pathname.startsWith("/order/clinical");
+    if (!isEditMode && !(orderParam && pathMatchesWorkflow)) {
+      resetOrder();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Seed workflowType into orderData on mount (or when editing an existing order
   // that already has a workflowType — keep it so it is not reset on re-render).
@@ -85,10 +98,14 @@ const ClinicalOrderEnter = () => {
   // Sync local lab number when context changes (e.g., order loaded from dashboard)
   useEffect(() => {
     const contextLabNo = labNumber || orderData?.sampleOrderItems?.labNo;
+    const pathMatchesWorkflow = location.pathname.startsWith("/order/clinical");
+    if (!pathMatchesWorkflow) return;
     if (contextLabNo && contextLabNo !== localLabNumber) {
       setLocalLabNumber(contextLabNo);
+    } else if (!contextLabNo && localLabNumber) {
+      setLocalLabNumber("");
     }
-  }, [labNumber, orderData?.sampleOrderItems?.labNo]);
+  }, [labNumber, orderData?.sampleOrderItems?.labNo, location.pathname]);
 
   useEffect(() => {
     componentMounted.current = true;
@@ -180,7 +197,11 @@ const ClinicalOrderEnter = () => {
     try {
       await saveOrderEntry(false);
       markStepComplete("enter");
-      history.push("/order/clinical/collect");
+      history.push(
+        labNumber
+          ? `/order/clinical/collect?order=${encodeURIComponent(labNumber)}`
+          : "/order/clinical/collect",
+      );
     } catch (error) {
       addNotification({
         kind: NotificationKinds.error,

--- a/frontend/src/components/order/steps/EnvironmentalOrderEnter.jsx
+++ b/frontend/src/components/order/steps/EnvironmentalOrderEnter.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect, useRef } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { useIntl, FormattedMessage } from "react-intl";
 import {
   Grid,
@@ -35,6 +35,7 @@ const WORKFLOW_TYPE = "environmental";
 const EnvironmentalOrderEnter = () => {
   const intl = useIntl();
   const history = useHistory();
+  const location = useLocation();
   const componentMounted = useRef(true);
   const {
     orderData,
@@ -46,17 +47,31 @@ const EnvironmentalOrderEnter = () => {
     markStepComplete,
     isReadOnly,
     isEditMode,
+    resetOrder,
   } = useOrderContext();
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
 
-  const [localLabNumber, setLocalLabNumber] = useState(
-    labNumber || orderData?.sampleOrderItems?.labNo || "",
-  );
+  // Initialise empty — the sync effect below populates from context only after
+  // the mount reset guard has run, preventing stale cross-domain lab numbers
+  // from a prior workflow session from pre-filling this field.
+  const [localLabNumber, setLocalLabNumber] = useState("");
   const [isGeneratingLabNo, setIsGeneratingLabNo] = useState(false);
   const [printLabelsExpanded, setPrintLabelsExpanded] = useState(false);
   const [errors, setErrors] = useState({});
   const [showNceForm, setShowNceForm] = useState(false);
+
+  // Reset on mount for new orders. Only skip reset when ?order= is present
+  // AND the URL path belongs to this workflow.
+  useEffect(() => {
+    const orderParam = new URLSearchParams(location.search).get("order");
+    const pathMatchesWorkflow = location.pathname.startsWith(
+      "/order/environmental",
+    );
+    if (!isEditMode && !(orderParam && pathMatchesWorkflow)) {
+      resetOrder();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Seed workflowType + clear patient status on mount.
   useEffect(() => {
@@ -84,10 +99,17 @@ const EnvironmentalOrderEnter = () => {
   // Sync local lab number when context changes.
   useEffect(() => {
     const contextLabNo = labNumber || orderData?.sampleOrderItems?.labNo;
+    const pathMatchesWorkflow = location.pathname.startsWith(
+      "/order/environmental",
+    );
+    if (!pathMatchesWorkflow) return;
     if (contextLabNo && contextLabNo !== localLabNumber) {
       setLocalLabNumber(contextLabNo);
+    } else if (!contextLabNo && localLabNumber) {
+      // Context was reset (mismatch wipe) — clear the local field too.
+      setLocalLabNumber("");
     }
-  }, [labNumber, orderData?.sampleOrderItems?.labNo]);
+  }, [labNumber, orderData?.sampleOrderItems?.labNo, location.pathname]);
 
   useEffect(() => {
     componentMounted.current = true;
@@ -207,7 +229,11 @@ const EnvironmentalOrderEnter = () => {
     try {
       await saveOrder(false, false, stamped);
       markStepComplete("enter");
-      history.push("/order/environmental/label");
+      history.push(
+        labNumber
+          ? `/order/environmental/label?order=${encodeURIComponent(labNumber)}`
+          : "/order/environmental/label",
+      );
     } catch (error) {
       addNotification({
         kind: NotificationKinds.error,

--- a/frontend/src/components/order/steps/OrderLabel.jsx
+++ b/frontend/src/components/order/steps/OrderLabel.jsx
@@ -457,7 +457,7 @@ const OrderLabel = () => {
     // The servlet's environmental specimen handling uses getSampleItemsBySampleId
     // (no status filter) for env/vector via isEnvOrVectorSample, so all
     // specimens are included regardless of status.
-    const url = `/LabelMakerServlet?labNo=${encodeURIComponent(labNumber)}&type=default&quantity=${orderQty}`;
+    const url = `/LabelMakerServlet?labNo=${encodeURIComponent(labNumber)}&type=default&quantity=${orderQty}&override=true`;
     if (!openPrintWindow(url)) {
       return;
     }
@@ -669,7 +669,11 @@ const OrderLabel = () => {
       await updateStorageNotes();
       markStepComplete("label");
       setCurrentStep(3);
-      history.push(`${workflowPrefix}/qa`);
+      history.push(
+        labNumber
+          ? `${workflowPrefix}/qa?order=${encodeURIComponent(labNumber)}`
+          : `${workflowPrefix}/qa`,
+      );
     } catch (error) {
       addNotification({
         kind: NotificationKinds.error,

--- a/frontend/src/components/order/steps/OrderLabel.jsx
+++ b/frontend/src/components/order/steps/OrderLabel.jsx
@@ -457,7 +457,7 @@ const OrderLabel = () => {
     // The servlet's environmental specimen handling uses getSampleItemsBySampleId
     // (no status filter) for env/vector via isEnvOrVectorSample, so all
     // specimens are included regardless of status.
-    const url = `/LabelMakerServlet?labNo=${encodeURIComponent(labNumber)}&type=default&quantity=${orderQty}&override=true`;
+    const url = `/LabelMakerServlet?labNo=${encodeURIComponent(labNumber)}&type=default&quantity=${orderQty}`;
     if (!openPrintWindow(url)) {
       return;
     }

--- a/frontend/src/components/order/steps/VectorOrderEnter.jsx
+++ b/frontend/src/components/order/steps/VectorOrderEnter.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect, useRef } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { useIntl, FormattedMessage } from "react-intl";
 import {
   Grid,
@@ -23,6 +23,7 @@ import {
 } from "../../common/CustomNotification";
 import { getFromOpenElisServer } from "../../utils/Utils";
 import VectorSection from "./sections/VectorSection";
+import RequesterSection from "./sections/RequesterSection";
 import ProgramSection from "./sections/ProgramSection";
 import SampleTestSection from "./sections/SampleTestSection";
 import "../order-workflow.scss";
@@ -32,6 +33,7 @@ const WORKFLOW_TYPE = "vector";
 const VectorOrderEnter = () => {
   const intl = useIntl();
   const history = useHistory();
+  const location = useLocation();
   const componentMounted = useRef(true);
   const {
     orderData,
@@ -43,17 +45,28 @@ const VectorOrderEnter = () => {
     markStepComplete,
     isReadOnly,
     isEditMode,
+    resetOrder,
   } = useOrderContext();
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
 
-  const [localLabNumber, setLocalLabNumber] = useState(
-    labNumber || orderData?.sampleOrderItems?.labNo || "",
-  );
+  // Initialise empty — populated by the sync effect below after the mount
+  // reset guard runs, preventing stale cross-domain lab numbers from bleeding in.
+  const [localLabNumber, setLocalLabNumber] = useState("");
   const [isGeneratingLabNo, setIsGeneratingLabNo] = useState(false);
   const [printLabelsExpanded, setPrintLabelsExpanded] = useState(false);
   const [errors, setErrors] = useState({});
   const [showNceForm, setShowNceForm] = useState(false);
+
+  // Reset on mount for new orders. Only skip reset when ?order= is present
+  // AND the URL path belongs to this workflow.
+  useEffect(() => {
+    const orderParam = new URLSearchParams(location.search).get("order");
+    const pathMatchesWorkflow = location.pathname.startsWith("/order/vector");
+    if (!isEditMode && !(orderParam && pathMatchesWorkflow)) {
+      resetOrder();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Seed workflowType + clear patient status on mount.
   useEffect(() => {
@@ -81,10 +94,14 @@ const VectorOrderEnter = () => {
   // Sync local lab number when context changes.
   useEffect(() => {
     const contextLabNo = labNumber || orderData?.sampleOrderItems?.labNo;
+    const pathMatchesWorkflow = location.pathname.startsWith("/order/vector");
+    if (!pathMatchesWorkflow) return;
     if (contextLabNo && contextLabNo !== localLabNumber) {
       setLocalLabNumber(contextLabNo);
+    } else if (!contextLabNo && localLabNumber) {
+      setLocalLabNumber("");
     }
-  }, [labNumber, orderData?.sampleOrderItems?.labNo]);
+  }, [labNumber, orderData?.sampleOrderItems?.labNo, location.pathname]);
 
   useEffect(() => {
     componentMounted.current = true;
@@ -176,7 +193,11 @@ const VectorOrderEnter = () => {
     try {
       await saveOrderEntry(false);
       markStepComplete("enter");
-      history.push("/order/vector/label");
+      history.push(
+        labNumber
+          ? `/order/vector/label?order=${encodeURIComponent(labNumber)}`
+          : "/order/vector/label",
+      );
     } catch (error) {
       addNotification({
         kind: NotificationKinds.error,
@@ -383,6 +404,13 @@ const VectorOrderEnter = () => {
           orderData={orderData}
           setOrderData={setOrderData}
           isReadOnly={isReadOnly && !isEditMode}
+        />
+
+        <RequesterSection
+          orderData={orderData}
+          setOrderData={setOrderData}
+          isReadOnly={isReadOnly && !isEditMode}
+          workflowType={WORKFLOW_TYPE}
         />
 
         {/* Program Selection */}

--- a/src/main/java/org/openelisglobal/barcode/BarcodeLabelMaker.java
+++ b/src/main/java/org/openelisglobal/barcode/BarcodeLabelMaker.java
@@ -272,12 +272,12 @@ public class BarcodeLabelMaker {
                 labels.add(orderLabel);
             }
 
-            // 1 specimen label per sampleitem
+            // 1 specimen label per sampleitem — use getSampleItemsBySampleId (no status
+            // filter) for all workflows. The status filter was meant to exclude drafts but
+            // at the label step the order is already submitted, and clinical items may not
+            // be in Entered status depending on the save path.
+            List<SampleItem> sampleItemList = sampleItemService.getSampleItemsBySampleId(sample.getId());
             boolean isEnvOrVector = isEnvOrVectorSample(sample);
-            // Environmental/vector sample items are not in Entered status at the label
-            // step, so fetch all items without a status filter for those workflows.
-            List<SampleItem> sampleItemList = isEnvOrVector ? sampleItemService.getSampleItemsBySampleId(sample.getId())
-                    : sampleItemService.getSampleItemsBySampleIdAndStatus(sample.getId(), getEnteredStatusSampleList());
             for (SampleItem sampleItem : sampleItemList) {
                 SpecimenLabel specLabel = isEnvOrVector ? buildEnvSpecimenLabel(sample, sampleItem, labNo)
                         : new SpecimenLabel(sampleService.getPatient(sample), sample, sampleItem, labNo);
@@ -313,8 +313,9 @@ public class BarcodeLabelMaker {
             }
             Sample sample = sampleService.getSampleByAccessionNumber(labNo);
             boolean isEnvOrVectorSpec = isEnvOrVectorSample(sample);
-            List<SampleItem> sampleItemList = sampleItemService.getSampleItemsBySampleIdAndStatus(sample.getId(),
-                    getEnteredStatusSampleList());
+            List<SampleItem> sampleItemList = isEnvOrVectorSpec
+                    ? sampleItemService.getSampleItemsBySampleId(sample.getId())
+                    : sampleItemService.getSampleItemsBySampleIdAndStatus(sample.getId(), getEnteredStatusSampleList());
             for (SampleItem sampleItem : sampleItemList) {
                 // when no specimen number was supplied, print labels for every sample item;
                 // otherwise only for the matching sort order
@@ -334,8 +335,9 @@ public class BarcodeLabelMaker {
         } else if ("specimenOrder".equals(type)) {
             Sample sample = sampleService.getSampleByAccessionNumber(labNo);
             boolean isEnvOrVectorSpecOrder = isEnvOrVectorSample(sample);
-            List<SampleItem> sampleItemList = sampleItemService.getSampleItemsBySampleIdAndStatus(sample.getId(),
-                    getEnteredStatusSampleList());
+            List<SampleItem> sampleItemList = isEnvOrVectorSpecOrder
+                    ? sampleItemService.getSampleItemsBySampleId(sample.getId())
+                    : sampleItemService.getSampleItemsBySampleIdAndStatus(sample.getId(), getEnteredStatusSampleList());
             for (SampleItem sampleItem : sampleItemList) {
                 SpecimenLabel specLabel = isEnvOrVectorSpecOrder ? buildEnvSpecimenLabel(sample, sampleItem, labNo)
                         : new SpecimenLabel(sampleService.getPatient(sample), sample, sampleItem, labNo);
@@ -464,11 +466,8 @@ public class BarcodeLabelMaker {
     }
 
     private SpecimenLabel buildEnvSpecimenLabel(Sample sample, SampleItem sampleItem, String labNo) {
-        ObservationHistoryService observationHistoryService = SpringContext.getBean(ObservationHistoryService.class);
-        String sampleType = resolveSpecimenTypeForItem(sampleItem);
-        String siteName = StringUtils.defaultString(observationHistoryService
-                .getRawValueForSample(ObservationType.VS_COLLECTION_SITE_NAME, sample.getId()));
-        return new SpecimenLabel(sampleItem, labNo, sampleType, null, siteName);
+        SampleService sampleService = SpringContext.getBean(SampleService.class);
+        return new SpecimenLabel(sampleService.getPatient(sample), sample, sampleItem, labNo);
     }
 
     private String resolveBlockIdContext(PathologySample pathologySample) {
@@ -560,9 +559,12 @@ public class BarcodeLabelMaker {
                     // Tolerate concurrent print requests racing to update the same label row
                     LogEvent.logWarn("BarcodeLabelMaker", "createLabelsAsStreamWithMaximumPrints",
                             "Optimistic lock on label print count (concurrent request): " + e.getMessage());
+                } catch (jakarta.persistence.PersistenceException e) {
+                    // Unique-constraint violation — a concurrent request inserted the same code
+                    // between our getDataByCode check and our insert. Recover by merging into
+                    // the winning row instead of failing the whole print request.
+                    mergePrintIncrementAfterRace(label, e);
                 } catch (RuntimeException e) {
-                    // DB connectivity, other constraint violations, etc. — rethrow so the caller
-                    // knows
                     throw e;
                 }
             }

--- a/src/main/java/org/openelisglobal/barcode/labeltype/OrderLabel.java
+++ b/src/main/java/org/openelisglobal/barcode/labeltype/OrderLabel.java
@@ -6,7 +6,6 @@ import org.openelisglobal.barcode.LabelField;
 import org.openelisglobal.barcode.util.BarcodeConfigUtil;
 import org.openelisglobal.common.provider.validation.AccessionNumberValidatorFactory.AccessionFormat;
 import org.openelisglobal.common.provider.validation.AlphanumAccessionValidator;
-import org.openelisglobal.common.services.SampleOrderService;
 import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.ConfigurationProperties.Property;
 import org.openelisglobal.common.util.StringUtil;
@@ -17,8 +16,12 @@ import org.openelisglobal.patient.service.PatientService;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.person.service.PersonService;
 import org.openelisglobal.person.valueholder.Person;
+import org.openelisglobal.provider.valueholder.Provider;
 import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.samplehuman.service.SampleHumanService;
 import org.openelisglobal.spring.util.SpringContext;
+import org.openelisglobal.vector.service.VectorSamplingSiteService;
+import org.openelisglobal.vector.valueholder.VectorSamplingSite;
 
 /**
  * Stores values and formatting for Order Labels
@@ -127,26 +130,86 @@ public class OrderLabel extends Label {
         ObservationHistoryService observationHistoryService = SpringContext.getBean(ObservationHistoryService.class);
         String workflowType = observationHistoryService.getRawValueForSample(ObservationType.ENV_WORKFLOW_TYPE,
                 sample.getId());
-        // Provider is saved the same way for all workflows via sampleOrderItems
-        SampleOrderService sampleOrderService = new SampleOrderService(sample);
-        org.openelisglobal.sample.bean.SampleOrderItem orderItem = sampleOrderService.getSampleOrderItem();
+        // Provider is stored in sample_human.provider_id — use SampleHumanService.
+        // Use getData() with a fresh Person shell (id only) so session.get() loads it
+        // directly by PK — avoids HQL type-mismatch and detached-proxy issues.
+        SampleHumanService sampleHumanService = SpringContext.getBean(SampleHumanService.class);
+        Provider sampleProvider = sampleHumanService.getProviderForSample(sample);
         String requesterName = "";
-        String firstName = StringUtil.replaceNullWithEmptyString(orderItem.getProviderFirstName());
-        String lastName = StringUtil.replaceNullWithEmptyString(orderItem.getProviderLastName());
-        String fullName = (firstName + " " + lastName).trim();
-        if (!fullName.isEmpty()) {
-            requesterName = StringUtils.substring(fullName, 0, 30);
+        if (sampleProvider != null) {
+            Person rawPerson = sampleProvider.getPerson();
+            if (rawPerson != null) {
+                String personId = rawPerson.getId();
+                if (!StringUtil.isNullorNill(personId)) {
+                    Person personShell = new Person();
+                    personShell.setId(personId);
+                    SpringContext.getBean(PersonService.class).getData(personShell);
+                    if (!StringUtil.isNullorNill(personShell.getId())) {
+                        String firstName = StringUtil.replaceNullWithEmptyString(personShell.getFirstName());
+                        String lastName = StringUtil.replaceNullWithEmptyString(personShell.getLastName());
+                        String fullName = (firstName + " " + lastName).trim();
+                        if (!fullName.isEmpty()) {
+                            requesterName = StringUtils.substring(fullName, 0, 30);
+                        }
+                    }
+                }
+            }
         }
 
-        // Site name differs by workflow: vector uses collection site observation,
-        // others use the referring site from the requester section
+        // Site name differs by workflow: each domain stores it under its own
+        // observation key.
+        // Vector → VS_COLLECTION_SITE_NAME
+        // Environmental → ENV_SAMPLING_SITE_NAME, with fallback to
+        // VS_COLLECTION_SITE_NAME
+        // Clinical → referring site from the requester section.
         String referringFacility;
-        if ("vector".equals(workflowType) || "environmental".equals(workflowType)) {
+        String envSiteType = null;
+        if ("vector".equals(workflowType)) {
             String vecSiteName = observationHistoryService.getRawValueForSample(ObservationType.VS_COLLECTION_SITE_NAME,
                     sample.getId());
             referringFacility = StringUtil.replaceNullWithEmptyString(vecSiteName);
+            String vecSiteIdStr = observationHistoryService.getRawValueForSample(ObservationType.VS_COLLECTION_SITE_ID,
+                    sample.getId());
+            if (!StringUtil.isNullorNill(vecSiteIdStr)) {
+                try {
+                    VectorSamplingSite vecSite = SpringContext.getBean(VectorSamplingSiteService.class)
+                            .get(Integer.valueOf(vecSiteIdStr.trim()));
+                    if (vecSite != null && !StringUtil.isNullorNill(vecSite.getType())) {
+                        envSiteType = vecSite.getType();
+                    }
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        } else if ("environmental".equals(workflowType)) {
+            String envSiteName = observationHistoryService.getRawValueForSample(ObservationType.ENV_SAMPLING_SITE_NAME,
+                    sample.getId());
+            if (StringUtil.isNullorNill(envSiteName)) {
+                envSiteName = observationHistoryService.getRawValueForSample(ObservationType.VS_COLLECTION_SITE_NAME,
+                        sample.getId());
+            }
+            referringFacility = StringUtil.replaceNullWithEmptyString(envSiteName);
+            envSiteType = observationHistoryService.getRawValueForSample(ObservationType.ENV_SITE_TYPE, sample.getId());
+            // If type was not stored on the order (e.g. created before type was added,
+            // or site type was blank at entry time), look it up live from the site record.
+            if (StringUtil.isNullorNill(envSiteType)) {
+                String siteIdStr = observationHistoryService.getRawValueForSample(ObservationType.ENV_SAMPLING_SITE_ID,
+                        sample.getId());
+                if (!StringUtil.isNullorNill(siteIdStr)) {
+                    try {
+                        VectorSamplingSiteService siteService = SpringContext.getBean(VectorSamplingSiteService.class);
+                        VectorSamplingSite site = siteService.get(Integer.valueOf(siteIdStr.trim()));
+                        if (site != null) {
+                            envSiteType = site.getType();
+                        }
+                    } catch (NumberFormatException ignored) {
+                        // non-numeric id — skip lookup
+                    }
+                }
+            }
         } else {
-            referringFacility = StringUtil.replaceNullWithEmptyString(orderItem.getReferringSiteName());
+            org.openelisglobal.common.services.RequesterService requesterService = new org.openelisglobal.common.services.RequesterService(
+                    sample.getId());
+            referringFacility = StringUtil.replaceNullWithEmptyString(requesterService.getReferringSiteName());
         }
 
         // Handle patient information - may be null for generic samples
@@ -199,11 +262,12 @@ public class OrderLabel extends Label {
             aboveFields.add(requesterField);
         }
 
-        if (sample != null && sample.hasGpsCoordinates()) {
-            LabelField gpsField = new LabelField(MessageUtil.getMessage("barcode.label.info.gps"),
-                    sample.getGpsCoordinatesDisplay(), 12);
-            gpsField.setDisplayFieldName(true);
-            aboveFields.add(gpsField);
+        if (!StringUtil.isNullorNill(envSiteType)) {
+            LabelField siteTypeField = new LabelField(
+                    MessageUtil.getMessageOrDefault("barcode.label.info.siteType", null, "Site Type"),
+                    StringUtils.substring(envSiteType, 0, 20), 12);
+            siteTypeField.setDisplayFieldName(true);
+            aboveFields.add(siteTypeField);
         }
 
         // adding bar code

--- a/src/main/java/org/openelisglobal/barcode/labeltype/SpecimenLabel.java
+++ b/src/main/java/org/openelisglobal/barcode/labeltype/SpecimenLabel.java
@@ -21,7 +21,9 @@ import org.openelisglobal.patient.service.PatientService;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.person.service.PersonService;
 import org.openelisglobal.person.valueholder.Person;
+import org.openelisglobal.provider.valueholder.Provider;
 import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.samplehuman.service.SampleHumanService;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.spring.util.SpringContext;
 import org.openelisglobal.test.service.TestServiceImpl;
@@ -180,6 +182,16 @@ public class SpecimenLabel extends Label {
         if (usePatientId)
             aboveFields.add(getAvailableIdField(patient));
 
+        if (sampleItem.getTypeOfSample() != null) {
+            String sampleType = StringUtils.defaultString(sampleItem.getTypeOfSample().getLocalizedName());
+            if (!StringUtil.isNullorNill(sampleType)) {
+                LabelField sampleTypeField = new LabelField(MessageUtil.getMessage("barcode.label.info.sampletype"),
+                        StringUtils.substring(sampleType, 0, 25), 10);
+                sampleTypeField.setDisplayFieldName(true);
+                aboveFields.add(sampleTypeField);
+            }
+        }
+
         // adding fields below bar code
         belowFields = new ArrayList<>();
 
@@ -201,16 +213,34 @@ public class SpecimenLabel extends Label {
                     StringUtil.replaceNullWithEmptyString(collectionTime), 4);
             belowFields.add(dateField);
         }
-        if (useCollectedBy) {
-            ObservationHistoryService observationHistoryService = SpringContext
-                    .getBean(ObservationHistoryService.class);
-            String workflowType = observationHistoryService.getRawValueForSample(ObservationType.ENV_WORKFLOW_TYPE,
-                    sample.getId());
-            String collectorLabel = "vector".equals(workflowType)
+        ObservationHistoryService observationHistoryService = SpringContext.getBean(ObservationHistoryService.class);
+        String workflowType = observationHistoryService.getRawValueForSample(ObservationType.ENV_WORKFLOW_TYPE,
+                sample.getId());
+        boolean isEnvOrVector = "vector".equals(workflowType) || "environmental".equals(workflowType);
+        if (useCollectedBy || isEnvOrVector) {
+            String collectorValue = StringUtil.replaceNullWithEmptyString(sampleItem.getCollector());
+            // For env/vector orders the collector field on sample_item is not populated;
+            // resolve the provider name from sample_human → provider → person instead.
+            if (StringUtil.isNullorNill(collectorValue) && isEnvOrVector) {
+                Provider sampleProvider = SpringContext.getBean(SampleHumanService.class).getProviderForSample(sample);
+                if (sampleProvider != null && sampleProvider.getPerson() != null) {
+                    String personId = sampleProvider.getPerson().getId();
+                    if (!StringUtil.isNullorNill(personId)) {
+                        Person personShell = new Person();
+                        personShell.setId(personId);
+                        SpringContext.getBean(PersonService.class).getData(personShell);
+                        if (!StringUtil.isNullorNill(personShell.getId())) {
+                            String first = StringUtil.replaceNullWithEmptyString(personShell.getFirstName());
+                            String last = StringUtil.replaceNullWithEmptyString(personShell.getLastName());
+                            collectorValue = (first + " " + last).trim();
+                        }
+                    }
+                }
+            }
+            String collectorLabel = isEnvOrVector
                     ? MessageUtil.getMessageOrDefault("barcode.label.info.provider", null, "Provider")
                     : MessageUtil.getMessage("barcode.label.info.collectorid");
-            LabelField collectorField = new LabelField(collectorLabel,
-                    StringUtils.substring(StringUtil.replaceNullWithEmptyString(sampleItem.getCollector()), 0, 15), 6);
+            LabelField collectorField = new LabelField(collectorLabel, StringUtils.substring(collectorValue, 0, 15), 6);
             collectorField.setDisplayFieldName(true);
             belowFields.add(collectorField);
         }

--- a/src/main/java/org/openelisglobal/barcode/service/BarcodeInfoServiceImpl.java
+++ b/src/main/java/org/openelisglobal/barcode/service/BarcodeInfoServiceImpl.java
@@ -166,7 +166,7 @@ public class BarcodeInfoServiceImpl implements BarcodeInfoService {
             info = new SampleBarcodeInfo();
             info.setSample(sample);
             info.setPrintedOrderCount(0);
-            sampleBarcodeInfoService.insert(info);
+            info = sampleBarcodeInfoService.get(sampleBarcodeInfoService.insert(info));
         }
         int current = info.getPrintedOrderCount() != null ? info.getPrintedOrderCount() : 0;
         info.setPrintedOrderCount(current + count);
@@ -182,7 +182,7 @@ public class BarcodeInfoServiceImpl implements BarcodeInfoService {
             info = new SampleItemBarcodeInfo();
             info.setSampleItem(sampleItem);
             info.setPrintedSpecimenCount(0);
-            sampleItemBarcodeInfoService.insert(info);
+            info = sampleItemBarcodeInfoService.get(sampleItemBarcodeInfoService.insert(info));
         }
         int current = info.getPrintedSpecimenCount() != null ? info.getPrintedSpecimenCount() : 0;
         info.setPrintedSpecimenCount(current + count);

--- a/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java
+++ b/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java
@@ -742,15 +742,8 @@ public class SamplePatientUpdateData {
         createObservation(getStringValue(envFields, "samplingSiteName"),
                 observationHistoryService.getObservationTypeIdForType(ObservationType.ENV_SAMPLING_SITE_NAME),
                 ValueType.LITERAL);
-        createObservation(getStringValue(envFields, "siteType"),
-                observationHistoryService.getObservationTypeIdForType(ObservationType.ENV_SITE_TYPE),
-                ValueType.LITERAL);
-        createObservation(getStringValue(envFields, "siteSubtype"),
-                observationHistoryService.getObservationTypeIdForType(ObservationType.ENV_SITE_SUBTYPE),
-                ValueType.LITERAL);
-        createObservation(getStringValue(envFields, "environmentalZone"),
-                observationHistoryService.getObservationTypeIdForType(ObservationType.ENV_ENVIRONMENTAL_ZONE),
-                ValueType.LITERAL);
+        // siteType, siteSubtype, environmentalZone are not snapshotted — they are
+        // resolved at read time from vector_sampling_site via ENV_SAMPLING_SITE_ID.
         createObservation(getStringValue(envFields, "regulatoryReference"),
                 observationHistoryService.getObservationTypeIdForType(ObservationType.ENV_REGULATORY_REFERENCE),
                 ValueType.LITERAL);

--- a/src/main/java/org/openelisglobal/sample/controller/rest/OrderSearchRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/OrderSearchRestController.java
@@ -82,7 +82,9 @@ import org.openelisglobal.test.service.TestSectionService;
 import org.openelisglobal.test.valueholder.TestSection;
 import org.openelisglobal.typeofsample.service.TypeOfSampleService;
 import org.openelisglobal.vector.service.VectorPoolService;
+import org.openelisglobal.vector.service.VectorSamplingSiteService;
 import org.openelisglobal.vector.valueholder.VectorPool;
+import org.openelisglobal.vector.valueholder.VectorSamplingSite;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -181,6 +183,9 @@ public class OrderSearchRestController extends BaseRestController {
 
     @Autowired
     private TestSectionService testSectionService;
+
+    @Autowired
+    private VectorSamplingSiteService vectorSamplingSiteService;
 
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
@@ -749,9 +754,7 @@ public class OrderSearchRestController extends BaseRestController {
             stepProgress.put("qa", qaComplete);
             response.put("stepProgress", stepProgress);
 
-            // Include storageSkipped flag (always false for vector — storage not
-            // applicable)
-            response.put("storageSkipped", !isVectorOrder && Boolean.TRUE.equals(sample.getStorageSkipped()));
+            response.put("storageSkipped", Boolean.TRUE.equals(sample.getStorageSkipped()));
 
             return ResponseEntity.ok(response);
 
@@ -1218,18 +1221,25 @@ public class OrderSearchRestController extends BaseRestController {
         if (samplingSiteName != null) {
             envFields.put("samplingSiteName", samplingSiteName);
         }
-        String siteType = observationHistoryService.getRawValueForSample(ObservationType.ENV_SITE_TYPE, sampleId);
-        if (siteType != null) {
-            envFields.put("siteType", siteType);
-        }
-        String siteSubtype = observationHistoryService.getRawValueForSample(ObservationType.ENV_SITE_SUBTYPE, sampleId);
-        if (siteSubtype != null) {
-            envFields.put("siteSubtype", siteSubtype);
-        }
-        String envZone = observationHistoryService.getRawValueForSample(ObservationType.ENV_ENVIRONMENTAL_ZONE,
-                sampleId);
-        if (envZone != null) {
-            envFields.put("environmentalZone", envZone);
+        // siteType, siteSubtype, environmentalZone are resolved live from the site
+        // record rather than read from stale observations.
+        if (samplingSiteId != null) {
+            try {
+                VectorSamplingSite site = vectorSamplingSiteService.get(Integer.valueOf(samplingSiteId.trim()));
+                if (site != null) {
+                    if (!GenericValidator.isBlankOrNull(site.getType())) {
+                        envFields.put("siteType", site.getType());
+                    }
+                    if (!GenericValidator.isBlankOrNull(site.getSubtype())) {
+                        envFields.put("siteSubtype", site.getSubtype());
+                    }
+                    if (!GenericValidator.isBlankOrNull(site.getEnvironmentalZone())) {
+                        envFields.put("environmentalZone", site.getEnvironmentalZone());
+                    }
+                }
+            } catch (NumberFormatException ignored) {
+                // non-numeric id stored — skip live lookup
+            }
         }
         String regulatoryRef = observationHistoryService.getRawValueForSample(ObservationType.ENV_REGULATORY_REFERENCE,
                 sampleId);
@@ -1308,8 +1318,21 @@ public class OrderSearchRestController extends BaseRestController {
         // Vector surveillance fields
         String vecCollectionSiteId = observationHistoryService
                 .getRawValueForSample(ObservationType.VS_COLLECTION_SITE_ID, sampleId);
-        if (vecCollectionSiteId != null)
+        if (vecCollectionSiteId != null) {
             envFields.put("vecCollectionSiteId", vecCollectionSiteId);
+            try {
+                VectorSamplingSite vecSite = vectorSamplingSiteService.get(Integer.valueOf(vecCollectionSiteId.trim()));
+                if (vecSite != null) {
+                    if (!GenericValidator.isBlankOrNull(vecSite.getType()))
+                        envFields.put("vecCollectionSiteType", vecSite.getType());
+                    if (!GenericValidator.isBlankOrNull(vecSite.getSubtype()))
+                        envFields.put("vecCollectionSiteSubtype", vecSite.getSubtype());
+                    if (!GenericValidator.isBlankOrNull(vecSite.getEnvironmentalZone()))
+                        envFields.put("vecCollectionSiteZone", vecSite.getEnvironmentalZone());
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
         String vecCollectionSiteName = observationHistoryService
                 .getRawValueForSample(ObservationType.VS_COLLECTION_SITE_NAME, sampleId);
         if (vecCollectionSiteName != null)

--- a/src/main/resources/languages/message_en.properties
+++ b/src/main/resources/languages/message_en.properties
@@ -390,6 +390,7 @@ barcode.label.info.quantity            = Qty
 barcode.label.info.from                = From
 barcode.label.info.tests               = Tests
 barcode.label.info.gps                 = GPS
+barcode.label.info.siteType            = Site Type
 barcode.label.info.blockNumber         = Block Number
 barcode.label.info.slideNumber         = Slide Number
 barcode.label.info.slideId             = Slide ID

--- a/src/main/resources/languages/message_fr.properties
+++ b/src/main/resources/languages/message_fr.properties
@@ -407,6 +407,7 @@ barcode.label.info.quantity            = Qt\u00E9
 barcode.label.info.from                = De
 barcode.label.info.tests               = Tests
 barcode.label.info.gps                 = GPS
+barcode.label.info.siteType            = Type de site
 barcode.label.info.blockNumber         = Num\u00E9ro de bloc
 barcode.label.info.slideNumber         = Num\u00E9ro de lame
 barcode.label.info.slideId             = ID de la lame


### PR DESCRIPTION
- Implemented automatic order loading based on URL query parameters in OrderContext.
- Updated OrderDashboard to include order ID in navigation URLs for continuity on refresh.
- Modified OrderStepper and SaveNavigationButtons to maintain order ID in navigation paths.
- Enhanced ClinicalOrderEnter and EnvironmentalOrderEnter to reset state based on URL parameters.
- Added site type information to labels in OrderLabel and SpecimenLabel for better clarity.
- Updated BarcodeInfoServiceImpl to ensure accurate tracking of printed orders.
- Refactored OrderSearchRestController to resolve site type information live from the database.
- Added new localization keys for site type in English and French message properties.

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
