### PR TITLE
fix: allow multi-line Provisional Clinical Diagnosis on Add Order

### DIFF
--- a/frontend/src/components/addOrder/AddOrder.jsx
+++ b/frontend/src/components/addOrder/AddOrder.jsx
@@ -17,6 +17,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TextArea,
   TextInput,
   Column,
   Grid,
@@ -1029,7 +1030,7 @@ const AddOrder = (props) => {
               />
             </Column>
             <Column lg={8} md={4} sm={4}>
-              <TextInput
+              <TextArea
                 name="provisionalDiagnosis"
                 placeholder={intl.formatMessage({
                   id: "input.placeholder.provisionalClinicalDiagnosis",
@@ -1042,6 +1043,7 @@ const AddOrder = (props) => {
                   id: "order.requester.provisionalDiagnosis.label",
                 })}
                 id="provisionalDiagnosisId"
+                rows={3}
               />
             </Column>
             {/* <Column lg={8} md={4} sm={4}>

--- a/src/main/resources/liquibase/3.5.x.x/045-widen-observation-history-value.xml
+++ b/src/main/resources/liquibase/3.5.x.x/045-widen-observation-history-value.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+      Widen observation_history.value from VARCHAR(80) to VARCHAR(500) so
+      free-text observations such as the Provisional Clinical Diagnosis
+      captured on Add Order can hold longer multi-line clinical content
+      (requirement: at least 250 characters).
+      Idempotent via an information_schema precondition.
+    -->
+    <changeSet author="openelis" id="widen-observation-history-value-to-500">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="80">SELECT character_maximum_length FROM information_schema.columns WHERE table_schema = 'clinlims' AND table_name = 'observation_history' AND column_name = 'value'</sqlCheck>
+        </preConditions>
+        <modifyDataType schemaName="clinlims" tableName="observation_history" columnName="value" newDataType="VARCHAR(500)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -117,4 +117,7 @@
   <!-- OGC-949 review follow-up (#3714): test_method unique-active index + test_id index + drop unused seq -->
   <include relativeToChangelogFile="true" file="044-test-method-indexes.xml"/>
 
+  <!-- Widen observation_history.value to fit longer Provisional Clinical Diagnosis text (>= 250 chars) -->
+  <include relativeToChangelogFile="true" file="045-widen-observation-history-value.xml"/>
+
 </databaseChangeLog>


### PR DESCRIPTION
Replace the single-line TextInput with a Carbon TextArea (3 rows) on the SamplePatientEntry Add Order panel so clinicians can capture longer diagnoses without character/visual truncation.




