### PR TITLE
fix(compliance): fix Laporan Hasil date parse error on non-US locales

### DIFF
--- a/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceReportRestController.java
+++ b/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceReportRestController.java
@@ -17,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.compliance.service.ComplianceEvaluationResult;
 import org.openelisglobal.compliance.service.ComplianceEvaluationService;
 import org.openelisglobal.compliance.service.ComplianceReportGenerationService;
@@ -98,8 +99,6 @@ public class ComplianceReportRestController {
             @RequestParam(required = false) String standardId, @RequestParam(required = false) String complianceStatus,
             @RequestParam(required = false) String generationStatus) {
 
-        // getSamplesReceivedInDateRange expects MM/dd/yyyy (the system date format).
-        // The frontend and LocalDate.toString() both produce yyyy-MM-dd, so convert.
         List<Sample> samples;
         String from = toSystemDateFormat(dateFrom);
         String to = toSystemDateFormat(dateTo);
@@ -433,8 +432,6 @@ public class ComplianceReportRestController {
         return s != null ? s : "–";
     }
 
-    // getSamplesReceivedInDateRange expects MM/dd/yyyy. The frontend sends
-    // yyyy-MM-dd, so parse and reformat before passing to the DAO.
     private String toSystemDateFormat(String isoDate) {
         if (isoDate == null || isoDate.isEmpty()) {
             return null;
@@ -448,6 +445,6 @@ public class ComplianceReportRestController {
     }
 
     private String formatToSystemDate(java.time.LocalDate date) {
-        return date.format(java.time.format.DateTimeFormatter.ofPattern("MM/dd/yyyy"));
+        return date.format(java.time.format.DateTimeFormatter.ofPattern(DateUtil.getDateFormat()));
     }
 }

--- a/src/test/java/org/openelisglobal/compliance/controller/rest/ComplianceReportRestControllerIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/compliance/controller/rest/ComplianceReportRestControllerIntegrationTest.java
@@ -1,0 +1,88 @@
+package org.openelisglobal.compliance.controller.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.common.util.ConfigurationProperties.Property;
+import org.openelisglobal.common.util.DefaultConfigurationProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+/**
+ * Integration tests for ComplianceReportRestController date-handling.
+ *
+ * The report endpoint converts the ISO yyyy-MM-dd dates sent by the React
+ * frontend into whatever format getSamplesReceivedInDateRange() expects via
+ * DateUtil.getDateFormat(). These tests pin DEFAULT_DATE_LOCALE to fr-FR
+ * (dd/MM/yyyy) so they are deterministic regardless of server configuration.
+ *
+ * Bug: formatToSystemDate() was hardcoded to "MM/dd/yyyy", producing
+ * "05/31/2026" for 2026-05-31. Under dd/MM/yyyy, month 31 is invalid →
+ * LIMSRuntimeException → 500. Fix: use DateUtil.getDateFormat() at runtime.
+ */
+public class ComplianceReportRestControllerIntegrationTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private DefaultConfigurationProperties configurationProperties;
+
+    private String originalDateLocale;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        originalDateLocale = ConfigurationProperties.getInstance().getPropertyValue(Property.DEFAULT_DATE_LOCALE);
+        // Pin to fr-FR (dd/MM/yyyy) so tests are deterministic regardless of the
+        // server locale configured in SystemConfiguration.properties.
+        configurationProperties.setPropertyValue(Property.DEFAULT_DATE_LOCALE, "fr-FR");
+    }
+
+    @After
+    public void restoreDateLocale() {
+        if (originalDateLocale != null) {
+            configurationProperties.setPropertyValue(Property.DEFAULT_DATE_LOCALE, originalDateLocale);
+        }
+    }
+
+    /**
+     * Regression test for the Laporan Hasil "Unparseable date" bug.
+     *
+     * With the locale pinned to fr-FR (dd/MM/yyyy), the broken hardcoded
+     * "MM/dd/yyyy" conversion produces "05/31/2026" which DateUtil refuses to parse
+     * (month 31 does not exist) → 500. The fix uses DateUtil.getDateFormat() which
+     * produces "31/05/2026" → 200.
+     *
+     * The date 2026-05-31 is chosen because its month (5) and day (31) cannot be
+     * swapped without creating an impossible month value, making the locale
+     * mismatch unambiguous.
+     */
+    @Test
+    public void getReport_ddMMyyyyLocale_dayGreaterThan12_mustReturn200NotDateParseError() throws Exception {
+        mockMvc.perform(get("/rest/complianceReport").param("dateFrom", "2026-05-31").param("dateTo", "2026-05-31")
+                .accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+    }
+
+    /**
+     * Full-month range through the same conversion path — sanity baseline.
+     */
+    @Test
+    public void getReport_ddMMyyyyLocale_isoDateRange_shouldReturn200() throws Exception {
+        mockMvc.perform(get("/rest/complianceReport").param("dateFrom", "2026-01-01").param("dateTo", "2026-12-31")
+                .accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+    }
+
+    /**
+     * No date params — the controller computes today.minusDays(90) and today via
+     * LocalDate and calls formatToSystemDate() on those too. Verifies the default
+     * window path does not blow up.
+     */
+    @Test
+    public void getReport_ddMMyyyyLocale_noDateParams_shouldReturn200UsingDefaultWindow() throws Exception {
+        mockMvc.perform(get("/rest/complianceReport").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- `formatToSystemDate()` was hardcoded to `MM/dd/yyyy`, but `DateUtil.convertStringDateToSqlDate()` parses using `DEFAULT_DATE_LOCALE` at runtime (`fr-FR` → `dd/MM/yyyy` on the Indonesia server). This produced `"05/31/2026"` for ISO input `2026-05-31`, failing with `Unparseable date` (month 31 does not exist) → HTTP 500 on `/LaporanHasil`.
- Fix: call `DateUtil.getDateFormat()` in `formatToSystemDate()` so the controller and the DAO always use the same runtime format, regardless of locale.
- Add `ComplianceReportRestControllerIntegrationTest` pinning `DEFAULT_DATE_LOCALE` to `fr-FR` so the regression test is deterministic on any server configuration.

## Test plan
- [ ] Run `mvn test -Dtest=ComplianceReportRestControllerIntegrationTest` — all 3 tests pass
- [ ] On Indonesia demo: open Laporan Hasil, set a date range with day > 12 (e.g. 2026-05-31), click Search — should return 200, not 500
- [ ] Verify no regression on other date-range reports