### PR TITLE
fix: round home dashboard turn-around times to whole hours

### DIFF
--- a/src/main/java/org/openelisglobal/common/rest/provider/PatientDashBoardProvider.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/PatientDashBoardProvider.java
@@ -77,7 +77,7 @@ public class PatientDashBoardProvider {
     @Autowired
     SystemUserService systemUserService;
 
-    private double calculateAverageReceptionToValidationTime() {
+    private long calculateAverageReceptionToValidationTime() {
         List<Analysis> analyses = analysisService.getAnalysesCompletedOnByStatusId(DateUtil.getNowAsSqlDate(),
                 iStatusService.getStatusID(AnalysisStatus.Finalized));
 
@@ -97,10 +97,10 @@ public class PatientDashBoardProvider {
                 sum += h;
             }
         }
-        return hours.isEmpty() ? 0.0 : (double) sum / hours.size();
+        return hours.isEmpty() ? 0L : Math.round((double) sum / hours.size());
     }
 
-    private double calculateAverageReceptionToResultTime() {
+    private long calculateAverageReceptionToResultTime() {
         Set<String> statusIdSet = new HashSet<>();
         statusIdSet.add(iStatusService.getStatusID(AnalysisStatus.SampleRejected));
         List<Analysis> analyses = analysisService
@@ -122,10 +122,10 @@ public class PatientDashBoardProvider {
                 sum += h;
             }
         }
-        return hours.isEmpty() ? 0.0 : (double) sum / hours.size();
+        return hours.isEmpty() ? 0L : Math.round((double) sum / hours.size());
     }
 
-    private double calculateAverageResultToValidationTime() {
+    private long calculateAverageResultToValidationTime() {
         List<Analysis> analyses = analysisService.getAnalysesCompletedOnByStatusId(DateUtil.getNowAsSqlDate(),
                 iStatusService.getStatusID(AnalysisStatus.Finalized));
 
@@ -145,7 +145,7 @@ public class PatientDashBoardProvider {
                 sum += h;
             }
         }
-        return hours.isEmpty() ? 0.0 : (double) sum / hours.size();
+        return hours.isEmpty() ? 0L : Math.round((double) sum / hours.size());
     }
 
     private List<Analysis> analysesWithDelayedTurnAroundTime() {

--- a/src/main/java/org/openelisglobal/common/rest/provider/bean/homedashboard/AverageTimeDisplayBean.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/bean/homedashboard/AverageTimeDisplayBean.java
@@ -2,33 +2,33 @@ package org.openelisglobal.common.rest.provider.bean.homedashboard;
 
 public class AverageTimeDisplayBean {
 
-    Double receptionToResult = 0.0;
+    Long receptionToResult = 0L;
 
-    Double resultToValidation = 0.0;
+    Long resultToValidation = 0L;
 
-    Double receptionToValidation = 0.0;
+    Long receptionToValidation = 0L;
 
-    public Double getReceptionToResult() {
+    public Long getReceptionToResult() {
         return receptionToResult;
     }
 
-    public void setReceptionToResult(Double receptionToResult) {
+    public void setReceptionToResult(Long receptionToResult) {
         this.receptionToResult = receptionToResult;
     }
 
-    public Double getResultToValidation() {
+    public Long getResultToValidation() {
         return resultToValidation;
     }
 
-    public void setResultToValidation(Double resultToValidation) {
+    public void setResultToValidation(Long resultToValidation) {
         this.resultToValidation = resultToValidation;
     }
 
-    public Double getReceptionToValidation() {
+    public Long getReceptionToValidation() {
         return receptionToValidation;
     }
 
-    public void setReceptionToValidation(Double receptionToValidation) {
+    public void setReceptionToValidation(Long receptionToValidation) {
         this.receptionToValidation = receptionToValidation;
     }
 }

--- a/src/main/java/org/openelisglobal/common/rest/provider/bean/homedashboard/DashBoardMetrics.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/bean/homedashboard/DashBoardMetrics.java
@@ -18,7 +18,7 @@ public class DashBoardMetrics {
 
     Integer incomigOrders = 0;
 
-    Double averageTurnAroudTime = 0.0;
+    Long averageTurnAroudTime = 0L;
 
     Integer delayedTurnAround = 0;
 
@@ -86,11 +86,11 @@ public class DashBoardMetrics {
         this.incomigOrders = incomigOrders;
     }
 
-    public Double getAverageTurnAroudTime() {
+    public Long getAverageTurnAroudTime() {
         return averageTurnAroudTime;
     }
 
-    public void setAverageTurnAroudTime(Double averageTurnAroudTime) {
+    public void setAverageTurnAroudTime(Long averageTurnAroudTime) {
         this.averageTurnAroudTime = averageTurnAroudTime;
     }
 


### PR DESCRIPTION
Average Reception-To-Validation, Reception-To-Result, and Result-To-Validation times are now returned as Long values rounded to the nearest hour (Math.round), removing the decimal component from the home dashboard JSON payloads.


