### PR TITLE
OGC-782 M3: microbiology order routing

### DIFF
--- a/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
+++ b/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
@@ -122,22 +122,22 @@ without duplicate accessioning.
 
 ### Tests First
 
-- [ ] T040 [M3] Create branch `feat/782-ogc-782-microbiology-mvp-m3-order-routing` from `develop` after M2 merge in `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
-- [ ] T041 [P] [M3] Add failing routing resolver unit tests in `src/test/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceTest.java`.
-- [ ] T042 [P] [M3] Add failing order-save integration tests for non-micro, bacteriology, and sibling workflow cases in `src/test/java/org/openelisglobal/microbiology/MicroOrderRoutingIntegrationTest.java`.
-- [ ] T043 [P] [M3] Add failing idempotency integration test for repeated order saves in `src/test/java/org/openelisglobal/microbiology/MicroOrderRoutingIdempotencyTest.java`.
-- [ ] T044 [P] [M3] Add failing controller/contract test for case lookup by accession/sample item in `src/test/java/org/openelisglobal/microbiology/controller/MicroCaseLookupRestControllerTest.java`.
+- [X] T040 [M3] Create branch `feat/782-ogc-782-microbiology-mvp-m3-order-routing` from the M2 stacked branch in `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
+- [X] T041 [P] [M3] Add failing routing resolver unit tests in `src/test/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceTest.java`.
+- [X] T042 [P] [M3] Add failing order-save integration tests for non-micro, bacteriology, and sibling workflow cases in `src/test/java/org/openelisglobal/microbiology/MicroOrderRoutingIntegrationTest.java`.
+- [X] T043 [P] [M3] Add failing idempotency integration test for repeated order saves in `src/test/java/org/openelisglobal/microbiology/MicroOrderRoutingIdempotencyTest.java`.
+- [X] T044 [P] [M3] Add failing controller/contract test for case lookup by accession/sample item in `src/test/java/org/openelisglobal/microbiology/controller/MicroCaseLookupRestControllerTest.java`.
 
 ### Implementation
 
-- [ ] T045 [M3] Add routing service contract in `src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingService.java`.
-- [ ] T046 [M3] Implement order routing service in `src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceImpl.java`.
-- [ ] T047 [M3] Wire routing from the existing order/sample save integration point in `src/main/java/org/openelisglobal/sample/service/SampleServiceImpl.java`.
-- [ ] T048 [M3] Add case lookup endpoint and DTO support in `src/main/java/org/openelisglobal/microbiology/controller/rest/MicroCaseRestController.java` and `src/main/java/org/openelisglobal/microbiology/form/MicroCaseLookupForm.java`.
-- [ ] T049 [M3] Add configuration error handling for missing culture workflow/method defaults in `src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceImpl.java`.
-- [ ] T050 [M3] Run focused backend validation `mvn -q -Dtest='MicroOrderRoutingServiceTest,MicroOrderRoutingIntegrationTest,MicroOrderRoutingIdempotencyTest,MicroCaseLookupRestControllerTest' test` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
-- [ ] T051 [M3] Run formatting and migration hygiene checks `mvn spotless:apply && git diff --check` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
-- [ ] T052 [M3] Open draft PR for `feat/782-ogc-782-microbiology-mvp-m3-order-routing` to `develop` with validation evidence and link it from PR #3782.
+- [X] T045 [M3] Add routing service contract in `src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingService.java`.
+- [X] T046 [M3] Implement order routing service in `src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceImpl.java`.
+- [X] T047 [M3] Wire routing from the existing order/sample save integration point in `src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java`.
+- [X] T048 [M3] Add case lookup endpoint and DTO support in `src/main/java/org/openelisglobal/microbiology/controller/rest/MicroCaseRestController.java` and `src/main/java/org/openelisglobal/microbiology/form/MicroCaseLookupForm.java`.
+- [X] T049 [M3] Add configuration error handling for missing culture workflow/method defaults in `src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceImpl.java`.
+- [X] T050 [M3] Run focused backend validation `mvn -q -Dtest='MicroOrderRoutingServiceTest,MicroOrderRoutingIntegrationTest,MicroOrderRoutingIdempotencyTest,MicroCaseLookupRestControllerTest' test` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
+- [X] T051 [M3] Run formatting and migration hygiene checks `mvn spotless:apply && git diff --check` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
+- [ ] T052 [M3] Open draft PR for `feat/782-ogc-782-microbiology-mvp-m3-order-routing` to the M2 stacked branch with validation evidence and link it from PR #3782.
 
 ## Phase 4: M4 - Case Workbench
 

--- a/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
+++ b/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
@@ -137,7 +137,7 @@ without duplicate accessioning.
 - [X] T049 [M3] Add configuration error handling for missing culture workflow/method defaults in `src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceImpl.java`.
 - [X] T050 [M3] Run focused backend validation `mvn -q -Dtest='MicroOrderRoutingServiceTest,MicroOrderRoutingIntegrationTest,MicroOrderRoutingIdempotencyTest,MicroCaseLookupRestControllerTest' test` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
 - [X] T051 [M3] Run formatting and migration hygiene checks `mvn spotless:apply && git diff --check` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
-- [ ] T052 [M3] Open draft PR for `feat/782-ogc-782-microbiology-mvp-m3-order-routing` to the M2 stacked branch with validation evidence and link it from PR #3782.
+- [X] T052 [M3] Open draft PR for `feat/782-ogc-782-microbiology-mvp-m3-order-routing` to the M2 stacked branch with validation evidence and link it from PR #3782.
 
 ## Phase 4: M4 - Case Workbench
 

--- a/src/main/java/org/openelisglobal/microbiology/controller/rest/MicroCaseRestController.java
+++ b/src/main/java/org/openelisglobal/microbiology/controller/rest/MicroCaseRestController.java
@@ -1,14 +1,19 @@
 package org.openelisglobal.microbiology.controller.rest;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.openelisglobal.common.rest.BaseRestController;
 import org.openelisglobal.microbiology.form.MicroCaseDetailForm;
+import org.openelisglobal.microbiology.form.MicroCaseLookupForm;
 import org.openelisglobal.microbiology.service.MicroCaseService;
+import org.openelisglobal.microbiology.valueholder.MicroCase;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,5 +34,25 @@ public class MicroCaseRestController extends BaseRestController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
         return ResponseEntity.ok(detail);
+    }
+
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<MicroCaseLookupForm>> getCasesForSampleItem(@RequestParam String sampleItemId) {
+        List<MicroCaseLookupForm> rows = new ArrayList<>();
+        for (MicroCase microCase : caseService.getSiblingCases(sampleItemId)) {
+            rows.add(toLookupForm(microCase));
+        }
+        return ResponseEntity.ok(rows);
+    }
+
+    private MicroCaseLookupForm toLookupForm(MicroCase microCase) {
+        MicroCaseLookupForm form = new MicroCaseLookupForm();
+        form.id = microCase.getId();
+        form.sampleItemId = microCase.getSampleItemId();
+        form.workflowType = microCase.getWorkflowType();
+        form.stage = microCase.getStage();
+        form.priority = microCase.getPriority();
+        return form;
     }
 }

--- a/src/main/java/org/openelisglobal/microbiology/form/MicroCaseLookupForm.java
+++ b/src/main/java/org/openelisglobal/microbiology/form/MicroCaseLookupForm.java
@@ -1,0 +1,9 @@
+package org.openelisglobal.microbiology.form;
+
+public class MicroCaseLookupForm {
+    public String id;
+    public String sampleItemId;
+    public String workflowType;
+    public String stage;
+    public String priority;
+}

--- a/src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingService.java
+++ b/src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingService.java
@@ -1,0 +1,10 @@
+package org.openelisglobal.microbiology.service;
+
+import java.util.List;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.microbiology.valueholder.MicroCase;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+
+public interface MicroOrderRoutingService {
+    List<MicroCase> routeAnalysesForSampleItem(SampleItem sampleItem, List<Analysis> analyses, String performedBy);
+}

--- a/src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceImpl.java
@@ -1,0 +1,79 @@
+package org.openelisglobal.microbiology.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.method.valueholder.Method;
+import org.openelisglobal.microbiology.valueholder.MicroCase;
+import org.openelisglobal.microbiology.valueholder.MicroCultureSetup;
+import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.test.valueholder.Test;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MicroOrderRoutingServiceImpl implements MicroOrderRoutingService {
+
+    private final MicroCaseService caseService;
+    private final MicrobiologyReferenceService referenceService;
+
+    public MicroOrderRoutingServiceImpl(MicroCaseService caseService, MicrobiologyReferenceService referenceService) {
+        this.caseService = caseService;
+        this.referenceService = referenceService;
+    }
+
+    @Override
+    @Transactional
+    public List<MicroCase> routeAnalysesForSampleItem(SampleItem sampleItem, List<Analysis> analyses,
+            String performedBy) {
+        if (sampleItem == null || sampleItem.getId() == null || analyses == null || analyses.isEmpty()) {
+            return List.of();
+        }
+
+        Map<MicroWorkflowType, String> cultureMethodsByWorkflow = new LinkedHashMap<>();
+        for (Analysis analysis : analyses) {
+            Test test = analysis == null ? null : analysis.getTest();
+            MicroWorkflowType workflowType = workflowTypeFor(test);
+            if (workflowType == null || cultureMethodsByWorkflow.containsKey(workflowType)) {
+                continue;
+            }
+            String methodId = methodIdFor(test);
+            MicroCultureSetup setup = referenceService.getActiveCultureSetupForMethod(methodId, workflowType);
+            if (setup == null) {
+                throw new IllegalStateException("No active microbiology culture setup for method " + methodId
+                        + " and workflow " + workflowType.name());
+            }
+            cultureMethodsByWorkflow.put(workflowType, methodId);
+        }
+
+        List<MicroCase> routedCases = new ArrayList<>();
+        for (Map.Entry<MicroWorkflowType, String> entry : cultureMethodsByWorkflow.entrySet()) {
+            routedCases.add(
+                    caseService.createOrGetCase(sampleItem.getId(), entry.getKey(), entry.getValue(), performedBy));
+        }
+        return routedCases;
+    }
+
+    private MicroWorkflowType workflowTypeFor(Test test) {
+        if (test == null || test.getCultureWorkflowType() == null || test.getCultureWorkflowType().trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return MicroWorkflowType.valueOf(test.getCultureWorkflowType());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Unsupported microbiology workflow type: " + test.getCultureWorkflowType(),
+                    e);
+        }
+    }
+
+    private String methodIdFor(Test test) {
+        Method method = test.getMethod();
+        if (method == null || method.getId() == null || method.getId().trim().isEmpty()) {
+            throw new IllegalStateException("Microbiology workflow tests require a culture method");
+        }
+        return method.getId();
+    }
+}

--- a/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
+++ b/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
@@ -33,6 +33,7 @@ import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.openelisglobal.labelpreset.dto.OrderLabelPersistRequest;
 import org.openelisglobal.labelpreset.service.OrderLabelRequestService;
 import org.openelisglobal.labelpreset.valueholder.OrderLabelRequest;
+import org.openelisglobal.microbiology.service.MicroOrderRoutingService;
 import org.openelisglobal.note.service.NoteService;
 import org.openelisglobal.note.service.NoteServiceImpl.NoteType;
 import org.openelisglobal.note.valueholder.Note;
@@ -132,6 +133,8 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
     private org.springframework.context.ApplicationEventPublisher eventPublisher;
     @Autowired
     private OrderLabelRequestService orderLabelRequestService;
+    @Autowired(required = false)
+    private MicroOrderRoutingService microOrderRoutingService;
 
     @Transactional
     @Override
@@ -433,6 +436,7 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
                     persistAnalysisNotificationConfigs(analysis, updateData);
                 }
             }
+            routeMicrobiologyCases(savedItem, sampleTestCollection, updateData.getCurrentUserId());
         }
 
         persistOrderSpecimenBarcodeCounts(updateData.getSample(), orderLabelQuantity, specimenLabelQuantities);
@@ -505,6 +509,14 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
 
     private int normalizeLabelQuantity(Integer quantity) {
         return quantity != null && quantity > 0 ? quantity : 1;
+    }
+
+    private void routeMicrobiologyCases(SampleItem sampleItem, SampleTestCollection sampleTestCollection,
+            String currentUserId) {
+        if (microOrderRoutingService == null) {
+            return;
+        }
+        microOrderRoutingService.routeAnalysesForSampleItem(sampleItem, sampleTestCollection.analysises, currentUserId);
     }
 
     /*

--- a/src/test/java/org/openelisglobal/microbiology/MicroOrderRoutingIdempotencyTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/MicroOrderRoutingIdempotencyTest.java
@@ -1,0 +1,83 @@
+package org.openelisglobal.microbiology;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.method.valueholder.Method;
+import org.openelisglobal.microbiology.fixture.MicrobiologyTestFixtures;
+import org.openelisglobal.microbiology.service.MicroCaseService;
+import org.openelisglobal.microbiology.service.MicroOrderRoutingService;
+import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class MicroOrderRoutingIdempotencyTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private javax.sql.DataSource dataSource;
+
+    @Autowired
+    private MicroOrderRoutingService routingService;
+
+    @Autowired
+    private MicroCaseService caseService;
+
+    private MicrobiologyTestFixtures fixtures;
+    private String sampleItemId;
+    private String methodId;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        fixtures = new MicrobiologyTestFixtures(new JdbcTemplate(dataSource));
+        methodId = fixtures.firstMethodId();
+        sampleItemId = fixtures.insertSampleWithSampleItem("OGC782-M3I");
+        fixtures.insertReferenceData(methodId);
+    }
+
+    @After
+    public void tearDown() {
+        if (fixtures != null && sampleItemId != null) {
+            fixtures.deleteCaseDataForSampleItem(sampleItemId);
+            fixtures.deleteSampleItemAndSample(sampleItemId);
+            fixtures.deleteReferenceData();
+        }
+    }
+
+    @Test
+    public void repeatedRoutingDoesNotDuplicateCases() {
+        Analysis bacteriology = analysis(MicroWorkflowType.BACTERIOLOGY.name(), methodId);
+
+        routingService.routeAnalysesForSampleItem(sampleItem(sampleItemId), List.of(bacteriology),
+                MicrobiologyTestFixtures.DEFAULT_USER_ID);
+        routingService.routeAnalysesForSampleItem(sampleItem(sampleItemId), List.of(bacteriology),
+                MicrobiologyTestFixtures.DEFAULT_USER_ID);
+
+        assertEquals(1, caseService.getSiblingCases(sampleItemId).size());
+    }
+
+    private SampleItem sampleItem(String id) {
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId(id);
+        return sampleItem;
+    }
+
+    private Analysis analysis(String workflowType, String methodId) {
+        org.openelisglobal.test.valueholder.Test test = new org.openelisglobal.test.valueholder.Test();
+        test.setId("test-" + workflowType + "-" + methodId);
+        test.setCultureWorkflowType(workflowType);
+        Method method = new Method();
+        method.setId(methodId);
+        test.setMethod(method);
+        Analysis analysis = new Analysis();
+        analysis.setTest(test);
+        return analysis;
+    }
+}

--- a/src/test/java/org/openelisglobal/microbiology/MicroOrderRoutingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/MicroOrderRoutingIntegrationTest.java
@@ -1,0 +1,86 @@
+package org.openelisglobal.microbiology;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.method.valueholder.Method;
+import org.openelisglobal.microbiology.fixture.MicrobiologyTestFixtures;
+import org.openelisglobal.microbiology.service.MicroCaseService;
+import org.openelisglobal.microbiology.service.MicroOrderRoutingService;
+import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class MicroOrderRoutingIntegrationTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private javax.sql.DataSource dataSource;
+
+    @Autowired
+    private MicroOrderRoutingService routingService;
+
+    @Autowired
+    private MicroCaseService caseService;
+
+    private MicrobiologyTestFixtures fixtures;
+    private String sampleItemId;
+    private String methodId;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        fixtures = new MicrobiologyTestFixtures(new JdbcTemplate(dataSource));
+        methodId = fixtures.firstMethodId();
+        sampleItemId = fixtures.insertSampleWithSampleItem("OGC782-M3");
+        fixtures.insertReferenceData(methodId);
+        fixtures.insertTbCultureSetup(methodId);
+    }
+
+    @After
+    public void tearDown() {
+        if (fixtures != null && sampleItemId != null) {
+            fixtures.deleteCaseDataForSampleItem(sampleItemId);
+            fixtures.deleteSampleItemAndSample(sampleItemId);
+            fixtures.deleteReferenceData();
+        }
+    }
+
+    @Test
+    public void routesNonMicroBacteriologyAndSiblingWorkflowCases() {
+        routingService.routeAnalysesForSampleItem(sampleItem(sampleItemId), List.of(analysis(null, methodId)),
+                MicrobiologyTestFixtures.DEFAULT_USER_ID);
+        assertEquals(0, caseService.getSiblingCases(sampleItemId).size());
+
+        routingService.routeAnalysesForSampleItem(sampleItem(sampleItemId),
+                List.of(analysis(MicroWorkflowType.BACTERIOLOGY.name(), methodId),
+                        analysis(MicroWorkflowType.MYCOBACTERIOLOGY_TB.name(), methodId)),
+                MicrobiologyTestFixtures.DEFAULT_USER_ID);
+
+        assertEquals(2, caseService.getSiblingCases(sampleItemId).size());
+    }
+
+    private SampleItem sampleItem(String id) {
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId(id);
+        return sampleItem;
+    }
+
+    private Analysis analysis(String workflowType, String methodId) {
+        org.openelisglobal.test.valueholder.Test test = new org.openelisglobal.test.valueholder.Test();
+        test.setId("test-" + workflowType + "-" + methodId);
+        test.setCultureWorkflowType(workflowType);
+        Method method = new Method();
+        method.setId(methodId);
+        test.setMethod(method);
+        Analysis analysis = new Analysis();
+        analysis.setTest(test);
+        return analysis;
+    }
+}

--- a/src/test/java/org/openelisglobal/microbiology/controller/MicroCaseLookupRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/controller/MicroCaseLookupRestControllerTest.java
@@ -1,0 +1,40 @@
+package org.openelisglobal.microbiology.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.Test;
+import org.openelisglobal.microbiology.controller.rest.MicroCaseRestController;
+import org.openelisglobal.microbiology.form.MicroCaseLookupForm;
+import org.openelisglobal.microbiology.service.MicroCaseService;
+import org.openelisglobal.microbiology.valueholder.MicroCase;
+import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
+import org.springframework.http.ResponseEntity;
+
+public class MicroCaseLookupRestControllerTest {
+
+    @Test
+    public void getCasesForSampleItemReturnsSiblingCaseLookupRows() {
+        MicroCaseService service = org.mockito.Mockito.mock(MicroCaseService.class);
+        MicroCase bacteriology = caseRow("case-1", MicroWorkflowType.BACTERIOLOGY);
+        MicroCase tb = caseRow("case-2", MicroWorkflowType.MYCOBACTERIOLOGY_TB);
+        when(service.getSiblingCases("1001")).thenReturn(List.of(bacteriology, tb));
+
+        ResponseEntity<List<MicroCaseLookupForm>> response = new MicroCaseRestController(service)
+                .getCasesForSampleItem("1001");
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        assertEquals("case-1", response.getBody().get(0).id);
+        assertEquals(MicroWorkflowType.BACTERIOLOGY.name(), response.getBody().get(0).workflowType);
+    }
+
+    private MicroCase caseRow(String caseId, MicroWorkflowType workflowType) {
+        MicroCase microCase = new MicroCase();
+        microCase.setId(caseId);
+        microCase.setSampleItemId("1001");
+        microCase.setWorkflowType(workflowType.name());
+        return microCase;
+    }
+}

--- a/src/test/java/org/openelisglobal/microbiology/fixture/MicrobiologyTestFixtures.java
+++ b/src/test/java/org/openelisglobal/microbiology/fixture/MicrobiologyTestFixtures.java
@@ -16,6 +16,7 @@ public class MicrobiologyTestFixtures {
     public static final String RULE_ID = "ogc782-rule";
     public static final String PANEL_ID = "ogc782-panel";
     public static final String SETUP_ID = "ogc782-setup";
+    public static final String TB_SETUP_ID = "ogc782-tb-setup";
     public static final String DEFAULT_USER_ID = "1";
 
     private final JdbcTemplate jdbc;
@@ -88,7 +89,15 @@ public class MicrobiologyTestFixtures {
                 + " '18-24h', 'Ambient', 'Y', NOW())", SETUP_ID, Long.valueOf(methodId));
     }
 
+    public void insertTbCultureSetup(String methodId) {
+        jdbc.update("INSERT INTO clinlims.micro_culture_setup"
+                + " (id, method_id, name, workflow_type, media_defaults, incubation_defaults, atmosphere_defaults,"
+                + " is_active, lastupdated) VALUES (?, ?, 'TB culture', 'MYCOBACTERIOLOGY_TB', 'MGIT',"
+                + " 'up to 42 days', 'Ambient', 'Y', NOW())", TB_SETUP_ID, Long.valueOf(methodId));
+    }
+
     public void deleteReferenceData() {
+        jdbc.update("DELETE FROM clinlims.micro_culture_setup WHERE id = ?", TB_SETUP_ID);
         jdbc.update("DELETE FROM clinlims.micro_culture_setup WHERE id = ?", SETUP_ID);
         jdbc.update("DELETE FROM clinlims.micro_breakpoint_rule WHERE id = ?", RULE_ID);
         jdbc.update("DELETE FROM clinlims.micro_breakpoint_standard WHERE id = ?", STANDARD_ID);

--- a/src/test/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/service/MicroOrderRoutingServiceTest.java
@@ -1,0 +1,94 @@
+package org.openelisglobal.microbiology.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.method.valueholder.Method;
+import org.openelisglobal.microbiology.valueholder.MicroCase;
+import org.openelisglobal.microbiology.valueholder.MicroCultureSetup;
+import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MicroOrderRoutingServiceTest {
+
+    @Mock
+    private MicroCaseService caseService;
+
+    @Mock
+    private MicrobiologyReferenceService referenceService;
+
+    @Test
+    public void routeAnalysesIgnoresNonMicrobiologyTests() {
+        MicroOrderRoutingService service = new MicroOrderRoutingServiceImpl(caseService, referenceService);
+
+        List<MicroCase> routed = service.routeAnalysesForSampleItem(sampleItem("1001"), List.of(analysis(null, "1")),
+                "1");
+
+        assertTrue(routed.isEmpty());
+        verify(caseService, never()).createOrGetCase(any(String.class), any(MicroWorkflowType.class), any(String.class),
+                any(String.class));
+    }
+
+    @Test
+    public void routeAnalysesCreatesOneCasePerWorkflowWithConfiguredCultureSetup() {
+        MicroOrderRoutingService service = new MicroOrderRoutingServiceImpl(caseService, referenceService);
+        when(referenceService.getActiveCultureSetupForMethod("1", MicroWorkflowType.BACTERIOLOGY))
+                .thenReturn(cultureSetup("1", MicroWorkflowType.BACTERIOLOGY));
+
+        service.routeAnalysesForSampleItem(sampleItem("1001"),
+                Arrays.asList(analysis(MicroWorkflowType.BACTERIOLOGY.name(), "1"),
+                        analysis(MicroWorkflowType.BACTERIOLOGY.name(), "1")),
+                "1");
+
+        ArgumentCaptor<MicroWorkflowType> workflowCaptor = ArgumentCaptor.forClass(MicroWorkflowType.class);
+        verify(caseService).createOrGetCase(eq("1001"), workflowCaptor.capture(), any(String.class), any(String.class));
+        assertEquals(MicroWorkflowType.BACTERIOLOGY, workflowCaptor.getValue());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void routeAnalysesRejectsWorkflowWithoutConfiguredCultureSetup() {
+        MicroOrderRoutingService service = new MicroOrderRoutingServiceImpl(caseService, referenceService);
+
+        service.routeAnalysesForSampleItem(sampleItem("1001"),
+                List.of(analysis(MicroWorkflowType.BACTERIOLOGY.name(), "1")), "1");
+    }
+
+    private SampleItem sampleItem(String id) {
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setId(id);
+        return sampleItem;
+    }
+
+    private Analysis analysis(String workflowType, String methodId) {
+        org.openelisglobal.test.valueholder.Test test = new org.openelisglobal.test.valueholder.Test();
+        test.setId("test-" + workflowType + "-" + methodId);
+        test.setCultureWorkflowType(workflowType);
+        Method method = new Method();
+        method.setId(methodId);
+        test.setMethod(method);
+        Analysis analysis = new Analysis();
+        analysis.setTest(test);
+        return analysis;
+    }
+
+    private MicroCultureSetup cultureSetup(String methodId, MicroWorkflowType workflowType) {
+        MicroCultureSetup setup = new MicroCultureSetup();
+        setup.setMethodId(methodId);
+        setup.setWorkflowType(workflowType.name());
+        return setup;
+    }
+}


### PR DESCRIPTION
## Summary
- routes ordered analyses with Test Catalog microbiology workflow configuration into MicroCase records
- creates one case per SampleItem + workflow and preserves sibling bacteriology/TB workflows
- wires routing into the existing SamplePatientEntryServiceImpl order-entry persistence path after analyses are created/found
- adds lookup DTO/API for opening routed cases by sample item
- adds configuration failure behavior for missing culture method/setup

## Stack
- Parent spec PR: #3782
- Stacked on M2 case core: #3784
- Base branch: feat/782-ogc-782-microbiology-mvp-m2-case-core

## Validation
- mvn -q -Dtest='MicroOrderRoutingServiceTest,MicroOrderRoutingIntegrationTest,MicroOrderRoutingIdempotencyTest,MicroCaseLookupRestControllerTest' test
- mvn spotless:apply
- git diff --check

## Migration hygiene
- No migration added; M3 uses M1 Test Catalog workflow config and M2 case tables only.