### PR TITLE
OGC-782 M4: Microbiology case workbench

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -21,9 +21,6 @@ dotenv.config({ path: new URL("../.env", import.meta.url).pathname });
 // Demo story proof on the build stack (video-ready).
 const CORE_DEMO_TESTS = ["**/demo/core/**/*.spec.ts"];
 
-// Core foundational verification (ci-safe).
-const CORE_FOUNDATIONAL_TESTS = ["**/foundational/core/**/*.spec.ts"];
-
 // Harness demo story proof (video-ready).
 const HARNESS_DEMO_TESTS = ["**/demo/harness/**/*.spec.ts"];
 
@@ -96,7 +93,10 @@ export default defineConfig({
     // Core foundational verification — runs on CI build stack.
     {
       name: "core-app",
-      testMatch: CORE_FOUNDATIONAL_TESTS,
+      testMatch: [
+        "**/foundational/core/**/*.spec.ts",
+        "playwright/tests/foundational/core/microbiology-case-workbench.spec.ts",
+      ],
       use: {
         ...devices["Desktop Chrome"],
         storageState: "playwright/.auth/user.json",

--- a/frontend/playwright/helpers/seed-microbiology-data.ts
+++ b/frontend/playwright/helpers/seed-microbiology-data.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from "child_process";
+import { resolveDbContainer } from "./db-container";
+
+interface SeededMicrobiologyCase {
+  caseId: string;
+  sampleItemId: string;
+  sampleId: string;
+}
+
+function pgLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function psql(sql: string): string {
+  return execFileSync(
+    "docker",
+    [
+      "exec",
+      "-i",
+      resolveDbContainer(),
+      "psql",
+      "-U",
+      "clinlims",
+      "-d",
+      "clinlims",
+      "-At",
+      "-c",
+      sql,
+    ],
+    { encoding: "utf8" },
+  ).trim();
+}
+
+export function seedMicrobiologyCase(): SeededMicrobiologyCase {
+  const suffix = Date.now().toString(36);
+  const caseId = `pw-micro-case-${suffix}`;
+  const activityId = `pw-micro-act-${suffix}`;
+  const accession = `PWMICRO${suffix}`.slice(0, 24);
+  const sql = `
+WITH method_row AS (
+  SELECT id AS method_id FROM clinlims.method ORDER BY id LIMIT 1
+), sample_row AS (
+  INSERT INTO clinlims.sample
+    (id, accession_number, entered_date, received_date, lastupdated, sys_user_id)
+  SELECT nextval('clinlims.sample_seq'), ${pgLiteral(accession)}, CURRENT_DATE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1
+  RETURNING id
+), sample_item_row AS (
+  INSERT INTO clinlims.sample_item (id, samp_id, sort_order, status_id, lastupdated)
+  SELECT nextval('clinlims.sample_item_seq'), sample_row.id, 1, 1, CURRENT_TIMESTAMP
+  FROM sample_row
+  RETURNING id, samp_id
+), case_row AS (
+  INSERT INTO clinlims.micro_case
+    (id, sample_item_id, workflow_type, stage, priority, culture_method_id, created_at, created_by, final_release_state, lastupdated, last_updated)
+  SELECT ${pgLiteral(caseId)}, sample_item_row.id, 'BACTERIOLOGY', 'RECEIVED', 'ROUTINE',
+    method_row.method_id, CURRENT_TIMESTAMP, '1', 'NOT_READY', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+  FROM sample_item_row CROSS JOIN method_row
+  RETURNING id, sample_item_id
+), activity_row AS (
+  INSERT INTO clinlims.micro_case_activity
+    (id, case_id, activity_type, occurred_at, performed_by, note, lastupdated, last_updated)
+  SELECT ${pgLiteral(activityId)}, case_row.id, 'CASE_CREATED', CURRENT_TIMESTAMP, '1', 'Case created', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+  FROM case_row
+)
+SELECT case_row.id || '|' || case_row.sample_item_id || '|' || sample_item_row.samp_id
+FROM case_row JOIN sample_item_row ON case_row.sample_item_id = sample_item_row.id;
+`;
+  const [createdCaseId, sampleItemId, sampleId] = psql(sql).split("|");
+  return { caseId: createdCaseId, sampleItemId, sampleId };
+}
+
+export function cleanupMicrobiologyCase(seeded: SeededMicrobiologyCase): void {
+  const sql = `
+DELETE FROM clinlims.micro_isolate WHERE case_id = ${pgLiteral(seeded.caseId)};
+DELETE FROM clinlims.micro_case_activity WHERE case_id = ${pgLiteral(seeded.caseId)};
+DELETE FROM clinlims.micro_case WHERE id = ${pgLiteral(seeded.caseId)};
+DELETE FROM clinlims.sample_item WHERE id = ${pgLiteral(seeded.sampleItemId)};
+DELETE FROM clinlims.sample WHERE id = ${pgLiteral(seeded.sampleId)};
+`;
+  try {
+    psql(sql);
+  } catch (error) {
+    console.warn(`Microbiology cleanup failed: ${error}`);
+  }
+}

--- a/frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts
+++ b/frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "../../../helpers/test-base";
+import {
+  cleanupMicrobiologyCase,
+  seedMicrobiologyCase,
+} from "../../../helpers/seed-microbiology-data";
+import { LONG_TIMEOUT } from "../../../helpers/timeouts";
+
+test.describe("Microbiology case workbench", () => {
+  test("records setup activity and creates an isolate", async ({ page }) => {
+    const seeded = seedMicrobiologyCase();
+    try {
+      await page.goto(`/MicrobiologyCaseView/${seeded.caseId}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      await expect(
+        page.getByRole("heading", { name: "Microbiology case" }),
+      ).toBeVisible({ timeout: LONG_TIMEOUT });
+      const caseHeader = page.locator("header");
+      await expect(caseHeader.getByText("RECEIVED")).toBeVisible();
+
+      await page.getByLabel("Activity note").fill("setup complete");
+      await page.getByRole("button", { name: "Record activity" }).click();
+      await expect(caseHeader.getByText("SETUP_RECORDED")).toBeVisible({
+        timeout: LONG_TIMEOUT,
+      });
+      await expect(page.getByText(/setup complete/)).toBeVisible();
+
+      await page.getByLabel("Preliminary organism").fill("Escherichia coli");
+      await page.getByRole("button", { name: "Create isolate" }).click();
+      await expect(page.getByText(/ISO-1: Escherichia coli/)).toBeVisible({
+        timeout: LONG_TIMEOUT,
+      });
+      await expect(page.getByText(/ISOLATE_CREATED/)).toBeVisible();
+    } finally {
+      cleanupMicrobiologyCase(seeded);
+    }
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -95,6 +95,9 @@ const AnalyzerTypesPage = lazyWithRetry(
 const AnalyzerFormPage = lazyWithRetry(
   () => import("./components/analyzers/AnalyzerForm/AnalyzerForm"),
 );
+const MicrobiologyPage = lazyWithRetry(
+  () => import("./pages/MicrobiologyPage"),
+);
 const QcRulePage = lazyWithRetry(
   () => import("./components/analyzers/QcRules/QcRuleBuilderModal"),
 );
@@ -540,6 +543,16 @@ export default function App() {
                   component={() => <CytologyCaseView />}
                   role=""
                   labUnitRole={{ Cytology: [Roles.RESULTS] }}
+                />
+                <SecureRoute
+                  path="/MicrobiologyCaseView/:caseId"
+                  exact
+                  component={() => (
+                    <Suspense fallback={null}>
+                      <MicrobiologyPage />
+                    </Suspense>
+                  )}
+                  role=""
                 />
                 <SecureRoute
                   path="/GenericSample/Order"

--- a/frontend/src/components/microbiology/CaseTimelinePanel.jsx
+++ b/frontend/src/components/microbiology/CaseTimelinePanel.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import { Button, Select, SelectItem, Stack, TextArea } from "@carbon/react";
+import { useIntl } from "react-intl";
+
+const STAGE_OPTIONS = [
+  "SETUP_RECORDED",
+  "INCUBATING",
+  "GROWTH_DETECTED",
+  "NO_GROWTH_READY",
+  "REJECTED",
+];
+
+const CaseTimelinePanel = ({ activities = [], onRecordActivity, saving }) => {
+  const intl = useIntl();
+  const [nextStage, setNextStage] = useState("SETUP_RECORDED");
+  const [note, setNote] = useState("");
+
+  const submit = () => {
+    onRecordActivity({ nextStage, note });
+    setNote("");
+  };
+
+  return (
+    <section aria-labelledby="microbiology-timeline-heading">
+      <Stack gap={5}>
+        <h3 id="microbiology-timeline-heading">
+          {intl.formatMessage({ id: "microbiology.case.timeline" })}
+        </h3>
+        <div>
+          {activities.length === 0 ? (
+            <p>
+              {intl.formatMessage({ id: "microbiology.case.timeline.empty" })}
+            </p>
+          ) : (
+            <ol>
+              {activities.map((activity) => (
+                <li
+                  key={
+                    activity.id ||
+                    `${activity.activityType}-${activity.occurredAt}`
+                  }
+                >
+                  <strong>{activity.activityType}</strong>
+                  {activity.note ? `: ${activity.note}` : ""}
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+        <Select
+          id="microbiology-next-stage"
+          labelText={intl.formatMessage({ id: "microbiology.case.nextStage" })}
+          value={nextStage}
+          onChange={(event) => setNextStage(event.target.value)}
+        >
+          {STAGE_OPTIONS.map((stage) => (
+            <SelectItem key={stage} value={stage} text={stage} />
+          ))}
+        </Select>
+        <TextArea
+          id="microbiology-activity-note"
+          labelText={intl.formatMessage({
+            id: "microbiology.case.activityNote",
+          })}
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+        />
+        <Button onClick={submit} disabled={saving}>
+          {intl.formatMessage({ id: "microbiology.case.recordActivity" })}
+        </Button>
+      </Stack>
+    </section>
+  );
+};
+
+export default CaseTimelinePanel;

--- a/frontend/src/components/microbiology/IsolatePanel.jsx
+++ b/frontend/src/components/microbiology/IsolatePanel.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import { Button, Select, SelectItem, Stack, TextInput } from "@carbon/react";
+import { useIntl } from "react-intl";
+
+const SIGNIFICANCE_OPTIONS = [
+  "UNKNOWN",
+  "CLINICALLY_SIGNIFICANT",
+  "CONTAMINANT",
+  "NORMAL_FLORA",
+];
+
+const IsolatePanel = ({ caseId, isolates = [], onCreateIsolate, saving }) => {
+  const intl = useIntl();
+  const [isolateLabel, setIsolateLabel] = useState("ISO-1");
+  const [preliminaryOrganismText, setPreliminaryOrganismText] = useState("");
+  const [significance, setSignificance] = useState("CLINICALLY_SIGNIFICANT");
+
+  const submit = () => {
+    onCreateIsolate({
+      caseId,
+      isolateLabel,
+      preliminaryOrganismText,
+      significance,
+    });
+    setPreliminaryOrganismText("");
+  };
+
+  return (
+    <section aria-labelledby="microbiology-isolates-heading">
+      <Stack gap={5}>
+        <h3 id="microbiology-isolates-heading">
+          {intl.formatMessage({ id: "microbiology.case.isolates" })}
+        </h3>
+        {isolates.length === 0 ? (
+          <p>
+            {intl.formatMessage({ id: "microbiology.case.isolates.empty" })}
+          </p>
+        ) : (
+          <ul>
+            {isolates.map((isolate) => (
+              <li key={isolate.id}>
+                <strong>{isolate.isolateLabel}</strong>
+                {isolate.preliminaryOrganismText
+                  ? `: ${isolate.preliminaryOrganismText}`
+                  : ""}
+              </li>
+            ))}
+          </ul>
+        )}
+        <TextInput
+          id="microbiology-isolate-label"
+          labelText={intl.formatMessage({
+            id: "microbiology.case.isolateLabel",
+          })}
+          value={isolateLabel}
+          onChange={(event) => setIsolateLabel(event.target.value)}
+        />
+        <TextInput
+          id="microbiology-preliminary-organism"
+          labelText={intl.formatMessage({
+            id: "microbiology.case.preliminaryOrganism",
+          })}
+          value={preliminaryOrganismText}
+          onChange={(event) => setPreliminaryOrganismText(event.target.value)}
+        />
+        <Select
+          id="microbiology-isolate-significance"
+          labelText={intl.formatMessage({
+            id: "microbiology.case.significance",
+          })}
+          value={significance}
+          onChange={(event) => setSignificance(event.target.value)}
+        >
+          {SIGNIFICANCE_OPTIONS.map((option) => (
+            <SelectItem key={option} value={option} text={option} />
+          ))}
+        </Select>
+        <Button onClick={submit} disabled={saving || !isolateLabel.trim()}>
+          {intl.formatMessage({ id: "microbiology.case.createIsolate" })}
+        </Button>
+      </Stack>
+    </section>
+  );
+};
+
+export default IsolatePanel;

--- a/frontend/src/components/microbiology/MicrobiologyCaseView.jsx
+++ b/frontend/src/components/microbiology/MicrobiologyCaseView.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from "react";
+import { InlineNotification, Loading, Stack, Tag } from "@carbon/react";
+import { useIntl } from "react-intl";
+import { useParams } from "react-router-dom";
+import CaseTimelinePanel from "./CaseTimelinePanel";
+import IsolatePanel from "./IsolatePanel";
+import MicrobiologyService from "./MicrobiologyService";
+
+const MicrobiologyCaseView = ({
+  caseId: caseIdProp,
+  service = MicrobiologyService,
+}) => {
+  const intl = useIntl();
+  const params = useParams();
+  const caseId = caseIdProp || params.caseId;
+  const [caseDetail, setCaseDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadCase = () => {
+    setLoading(true);
+    service.getCaseDetail(caseId).then((detail) => {
+      if (!detail || detail.status) {
+        setError(intl.formatMessage({ id: "microbiology.case.loadError" }));
+        setCaseDetail(null);
+      } else {
+        setError("");
+        setCaseDetail(detail);
+      }
+      setLoading(false);
+    });
+  };
+
+  useEffect(() => {
+    loadCase();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [caseId]);
+
+  const recordActivity = (payload) => {
+    setSaving(true);
+    service.recordCaseActivity(caseId, payload).then((detail) => {
+      setCaseDetail(detail);
+      setSaving(false);
+    });
+  };
+
+  const createIsolate = (payload) => {
+    setSaving(true);
+    service.createIsolate(payload).then(() => {
+      service.getCaseDetail(caseId).then((detail) => {
+        setCaseDetail(detail);
+        setSaving(false);
+      });
+    });
+  };
+
+  if (loading) {
+    return <Loading withOverlay={false} />;
+  }
+
+  if (error) {
+    return (
+      <InlineNotification
+        kind="error"
+        title={intl.formatMessage({ id: "microbiology.case.error" })}
+        subtitle={error}
+        hideCloseButton
+      />
+    );
+  }
+
+  return (
+    <main data-testid="microbiology-case-view">
+      <Stack gap={7}>
+        <header>
+          <h2>{intl.formatMessage({ id: "microbiology.case.title" })}</h2>
+          <p>
+            {intl.formatMessage({ id: "microbiology.case.sampleItem" })}:{" "}
+            <strong>{caseDetail.sampleItemId}</strong>
+          </p>
+          <p>
+            {intl.formatMessage({ id: "microbiology.case.workflow" })}:{" "}
+            <strong>{caseDetail.workflowType}</strong>
+          </p>
+          <Tag type="blue">{caseDetail.stage}</Tag>
+        </header>
+        <CaseTimelinePanel
+          activities={caseDetail.activities}
+          onRecordActivity={recordActivity}
+          saving={saving}
+        />
+        <IsolatePanel
+          caseId={caseDetail.id}
+          isolates={caseDetail.isolates}
+          onCreateIsolate={createIsolate}
+          saving={saving}
+        />
+      </Stack>
+    </main>
+  );
+};
+
+export default MicrobiologyCaseView;

--- a/frontend/src/components/microbiology/MicrobiologyService.js
+++ b/frontend/src/components/microbiology/MicrobiologyService.js
@@ -1,0 +1,37 @@
+import {
+  getFromOpenElisServer,
+  postToOpenElisServerJsonResponse,
+} from "../utils/Utils";
+
+const DEFAULT_USER_ID = "1";
+
+export const getCaseDetail = (caseId) =>
+  new Promise((resolve) => {
+    getFromOpenElisServer(`/rest/microbiology/cases/${caseId}`, resolve);
+  });
+
+export const recordCaseActivity = (caseId, payload) =>
+  new Promise((resolve) => {
+    postToOpenElisServerJsonResponse(
+      `/rest/microbiology/cases/${caseId}/activities`,
+      JSON.stringify({ performedBy: DEFAULT_USER_ID, ...payload }),
+      resolve,
+    );
+  });
+
+export const createIsolate = (payload) =>
+  new Promise((resolve) => {
+    postToOpenElisServerJsonResponse(
+      "/rest/microbiology/isolates",
+      JSON.stringify({ performedBy: DEFAULT_USER_ID, ...payload }),
+      resolve,
+    );
+  });
+
+const MicrobiologyService = {
+  getCaseDetail,
+  recordCaseActivity,
+  createIsolate,
+};
+
+export default MicrobiologyService;

--- a/frontend/src/components/microbiology/__tests__/IsolatePanel.test.jsx
+++ b/frontend/src/components/microbiology/__tests__/IsolatePanel.test.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import { IntlProvider } from "react-intl";
+import IsolatePanel from "../IsolatePanel";
+import messages from "../../../languages/en.json";
+
+const renderPanel = (onCreateIsolate) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <IsolatePanel
+        caseId="case-1"
+        isolates={[]}
+        onCreateIsolate={onCreateIsolate}
+        saving={false}
+      />
+    </IntlProvider>,
+  );
+
+describe("IsolatePanel", () => {
+  it("submits isolate creation details", async () => {
+    const onCreateIsolate = vi.fn();
+    renderPanel(onCreateIsolate);
+
+    fireEvent.change(screen.getByLabelText("Preliminary organism"), {
+      target: { value: "Escherichia coli" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create isolate" }));
+
+    await waitFor(() =>
+      expect(onCreateIsolate).toHaveBeenCalledWith({
+        caseId: "case-1",
+        isolateLabel: "ISO-1",
+        preliminaryOrganismText: "Escherichia coli",
+        significance: "CLINICALLY_SIGNIFICANT",
+      }),
+    );
+  });
+});

--- a/frontend/src/components/microbiology/__tests__/MicrobiologyCaseView.test.jsx
+++ b/frontend/src/components/microbiology/__tests__/MicrobiologyCaseView.test.jsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import { IntlProvider } from "react-intl";
+import { MemoryRouter } from "react-router-dom";
+import MicrobiologyCaseView from "../MicrobiologyCaseView";
+import messages from "../../../languages/en.json";
+
+const caseDetail = {
+  id: "case-1",
+  sampleItemId: "1001",
+  workflowType: "BACTERIOLOGY",
+  stage: "RECEIVED",
+  activities: [
+    { id: "a1", activityType: "CASE_CREATED", note: "Case created" },
+  ],
+  isolates: [],
+};
+
+const renderCase = (service) =>
+  render(
+    <MemoryRouter>
+      <IntlProvider locale="en" messages={messages}>
+        <MicrobiologyCaseView caseId="case-1" service={service} />
+      </IntlProvider>
+    </MemoryRouter>,
+  );
+
+describe("MicrobiologyCaseView", () => {
+  it("loads case details and records setup activity", async () => {
+    const service = {
+      getCaseDetail: vi.fn().mockResolvedValue(caseDetail),
+      recordCaseActivity: vi.fn().mockResolvedValue({
+        ...caseDetail,
+        stage: "SETUP_RECORDED",
+        activities: [
+          ...caseDetail.activities,
+          { id: "a2", activityType: "STAGE_CHANGED", note: "setup complete" },
+        ],
+      }),
+      createIsolate: vi.fn(),
+    };
+
+    renderCase(service);
+
+    expect(await screen.findByText("Microbiology case")).toBeInTheDocument();
+    expect(screen.getByText("RECEIVED")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Activity note"), {
+      target: { value: "setup complete" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Record activity" }));
+
+    await waitFor(() =>
+      expect(service.recordCaseActivity).toHaveBeenCalledWith("case-1", {
+        nextStage: "SETUP_RECORDED",
+        note: "setup complete",
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getAllByText("SETUP_RECORDED").length).toBeGreaterThan(0),
+    );
+    expect(screen.getByText(/setup complete/)).toBeInTheDocument();
+  });
+
+  it("refreshes the case timeline after creating an isolate", async () => {
+    const refreshedCase = {
+      ...caseDetail,
+      activities: [
+        ...caseDetail.activities,
+        {
+          id: "a2",
+          activityType: "ISOLATE_CREATED",
+          note: "ISO-1 Escherichia coli",
+        },
+      ],
+      isolates: [
+        {
+          id: "iso-1",
+          isolateLabel: "ISO-1",
+          preliminaryOrganismText: "Escherichia coli",
+        },
+      ],
+    };
+    const service = {
+      getCaseDetail: vi
+        .fn()
+        .mockResolvedValueOnce(caseDetail)
+        .mockResolvedValueOnce(refreshedCase),
+      recordCaseActivity: vi.fn(),
+      createIsolate: vi.fn().mockResolvedValue({ id: "iso-1" }),
+    };
+
+    renderCase(service);
+
+    expect(await screen.findByText("Microbiology case")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Preliminary organism"), {
+      target: { value: "Escherichia coli" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create isolate" }));
+
+    await waitFor(() =>
+      expect(service.createIsolate).toHaveBeenCalledWith({
+        caseId: "case-1",
+        isolateLabel: "ISO-1",
+        preliminaryOrganismText: "Escherichia coli",
+        significance: "CLINICALLY_SIGNIFICANT",
+      }),
+    );
+    expect(
+      await screen.findByText(
+        (_, element) =>
+          element?.tagName.toLowerCase() === "li" &&
+          element.textContent === "ISO-1: Escherichia coli",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/ISOLATE_CREATED/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -6084,5 +6084,21 @@
   "orderEntry.labels.source.presetDefault": "Preset default",
   "orderEntry.labels.locked.tooltipFor": "{label} is locked by the test configuration and cannot be changed.",
   "orderEntry.labels.total": "Total labels: {total}",
-  "orderEntry.labels.heading": "LABELS"
+  "orderEntry.labels.heading": "LABELS",
+  "microbiology.case.activityNote": "Activity note",
+  "microbiology.case.createIsolate": "Create isolate",
+  "microbiology.case.error": "Microbiology case error",
+  "microbiology.case.isolateLabel": "Isolate label",
+  "microbiology.case.isolates": "Isolates",
+  "microbiology.case.isolates.empty": "No isolates recorded",
+  "microbiology.case.loadError": "Unable to load microbiology case",
+  "microbiology.case.nextStage": "Next stage",
+  "microbiology.case.preliminaryOrganism": "Preliminary organism",
+  "microbiology.case.recordActivity": "Record activity",
+  "microbiology.case.sampleItem": "Sample item",
+  "microbiology.case.significance": "Significance",
+  "microbiology.case.timeline": "Case timeline",
+  "microbiology.case.timeline.empty": "No case activity recorded",
+  "microbiology.case.title": "Microbiology case",
+  "microbiology.case.workflow": "Workflow"
 }

--- a/frontend/src/pages/MicrobiologyPage.jsx
+++ b/frontend/src/pages/MicrobiologyPage.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import MicrobiologyCaseView from "../components/microbiology/MicrobiologyCaseView";
+
+const MicrobiologyPage = () => <MicrobiologyCaseView />;
+
+export default MicrobiologyPage;

--- a/specs/782-ogc-782-microbiology-mvp-spec/playwright-plan.md
+++ b/specs/782-ogc-782-microbiology-mvp-spec/playwright-plan.md
@@ -1,0 +1,25 @@
+# Playwright Plan: OGC-782 Microbiology MVP
+
+## M4 Case Workbench
+
+- Flow: `microbiology-case-workbench`
+- Route: `/MicrobiologyCaseView/:caseId`
+- Setup: seed one bacteriology `micro_case` with a `sample_item` and initial
+  `CASE_CREATED` activity through test-only Postgres setup.
+- User actions:
+  - open the case workbench,
+  - record setup activity with next stage `SETUP_RECORDED`,
+  - create isolate `ISO-1` with preliminary organism text.
+- Expected outcomes:
+  - case header renders sample item, workflow, and current stage,
+  - visible stage changes to `SETUP_RECORDED`,
+  - timeline shows the setup note,
+  - isolate list shows `ISO-1: Escherichia coli`,
+  - timeline shows the `ISOLATE_CREATED` activity after case refresh.
+- Project: `core-app`
+- Evidence command:
+  `cd frontend && npm run pw:test -- playwright/tests/foundational/core/microbiology-case-workbench.spec.ts --project=core-app`
+- Evidence result: passed locally on 2026-06-27 against the worktree dev stack
+  after rebuilding `target/OpenELIS-Global.war`, recreating the OpenELIS dev
+  containers, and confirming Liquibase had applied the microbiology M1/M2
+  tables.

--- a/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
+++ b/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
@@ -175,7 +175,7 @@ timeline updates.
 - [X] T069 [M4] Run `/audit-playwright frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts` and address findings in `frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts`.
 - [X] T070 [M4] Run narrow Playwright evidence command `cd frontend && npm run pw:test -- playwright/tests/foundational/core/microbiology-case-workbench.spec.ts --project=core-app` and attach screenshot/trace results to the PR.
 - [X] T071 [M4] Run focused backend/frontend validation `mvn -q -Dtest='MicroCaseRestControllerTest,MicroCaseLookupRestControllerTest,MicrobiologyArchitectureTest' test` and `cd frontend && npm test -- MicrobiologyCaseView.test.jsx IsolatePanel.test.jsx` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
-- [ ] T072 [M4] Open draft PR for `feat/782-ogc-782-microbiology-mvp-m4-case-workbench` to the M3 stacked branch with TDD and Playwright evidence and link it from PR #3782.
+- [X] T072 [M4] Open draft PR for `feat/782-ogc-782-microbiology-mvp-m4-case-workbench` to the M3 stacked branch with TDD and Playwright evidence and link it from PR #3782.
 
 ## Phase 5: M5 - Manual AST
 

--- a/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
+++ b/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
@@ -153,29 +153,29 @@ timeline updates.
 
 ### Tests First
 
-- [ ] T053 [M4] Create branch `feat/782-ogc-782-microbiology-mvp-m4-case-workbench` from `develop` after M3 merge in `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
-- [ ] T054 [P] [M4] Run `/plan-record-playwright --flows microbiology-case-workbench` and record the planned route, setup data, assertions, and project target in `specs/782-ogc-782-microbiology-mvp-spec/playwright-plan.md`.
-- [ ] T055 [P] [M4] Add failing MockMvc tests for activity creation and isolate creation in `src/test/java/org/openelisglobal/microbiology/controller/MicroCaseRestControllerTest.java`.
-- [ ] T056 [P] [M4] Add failing React interaction tests for case detail loading and setup event save in `frontend/src/components/microbiology/__tests__/MicrobiologyCaseView.test.jsx`.
-- [ ] T057 [P] [M4] Add failing React interaction tests for isolate creation/update in `frontend/src/components/microbiology/__tests__/IsolatePanel.test.jsx`.
-- [ ] T058 [P] [M4] Use `/write-playwright-test frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts --project core-app` to create a red Playwright test for routed case setup and isolate creation.
+- [X] T053 [M4] Create branch `feat/782-ogc-782-microbiology-mvp-m4-case-workbench` from the M3 stacked branch in `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
+- [X] T054 [P] [M4] Run `/plan-record-playwright --flows microbiology-case-workbench` and record the planned route, setup data, assertions, and project target in `specs/782-ogc-782-microbiology-mvp-spec/playwright-plan.md`.
+- [X] T055 [P] [M4] Add failing MockMvc tests for activity creation and isolate creation in `src/test/java/org/openelisglobal/microbiology/controller/MicroCaseRestControllerTest.java`.
+- [X] T056 [P] [M4] Add failing React interaction tests for case detail loading and setup event save in `frontend/src/components/microbiology/__tests__/MicrobiologyCaseView.test.jsx`.
+- [X] T057 [P] [M4] Add failing React interaction tests for isolate creation/update in `frontend/src/components/microbiology/__tests__/IsolatePanel.test.jsx`.
+- [X] T058 [P] [M4] Use `/write-playwright-test frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts --project core-app` to create a red Playwright test for routed case setup and isolate creation.
 
 ### Implementation
 
-- [ ] T059 [M4] Add activity mutation endpoints in `src/main/java/org/openelisglobal/microbiology/controller/rest/MicroCaseRestController.java`.
-- [ ] T060 [M4] Add isolate mutation endpoints in `src/main/java/org/openelisglobal/microbiology/controller/rest/MicroIsolateRestController.java`.
-- [ ] T061 [P] [M4] Add frontend API client functions in `frontend/src/components/microbiology/MicrobiologyService.js`.
-- [ ] T062 [P] [M4] Add case page route in `frontend/src/pages/MicrobiologyPage.jsx` and `frontend/src/App.jsx`.
-- [ ] T063 [M4] Add case view shell and context header in `frontend/src/components/microbiology/MicrobiologyCaseView.jsx`.
-- [ ] T064 [M4] Add timeline and setup activity panel in `frontend/src/components/microbiology/CaseTimelinePanel.jsx`.
-- [ ] T065 [M4] Add isolate panel in `frontend/src/components/microbiology/IsolatePanel.jsx`.
-- [ ] T066 [P] [M4] Add React Intl keys for case workbench UI in `frontend/src/languages/en.json`.
-- [ ] T067 [M4] Register `frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts` in `frontend/playwright.config.ts`.
-- [ ] T068 [M4] Run Playwright registration validation `python3 .ai/skills/playwright/scripts/validate-playwright-project.py frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
-- [ ] T069 [M4] Run `/audit-playwright frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts` and address findings in `frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts`.
-- [ ] T070 [M4] Run narrow Playwright evidence command `cd frontend && npm run pw:test -- playwright/tests/foundational/core/microbiology-case-workbench.spec.ts --project=core-app` and attach screenshot/trace results to the PR.
-- [ ] T071 [M4] Run focused backend/frontend validation `mvn -q -Dtest='MicroCaseRestControllerTest' test && cd frontend && npm test -- --runInBand MicrobiologyCaseView.test.jsx IsolatePanel.test.jsx` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
-- [ ] T072 [M4] Open draft PR for `feat/782-ogc-782-microbiology-mvp-m4-case-workbench` to `develop` with TDD and Playwright evidence and link it from PR #3782.
+- [X] T059 [M4] Add activity mutation endpoints in `src/main/java/org/openelisglobal/microbiology/controller/rest/MicroCaseRestController.java`.
+- [X] T060 [M4] Add isolate mutation endpoints in `src/main/java/org/openelisglobal/microbiology/controller/rest/MicroIsolateRestController.java`.
+- [X] T061 [P] [M4] Add frontend API client functions in `frontend/src/components/microbiology/MicrobiologyService.js`.
+- [X] T062 [P] [M4] Add case page route in `frontend/src/pages/MicrobiologyPage.jsx` and `frontend/src/App.jsx`.
+- [X] T063 [M4] Add case view shell and context header in `frontend/src/components/microbiology/MicrobiologyCaseView.jsx`.
+- [X] T064 [M4] Add timeline and setup activity panel in `frontend/src/components/microbiology/CaseTimelinePanel.jsx`.
+- [X] T065 [M4] Add isolate panel in `frontend/src/components/microbiology/IsolatePanel.jsx`.
+- [X] T066 [P] [M4] Add React Intl keys for case workbench UI in `frontend/src/languages/en.json`.
+- [X] T067 [M4] Register `frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts` in `frontend/playwright.config.ts`.
+- [X] T068 [M4] Run Playwright registration validation `python3 .ai/skills/playwright/scripts/validate-playwright-project.py playwright/tests/foundational/core/microbiology-case-workbench.spec.ts` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
+- [X] T069 [M4] Run `/audit-playwright frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts` and address findings in `frontend/playwright/tests/foundational/core/microbiology-case-workbench.spec.ts`.
+- [X] T070 [M4] Run narrow Playwright evidence command `cd frontend && npm run pw:test -- playwright/tests/foundational/core/microbiology-case-workbench.spec.ts --project=core-app` and attach screenshot/trace results to the PR.
+- [X] T071 [M4] Run focused backend/frontend validation `mvn -q -Dtest='MicroCaseRestControllerTest,MicroCaseLookupRestControllerTest,MicrobiologyArchitectureTest' test` and `cd frontend && npm test -- MicrobiologyCaseView.test.jsx IsolatePanel.test.jsx` from `/Users/pmanko/.codex/worktrees/1c9d/OpenELIS-Global-2`.
+- [ ] T072 [M4] Open draft PR for `feat/782-ogc-782-microbiology-mvp-m4-case-workbench` to the M3 stacked branch with TDD and Playwright evidence and link it from PR #3782.
 
 ## Phase 5: M5 - Manual AST
 

--- a/src/main/java/org/openelisglobal/microbiology/controller/rest/MicroCaseRestController.java
+++ b/src/main/java/org/openelisglobal/microbiology/controller/rest/MicroCaseRestController.java
@@ -3,15 +3,20 @@ package org.openelisglobal.microbiology.controller.rest;
 import java.util.ArrayList;
 import java.util.List;
 import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.microbiology.form.MicroCaseActivityRequestForm;
 import org.openelisglobal.microbiology.form.MicroCaseDetailForm;
 import org.openelisglobal.microbiology.form.MicroCaseLookupForm;
 import org.openelisglobal.microbiology.service.MicroCaseService;
+import org.openelisglobal.microbiology.service.MicroCaseStateService;
 import org.openelisglobal.microbiology.valueholder.MicroCase;
+import org.openelisglobal.microbiology.valueholder.MicroCaseStage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,9 +26,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MicroCaseRestController extends BaseRestController {
 
     private final MicroCaseService caseService;
+    private final MicroCaseStateService stateService;
 
-    public MicroCaseRestController(MicroCaseService caseService) {
+    public MicroCaseRestController(MicroCaseService caseService, MicroCaseStateService stateService) {
         this.caseService = caseService;
+        this.stateService = stateService;
     }
 
     @GetMapping("/{caseId}")
@@ -44,6 +51,14 @@ public class MicroCaseRestController extends BaseRestController {
             rows.add(toLookupForm(microCase));
         }
         return ResponseEntity.ok(rows);
+    }
+
+    @PostMapping("/{caseId}/activities")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<MicroCaseDetailForm> recordActivity(@PathVariable String caseId,
+            @RequestBody MicroCaseActivityRequestForm request) {
+        stateService.advanceStage(caseId, MicroCaseStage.valueOf(request.nextStage), request.performedBy, request.note);
+        return ResponseEntity.ok(caseService.getCaseDetail(caseId));
     }
 
     private MicroCaseLookupForm toLookupForm(MicroCase microCase) {

--- a/src/main/java/org/openelisglobal/microbiology/controller/rest/MicroIsolateRestController.java
+++ b/src/main/java/org/openelisglobal/microbiology/controller/rest/MicroIsolateRestController.java
@@ -1,0 +1,73 @@
+package org.openelisglobal.microbiology.controller.rest;
+
+import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.microbiology.form.MicroIsolateForm;
+import org.openelisglobal.microbiology.form.MicroIsolateRequestForm;
+import org.openelisglobal.microbiology.service.MicroIsolateService;
+import org.openelisglobal.microbiology.valueholder.MicroIsolate;
+import org.openelisglobal.microbiology.valueholder.MicroIsolateIdentificationStatus;
+import org.openelisglobal.microbiology.valueholder.MicroIsolateSignificance;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rest/microbiology/isolates")
+public class MicroIsolateRestController extends BaseRestController {
+
+    private final MicroIsolateService isolateService;
+
+    public MicroIsolateRestController(MicroIsolateService isolateService) {
+        this.isolateService = isolateService;
+    }
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<MicroIsolateForm> createIsolate(@RequestBody MicroIsolateRequestForm request) {
+        MicroIsolate isolate = isolateService.createIsolate(request.caseId, request.isolateLabel, request.organismId,
+                request.preliminaryOrganismText, significance(request.significance), request.performedBy);
+        return ResponseEntity.ok(toForm(isolate));
+    }
+
+    @PutMapping("/{isolateId}/identification")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<MicroIsolateForm> updateIdentification(@PathVariable String isolateId,
+            @RequestBody MicroIsolateRequestForm request) {
+        MicroIsolate isolate = isolateService.updateIdentification(isolateId, request.organismId,
+                request.preliminaryOrganismText, significance(request.significance),
+                identificationStatus(request.identificationStatus), request.performedBy);
+        return ResponseEntity.ok(toForm(isolate));
+    }
+
+    private MicroIsolateSignificance significance(String significance) {
+        if (significance == null || significance.trim().isEmpty()) {
+            return MicroIsolateSignificance.UNKNOWN;
+        }
+        return MicroIsolateSignificance.valueOf(significance);
+    }
+
+    private MicroIsolateIdentificationStatus identificationStatus(String identificationStatus) {
+        if (identificationStatus == null || identificationStatus.trim().isEmpty()) {
+            return MicroIsolateIdentificationStatus.PRELIMINARY;
+        }
+        return MicroIsolateIdentificationStatus.valueOf(identificationStatus);
+    }
+
+    private MicroIsolateForm toForm(MicroIsolate isolate) {
+        MicroIsolateForm form = new MicroIsolateForm();
+        form.id = isolate.getId();
+        form.caseId = isolate.getCaseId();
+        form.isolateLabel = isolate.getIsolateLabel();
+        form.organismId = isolate.getOrganismId();
+        form.preliminaryOrganismText = isolate.getPreliminaryOrganismText();
+        form.significance = isolate.getSignificance();
+        form.identificationStatus = isolate.getIdentificationStatus();
+        form.createdAt = isolate.getCreatedAt();
+        return form;
+    }
+}

--- a/src/main/java/org/openelisglobal/microbiology/form/MicroCaseActivityRequestForm.java
+++ b/src/main/java/org/openelisglobal/microbiology/form/MicroCaseActivityRequestForm.java
@@ -1,0 +1,7 @@
+package org.openelisglobal.microbiology.form;
+
+public class MicroCaseActivityRequestForm {
+    public String nextStage;
+    public String note;
+    public String performedBy;
+}

--- a/src/main/java/org/openelisglobal/microbiology/form/MicroIsolateRequestForm.java
+++ b/src/main/java/org/openelisglobal/microbiology/form/MicroIsolateRequestForm.java
@@ -1,0 +1,12 @@
+package org.openelisglobal.microbiology.form;
+
+public class MicroIsolateRequestForm {
+    public String caseId;
+    public String isolateLabel;
+    public String isolateId;
+    public String organismId;
+    public String preliminaryOrganismText;
+    public String significance;
+    public String identificationStatus;
+    public String performedBy;
+}

--- a/src/test/java/org/openelisglobal/microbiology/MicrobiologyArchitectureTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/MicrobiologyArchitectureTest.java
@@ -5,15 +5,19 @@ import static org.junit.Assert.assertFalse;
 import java.lang.reflect.Method;
 import org.junit.Test;
 import org.openelisglobal.microbiology.controller.rest.MicroCaseRestController;
+import org.openelisglobal.microbiology.controller.rest.MicroIsolateRestController;
 import org.springframework.transaction.annotation.Transactional;
 
 public class MicrobiologyArchitectureTest {
 
     @Test
     public void microbiologyControllersDoNotDeclareTransactions() {
-        assertFalse(MicroCaseRestController.class.isAnnotationPresent(Transactional.class));
-        for (Method method : MicroCaseRestController.class.getDeclaredMethods()) {
-            assertFalse(method.isAnnotationPresent(Transactional.class));
+        Class<?>[] controllers = { MicroCaseRestController.class, MicroIsolateRestController.class };
+        for (Class<?> controller : controllers) {
+            assertFalse(controller.isAnnotationPresent(Transactional.class));
+            for (Method method : controller.getDeclaredMethods()) {
+                assertFalse(method.isAnnotationPresent(Transactional.class));
+            }
         }
     }
 }

--- a/src/test/java/org/openelisglobal/microbiology/controller/MicroCaseLookupRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/controller/MicroCaseLookupRestControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.openelisglobal.microbiology.controller.rest.MicroCaseRestController;
 import org.openelisglobal.microbiology.form.MicroCaseLookupForm;
 import org.openelisglobal.microbiology.service.MicroCaseService;
+import org.openelisglobal.microbiology.service.MicroCaseStateService;
 import org.openelisglobal.microbiology.valueholder.MicroCase;
 import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
 import org.springframework.http.ResponseEntity;
@@ -21,8 +22,8 @@ public class MicroCaseLookupRestControllerTest {
         MicroCase tb = caseRow("case-2", MicroWorkflowType.MYCOBACTERIOLOGY_TB);
         when(service.getSiblingCases("1001")).thenReturn(List.of(bacteriology, tb));
 
-        ResponseEntity<List<MicroCaseLookupForm>> response = new MicroCaseRestController(service)
-                .getCasesForSampleItem("1001");
+        ResponseEntity<List<MicroCaseLookupForm>> response = new MicroCaseRestController(service,
+                org.mockito.Mockito.mock(MicroCaseStateService.class)).getCasesForSampleItem("1001");
 
         assertEquals(200, response.getStatusCode().value());
         assertEquals(2, response.getBody().size());

--- a/src/test/java/org/openelisglobal/microbiology/controller/MicroCaseRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/controller/MicroCaseRestControllerTest.java
@@ -1,13 +1,23 @@
 package org.openelisglobal.microbiology.controller;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.openelisglobal.microbiology.controller.rest.MicroCaseRestController;
+import org.openelisglobal.microbiology.controller.rest.MicroIsolateRestController;
+import org.openelisglobal.microbiology.form.MicroCaseActivityRequestForm;
 import org.openelisglobal.microbiology.form.MicroCaseDetailForm;
+import org.openelisglobal.microbiology.form.MicroIsolateForm;
+import org.openelisglobal.microbiology.form.MicroIsolateRequestForm;
 import org.openelisglobal.microbiology.service.MicroCaseService;
+import org.openelisglobal.microbiology.service.MicroCaseStateService;
+import org.openelisglobal.microbiology.service.MicroIsolateService;
+import org.openelisglobal.microbiology.valueholder.MicroCase;
 import org.openelisglobal.microbiology.valueholder.MicroCaseStage;
+import org.openelisglobal.microbiology.valueholder.MicroIsolate;
+import org.openelisglobal.microbiology.valueholder.MicroIsolateSignificance;
 import org.springframework.http.ResponseEntity;
 
 public class MicroCaseRestControllerTest {
@@ -20,7 +30,8 @@ public class MicroCaseRestControllerTest {
         detail.stage = MicroCaseStage.RECEIVED.name();
         when(service.getCaseDetail("case-1")).thenReturn(detail);
 
-        ResponseEntity<MicroCaseDetailForm> response = new MicroCaseRestController(service).getCaseDetail("case-1");
+        ResponseEntity<MicroCaseDetailForm> response = new MicroCaseRestController(service,
+                org.mockito.Mockito.mock(MicroCaseStateService.class)).getCaseDetail("case-1");
 
         assertEquals(200, response.getStatusCode().value());
         assertEquals("case-1", response.getBody().id);
@@ -31,8 +42,60 @@ public class MicroCaseRestControllerTest {
     public void getCaseDetailReturns404WhenMissing() {
         MicroCaseService service = org.mockito.Mockito.mock(MicroCaseService.class);
 
-        ResponseEntity<MicroCaseDetailForm> response = new MicroCaseRestController(service).getCaseDetail("missing");
+        ResponseEntity<MicroCaseDetailForm> response = new MicroCaseRestController(service,
+                org.mockito.Mockito.mock(MicroCaseStateService.class)).getCaseDetail("missing");
 
         assertEquals(404, response.getStatusCode().value());
+    }
+
+    @Test
+    public void recordActivityAdvancesCaseStageAndReturnsUpdatedCaseDetail() {
+        MicroCaseService caseService = org.mockito.Mockito.mock(MicroCaseService.class);
+        MicroCaseStateService stateService = org.mockito.Mockito.mock(MicroCaseStateService.class);
+        MicroCase updated = new MicroCase();
+        updated.setId("case-1");
+        updated.setStage(MicroCaseStage.SETUP_RECORDED.name());
+        MicroCaseDetailForm detail = new MicroCaseDetailForm();
+        detail.id = "case-1";
+        detail.stage = MicroCaseStage.SETUP_RECORDED.name();
+        when(stateService.advanceStage(eq("case-1"), eq(MicroCaseStage.SETUP_RECORDED), eq("1"), eq("setup complete")))
+                .thenReturn(updated);
+        when(caseService.getCaseDetail("case-1")).thenReturn(detail);
+        MicroCaseActivityRequestForm request = new MicroCaseActivityRequestForm();
+        request.nextStage = MicroCaseStage.SETUP_RECORDED.name();
+        request.note = "setup complete";
+        request.performedBy = "1";
+
+        ResponseEntity<MicroCaseDetailForm> response = new MicroCaseRestController(caseService, stateService)
+                .recordActivity("case-1", request);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(MicroCaseStage.SETUP_RECORDED.name(), response.getBody().stage);
+    }
+
+    @Test
+    public void createIsolateReturnsIsolateDto() {
+        MicroIsolateService isolateService = org.mockito.Mockito.mock(MicroIsolateService.class);
+        MicroIsolate isolate = new MicroIsolate();
+        isolate.setId("iso-1");
+        isolate.setCaseId("case-1");
+        isolate.setIsolateLabel("ISO-1");
+        isolate.setPreliminaryOrganismText("Escherichia coli");
+        isolate.setSignificance(MicroIsolateSignificance.CLINICALLY_SIGNIFICANT.name());
+        when(isolateService.createIsolate(eq("case-1"), eq("ISO-1"), eq(null), eq("Escherichia coli"),
+                eq(MicroIsolateSignificance.CLINICALLY_SIGNIFICANT), eq("1"))).thenReturn(isolate);
+        MicroIsolateRequestForm request = new MicroIsolateRequestForm();
+        request.caseId = "case-1";
+        request.isolateLabel = "ISO-1";
+        request.preliminaryOrganismText = "Escherichia coli";
+        request.significance = MicroIsolateSignificance.CLINICALLY_SIGNIFICANT.name();
+        request.performedBy = "1";
+
+        ResponseEntity<MicroIsolateForm> response = new MicroIsolateRestController(isolateService)
+                .createIsolate(request);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("iso-1", response.getBody().id);
+        assertEquals("ISO-1", response.getBody().isolateLabel);
     }
 }


### PR DESCRIPTION
## Summary
- adds microbiology case workbench REST mutations for case activities and isolate creation/update
- adds React case workbench route with timeline and isolate panels
- adds seeded Playwright coverage for setup activity, isolate creation, and visible timeline refresh

## Validation
- mvn -q -Dtest='MicroCaseRestControllerTest,MicroCaseLookupRestControllerTest,MicrobiologyArchitectureTest' test
- cd frontend && npm test -- MicrobiologyCaseView.test.jsx IsolatePanel.test.jsx
- python3 .ai/skills/playwright/scripts/validate-playwright-project.py playwright/tests/foundational/core/microbiology-case-workbench.spec.ts
- cd frontend && npm run pw:test -- playwright/tests/foundational/core/microbiology-case-workbench.spec.ts --project=core-app

## Evidence Notes
- Playwright passed locally on 2026-06-27 after rebuilding target/OpenELIS-Global.war and running this worktree's dev stack so Liquibase applied the M1/M2 microbiology schema.
- Existing global console noise remains from unrelated missing analyzer/menu translations during auth/navigation; the M4 flow itself passed.

Stacked under parent spec PR #3782 and M3 PR #3785.