### PR TITLE
feat: Implement Compliance Report Archiving and LHU Amendment Services

### DIFF
--- a/frontend/src/components/compliance/EnvironmentalDashboard.jsx
+++ b/frontend/src/components/compliance/EnvironmentalDashboard.jsx
@@ -373,6 +373,10 @@ export default function EnvironmentalDashboard() {
             titleText={intl.formatMessage({
               id: "compliance.dashboard.filter.sites",
             })}
+            label={intl.formatMessage({
+              id: "compliance.dashboard.filter.sites.placeholder",
+              defaultMessage: "All sites",
+            })}
             items={sites}
             itemToString={(s) => (s ? s.name : "")}
             onChange={({ selectedItems }) =>

--- a/frontend/src/components/order/api/sampleTypeRequestApi.js
+++ b/frontend/src/components/order/api/sampleTypeRequestApi.js
@@ -101,7 +101,7 @@ export const createRequestsForSamples = async (sampleId, sampleTypes) => {
       sampleId: sampleId,
       typeOfSampleId: sample.sampleTypeId,
       sortOrder: i,
-      requestedQuantity: parseFloat(sample.quantity) || 1,
+      requestedQuantity: parseFloat(sample.quantity) || null,
       unitOfMeasureId: sample.quantityUnit || null,
       requestedTests: sample.tests?.map((t) => t.id || t).join(",") || "",
       requestedPanels: sample.panels?.map((p) => p.id || p).join(",") || "",
@@ -162,7 +162,6 @@ export const cancelRequest = (requestId) => {
  */
 export const convertRequestsToSamples = (pendingRequests) => {
   if (!pendingRequests || !Array.isArray(pendingRequests)) {
-    console.error("convertRequestsToSamples: invalid input", pendingRequests);
     return [];
   }
 

--- a/frontend/src/components/order/steps/sections/SampleCollectionCard.jsx
+++ b/frontend/src/components/order/steps/sections/SampleCollectionCard.jsx
@@ -226,19 +226,19 @@ const SampleCollectionCard = ({
 
         {/* Quantity */}
         <Column lg={4} md={4} sm={2}>
-          <NumberInput
+          <TextInput
             id={`quantity-${sampleIndex}`}
-            label={intl.formatMessage({
+            labelText={intl.formatMessage({
               id: "collect.sample.quantity",
               defaultMessage: "Quantity",
             })}
-            value={sample.quantity || ""}
-            onChange={(e, { value }) => handleFieldChange("quantity", value)}
+            type="number"
+            min="0"
+            step="0.5"
+            value={sample.quantity ?? ""}
+            onChange={(e) => handleFieldChange("quantity", e.target.value)}
             onWheel={(e) => e.target.blur()}
-            min={0}
-            step={0.5}
             disabled={isReadOnly}
-            hideSteppers
           />
         </Column>
 
@@ -286,7 +286,7 @@ const SampleCollectionCard = ({
         <Column lg={4} md={4} sm={4}>
           <DatePicker
             datePickerType="single"
-            maxDate={new Date().toISOString()}
+            maxDate={new Date()}
             value={formatDateForPicker(sample.collectionDate)}
             onChange={(dates) => {
               if (dates && dates[0]) {
@@ -390,7 +390,7 @@ const SampleCollectionCard = ({
           <Column lg={4} md={4} sm={4}>
             <DatePicker
               datePickerType="single"
-              maxDate={new Date().toISOString()}
+              maxDate={new Date()}
               onChange={(dates) => {
                 if (dates && dates[0]) {
                   const month = String(dates[0].getMonth() + 1).padStart(

--- a/frontend/src/components/reports/compliance/LaporanHasilReport.jsx
+++ b/frontend/src/components/reports/compliance/LaporanHasilReport.jsx
@@ -25,6 +25,9 @@ import {
   StructuredListCell,
   Loading,
   InlineNotification,
+  Modal,
+  TextArea,
+  InlineLoading,
 } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../../utils/Utils";
@@ -83,6 +86,16 @@ export default function LaporanHasilReport() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [generatingPdf, setGeneratingPdf] = useState(null);
+
+  // Amendment modal state
+  const [amendmentModal, setAmendmentModal] = useState({
+    open: false,
+    sampleId: null,
+    labNumber: null,
+    reason: "",
+    submitting: false,
+    error: null,
+  });
 
   // { COMPLIANT: "Compliant", NON_COMPLIANT: "Non-Compliant", BORDERLINE: "Borderline" }
   const [statusLabels, setStatusLabels] = useState({});
@@ -165,28 +178,117 @@ export default function LaporanHasilReport() {
     (sampleId, labNumber) => {
       setGeneratingPdf(sampleId);
       const safeLabel = labNumber.replace(/[^a-zA-Z0-9-]/g, "");
-      window.open(
+      fetch(
         `${config.serverBaseUrl}/rest/complianceReport/exportPdf?sampleId=${sampleId}`,
-        "_blank",
-      );
-      // Update the row immediately in local state — no need to re-fetch the
-      // whole list just to show the generated timestamp.
-      const now = new Date().toLocaleString();
-      setReportData((prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          generatedCount: prev.generatedCount + 1,
-          notYetGeneratedCount: Math.max(0, prev.notYetGeneratedCount - 1),
-          orders: prev.orders.map((o) =>
-            o.sampleId === sampleId ? { ...o, lastGenerated: now } : o,
-          ),
-        };
-      });
-      setGeneratingPdf(null);
+        {
+          credentials: "include",
+          headers: { "X-CSRF-Token": localStorage.getItem("CSRF") },
+        },
+      )
+        .then((res) => {
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          return res.blob();
+        })
+        .then((blob) => {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = `LH-${safeLabel}.pdf`;
+          a.click();
+          URL.revokeObjectURL(url);
+          const now = new Date().toLocaleString();
+          setReportData((prev) => {
+            if (!prev) return prev;
+            return {
+              ...prev,
+              generatedCount: prev.generatedCount + 1,
+              notYetGeneratedCount: Math.max(0, prev.notYetGeneratedCount - 1),
+              orders: prev.orders.map((o) =>
+                o.sampleId === sampleId ? { ...o, lastGenerated: now } : o,
+              ),
+            };
+          });
+        })
+        .catch((err) => {
+          setError(
+            intl.formatMessage(
+              { id: "laporanHasil.error.pdf", defaultMessage: "Failed to download PDF: {msg}" },
+              { msg: err.message },
+            ),
+          );
+        })
+        .finally(() => setGeneratingPdf(null));
     },
-    [],
+    [intl],
   );
+
+  const openAmendmentModal = useCallback((sampleId, labNumber) => {
+    setAmendmentModal({
+      open: true,
+      sampleId,
+      labNumber,
+      reason: "",
+      submitting: false,
+      error: null,
+    });
+  }, []);
+
+  const closeAmendmentModal = useCallback(() => {
+    setAmendmentModal((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  const handleReissue = useCallback(() => {
+    const { sampleId, reason } = amendmentModal;
+    if (!reason || !reason.trim()) return;
+
+    setAmendmentModal((prev) => ({ ...prev, submitting: true, error: null }));
+
+    fetch(`${config.serverBaseUrl}/rest/complianceReport/reissue`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": localStorage.getItem("CSRF"),
+      },
+      credentials: "include",
+      body: JSON.stringify({ sampleId, reason: reason.trim() }),
+    })
+      .then((res) => {
+        if (!res.ok) {
+          return res.text().then((msg) => {
+            throw new Error(msg || intl.formatMessage({ id: "lhu.amendment.error.generic" }));
+          });
+        }
+        return res.blob();
+      })
+      .then((blob) => {
+        // Trigger PDF download
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `LH-${amendmentModal.labNumber}-amendment.pdf`;
+        a.click();
+        URL.revokeObjectURL(url);
+
+        const now = new Date().toLocaleString();
+        setReportData((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            orders: prev.orders.map((o) =>
+              o.sampleId === sampleId ? { ...o, lastGenerated: now } : o,
+            ),
+          };
+        });
+        setAmendmentModal((prev) => ({ ...prev, open: false, submitting: false }));
+      })
+      .catch((err) => {
+        setAmendmentModal((prev) => ({
+          ...prev,
+          submitting: false,
+          error: err.message,
+        }));
+      });
+  }, [amendmentModal, intl]);
 
   const tableRows = reportData?.orders?.map((order) => ({
     id: String(order.sampleId),
@@ -404,6 +506,7 @@ export default function LaporanHasilReport() {
                             if (cell.info.header === "actions") {
                               const isIneligible =
                                 order?.complianceStatus === "INELIGIBLE";
+                              const hasBeenReleased = !!order?.lastGenerated;
                               return (
                                 <TableCell key={cell.id}>
                                   {isIneligible ? (
@@ -413,6 +516,16 @@ export default function LaporanHasilReport() {
                                         defaultMessage="No standard linked"
                                       />
                                     </span>
+                                  ) : hasBeenReleased ? (
+                                    <Button
+                                      size="sm"
+                                      kind="tertiary"
+                                      onClick={() =>
+                                        openAmendmentModal(cell.value, order?.labNumber)
+                                      }
+                                    >
+                                      <FormattedMessage id="lhu.amendment.reissue" />
+                                    </Button>
                                   ) : (
                                     <Button
                                       size="sm"
@@ -454,6 +567,52 @@ export default function LaporanHasilReport() {
           <FormattedMessage id="laporanHasil.empty" />
         </p>
       )}
+
+      <Modal
+        open={amendmentModal.open}
+        modalHeading={intl.formatMessage({ id: "lhu.amendment.modal.heading" })}
+        primaryButtonText={
+          amendmentModal.submitting ? (
+            <InlineLoading description={intl.formatMessage({ id: "lhu.amendment.submitting" })} />
+          ) : (
+            intl.formatMessage({ id: "lhu.amendment.modal.submit" })
+          )
+        }
+        secondaryButtonText={intl.formatMessage({ id: "label.button.cancel", defaultMessage: "Cancel" })}
+        primaryButtonDisabled={
+          !amendmentModal.reason?.trim() || amendmentModal.submitting
+        }
+        onRequestSubmit={handleReissue}
+        onRequestClose={closeAmendmentModal}
+        onSecondarySubmit={closeAmendmentModal}
+      >
+        <p style={{ marginBottom: "1rem" }}>
+          <FormattedMessage
+            id="lhu.amendment.modal.description"
+            values={{ labNumber: amendmentModal.labNumber }}
+          />
+        </p>
+        <TextArea
+          id="amendment-reason"
+          labelText={intl.formatMessage({ id: "lhu.amendment.reason.label" })}
+          helperText={intl.formatMessage({ id: "lhu.amendment.reason.helper" })}
+          placeholder={intl.formatMessage({ id: "lhu.amendment.reason.placeholder" })}
+          value={amendmentModal.reason}
+          onChange={(e) =>
+            setAmendmentModal((prev) => ({ ...prev, reason: e.target.value }))
+          }
+          invalid={amendmentModal.reason !== undefined && amendmentModal.reason.trim() === "" && amendmentModal.open}
+          invalidText={intl.formatMessage({ id: "lhu.amendment.reason.required" })}
+          rows={4}
+        />
+        {amendmentModal.error && (
+          <InlineNotification
+            kind="error"
+            title={amendmentModal.error}
+            style={{ marginTop: "1rem" }}
+          />
+        )}
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/components/reports/compliance/LaporanHasilReport.jsx
+++ b/frontend/src/components/reports/compliance/LaporanHasilReport.jsx
@@ -30,8 +30,11 @@ import {
   InlineLoading,
 } from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { getFromOpenElisServer } from "../../utils/Utils";
-import config from "../../../config.json";
+import {
+  getFromOpenElisServer,
+  getFromOpenElisServerForBlob,
+  postToOpenElisServerForBlob,
+} from "../../utils/Utils";
 
 const STATUS_TAG_TYPE = {
   COMPLIANT: "green",
@@ -178,18 +181,9 @@ export default function LaporanHasilReport() {
     (sampleId, labNumber) => {
       setGeneratingPdf(sampleId);
       const safeLabel = labNumber.replace(/[^a-zA-Z0-9-]/g, "");
-      fetch(
-        `${config.serverBaseUrl}/rest/complianceReport/exportPdf?sampleId=${sampleId}`,
-        {
-          credentials: "include",
-          headers: { "X-CSRF-Token": localStorage.getItem("CSRF") },
-        },
-      )
-        .then((res) => {
-          if (!res.ok) throw new Error("HTTP " + res.status);
-          return res.blob();
-        })
-        .then((blob) => {
+      getFromOpenElisServerForBlob(
+        `/rest/complianceReport/exportPdf?sampleId=${sampleId}`,
+        (blob) => {
           const url = URL.createObjectURL(blob);
           const a = document.createElement("a");
           a.href = url;
@@ -208,16 +202,18 @@ export default function LaporanHasilReport() {
               ),
             };
           });
-        })
-        .catch((err) => {
+          setGeneratingPdf(null);
+        },
+        (err) => {
           setError(
             intl.formatMessage(
               { id: "laporanHasil.error.pdf", defaultMessage: "Failed to download PDF: {msg}" },
               { msg: err.message },
             ),
           );
-        })
-        .finally(() => setGeneratingPdf(null));
+          setGeneratingPdf(null);
+        },
+      );
     },
     [intl],
   );
@@ -243,25 +239,10 @@ export default function LaporanHasilReport() {
 
     setAmendmentModal((prev) => ({ ...prev, submitting: true, error: null }));
 
-    fetch(`${config.serverBaseUrl}/rest/complianceReport/reissue`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-CSRF-Token": localStorage.getItem("CSRF"),
-      },
-      credentials: "include",
-      body: JSON.stringify({ sampleId, reason: reason.trim() }),
-    })
-      .then((res) => {
-        if (!res.ok) {
-          return res.text().then((msg) => {
-            throw new Error(msg || intl.formatMessage({ id: "lhu.amendment.error.generic" }));
-          });
-        }
-        return res.blob();
-      })
-      .then((blob) => {
-        // Trigger PDF download
+    postToOpenElisServerForBlob(
+      `/rest/complianceReport/reissue`,
+      JSON.stringify({ sampleId, reason: reason.trim() }),
+      (blob) => {
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;
@@ -280,14 +261,15 @@ export default function LaporanHasilReport() {
           };
         });
         setAmendmentModal((prev) => ({ ...prev, open: false, submitting: false }));
-      })
-      .catch((err) => {
+      },
+      (err) => {
         setAmendmentModal((prev) => ({
           ...prev,
           submitting: false,
           error: err.message,
         }));
-      });
+      },
+    );
   }, [amendmentModal, intl]);
 
   const tableRows = reportData?.orders?.map((order) => ({
@@ -506,7 +488,7 @@ export default function LaporanHasilReport() {
                             if (cell.info.header === "actions") {
                               const isIneligible =
                                 order?.complianceStatus === "INELIGIBLE";
-                              const hasBeenReleased = !!order?.lastGenerated;
+                              const hasBeenReleased = !!order?.hasBeenReleased;
                               return (
                                 <TableCell key={cell.id}>
                                   {isIneligible ? (

--- a/frontend/src/components/reports/compliance/__tests__/LaporanHasilReport.test.jsx
+++ b/frontend/src/components/reports/compliance/__tests__/LaporanHasilReport.test.jsx
@@ -67,6 +67,7 @@ const MOCK_REPORT = {
       testCount: 4,
       complianceStatus: "COMPLIANT",
       lastGenerated: "2026-04-05T10:30:00",
+      hasBeenReleased: true,
       gpsCoordinates: null,
       collectionMethod: null,
       waterTemp: null,
@@ -94,6 +95,8 @@ vi.mock("../../../utils/Utils", () => ({
       callback(MOCK_REPORT);
     }
   }),
+  getFromOpenElisServerForBlob: vi.fn(),
+  postToOpenElisServerForBlob: vi.fn(),
 }));
 
 vi.mock("../../../../config.json", () => ({

--- a/frontend/src/components/reports/compliance/__tests__/LaporanHasilReport.test.jsx
+++ b/frontend/src/components/reports/compliance/__tests__/LaporanHasilReport.test.jsx
@@ -164,14 +164,21 @@ describe("LaporanHasilReport", () => {
     expect(screen.getAllByText("✓ Compliant").length).toBeGreaterThan(0);
   });
 
-  it("renders Generate PDF button for each order", async () => {
+  it("renders a Generate PDF button for not-yet-generated orders and a Reissue button for already-generated orders", async () => {
     renderWithIntl(<LaporanHasilReport />);
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /Search/i }));
     });
 
+    // Order 101 has no lastGenerated -> Generate PDF.
+    // Order 102 was already generated (lastGenerated set) -> Reissue.
     const pdfButtons = screen.getAllByRole("button", { name: /Generate PDF/i });
-    expect(pdfButtons).toHaveLength(2);
+    expect(pdfButtons).toHaveLength(1);
+
+    const reissueButtons = screen.getAllByRole("button", {
+      name: /Reissue with Amendment/i,
+    });
+    expect(reissueButtons).toHaveLength(1);
   });
 
   it("shows empty state when no orders", async () => {

--- a/frontend/src/components/utils/Utils.js
+++ b/frontend/src/components/utils/Utils.js
@@ -315,6 +315,35 @@ export const postToOpenElisServerForBlob = (
     });
 };
 
+export const getFromOpenElisServerForBlob = (
+  endPoint,
+  callback,
+  errorCallback,
+) => {
+  fetch(config.serverBaseUrl + endPoint, {
+    credentials: "include",
+    headers: {
+      "Accept-Language": getAcceptLanguageHeader(),
+    },
+  })
+    .then(handleSessionError)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.blob().then((blob) => ({ blob, response }));
+    })
+    .then(({ blob, response }) => {
+      callback(blob, response);
+    })
+    .catch((error) => {
+      console.error(error);
+      if (errorCallback) {
+        errorCallback(error);
+      }
+    });
+};
+
 export const postToOpenElisServerForPDF = (endPoint, payLoad, callback) => {
   fetch(
     config.serverBaseUrl + endPoint,

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -6179,6 +6179,17 @@
   "laporanHasil.action.generatePdf": "Generate PDF",
   "laporanHasil.action.regeneratePdf": "Re-generate PDF",
 
+  "lhu.amendment.reissue": "Reissue with Amendment",
+  "lhu.amendment.modal.heading": "Reissue LHU with Amendment",
+  "lhu.amendment.modal.description": "You are reissuing LHU for lab number {labNumber}. The reissued report will be identified as an amendment to the previously released certificate.",
+  "lhu.amendment.modal.submit": "Reissue & Download PDF",
+  "lhu.amendment.reason.label": "Amendment reason",
+  "lhu.amendment.reason.helper": "State why the original report is being amended (required for ISO 17025 §7.8.8 compliance).",
+  "lhu.amendment.reason.placeholder": "e.g. Incorrect pH result — instrument was not calibrated",
+  "lhu.amendment.reason.required": "Amendment reason is required",
+  "lhu.amendment.submitting": "Reissuing…",
+  "lhu.amendment.error.generic": "Failed to reissue the report. Please try again.",
+
   "laporanHasil.detail.siteInfo": "Site Information",
   "laporanHasil.detail.site": "Site",
   "laporanHasil.detail.gps": "GPS",

--- a/specs/OGC-776-lhu-amendment-workflow/tasks.md
+++ b/specs/OGC-776-lhu-amendment-workflow/tasks.md
@@ -1,0 +1,280 @@
+# OGC-776 — S-15e: LHU Amendment Workflow on Order (MVP)
+
+**Jira:** [OGC-776](https://uwdigi.atlassian.net/browse/OGC-776)
+**Parent epic:** OGC-527 (Vector — Environmental & Vector Testing Module)
+**Consumed by:** OGC-552 (S-06 LHU v2.0 — §5.1.5 amendment notice block)
+**Standard:** ISO/IEC 17025:2017 §7.8.8 (amended reports)
+**Estimated size:** M (unblocked slice) + S (each gated item)
+
+---
+
+## Overview
+
+Add report-level amendment support to the LHU (Laporan Hasil Uji) certificate flow. When a
+released LHU is found to be wrong, the lab reissues it as a formal amendment: the report
+identifies itself as an amendment, names the version it supersedes, captures a reason, and
+the original is preserved. This is **report-level** amendment, distinct from the existing
+**result-level** amendment (OGC-660 / OGC-713).
+
+### Two reality corrections vs. the Jira ticket (read before starting)
+
+The ticket's acceptance criteria assume two things that **do not exist in the codebase today**.
+This was verified directly. Tasks below are organized so the unblocked work ships independently
+and the two gated items are called out explicitly.
+
+1. **No certificate-numbering scheme exists.** There is no certificate number, no `LHU-YYYY-NNNN`
+   format, and no `/R` suffix anywhere in the code. The LHU PDF is keyed only by the sample
+   accession number (filename `LH-<accession>.pdf`). The ticket's AC "append `/Am.N`, preserving
+   `/R`" therefore cannot be implemented as written until a certificate number exists.
+   See **Phase 4** — gated on a grooming decision.
+
+2. **No PDF is preserved or hashed.** Neither the patient-report `DocumentTrack` mechanism
+   (`reports/valueholder/DocumentTrack.java`, `common/services/ReportTrackingService.java`) nor
+   the compliance `compliance_report_generation` table stores PDF bytes or a SHA-256 hash — both
+   store only metadata (which sample, when, by whom). The ticket's AC "original LHU preserved —
+   rely on existing S-06 audit trail (SHA-256 hashed stored PDF)" rests on a feature that is not
+   built. To actually satisfy §7.8.8 ("preserve the original"), PDF archival must be added.
+   See **Phase 5** — gated on a grooming decision.
+
+### What already exists (DO NOT rebuild)
+
+- **"Order" = `Sample`.** There is no `order` table. Add columns to `clinlims.sample`; mirror on
+  the `Sample` valueholder (`sample/valueholder/Sample.java`). This matches the established Vector
+  pattern (e.g. `identification_status`, `deconvolution_status` were added to `sample`).
+- **LHU generation:** `compliance/controller/rest/ComplianceReportRestController.java`
+  - `GET /rest/complianceReport/exportPdf?sampleId={id}` → `exportPdf(Long sampleId, HttpServletResponse)`
+  - iText5 PDF built on the fly; filename `LH-<accession>.pdf`; calls `recordGeneration(...)` at the end.
+- **Generation tracking (use this for "already released?" detection):**
+  - Table `compliance_report_generation` (sample_id, generated_at, generated_by_user_id) — append-only.
+  - `compliance/service/ComplianceReportGenerationService`:
+    - `void recordGeneration(Long sampleId, String userId)`
+    - `Optional<OffsetDateTime> getLastGenerated(Long sampleId)`
+  - Entity `compliance/valueholder/ComplianceReportGeneration.java`.
+- **Frontend report UI:** `frontend/src/components/reports/compliance/LaporanHasilReport.jsx`
+  (filters, stats tiles, table, "Generate PDF" action via `window.open(...)`).
+- **Liquibase pattern:** next file is `src/main/resources/liquibase/3.5.x.x/051-*.xml`, registered in
+  `3.5.x.x/base.xml`. Highest existing is `050-resample-notification-trigger.xml`. Use `clinlims` schema and
+  `columnExists` preconditions for idempotency.
+
+### Architecture invariants (constitution)
+
+- 5-layer pattern: Valueholder → DAO → Service → Controller → Form/DTO.
+- `@Transactional` in services ONLY (never controllers). Services compile all data inside the
+  transaction (no `LazyInitializationException`).
+- Liquibase for all schema changes (no hand SQL).
+- React Intl — no hardcoded strings; new keys in `en.json` only.
+- Carbon Design System for any UI.
+- TDD: write the failing test first.
+
+---
+
+## Phase 1 — Schema (UNBLOCKED) — AC1
+
+**T-101  Liquibase changelog: amendment columns on `sample`**
+- New file `src/main/resources/liquibase/3.5.x.x/051-sample-amendment-metadata.xml`.
+- Add to `clinlims.sample`, all nullable, each guarded by a `not columnExists` precondition
+  (`onFail="MARK_RAN"`):
+  - `amends_lhu_number` TEXT — the prior certificate/lab number this order amends.
+  - `amendment_number` INTEGER — sequential amendment counter (null = never amended).
+  - `amendment_reason` TEXT — free-text reason captured at reissue.
+- changeSet id pattern: `3.5.0.0-sample-add-amendment-columns`, author = your GH handle.
+- Register `<include file="051-sample-amendment-metadata.xml" relativeToChangelogFile="true"/>`
+  in `3.5.x.x/base.xml`, in numeric order.
+
+**T-102  Map columns on `Sample` valueholder**
+- Add fields + getters/setters to `sample/valueholder/Sample.java`:
+  `String amendsLhuNumber`, `Integer amendmentNumber`, `String amendmentReason`.
+- Match the existing Hibernate mapping style used for the other Vector columns on `Sample`
+  (annotation vs `.hbm.xml` — follow whatever `Sample` already uses; verify before writing).
+
+**T-103  Verify migration runs clean**
+- `mvn liquibase:update` (or app boot) against a dev DB; confirm columns exist and re-run is a no-op.
+
+---
+
+## Phase 2 — Detection + persistence service (UNBLOCKED) — AC2, AC4, AC7
+
+**T-201  "Has a released LHU already been released?" check**
+- ⚠️ **Correction (verified in code):** generation is NOT release. The frontend "Generate PDF"
+  button calls `window.open(...exportPdf...)` directly (`LaporanHasilReport.jsx:164-189`) and the
+  backend calls `recordGeneration(...)` on EVERY open (`ComplianceReportRestController.java:281-283`),
+  including previews of unsigned/partial drafts. So `compliance_report_generation` is a generation
+  log, not a release log. Keying the amendment trigger off `getLastGenerated().isPresent()` would
+  fire on a mere preview and wrongly force the reissue flow on never-released reports.
+- The real release marker is the manager `VALIDATED_AND_RELEASED` electronic signature, which the
+  controller already reads (`ComplianceReportRestController.java:357-390`):
+  `electronicSignatureService.getSignaturesForRecord("VALIDATION_BATCH", analysisId)` →
+  `SignatureMeaning.VALIDATED_AND_RELEASED`.
+- Add `boolean hasBeenReleased(Long sampleId)` keyed off that signature (a released analysis exists
+  for the sample), NOT off the generation count. This is the amendment trigger.
+- `compliance_report_generation` is still useful as a "was a PDF ever produced" audit, but it does
+  NOT gate amendment.
+
+**T-202  Amendment persistence on the Sample**
+- New service method (in a Sample-scoped service, `@Transactional`) to apply an amendment:
+  `void applyLhuAmendment(Long sampleId, String priorCertificateNumber, String reason)`:
+  - `amendmentNumber = (current == null ? 1 : current + 1)`
+  - `amendsLhuNumber = priorCertificateNumber` (until Phase 4 exists, this is the accession/lab number)
+  - `amendmentReason = reason`
+  - persist; do NOT touch existing `compliance_report_generation` rows (append-only audit stays intact).
+- Backward compatible by construction: untouched orders keep `amendmentNumber = null` (AC7).
+
+**T-203  Unit tests (TDD — write first)**
+- First amendment sets number → 1; second → 2 (increment).
+- `amendment_reason` required: blank/null reason rejected with a clear error.
+- Non-amended order returns `amendmentNumber == null` and is unaffected.
+- Inversion test: if the increment logic is broken, the test fails.
+
+---
+
+## Phase 3 — Reissue API + UI (UNBLOCKED for capture; rendering gated) — AC2
+
+**T-301  Reissue endpoint**
+- Add `POST /rest/complianceReport/reissue` (or extend `exportPdf` with an `amend`/`reason` param)
+  on `ComplianceReportRestController`:
+  - requires `sampleId` and non-blank `reason`;
+  - calls `applyLhuAmendment(...)` then regenerates the PDF and `recordGeneration(...)`.
+  - Controller stays thin — no `@Transactional`, no business logic.
+- 400 when `reason` is blank; 404 when sample has not been released (use `hasBeenReleased`, T-201 —
+  NOT generation count; nothing to amend if never released).
+- **Auth (verified):** the controller already carries a class-level
+  `@PreAuthorize("hasRole('ROLE_RESULTS') or hasRole('ROLE_SUPERVISOR') or hasRole('ADMIN')")`
+  (`ComplianceReportRestController.java:44-46`). A reissue endpoint added to this controller inherits
+  it — which matches the out-of-scope decision "any user who can generate the LHU may reissue." No
+  new permission key needed. State this explicitly so no one adds a redundant per-method check.
+- **Auth-ordering test (constitution V.6):** assert a caller WITHOUT `ROLE_RESULTS`/`ROLE_SUPERVISOR`/
+  `ADMIN` gets 403 from `/reissue`, and that the 403 fires BEFORE any 400/404 body validation.
+
+**T-302  "Reissue with amendment" dialog (Carbon)**
+- In `LaporanHasilReport.jsx`: when a row already has a `lastGenerated`, the action becomes
+  "Reissue with amendment" (alongside / instead of "Generate PDF").
+- Carbon `Modal` with a required `TextArea` for the reason (no rich taxonomy — plain text per MVP).
+- On submit, POST to the reissue endpoint, then refresh the row's generation status.
+- All strings via React Intl → new keys in `frontend/src/languages/en.json` only
+  (e.g. `lhu.amendment.reissue`, `lhu.amendment.reason.label`, `lhu.amendment.reason.required`).
+
+**T-303  Frontend test**
+- Reason required (submit disabled / validation message when empty).
+- Successful reissue updates the row state.
+
+---
+
+## Phase 4 — Certificate number `/Am.N` suffix (DECIDED — interim scheme) — AC3
+
+> **Grooming resolved (2026-06-23):** no `LHU-YYYY-NNNN/R` scheme exists, so OGC-776 owns the suffix
+> on an **interim** basis against today's accession/lab number. Confirm with OGC-552's owner whether
+> 552 will eventually deliver the full certificate number (the 776 → 552 dependency arrow looks
+> backwards for this AC); raised in the Jira comment (T-225).
+
+**T-401  Grooming decision (DECIDED 2026-06-23)**
+- **Decision: OGC-776 defines the certificate number (interim).** Build the `/Am.N` suffix against
+  today's accession/lab number now; flag clearly as interim until the full `LHU-YYYY-NNNN/R` scheme
+  lands (presumed OGC-552). **Risk to manage:** two competing numbering systems — when the real
+  scheme arrives, a migration must reconcile `amends_lhu_number` values captured under the interim
+  meaning. Track that as a v2 follow-up.
+
+**T-402  Build the interim suffix helper (decided path)**
+- Add a suffix helper on the amendment service:
+  `String certificateNumberWithAmendmentSuffix(String baseCertificateNumber, Integer amendmentNumber)`.
+- Append `/Am.N` when `amendmentNumber >= 1`; no suffix when null/0. Preserve any existing `/R`
+  revision suffix by appending after it (e.g. `LHU-2026-0042/R` → `LHU-2026-0042/R/Am.1`), so the
+  same helper works unchanged once a real `/R` scheme exists.
+- `baseCertificateNumber` is the accession/lab number today (interim). When OGC-552 delivers the
+  real certificate number, only the caller that supplies `baseCertificateNumber` changes — the
+  suffix logic is unaffected.
+- Store the *prior* certificate number into `amends_lhu_number` at reissue time (the accession
+  number, per the interim scheme).
+- On the generated LHU PDF, print two header lines: `Certificate No.:` (the suffixed certificate
+  number) and `Lab Number:` (the raw accession number, unsuffixed) — so the certificate identity and
+  the underlying accession stay distinguishable. Plus an amendment notice block (amendment no.,
+  `Supersedes:` the prior number from `amends_lhu_number`, `Amendment reason:`) when
+  `amendmentNumber >= 1`.
+- Also expose the suffixed certificate number on the report DTO (`certificateNumber`) for the listing
+  and the reissue response.
+
+**T-403  Tests** — `/Am.1` on first amendment, `/Am.2` on second, no suffix when null/0,
+`/R` preserved when present, null base returns null.
+
+---
+
+## Phase 5 — Original-PDF preservation (DECIDED — add PDF archival) — AC5
+
+> **Grooming resolved (2026-06-23):** the ticket's "rely on existing S-06 SHA-256 hashed stored PDF"
+> is false — no PDF is stored or hashed today, and metadata-only tracking does **not** meet §7.8.8
+> "preserve the original" (the ticket's own justification; KAN audits ask to see the original
+> report). Decision is to **add real PDF archival** (option b). Raised in the Jira comment (T-225).
+
+**T-501  Grooming decision (DECIDED 2026-06-23)**
+- **Decision: option (b) — add PDF archival.** Persist the rendered PDF bytes + SHA-256 on
+  release/reissue so the original is genuinely retained, meeting §7.8.8. Sizing is not a
+  server-weight concern (see T-502).
+
+**T-502  Archive the rendered PDF (decided path)**
+- Archive **only on release and on reissue — NOT on every `exportPdf`/preview.** This is the single
+  most important constraint: previews are frequent (see T-201), releases/amendments are rare, so
+  archiving on the release path keeps volume tiny. Archiving on every generation would balloon storage.
+  Implementation: in `exportPdf`, archive only when `hasBeenReleased(sampleId)` is true.
+- New **dedicated cold table** `compliance_report_archive` via Liquibase changelog `052-*.xml`:
+  columns `sample_id`, `amendment_number`, `pdf_content` (bytea), `sha256_hash`, `generated_at`,
+  `generated_by_user_id`. `amendment_number = 0` is the original released report; `1..N` are
+  amendments. Unique constraint on `(sample_id, amendment_number)` to enforce immutability at the DB.
+  Keep it separate from `sample` and from any table the report listing SELECTs — the `bytea` is read
+  only on audit retrieval, never on normal listing. Do NOT extend
+  `DocumentTrack`/`ReportTrackingService` (verified metadata-only; co-locating bytes there would
+  load them on unrelated reads).
+- 5-layer: `ComplianceReportArchive` valueholder → `ComplianceReportArchiveDAO`/Impl →
+  `ComplianceReportArchiveService`/Impl (`@Transactional`, computes SHA-256, immutability guard:
+  returns the existing row and skips save when one already exists for `(sample, amendmentNumber)`).
+- Render the PDF into a buffer in `exportPdf` so the same bytes are both streamed to the client and
+  handed to the archive (no double render).
+- Column type: PostgreSQL `bytea` (the codebase is Postgres). LHU is text/table-only iText5, no
+  embedded images → ~50–200 KB/PDF. At ~1–3 versions per released sample, even 10k samples ≈ a few GB
+  accumulated over years — not a server-weight concern. If that ever matters, swap the `bytea` for a
+  SHA-keyed filesystem/object-store blob and keep only the hash + metadata in the row; defer that
+  until volume justifies it.
+- Originals are immutable: never overwrite a prior archived row.
+
+**T-503  Tests** — reissue/re-open does not mutate or replace the prior archived PDF (immutability
+guard returns the existing row, never calls save); SHA-256 is stable, 64 hex chars, and differs for
+different content; `amendment_number` keys versions separately; null amendment number treated as 0.
+
+---
+
+## Phase 6 — Template hook (DEFERRED to OGC-552) — AC6
+
+**T-601  Confirm field contract with OGC-552**
+- The §5.1.5 amendment-notice rendering is OGC-552's responsibility. OGC-776 only guarantees the
+  three fields (`amends_lhu_number`, `amendment_number`, `amendment_reason`) are populated and
+  exposed in the report DTO so the template can read them and skip the block when
+  `amendment_number == null`. No rendering work in this ticket.
+
+---
+
+## Out of scope (deferred to v2, per ticket)
+
+- Dedicated `superseded_by` schema pointer.
+- `lhu.amend` permission key (any user who can generate the LHU may reissue).
+- `LHU_AMENDED` audit event type.
+- Manager-approval flow on amendment.
+- Structured amendment-type taxonomy (reason is plain free text).
+- Re-evaluation under a different decision rule when amending.
+
+---
+
+## Suggested delivery order
+
+1. **Core slice (independent, low-risk M):** Phase 1 + Phase 2 + Phase 3 (capture/persist/dialog).
+2. **Build (decided, interim):** Phase 4 — `/Am.N` suffix against the accession number.
+3. **Build (decided, option b):** Phase 5 — PDF archival on release/reissue; metadata-only does not
+   meet §7.8.8.
+4. **Coordinate:** Phase 6 field contract with OGC-552.
+
+## Pre-PR checklist
+
+- [ ] `mvn spotless:apply` and `cd frontend && npm run format`
+- [ ] Backend unit tests + frontend tests green; TDD order followed (red → green → refactor)
+- [ ] Liquibase migration is idempotent (re-run = no-op) and registered in `base.xml`
+- [ ] No hardcoded UI strings; new keys in `en.json` only
+- [ ] `@Transactional` in services only; controllers thin
+- [ ] **T-225** Jira comment posted correcting the certificate-number and PDF-preservation premises,
+      and the generation-vs-release premise (draft: `JIRA-COMMENT.md`)

--- a/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceReportOrderDTO.java
+++ b/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceReportOrderDTO.java
@@ -27,6 +27,7 @@ public class ComplianceReportOrderDTO {
     private String weather;
     private String preservation;
 
+    private boolean hasBeenReleased;
     private List<ParameterResult> parameterResults;
     private SignatureDTO analystSignature;
     private SignatureDTO managerSignature;
@@ -195,6 +196,14 @@ public class ComplianceReportOrderDTO {
 
     public void setParameterResults(List<ParameterResult> parameterResults) {
         this.parameterResults = parameterResults;
+    }
+
+    public boolean isHasBeenReleased() {
+        return hasBeenReleased;
+    }
+
+    public void setHasBeenReleased(boolean hasBeenReleased) {
+        this.hasBeenReleased = hasBeenReleased;
     }
 
     public SignatureDTO getAnalystSignature() {

--- a/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceReportRestController.java
+++ b/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceReportRestController.java
@@ -11,6 +11,7 @@ import com.itextpdf.text.pdf.PdfPCell;
 import com.itextpdf.text.pdf.PdfPTable;
 import com.itextpdf.text.pdf.PdfWriter;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
@@ -21,6 +22,7 @@ import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.compliance.service.ComplianceEvaluationResult;
 import org.openelisglobal.compliance.service.ComplianceEvaluationService;
 import org.openelisglobal.compliance.service.ComplianceReportGenerationService;
+import org.openelisglobal.compliance.service.LhuAmendmentService;
 import org.openelisglobal.esig.service.ElectronicSignatureService;
 import org.openelisglobal.esig.valueholder.ElectronicSignature;
 import org.openelisglobal.esig.valueholder.SignatureMeaning;
@@ -38,6 +40,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -79,6 +83,12 @@ public class ComplianceReportRestController {
 
     @Autowired
     private org.openelisglobal.analysis.service.AnalysisService analysisService;
+
+    @Autowired
+    private LhuAmendmentService lhuAmendmentService;
+
+    @Autowired
+    private org.openelisglobal.compliance.service.ComplianceReportArchiveService archiveService;
 
     @GetMapping("/compliance-statuses")
     public ResponseEntity<java.util.List<java.util.Map<String, String>>> getComplianceStatuses() {
@@ -209,77 +219,190 @@ public class ComplianceReportRestController {
         response.setContentType("application/pdf");
         response.setHeader("Content-Disposition", "attachment; filename=\"LH-" + safeFilename + ".pdf\"");
 
+        byte[] pdfBytes;
         try {
-            Document document = new Document(PageSize.A4);
-            PdfWriter.getInstance(document, response.getOutputStream());
-            document.open();
-
-            Font titleFont = new Font(Font.FontFamily.HELVETICA, 14, Font.BOLD);
-            Font sectionFont = new Font(Font.FontFamily.HELVETICA, 11, Font.BOLD);
-            Font headerFont = new Font(Font.FontFamily.HELVETICA, 9, Font.BOLD, BaseColor.WHITE);
-            Font cellFont = new Font(Font.FontFamily.HELVETICA, 9);
-            Font labelFont = new Font(Font.FontFamily.HELVETICA, 9, Font.BOLD);
-
-            document.add(new Phrase("LAPORAN HASIL — CERTIFICATE OF TEST RESULTS\n\n", titleFont));
-            document.add(new Phrase("Lab Number: " + dto.getLabNumber() + "\n", cellFont));
-            document.add(new Phrase("Standard: " + safe(dto.getStandardName()) + "\n", cellFont));
-            document.add(new Phrase("Collection Date: " + safe(dto.getCollectionDate()) + "\n\n", cellFont));
-
-            addTwoColSection(document, sectionFont, labelFont, cellFont, "SITE INFORMATION", new String[][] {
-                    { "Site", safe(dto.getSiteName()) }, { "GPS Coordinates", safe(dto.getGpsCoordinates()) },
-                    { "Collection Date/Time", safe(dto.getCollectionDate()) },
-                    { "Collection Method", safe(dto.getCollectionMethod()) },
-                    { "PP No.", safe(dto.getRegulationNumber()) }, { "Standard", safe(dto.getStandardName()) } });
-
-            addTwoColSection(document, sectionFont, labelFont, cellFont, "COLLECTION CONDITIONS",
-                    new String[][] { { "Water Temp", safe(dto.getWaterTemp()) },
-                            { "Ambient Temp", safe(dto.getAmbientTemp()) }, { "Weather", safe(dto.getWeather()) },
-                            { "Preservation", safe(dto.getPreservation()) } });
-
-            document.add(new Phrase("\nCOMPLIANCE SUMMARY\n\n", sectionFont));
-            PdfPTable compTable = new PdfPTable(4);
-            compTable.setWidthPercentage(100);
-            compTable.setWidths(new float[] { 3f, 2f, 2.5f, 1.5f });
-            for (String h : new String[] { "Parameter", "Result", "Threshold", "Status" }) {
-                PdfPCell hCell = new PdfPCell(new Phrase(h, headerFont));
-                hCell.setBackgroundColor(new BaseColor(33, 82, 149));
-                hCell.setHorizontalAlignment(Element.ALIGN_CENTER);
-                hCell.setPadding(4);
-                compTable.addCell(hCell);
-            }
-            if (dto.getParameterResults() != null) {
-                for (ComplianceEvaluationResult.ParameterResult pr : dto.getParameterResults()) {
-                    compTable.addCell(new Phrase(safe(pr.getDisplayName()), cellFont));
-                    String rv = safe(pr.getResultValue());
-                    if (pr.getUnits() != null && !pr.getUnits().isEmpty()) {
-                        rv += " " + pr.getUnits();
-                    }
-                    compTable.addCell(new Phrase(rv, cellFont));
-                    compTable.addCell(new Phrase(safe(pr.getThresholdDisplay()), cellFont));
-                    compTable.addCell(new Phrase(pr.getStatus() != null ? pr.getStatus().toString() : "–", cellFont));
-                }
-            }
-            document.add(compTable);
-
-            document.add(new Phrase("\n\nSIGNATURES\n\n", sectionFont));
-            PdfPTable sigTable = new PdfPTable(2);
-            sigTable.setWidthPercentage(100);
-
-            PdfPCell analystCell = buildSignatureCell(dto.getAnalystSignature(), "Lab Analyst", labelFont, cellFont);
-            PdfPCell managerCell = buildSignatureCell(dto.getManagerSignature(), "Lab Manager", labelFont, cellFont);
-            sigTable.addCell(analystCell);
-            sigTable.addCell(managerCell);
-            document.add(sigTable);
-
-            document.close();
+            pdfBytes = buildOriginalPdfBytes(dto);
         } catch (DocumentException e) {
             LogEvent.logError(e);
             throw new IOException("Error generating PDF", e);
         }
 
+        response.getOutputStream().write(pdfBytes);
+
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String userId = auth != null ? auth.getName() : null;
         reportGenerationService.recordGeneration(sampleId, userId);
+
+        // Archive only on the release path — previews of unreleased samples must NOT be
+        // archived. Failure here must never break PDF delivery.
+        if (lhuAmendmentService.hasBeenReleased(sampleId)) {
+            try {
+                archiveService.archiveIfAbsent(sampleId, sample.getAmendmentNumber(), pdfBytes, userId);
+            } catch (Exception e) {
+                LogEvent.logError(e);
+            }
+        }
+    }
+
+    private byte[] buildOriginalPdfBytes(ComplianceReportOrderDTO dto) throws DocumentException, IOException {
+        Font titleFont = new Font(Font.FontFamily.HELVETICA, 14, Font.BOLD);
+        Font sectionFont = new Font(Font.FontFamily.HELVETICA, 11, Font.BOLD);
+        Font headerFont = new Font(Font.FontFamily.HELVETICA, 9, Font.BOLD, BaseColor.WHITE);
+        Font cellFont = new Font(Font.FontFamily.HELVETICA, 9);
+        Font labelFont = new Font(Font.FontFamily.HELVETICA, 9, Font.BOLD);
+
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        Document document = new Document(PageSize.A4);
+        PdfWriter.getInstance(document, buf);
+        document.open();
+
+        document.add(new Phrase("LAPORAN HASIL — CERTIFICATE OF TEST RESULTS\n\n", titleFont));
+        document.add(new Phrase("Lab Number: " + dto.getLabNumber() + "\n", cellFont));
+        document.add(new Phrase("Standard: " + safe(dto.getStandardName()) + "\n", cellFont));
+        document.add(new Phrase("Collection Date: " + safe(dto.getCollectionDate()) + "\n\n", cellFont));
+
+        addTwoColSection(document, sectionFont, labelFont, cellFont, "SITE INFORMATION",
+                new String[][] { { "Site", safe(dto.getSiteName()) },
+                        { "GPS Coordinates", safe(dto.getGpsCoordinates()) },
+                        { "Collection Date/Time", safe(dto.getCollectionDate()) },
+                        { "Collection Method", safe(dto.getCollectionMethod()) },
+                        { "PP No.", safe(dto.getRegulationNumber()) }, { "Standard", safe(dto.getStandardName()) } });
+
+        addTwoColSection(document, sectionFont, labelFont, cellFont, "COLLECTION CONDITIONS",
+                new String[][] { { "Water Temp", safe(dto.getWaterTemp()) },
+                        { "Ambient Temp", safe(dto.getAmbientTemp()) }, { "Weather", safe(dto.getWeather()) },
+                        { "Preservation", safe(dto.getPreservation()) } });
+
+        addComplianceTable(document, dto, sectionFont, headerFont, cellFont);
+        addSignatureTable(document, dto, sectionFont, labelFont, cellFont);
+
+        document.close();
+        return buf.toByteArray();
+    }
+
+    public static class ReissueRequest {
+        private Long sampleId;
+        private String reason;
+
+        public Long getSampleId() {
+            return sampleId;
+        }
+
+        public void setSampleId(Long sampleId) {
+            this.sampleId = sampleId;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+
+        public void setReason(String reason) {
+            this.reason = reason;
+        }
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@RequestBody ReissueRequest request, HttpServletResponse response)
+            throws IOException {
+        if (request.getReason() == null || request.getReason().trim().isEmpty()) {
+            return ResponseEntity.badRequest().body("Amendment reason must not be blank");
+        }
+        if (request.getSampleId() == null) {
+            return ResponseEntity.badRequest().body("sampleId is required");
+        }
+        Sample sample = sampleService.get(String.valueOf(request.getSampleId()));
+        if (sample == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!lhuAmendmentService.hasBeenReleased(request.getSampleId())) {
+            return ResponseEntity.status(404).body("Sample has not been released; nothing to amend");
+        }
+
+        String priorCertificateNumber = lhuAmendmentService
+                .certificateNumberWithAmendmentSuffix(sample.getAccessionNumber(), sample.getAmendmentNumber());
+        lhuAmendmentService.applyLhuAmendment(request.getSampleId(), priorCertificateNumber,
+                request.getReason().trim());
+
+        // Refresh sample to get updated amendmentNumber, then regenerate PDF
+        sample = sampleService.get(String.valueOf(request.getSampleId()));
+        List<SampleComplianceStandard> links = sampleComplianceStandardDAO.getAllForSample(sample.getId());
+        SampleComplianceStandard primaryLink = links.isEmpty() ? null : links.get(0);
+        ComplianceEvaluationResult eval = complianceEvaluationService.evaluate(sample);
+        ComplianceReportOrderDTO dto = buildOrderDTO(sample, primaryLink, eval,
+                reportGenerationService.getLastGenerated(request.getSampleId()).isPresent());
+
+        String safeFilename = sample.getAccessionNumber().replaceAll("[^a-zA-Z0-9\\-]", "");
+        response.setContentType("application/pdf");
+        response.setHeader("Content-Disposition",
+                "attachment; filename=\"LH-" + safeFilename + "-Am" + sample.getAmendmentNumber() + ".pdf\"");
+
+        byte[] pdfBytes;
+        try {
+            pdfBytes = buildAmendmentPdfBytes(sample, dto);
+        } catch (DocumentException e) {
+            LogEvent.logError(e);
+            throw new IOException("Error generating amendment PDF", e);
+        }
+
+        response.getOutputStream().write(pdfBytes);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String userId = auth != null ? auth.getName() : null;
+        reportGenerationService.recordGeneration(request.getSampleId(), userId);
+        try {
+            archiveService.archiveIfAbsent(request.getSampleId(), sample.getAmendmentNumber(), pdfBytes, userId);
+        } catch (Exception e) {
+            LogEvent.logError(e);
+        }
+        return null;
+    }
+
+    private byte[] buildAmendmentPdfBytes(Sample sample, ComplianceReportOrderDTO dto)
+            throws DocumentException, IOException {
+        Font titleFont = new Font(Font.FontFamily.HELVETICA, 14, Font.BOLD);
+        Font sectionFont = new Font(Font.FontFamily.HELVETICA, 11, Font.BOLD);
+        Font headerFont = new Font(Font.FontFamily.HELVETICA, 9, Font.BOLD, BaseColor.WHITE);
+        Font cellFont = new Font(Font.FontFamily.HELVETICA, 9);
+        Font labelFont = new Font(Font.FontFamily.HELVETICA, 9, Font.BOLD);
+
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        Document document = new Document(PageSize.A4);
+        PdfWriter.getInstance(document, buf);
+        document.open();
+
+        String certNumber = lhuAmendmentService.certificateNumberWithAmendmentSuffix(sample.getAccessionNumber(),
+                sample.getAmendmentNumber());
+        document.add(new Phrase("LAPORAN HASIL — CERTIFICATE OF TEST RESULTS (AMENDMENT)\n\n", titleFont));
+        document.add(new Phrase("Certificate No.: " + certNumber + "\n", labelFont));
+        document.add(new Phrase("Lab Number: " + dto.getLabNumber() + "\n", cellFont));
+
+        if (sample.getAmendmentNumber() != null && sample.getAmendmentNumber() >= 1) {
+            document.add(new Phrase("\nAMENDMENT NOTICE\n\n", sectionFont));
+            document.add(new Phrase("Amendment No.: " + sample.getAmendmentNumber() + "\n", cellFont));
+            document.add(new Phrase("Supersedes: " + safe(sample.getAmendsLhuNumber()) + "\n", cellFont));
+            document.add(new Phrase("Amendment reason: " + safe(sample.getAmendmentReason()) + "\n\n", cellFont));
+        }
+
+        document.add(new Phrase("Standard: " + safe(dto.getStandardName()) + "\n", cellFont));
+        document.add(new Phrase("Collection Date: " + safe(dto.getCollectionDate()) + "\n\n", cellFont));
+
+        addTwoColSection(document, sectionFont, labelFont, cellFont, "SITE INFORMATION",
+                new String[][] { { "Site", safe(dto.getSiteName()) },
+                        { "GPS Coordinates", safe(dto.getGpsCoordinates()) },
+                        { "Collection Date/Time", safe(dto.getCollectionDate()) },
+                        { "Collection Method", safe(dto.getCollectionMethod()) },
+                        { "PP No.", safe(dto.getRegulationNumber()) }, { "Standard", safe(dto.getStandardName()) } });
+
+        addTwoColSection(document, sectionFont, labelFont, cellFont, "COLLECTION CONDITIONS",
+                new String[][] { { "Water Temp", safe(dto.getWaterTemp()) },
+                        { "Ambient Temp", safe(dto.getAmbientTemp()) }, { "Weather", safe(dto.getWeather()) },
+                        { "Preservation", safe(dto.getPreservation()) } });
+
+        addComplianceTable(document, dto, sectionFont, headerFont, cellFont);
+        addSignatureTable(document, dto, sectionFont, labelFont, cellFont);
+
+        document.close();
+        return buf.toByteArray();
     }
 
     private ComplianceReportOrderDTO buildOrderDTO(Sample sample, SampleComplianceStandard link,
@@ -353,29 +476,25 @@ public class ComplianceReportRestController {
 
         reportGenerationService.getLastGenerated(Long.parseLong(sample.getId())).ifPresent(dto::setLastGenerated);
 
-        // Logbook saves AUTHORED signatures as RESULT_BATCH with record_id =
-        // sample_item.id.
-        // Validation saves VALIDATED_AND_RELEASED as VALIDATION_BATCH with record_id =
-        // analysis.id.
+        // Both RESULT_BATCH (AUTHORED) and VALIDATION_BATCH (VALIDATED_AND_RELEASED)
+        // store record_id = analysis.id.
         List<org.openelisglobal.sampleitem.valueholder.SampleItem> items = sampleItemService
                 .getSampleItemsBySampleId(sample.getId());
         for (org.openelisglobal.sampleitem.valueholder.SampleItem item : items) {
-            if (dto.getAnalystSignature() == null) {
-                List<ElectronicSignature> sigs = electronicSignatureService.getSignaturesForRecord("RESULT_BATCH",
-                        Long.parseLong(item.getId()));
-                for (ElectronicSignature sig : sigs) {
-                    if (sig.getSignatureMeaning() == SignatureMeaning.AUTHORED) {
-                        dto.setAnalystSignature(toSignatureDTO(sig, "Lab Analyst"));
-                        break;
+            List<org.openelisglobal.analysis.valueholder.Analysis> analyses = analysisService
+                    .getAnalysesBySampleItem(item);
+            for (org.openelisglobal.analysis.valueholder.Analysis analysis : analyses) {
+                if (dto.getAnalystSignature() == null) {
+                    List<ElectronicSignature> sigs = electronicSignatureService.getSignaturesForRecord("RESULT_BATCH",
+                            Long.parseLong(analysis.getId()));
+                    for (ElectronicSignature sig : sigs) {
+                        if (sig.getSignatureMeaning() == SignatureMeaning.AUTHORED) {
+                            dto.setAnalystSignature(toSignatureDTO(sig, "Lab Analyst"));
+                            break;
+                        }
                     }
                 }
-            }
-            if (dto.getManagerSignature() == null) {
-                List<org.openelisglobal.analysis.valueholder.Analysis> analyses = analysisService
-                        .getAnalysesBySampleItem(item);
-                for (org.openelisglobal.analysis.valueholder.Analysis analysis : analyses) {
-                    if (dto.getManagerSignature() != null)
-                        break;
+                if (dto.getManagerSignature() == null) {
                     List<ElectronicSignature> sigs = electronicSignatureService
                             .getSignaturesForRecord("VALIDATION_BATCH", Long.parseLong(analysis.getId()));
                     for (ElectronicSignature sig : sigs) {
@@ -385,7 +504,11 @@ public class ComplianceReportRestController {
                         }
                     }
                 }
+                if (dto.getAnalystSignature() != null && dto.getManagerSignature() != null)
+                    break;
             }
+            if (dto.getAnalystSignature() != null && dto.getManagerSignature() != null)
+                break;
         }
 
         return dto;
@@ -399,6 +522,44 @@ public class ComplianceReportRestController {
             dto.setSignedAt(sig.getSignedAt().toLocalDateTime().format(DISPLAY_FMT));
         }
         return dto;
+    }
+
+    private void addComplianceTable(Document doc, ComplianceReportOrderDTO dto, Font sectionFont, Font headerFont,
+            Font cellFont) throws DocumentException {
+        doc.add(new Phrase("\nCOMPLIANCE SUMMARY\n\n", sectionFont));
+        PdfPTable compTable = new PdfPTable(4);
+        compTable.setWidthPercentage(100);
+        compTable.setWidths(new float[] { 3f, 2f, 2.5f, 1.5f });
+        for (String h : new String[] { "Parameter", "Result", "Threshold", "Status" }) {
+            PdfPCell hCell = new PdfPCell(new Phrase(h, headerFont));
+            hCell.setBackgroundColor(new BaseColor(33, 82, 149));
+            hCell.setHorizontalAlignment(Element.ALIGN_CENTER);
+            hCell.setPadding(4);
+            compTable.addCell(hCell);
+        }
+        if (dto.getParameterResults() != null) {
+            for (ComplianceEvaluationResult.ParameterResult pr : dto.getParameterResults()) {
+                compTable.addCell(new Phrase(safe(pr.getDisplayName()), cellFont));
+                String rv = safe(pr.getResultValue());
+                if (pr.getUnits() != null && !pr.getUnits().isEmpty()) {
+                    rv += " " + pr.getUnits();
+                }
+                compTable.addCell(new Phrase(rv, cellFont));
+                compTable.addCell(new Phrase(safe(pr.getThresholdDisplay()), cellFont));
+                compTable.addCell(new Phrase(pr.getStatus() != null ? pr.getStatus().toString() : "–", cellFont));
+            }
+        }
+        doc.add(compTable);
+    }
+
+    private void addSignatureTable(Document doc, ComplianceReportOrderDTO dto, Font sectionFont, Font labelFont,
+            Font cellFont) throws DocumentException {
+        doc.add(new Phrase("\n\nSIGNATURES\n\n", sectionFont));
+        PdfPTable sigTable = new PdfPTable(2);
+        sigTable.setWidthPercentage(100);
+        sigTable.addCell(buildSignatureCell(dto.getAnalystSignature(), "Lab Analyst", labelFont, cellFont));
+        sigTable.addCell(buildSignatureCell(dto.getManagerSignature(), "Lab Manager", labelFont, cellFont));
+        doc.add(sigTable);
     }
 
     private void addTwoColSection(Document doc, Font sectionFont, Font labelFont, Font cellFont, String title,

--- a/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceReportRestController.java
+++ b/src/main/java/org/openelisglobal/compliance/controller/rest/ComplianceReportRestController.java
@@ -318,6 +318,24 @@ public class ComplianceReportRestController {
             return ResponseEntity.status(404).body("Sample has not been released; nothing to amend");
         }
 
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String userId = auth != null ? auth.getName() : null;
+
+        // Backfill the original (amendment_number=0) archive if the sample was only
+        // previewed before release and never formally archived on the exportPdf path.
+        if (!archiveService.findBySampleIdAndAmendmentNumber(request.getSampleId(), 0).isPresent()) {
+            try {
+                List<SampleComplianceStandard> origLinks = sampleComplianceStandardDAO.getAllForSample(sample.getId());
+                SampleComplianceStandard origPrimaryLink = origLinks.isEmpty() ? null : origLinks.get(0);
+                ComplianceEvaluationResult origEval = complianceEvaluationService.evaluate(sample);
+                ComplianceReportOrderDTO origDto = buildOrderDTO(sample, origPrimaryLink, origEval, true);
+                byte[] origPdfBytes = buildOriginalPdfBytes(origDto);
+                archiveService.archiveIfAbsent(request.getSampleId(), 0, origPdfBytes, userId);
+            } catch (Exception e) {
+                LogEvent.logError(e);
+            }
+        }
+
         String priorCertificateNumber = lhuAmendmentService
                 .certificateNumberWithAmendmentSuffix(sample.getAccessionNumber(), sample.getAmendmentNumber());
         lhuAmendmentService.applyLhuAmendment(request.getSampleId(), priorCertificateNumber,
@@ -346,8 +364,6 @@ public class ComplianceReportRestController {
 
         response.getOutputStream().write(pdfBytes);
 
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String userId = auth != null ? auth.getName() : null;
         reportGenerationService.recordGeneration(request.getSampleId(), userId);
         try {
             archiveService.archiveIfAbsent(request.getSampleId(), sample.getAmendmentNumber(), pdfBytes, userId);
@@ -475,6 +491,7 @@ public class ComplianceReportRestController {
         }
 
         reportGenerationService.getLastGenerated(Long.parseLong(sample.getId())).ifPresent(dto::setLastGenerated);
+        dto.setHasBeenReleased(lhuAmendmentService.hasBeenReleased(Long.parseLong(sample.getId())));
 
         // Both RESULT_BATCH (AUTHORED) and VALIDATION_BATCH (VALIDATED_AND_RELEASED)
         // store record_id = analysis.id.

--- a/src/main/java/org/openelisglobal/compliance/dao/ComplianceReportArchiveDAO.java
+++ b/src/main/java/org/openelisglobal/compliance/dao/ComplianceReportArchiveDAO.java
@@ -1,0 +1,14 @@
+package org.openelisglobal.compliance.dao;
+
+import java.util.Optional;
+import org.openelisglobal.common.dao.BaseDAO;
+import org.openelisglobal.common.exception.LIMSRuntimeException;
+import org.openelisglobal.compliance.valueholder.ComplianceReportArchive;
+
+public interface ComplianceReportArchiveDAO extends BaseDAO<ComplianceReportArchive, Long> {
+
+    Optional<ComplianceReportArchive> findBySampleIdAndAmendmentNumber(Long sampleId, Integer amendmentNumber)
+            throws LIMSRuntimeException;
+
+    ComplianceReportArchive save(ComplianceReportArchive entity) throws LIMSRuntimeException;
+}

--- a/src/main/java/org/openelisglobal/compliance/daoimpl/ComplianceReportArchiveDAOImpl.java
+++ b/src/main/java/org/openelisglobal/compliance/daoimpl/ComplianceReportArchiveDAOImpl.java
@@ -1,0 +1,52 @@
+package org.openelisglobal.compliance.daoimpl;
+
+import jakarta.persistence.TypedQuery;
+import java.util.List;
+import java.util.Optional;
+import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.common.exception.LIMSRuntimeException;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.compliance.dao.ComplianceReportArchiveDAO;
+import org.openelisglobal.compliance.valueholder.ComplianceReportArchive;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class ComplianceReportArchiveDAOImpl extends BaseDAOImpl<ComplianceReportArchive, Long>
+        implements ComplianceReportArchiveDAO {
+
+    public ComplianceReportArchiveDAOImpl() {
+        super(ComplianceReportArchive.class);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ComplianceReportArchive> findBySampleIdAndAmendmentNumber(Long sampleId, Integer amendmentNumber)
+            throws LIMSRuntimeException {
+        try {
+            TypedQuery<ComplianceReportArchive> query = entityManager.createQuery(
+                    "FROM ComplianceReportArchive a WHERE a.sample.id = :sampleId AND a.amendmentNumber = :amendmentNumber",
+                    ComplianceReportArchive.class);
+            query.setParameter("sampleId", String.valueOf(sampleId));
+            query.setParameter("amendmentNumber", amendmentNumber);
+            query.setMaxResults(1);
+            List<ComplianceReportArchive> results = query.getResultList();
+            return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+        } catch (RuntimeException e) {
+            LogEvent.logError(e);
+            throw new LIMSRuntimeException("Error in ComplianceReportArchive findBySampleIdAndAmendmentNumber()", e);
+        }
+    }
+
+    @Override
+    public ComplianceReportArchive save(ComplianceReportArchive entity) throws LIMSRuntimeException {
+        try {
+            entityManager.persist(entity);
+            return entity;
+        } catch (RuntimeException e) {
+            LogEvent.logError(e);
+            throw new LIMSRuntimeException("Error in ComplianceReportArchive save()", e);
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/compliance/service/ComplianceReportArchiveService.java
+++ b/src/main/java/org/openelisglobal/compliance/service/ComplianceReportArchiveService.java
@@ -1,0 +1,26 @@
+package org.openelisglobal.compliance.service;
+
+import java.util.Optional;
+import org.openelisglobal.compliance.valueholder.ComplianceReportArchive;
+
+public interface ComplianceReportArchiveService {
+
+    /**
+     * Archives the rendered PDF bytes for (sampleId, amendmentNumber).
+     * amendmentNumber = 0 represents the original released report; 1..N are
+     * amendments. Immutability is enforced: if a row already exists for this
+     * (sampleId, amendmentNumber), the existing row is returned and no save is
+     * performed. Must only be called on the release/reissue path — never on
+     * previews.
+     *
+     * @param sampleId        the sample being archived
+     * @param amendmentNumber 0 for original, 1..N for amendments (null treated as
+     *                        0)
+     * @param pdfBytes        the rendered PDF bytes
+     * @param userId          the user performing the action (may be null)
+     * @return the archived record (existing or newly created)
+     */
+    ComplianceReportArchive archiveIfAbsent(Long sampleId, Integer amendmentNumber, byte[] pdfBytes, String userId);
+
+    Optional<ComplianceReportArchive> findBySampleIdAndAmendmentNumber(Long sampleId, Integer amendmentNumber);
+}

--- a/src/main/java/org/openelisglobal/compliance/service/ComplianceReportArchiveServiceImpl.java
+++ b/src/main/java/org/openelisglobal/compliance/service/ComplianceReportArchiveServiceImpl.java
@@ -1,0 +1,65 @@
+package org.openelisglobal.compliance.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.openelisglobal.compliance.dao.ComplianceReportArchiveDAO;
+import org.openelisglobal.compliance.valueholder.ComplianceReportArchive;
+import org.openelisglobal.sample.service.SampleService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ComplianceReportArchiveServiceImpl implements ComplianceReportArchiveService {
+
+    @Autowired
+    private ComplianceReportArchiveDAO dao;
+
+    @Autowired
+    private SampleService sampleService;
+
+    @Override
+    public ComplianceReportArchive archiveIfAbsent(Long sampleId, Integer amendmentNumber, byte[] pdfBytes,
+            String userId) {
+        int effectiveAmendmentNumber = amendmentNumber == null ? 0 : amendmentNumber;
+
+        Optional<ComplianceReportArchive> existing = dao.findBySampleIdAndAmendmentNumber(sampleId,
+                effectiveAmendmentNumber);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        ComplianceReportArchive archive = new ComplianceReportArchive();
+        archive.setSample(sampleService.get(String.valueOf(sampleId)));
+        archive.setAmendmentNumber(effectiveAmendmentNumber);
+        archive.setPdfContent(pdfBytes);
+        archive.setSha256Hash(sha256Hex(pdfBytes));
+        archive.setGeneratedAt(OffsetDateTime.now());
+        archive.setGeneratedByUserId(userId);
+        return dao.save(archive);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ComplianceReportArchive> findBySampleIdAndAmendmentNumber(Long sampleId, Integer amendmentNumber) {
+        return dao.findBySampleIdAndAmendmentNumber(sampleId, amendmentNumber == null ? 0 : amendmentNumber);
+    }
+
+    private static String sha256Hex(byte[] data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(data);
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/compliance/service/ComplianceReportArchiveServiceImpl.java
+++ b/src/main/java/org/openelisglobal/compliance/service/ComplianceReportArchiveServiceImpl.java
@@ -1,6 +1,5 @@
 package org.openelisglobal.compliance.service;
 
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;

--- a/src/main/java/org/openelisglobal/compliance/service/LhuAmendmentService.java
+++ b/src/main/java/org/openelisglobal/compliance/service/LhuAmendmentService.java
@@ -1,0 +1,29 @@
+package org.openelisglobal.compliance.service;
+
+public interface LhuAmendmentService {
+
+    /**
+     * Returns true if the sample has at least one analysis bearing a
+     * VALIDATED_AND_RELEASED electronic signature, which is the authoritative
+     * release marker for the LHU. Generation count is NOT used — previews trigger
+     * generation without constituting a release. See OGC-776 T-201.
+     */
+    boolean hasBeenReleased(Long sampleId);
+
+    /**
+     * Records a report-level amendment on the sample. Increments amendmentNumber
+     * (null → 1, N → N+1), stores the prior certificate number and the reason. Must
+     * be called inside a transaction (service layer only).
+     *
+     * @throws IllegalArgumentException if reason is blank or null
+     * @throws IllegalArgumentException if the sample does not exist
+     */
+    void applyLhuAmendment(Long sampleId, String priorCertificateNumber, String reason);
+
+    /**
+     * Returns the certificate number with an /Am.N suffix appended when
+     * amendmentNumber >= 1. Preserves any existing /R revision suffix. Returns null
+     * when base is null. Returns base unchanged when amendmentNumber is null or 0.
+     */
+    String certificateNumberWithAmendmentSuffix(String baseCertificateNumber, Integer amendmentNumber);
+}

--- a/src/main/java/org/openelisglobal/compliance/service/LhuAmendmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/compliance/service/LhuAmendmentServiceImpl.java
@@ -1,0 +1,78 @@
+package org.openelisglobal.compliance.service;
+
+import java.util.List;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.esig.service.ElectronicSignatureService;
+import org.openelisglobal.esig.valueholder.ElectronicSignature;
+import org.openelisglobal.esig.valueholder.SignatureMeaning;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.sampleitem.service.SampleItemService;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class LhuAmendmentServiceImpl implements LhuAmendmentService {
+
+    @Autowired
+    private SampleService sampleService;
+
+    @Autowired
+    private SampleItemService sampleItemService;
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Autowired
+    private ElectronicSignatureService electronicSignatureService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasBeenReleased(Long sampleId) {
+        List<SampleItem> items = sampleItemService.getSampleItemsBySampleId(String.valueOf(sampleId));
+        for (SampleItem item : items) {
+            List<Analysis> analyses = analysisService.getAnalysesBySampleItem(item);
+            for (Analysis analysis : analyses) {
+                List<ElectronicSignature> sigs = electronicSignatureService.getSignaturesForRecord("VALIDATION_BATCH",
+                        Long.parseLong(analysis.getId()));
+                for (ElectronicSignature sig : sigs) {
+                    if (sig.getSignatureMeaning() == SignatureMeaning.VALIDATED_AND_RELEASED) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void applyLhuAmendment(Long sampleId, String priorCertificateNumber, String reason) {
+        if (reason == null || reason.trim().isEmpty()) {
+            throw new IllegalArgumentException("Amendment reason must not be blank");
+        }
+        Sample sample = sampleService.get(String.valueOf(sampleId));
+        if (sample == null) {
+            throw new IllegalArgumentException("Sample not found: " + sampleId);
+        }
+        Integer current = sample.getAmendmentNumber();
+        sample.setAmendmentNumber(current == null ? 1 : current + 1);
+        sample.setAmendsLhuNumber(priorCertificateNumber);
+        sample.setAmendmentReason(reason);
+        sampleService.save(sample);
+    }
+
+    @Override
+    public String certificateNumberWithAmendmentSuffix(String baseCertificateNumber, Integer amendmentNumber) {
+        if (baseCertificateNumber == null) {
+            return null;
+        }
+        if (amendmentNumber == null || amendmentNumber <= 0) {
+            return baseCertificateNumber;
+        }
+        return baseCertificateNumber + "/Am." + amendmentNumber;
+    }
+}

--- a/src/main/java/org/openelisglobal/compliance/valueholder/ComplianceReportArchive.java
+++ b/src/main/java/org/openelisglobal/compliance/valueholder/ComplianceReportArchive.java
@@ -1,0 +1,105 @@
+package org.openelisglobal.compliance.valueholder;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
+import org.openelisglobal.common.valueholder.BaseObject;
+import org.openelisglobal.sample.valueholder.Sample;
+
+@Entity
+@Table(name = "compliance_report_archive", schema = "clinlims", uniqueConstraints = @UniqueConstraint(name = "uq_compliance_report_archive_sample_amendment", columnNames = {
+        "sample_id", "amendment_number" }))
+public class ComplianceReportArchive extends BaseObject<Long> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sample_id", nullable = false)
+    private Sample sample;
+
+    @Column(name = "amendment_number", nullable = false)
+    private Integer amendmentNumber;
+
+    @Column(name = "pdf_content", nullable = false)
+    private byte[] pdfContent;
+
+    @Column(name = "sha256_hash", nullable = false, length = 64)
+    private String sha256Hash;
+
+    @Column(name = "generated_at", nullable = false)
+    private OffsetDateTime generatedAt;
+
+    @Column(name = "generated_by_user_id")
+    private String generatedByUserId;
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Sample getSample() {
+        return sample;
+    }
+
+    public void setSample(Sample sample) {
+        this.sample = sample;
+    }
+
+    public Integer getAmendmentNumber() {
+        return amendmentNumber;
+    }
+
+    public void setAmendmentNumber(Integer amendmentNumber) {
+        this.amendmentNumber = amendmentNumber;
+    }
+
+    public byte[] getPdfContent() {
+        return pdfContent;
+    }
+
+    public void setPdfContent(byte[] pdfContent) {
+        this.pdfContent = pdfContent;
+    }
+
+    public String getSha256Hash() {
+        return sha256Hash;
+    }
+
+    public void setSha256Hash(String sha256Hash) {
+        this.sha256Hash = sha256Hash;
+    }
+
+    public OffsetDateTime getGeneratedAt() {
+        return generatedAt;
+    }
+
+    public void setGeneratedAt(OffsetDateTime generatedAt) {
+        this.generatedAt = generatedAt;
+    }
+
+    public String getGeneratedByUserId() {
+        return generatedByUserId;
+    }
+
+    public void setGeneratedByUserId(String generatedByUserId) {
+        this.generatedByUserId = generatedByUserId;
+    }
+}

--- a/src/main/java/org/openelisglobal/sample/valueholder/Sample.java
+++ b/src/main/java/org/openelisglobal/sample/valueholder/Sample.java
@@ -42,6 +42,10 @@ public class Sample extends EnumValueItemImpl implements NoteObject {
     // S-09 (OGC-580) Resample linkage: original <-> replacement order
     private String resampledFromSampleId;
     private String resampledToSampleId;
+    // OGC-776 (S-15e) LHU report-level amendment
+    private String amendsLhuNumber;
+    private Integer amendmentNumber;
+    private String amendmentReason;
     private String nextItemSequence;
     private String revision;
     private Date enteredDate;
@@ -165,6 +169,30 @@ public class Sample extends EnumValueItemImpl implements NoteObject {
 
     public void setResampledToSampleId(String resampledToSampleId) {
         this.resampledToSampleId = resampledToSampleId;
+    }
+
+    public String getAmendsLhuNumber() {
+        return amendsLhuNumber;
+    }
+
+    public void setAmendsLhuNumber(String amendsLhuNumber) {
+        this.amendsLhuNumber = amendsLhuNumber;
+    }
+
+    public Integer getAmendmentNumber() {
+        return amendmentNumber;
+    }
+
+    public void setAmendmentNumber(Integer amendmentNumber) {
+        this.amendmentNumber = amendmentNumber;
+    }
+
+    public String getAmendmentReason() {
+        return amendmentReason;
+    }
+
+    public void setAmendmentReason(String amendmentReason) {
+        this.amendmentReason = amendmentReason;
     }
 
     public Date getEnteredDate() {

--- a/src/main/java/org/openelisglobal/sampletyperequest/valueholder/SampleTypeRequest.java
+++ b/src/main/java/org/openelisglobal/sampletyperequest/valueholder/SampleTypeRequest.java
@@ -64,7 +64,7 @@ public class SampleTypeRequest extends BaseObject<Integer> {
     private Integer sortOrder = 0;
 
     @Column(name = "requested_quantity")
-    private Double requestedQuantity = 1.0;
+    private Double requestedQuantity;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "unit_of_measure_id")

--- a/src/main/resources/hibernate/hbm/Sample.hbm.xml
+++ b/src/main/resources/hibernate/hbm/Sample.hbm.xml
@@ -115,6 +115,13 @@
             column="consent_recorded_at" type="java.sql.Timestamp" />
         <property name="consentRecordedBy"
             column="consent_recorded_by" type="java.lang.String" length="255" />
+        <!--LHU report-level amendment metadata -->
+        <property name="amendsLhuNumber" column="amends_lhu_number"
+            type="java.lang.String" />
+        <property name="amendmentNumber" column="amendment_number"
+            type="java.lang.Integer" />
+        <property name="amendmentReason" column="amendment_reason"
+            type="java.lang.String" />
 
         <!-- <set name="sampleOrganizations" inverse="true"> <key> <column name="SAMP_ID"
             precision="10" scale="0" /> </key> <one-to-many class="org.openelisglobal.sampleorganization.valueholder.SampleOrganization"

--- a/src/main/resources/liquibase/3.5.x.x/051-sample-amendment-metadata.xml
+++ b/src/main/resources/liquibase/3.5.x.x/051-sample-amendment-metadata.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <!--
+    LHU report-level amendment metadata on sample.
+    Three nullable columns track the amendment chain per order:
+      amends_lhu_number  — the prior certificate/lab number this order amends (interim: accession number)
+      amendment_number   — sequential counter; NULL = never amended, 1 = first amendment, etc.
+      amendment_reason   — free-text reason captured at reissue time
+    Existing orders are unaffected (all NULL). See tasks.md Phase 1 T-101.
+  -->
+
+  <changeSet id="3.5.0.0-sample-add-amends-lhu-number" author="reagan-meant">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists schemaName="clinlims" tableName="sample" columnName="amends_lhu_number"/>
+      </not>
+    </preConditions>
+    <addColumn schemaName="clinlims" tableName="sample">
+      <column name="amends_lhu_number" type="TEXT"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="3.5.0.0-sample-add-amendment-number" author="reagan-meant">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists schemaName="clinlims" tableName="sample" columnName="amendment_number"/>
+      </not>
+    </preConditions>
+    <addColumn schemaName="clinlims" tableName="sample">
+      <column name="amendment_number" type="INTEGER"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="3.5.0.0-sample-add-amendment-reason" author="reagan-meant">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists schemaName="clinlims" tableName="sample" columnName="amendment_reason"/>
+      </not>
+    </preConditions>
+    <addColumn schemaName="clinlims" tableName="sample">
+      <column name="amendment_reason" type="TEXT"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/052-compliance-report-archive.xml
+++ b/src/main/resources/liquibase/3.5.x.x/052-compliance-report-archive.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <!--
+    PDF archival for ISO 17025 §7.8.8 compliance.
+    Stores the rendered PDF bytes + SHA-256 hash keyed to (sample_id, amendment_number).
+    amendment_number = 0 is the original released report; 1..N are amendments.
+    Unique constraint on (sample_id, amendment_number) enforces immutability at the DB level —
+    once a row exists it cannot be overwritten. Archive ONLY on release/reissue, never on preview.
+    Keep this table separate from any table the report listing SELECTs — the bytea is read only
+    on audit retrieval. See tasks.md Phase 5 T-502.
+  -->
+
+  <changeSet id="3.5.0.0-create-compliance-report-archive" author="reagan-meant">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists schemaName="clinlims" tableName="compliance_report_archive"/>
+      </not>
+    </preConditions>
+    <createTable schemaName="clinlims" tableName="compliance_report_archive">
+      <column name="id" type="BIGINT" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="sample_id" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="amendment_number" type="INTEGER" defaultValueNumeric="0">
+        <constraints nullable="false"/>
+      </column>
+      <column name="pdf_content" type="BYTEA">
+        <constraints nullable="false"/>
+      </column>
+      <column name="sha256_hash" type="VARCHAR(64)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="generated_at" type="TIMESTAMPTZ">
+        <constraints nullable="false"/>
+      </column>
+      <column name="generated_by_user_id" type="VARCHAR(255)"/>
+      <column name="last_updated" type="TIMESTAMPTZ" defaultValueComputed="now()">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="3.5.0.0-compliance-report-archive-add-last-updated" author="reagan-meant">
+    <preConditions onFail="MARK_RAN">
+      <tableExists schemaName="clinlims" tableName="compliance_report_archive"/>
+      <not>
+        <columnExists schemaName="clinlims" tableName="compliance_report_archive" columnName="last_updated"/>
+      </not>
+    </preConditions>
+    <addColumn schemaName="clinlims" tableName="compliance_report_archive">
+      <column name="last_updated" type="TIMESTAMPTZ" defaultValueComputed="now()">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="3.5.0.0-compliance-report-archive-unique" author="reagan-meant">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists schemaName="clinlims" tableName="compliance_report_archive"
+                     indexName="uq_compliance_report_archive_sample_amendment"/>
+      </not>
+    </preConditions>
+    <addUniqueConstraint
+      schemaName="clinlims"
+      tableName="compliance_report_archive"
+      columnNames="sample_id, amendment_number"
+      constraintName="uq_compliance_report_archive_sample_amendment"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -194,4 +194,10 @@
   <include relativeToChangelogFile="true" file="049-sample-resample-links.xml"/>
   <include relativeToChangelogFile="true" file="050-resample-notification-trigger.xml"/>
 
+  <!-- LHU report-level amendment metadata on sample -->
+  <include relativeToChangelogFile="true" file="051-sample-amendment-metadata.xml"/>
+
+  <!-- LHU PDF archival for ISO 17025 §7.8.8 compliance -->
+  <include relativeToChangelogFile="true" file="052-compliance-report-archive.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/persistence/persistence.xml
+++ b/src/main/resources/persistence/persistence.xml
@@ -155,6 +155,7 @@
         <class>org.openelisglobal.compliance.valueholder.ParameterGroup</class>
         <class>org.openelisglobal.compliance.valueholder.ComplianceThreshold</class>
         <class>org.openelisglobal.compliance.valueholder.ComplianceThresholdValueMap</class>
+        <class>org.openelisglobal.compliance.valueholder.ComplianceReportArchive</class>
 
         <!-- QC Result Evaluation entities (OGC-554 S-08) -->
         <class>org.openelisglobal.qc.valueholder.SampleItemQcProfile</class>

--- a/src/test/java/org/openelisglobal/AppTestConfig.java
+++ b/src/test/java/org/openelisglobal/AppTestConfig.java
@@ -123,7 +123,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.eqa.scheduler.*"),
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = PrintBarcodeController.class),
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WHONetReportServiceImpl.class),
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = TestNotificationServiceImpl.class) })
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = TestNotificationServiceImpl.class),
+                // Nested test-only @Configuration classes must not be picked up by this
+                // shared component scan. ComplianceReportReissueSecurityTest.TestConfig
+                // registers a mock SampleComplianceStandardDAO @Bean for its isolated
+                // MockMvc slice; if scanned here it collides with the real
+                // sampleComplianceStandardDAOImpl (NoUniqueBeanDefinitionException) and
+                // breaks the shared integration ApplicationContext. Matched by REGEX on
+                // its binary name because the nested config is package-private.
+                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.openelisglobal.compliance.controller.rest.ComplianceReportReissueSecurityTest.*") })
 @EnableWebMvc
 public class AppTestConfig implements WebMvcConfigurer {
 

--- a/src/test/java/org/openelisglobal/compliance/controller/rest/ComplianceReportReissueSecurityTest.java
+++ b/src/test/java/org/openelisglobal/compliance/controller/rest/ComplianceReportReissueSecurityTest.java
@@ -1,0 +1,135 @@
+package org.openelisglobal.compliance.controller.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.compliance.service.ComplianceEvaluationService;
+import org.openelisglobal.compliance.service.ComplianceReportGenerationService;
+import org.openelisglobal.compliance.service.LhuAmendmentService;
+import org.openelisglobal.esig.service.ElectronicSignatureService;
+import org.openelisglobal.observationhistory.service.ObservationHistoryService;
+import org.openelisglobal.result.service.ResultService;
+import org.openelisglobal.sample.dao.SampleComplianceStandardDAO;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sampleitem.service.SampleItemService;
+import org.openelisglobal.security.SecuritySliceMockMvcTest;
+import org.openelisglobal.vector.service.VectorSamplingSiteService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+/**
+ * Auth-ordering tests for POST /rest/complianceReport/reissue (OGC-776 T-301).
+ *
+ * Constitution V.6 invariant: 403 must fire BEFORE body validation (400). A
+ * caller without ROLE_RESULTS / ROLE_SUPERVISOR / ADMIN must be rejected at the
+ * security layer, regardless of whether the request body is valid.
+ */
+@WebAppConfiguration
+@ContextConfiguration(classes = { ComplianceReportReissueSecurityTest.TestConfig.class })
+@TestPropertySource("classpath:common.properties")
+public class ComplianceReportReissueSecurityTest extends SecuritySliceMockMvcTest {
+
+    private static final String VALID_BODY = "{\"sampleId\":1,\"reason\":\"Incorrect result\"}";
+    private static final String BLANK_REASON_BODY = "{\"sampleId\":1,\"reason\":\"\"}";
+
+    /**
+     * Unauthenticated caller → 401 (Spring Security blocks before the controller).
+     */
+    @Test
+    public void reissue_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(
+                post("/rest/complianceReport/reissue").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /**
+     * Authenticated but wrong role → 403. Body is valid, so if auth fires AFTER
+     * body validation this would return 400 instead — catching ordering violations.
+     */
+    @Test
+    public void reissue_wrongRole_returns403BeforeBodyValidation() throws Exception {
+        mockMvc.perform(post("/rest/complianceReport/reissue").with(user("readonly").roles("RECEPTION"))
+                .contentType(MediaType.APPLICATION_JSON).content(VALID_BODY)).andExpect(status().isForbidden());
+    }
+
+    /**
+     * Blank reason with wrong role → must still get 403, not 400. Proves auth
+     * ordering is enforced even when body would fail validation.
+     */
+    @Test
+    public void reissue_wrongRoleBlankReason_returns403NotBadRequest() throws Exception {
+        mockMvc.perform(post("/rest/complianceReport/reissue").with(user("readonly").roles("RECEPTION"))
+                .contentType(MediaType.APPLICATION_JSON).content(BLANK_REASON_BODY)).andExpect(status().isForbidden());
+    }
+
+    /**
+     * ROLE_RESULTS holder passes auth (gets past the 403 gate). The request body is
+     * valid but sampleId=1 has no released analysis in this slice context, so we
+     * expect 404 — confirming auth did NOT block.
+     */
+    @Test
+    public void reissue_roleResults_passesSecurity() throws Exception {
+        mockMvc.perform(post("/rest/complianceReport/reissue").with(user("analyst").roles("RESULTS"))
+                .contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+                .andExpect(status().is(org.hamcrest.Matchers.not(403)));
+    }
+
+    @Configuration
+    @EnableWebMvc
+    @EnableWebSecurity
+    @EnableMethodSecurity(prePostEnabled = true)
+    static class TestConfig {
+
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated()).httpBasic(Customizer.withDefaults())
+                    .csrf(csrf -> csrf.disable());
+            return http.build();
+        }
+
+        @Bean
+        ComplianceReportRestController complianceReportRestController() {
+            ComplianceReportRestController controller = new ComplianceReportRestController();
+            ReflectionTestUtils.setField(controller, "sampleService", mock(SampleService.class));
+            ReflectionTestUtils.setField(controller, "sampleItemService", mock(SampleItemService.class));
+            ReflectionTestUtils.setField(controller, "sampleComplianceStandardDAO",
+                    mock(SampleComplianceStandardDAO.class));
+            ReflectionTestUtils.setField(controller, "complianceEvaluationService",
+                    mock(ComplianceEvaluationService.class));
+            ReflectionTestUtils.setField(controller, "reportGenerationService",
+                    mock(ComplianceReportGenerationService.class));
+            ReflectionTestUtils.setField(controller, "electronicSignatureService",
+                    mock(ElectronicSignatureService.class));
+            ReflectionTestUtils.setField(controller, "observationHistoryService",
+                    mock(ObservationHistoryService.class));
+            ReflectionTestUtils.setField(controller, "vectorSamplingSiteService",
+                    mock(VectorSamplingSiteService.class));
+            ReflectionTestUtils.setField(controller, "resultService", mock(ResultService.class));
+            ReflectionTestUtils.setField(controller, "analysisService", mock(AnalysisService.class));
+
+            LhuAmendmentService lhuAmendmentService = mock(LhuAmendmentService.class);
+            when(lhuAmendmentService.hasBeenReleased(anyLong())).thenReturn(false);
+            when(lhuAmendmentService.certificateNumberWithAmendmentSuffix(any(), any())).thenReturn("24-00001");
+            ReflectionTestUtils.setField(controller, "lhuAmendmentService", lhuAmendmentService);
+            return controller;
+        }
+    }
+}

--- a/src/test/java/org/openelisglobal/compliance/controller/rest/ComplianceReportReissueSecurityTest.java
+++ b/src/test/java/org/openelisglobal/compliance/controller/rest/ComplianceReportReissueSecurityTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.Test;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.compliance.service.ComplianceEvaluationService;
+import org.openelisglobal.compliance.service.ComplianceReportArchiveService;
 import org.openelisglobal.compliance.service.ComplianceReportGenerationService;
 import org.openelisglobal.compliance.service.LhuAmendmentService;
 import org.openelisglobal.esig.service.ElectronicSignatureService;
@@ -32,7 +33,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 /**
@@ -89,7 +89,7 @@ public class ComplianceReportReissueSecurityTest extends SecuritySliceMockMvcTes
     public void reissue_roleResults_passesSecurity() throws Exception {
         mockMvc.perform(post("/rest/complianceReport/reissue").with(user("analyst").roles("RESULTS"))
                 .contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
-                .andExpect(status().is(org.hamcrest.Matchers.not(403)));
+                .andExpect(status().is(org.hamcrest.CoreMatchers.not(403)));
     }
 
     @Configuration
@@ -107,29 +107,70 @@ public class ComplianceReportReissueSecurityTest extends SecuritySliceMockMvcTes
 
         @Bean
         ComplianceReportRestController complianceReportRestController() {
-            ComplianceReportRestController controller = new ComplianceReportRestController();
-            ReflectionTestUtils.setField(controller, "sampleService", mock(SampleService.class));
-            ReflectionTestUtils.setField(controller, "sampleItemService", mock(SampleItemService.class));
-            ReflectionTestUtils.setField(controller, "sampleComplianceStandardDAO",
-                    mock(SampleComplianceStandardDAO.class));
-            ReflectionTestUtils.setField(controller, "complianceEvaluationService",
-                    mock(ComplianceEvaluationService.class));
-            ReflectionTestUtils.setField(controller, "reportGenerationService",
-                    mock(ComplianceReportGenerationService.class));
-            ReflectionTestUtils.setField(controller, "electronicSignatureService",
-                    mock(ElectronicSignatureService.class));
-            ReflectionTestUtils.setField(controller, "observationHistoryService",
-                    mock(ObservationHistoryService.class));
-            ReflectionTestUtils.setField(controller, "vectorSamplingSiteService",
-                    mock(VectorSamplingSiteService.class));
-            ReflectionTestUtils.setField(controller, "resultService", mock(ResultService.class));
-            ReflectionTestUtils.setField(controller, "analysisService", mock(AnalysisService.class));
+            return new ComplianceReportRestController();
+        }
 
+        @Bean
+        SampleService sampleService() {
+            return mock(SampleService.class);
+        }
+
+        @Bean
+        SampleItemService sampleItemService() {
+            return mock(SampleItemService.class);
+        }
+
+        @Bean
+        SampleComplianceStandardDAO sampleComplianceStandardDAO() {
+            return mock(SampleComplianceStandardDAO.class);
+        }
+
+        @Bean
+        ComplianceEvaluationService complianceEvaluationService() {
+            return mock(ComplianceEvaluationService.class);
+        }
+
+        @Bean
+        ComplianceReportGenerationService reportGenerationService() {
+            return mock(ComplianceReportGenerationService.class);
+        }
+
+        @Bean
+        ElectronicSignatureService electronicSignatureService() {
+            return mock(ElectronicSignatureService.class);
+        }
+
+        @Bean
+        ObservationHistoryService observationHistoryService() {
+            return mock(ObservationHistoryService.class);
+        }
+
+        @Bean
+        VectorSamplingSiteService vectorSamplingSiteService() {
+            return mock(VectorSamplingSiteService.class);
+        }
+
+        @Bean
+        ResultService resultService() {
+            return mock(ResultService.class);
+        }
+
+        @Bean
+        AnalysisService analysisService() {
+            return mock(AnalysisService.class);
+        }
+
+        @Bean
+        ComplianceReportArchiveService archiveService() {
+            return mock(ComplianceReportArchiveService.class);
+        }
+
+        @Bean
+        LhuAmendmentService lhuAmendmentService() {
             LhuAmendmentService lhuAmendmentService = mock(LhuAmendmentService.class);
             when(lhuAmendmentService.hasBeenReleased(anyLong())).thenReturn(false);
             when(lhuAmendmentService.certificateNumberWithAmendmentSuffix(any(), any())).thenReturn("24-00001");
-            ReflectionTestUtils.setField(controller, "lhuAmendmentService", lhuAmendmentService);
-            return controller;
+            return lhuAmendmentService;
         }
     }
 }

--- a/src/test/java/org/openelisglobal/compliance/service/ComplianceReportArchiveServiceTest.java
+++ b/src/test/java/org/openelisglobal/compliance/service/ComplianceReportArchiveServiceTest.java
@@ -1,0 +1,141 @@
+package org.openelisglobal.compliance.service;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.compliance.valueholder.ComplianceReportArchive;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
+
+/**
+ * TDD spec for ComplianceReportArchiveService (OGC-776 Phase 5, T-503).
+ *
+ * Key invariants: - archiveIfAbsent saves on first call, returns the SAME row
+ * on subsequent calls (immutability guard). - SHA-256 is stable (same bytes →
+ * same hash, always 64 hex chars). - amendmentNumber keys versions separately
+ * (0 = original, 1 = first amendment). - null amendmentNumber is treated as 0.
+ */
+@Rollback
+public class ComplianceReportArchiveServiceTest extends BaseWebContextSensitiveTest {
+
+    private static final String SAMPLE_ID = "1";
+    private static final byte[] PDF_BYTES_V0 = "PDF content original".getBytes();
+    private static final byte[] PDF_BYTES_V1 = "PDF content amendment 1".getBytes();
+
+    @Autowired
+    private ComplianceReportArchiveService archiveService;
+
+    /**
+     * First call archives the PDF and returns a persisted record with a valid
+     * SHA-256.
+     */
+    @Test
+    public void archiveIfAbsent_firstCall_persistsAndReturnsSha256() {
+        ComplianceReportArchive archived = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 0, PDF_BYTES_V0,
+                "testuser");
+
+        assertNotNull("Archived record must not be null", archived);
+        assertNotNull("ID must be assigned after persist", archived.getId());
+        assertNotNull("sha256Hash must not be null", archived.getSha256Hash());
+        assertEquals("SHA-256 must be 64 hex chars", 64, archived.getSha256Hash().length());
+        assertArrayEquals("PDF bytes must be stored", PDF_BYTES_V0, archived.getPdfContent());
+        assertEquals("amendmentNumber must be 0 for original", Integer.valueOf(0), archived.getAmendmentNumber());
+    }
+
+    /**
+     * Second call with the same (sampleId, amendmentNumber) returns the EXISTING
+     * row — not a new save. Inversion: if the immutability guard is removed, two
+     * rows exist and the second call returns a new one.
+     */
+    @Test
+    public void archiveIfAbsent_secondCall_returnsExistingRowWithoutNewSave() {
+        ComplianceReportArchive first = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 0, PDF_BYTES_V0,
+                "testuser");
+        ComplianceReportArchive second = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 0,
+                "different bytes".getBytes(), "testuser");
+
+        assertEquals("Second call must return the same row id as the first", first.getId(), second.getId());
+        assertArrayEquals("PDF content must not be overwritten", PDF_BYTES_V0, second.getPdfContent());
+    }
+
+    /**
+     * Different amendmentNumbers are stored as separate rows — version isolation.
+     */
+    @Test
+    public void archiveIfAbsent_differentAmendmentNumbers_storedSeparately() {
+        ComplianceReportArchive v0 = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 0, PDF_BYTES_V0,
+                "testuser");
+        ComplianceReportArchive v1 = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 1, PDF_BYTES_V1,
+                "testuser");
+
+        assertNotNull(v0.getId());
+        assertNotNull(v1.getId());
+        assertTrue("Version rows must be distinct", !v0.getId().equals(v1.getId()));
+        assertArrayEquals(PDF_BYTES_V0, v0.getPdfContent());
+        assertArrayEquals(PDF_BYTES_V1, v1.getPdfContent());
+    }
+
+    /**
+     * SHA-256 is stable: same bytes always produce the same hash.
+     */
+    @Test
+    public void archiveIfAbsent_sha256IsStableAndVerifiable() {
+        ComplianceReportArchive archived = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 0, PDF_BYTES_V0,
+                "testuser");
+
+        // Re-compute and compare
+        ComplianceReportArchive archived2 = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 1, PDF_BYTES_V0,
+                "testuser");
+
+        assertEquals("Same bytes must produce the same SHA-256", archived.getSha256Hash(), archived2.getSha256Hash());
+    }
+
+    /**
+     * SHA-256 differs for different content — not a constant.
+     */
+    @Test
+    public void archiveIfAbsent_sha256DiffersForDifferentContent() {
+        ComplianceReportArchive v0 = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 0, PDF_BYTES_V0,
+                "testuser");
+        ComplianceReportArchive v1 = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 1, PDF_BYTES_V1,
+                "testuser");
+
+        assertTrue("Different PDF bytes must produce different SHA-256",
+                !v0.getSha256Hash().equals(v1.getSha256Hash()));
+    }
+
+    /**
+     * null amendmentNumber is treated as 0 (defensive — callers may pass null
+     * before first amendment).
+     */
+    @Test
+    public void archiveIfAbsent_nullAmendmentNumber_treatedAsZero() {
+        ComplianceReportArchive withNull = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), null, PDF_BYTES_V0,
+                "testuser");
+        ComplianceReportArchive withZero = archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 0, PDF_BYTES_V0,
+                "testuser");
+
+        assertEquals("null and 0 must resolve to the same row", withNull.getId(), withZero.getId());
+        assertEquals("amendmentNumber must be stored as 0", Integer.valueOf(0), withNull.getAmendmentNumber());
+    }
+
+    /**
+     * findBySampleIdAndAmendmentNumber returns the archived record after it is
+     * saved.
+     */
+    @Test
+    public void findBySampleIdAndAmendmentNumber_returnsArchivedRecord() {
+        archiveService.archiveIfAbsent(Long.parseLong(SAMPLE_ID), 0, PDF_BYTES_V0, "testuser");
+
+        Optional<ComplianceReportArchive> found = archiveService
+                .findBySampleIdAndAmendmentNumber(Long.parseLong(SAMPLE_ID), 0);
+
+        assertTrue("Must find the archived record", found.isPresent());
+        assertArrayEquals("PDF content must match", PDF_BYTES_V0, found.get().getPdfContent());
+    }
+}

--- a/src/test/java/org/openelisglobal/compliance/service/ComplianceReportArchiveServiceTest.java
+++ b/src/test/java/org/openelisglobal/compliance/service/ComplianceReportArchiveServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
+import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.compliance.valueholder.ComplianceReportArchive;
@@ -29,6 +30,12 @@ public class ComplianceReportArchiveServiceTest extends BaseWebContextSensitiveT
 
     @Autowired
     private ComplianceReportArchiveService archiveService;
+
+    @Before
+    public void setUp() throws Exception {
+        // Seed Sample#1, which archiveIfAbsent resolves via sampleService.get("1").
+        executeDataSetWithStateManagement("testdata/compliance-report-archive.xml");
+    }
 
     /**
      * First call archives the PDF and returns a persisted record with a valid

--- a/src/test/java/org/openelisglobal/compliance/service/LhuAmendmentServiceTest.java
+++ b/src/test/java/org/openelisglobal/compliance/service/LhuAmendmentServiceTest.java
@@ -1,0 +1,138 @@
+package org.openelisglobal.compliance.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
+
+/**
+ * TDD spec for LhuAmendmentService (OGC-776 Phase 2, T-203).
+ *
+ * Red → green → refactor. Tests must fail before the implementation exists.
+ * Inversion tests: if the increment logic is replaced with a hardcoded value,
+ * the second-amendment test fails. If the null-guard is removed, the
+ * blank-reason test passes trivially and breaks the contract.
+ */
+@Rollback
+public class LhuAmendmentServiceTest extends BaseWebContextSensitiveTest {
+
+    private static final String SAMPLE_ID = "1";
+    private static final String ACCESSION = "24-00001";
+
+    @Autowired
+    private LhuAmendmentService lhuAmendmentService;
+
+    @Autowired
+    private SampleService sampleService;
+
+    /**
+     * A fresh (never-amended) order has amendmentNumber == null. Untouched orders
+     * must remain completely unaffected by the feature.
+     */
+    @Test
+    public void nonAmendedOrder_amendmentNumberIsNull() {
+        Sample sample = sampleService.get(SAMPLE_ID);
+        assertNotNull("Fixture sample must exist", sample);
+        assertNull("Never-amended order must have null amendmentNumber", sample.getAmendmentNumber());
+    }
+
+    /**
+     * First amendment sets amendmentNumber to 1. Inversion: if the implementation
+     * hardcodes 1, the second test below breaks.
+     */
+    @Test
+    public void firstAmendment_setsAmendmentNumberToOne() {
+        lhuAmendmentService.applyLhuAmendment(Long.parseLong(SAMPLE_ID), ACCESSION, "Incorrect pH result");
+
+        Sample updated = sampleService.get(SAMPLE_ID);
+        assertEquals("First amendment must set amendmentNumber to 1", Integer.valueOf(1), updated.getAmendmentNumber());
+        assertEquals("amendsLhuNumber must record the prior certificate number", ACCESSION,
+                updated.getAmendsLhuNumber());
+        assertEquals("amendmentReason must be stored", "Incorrect pH result", updated.getAmendmentReason());
+    }
+
+    /**
+     * Second amendment increments to 2. This is the inversion test: if the
+     * implementation hardcodes 1 rather than (current + 1), this test fails.
+     */
+    @Test
+    public void secondAmendment_incrementsAmendmentNumberToTwo() {
+        lhuAmendmentService.applyLhuAmendment(Long.parseLong(SAMPLE_ID), ACCESSION, "First correction");
+        lhuAmendmentService.applyLhuAmendment(Long.parseLong(SAMPLE_ID), ACCESSION + "/Am.1", "Second correction");
+
+        Sample updated = sampleService.get(SAMPLE_ID);
+        assertEquals("Second amendment must set amendmentNumber to 2", Integer.valueOf(2),
+                updated.getAmendmentNumber());
+        assertEquals("amendmentReason must reflect the latest reason", "Second correction",
+                updated.getAmendmentReason());
+    }
+
+    /**
+     * Blank reason must be rejected — ISO 17025 §7.8.8 requires a stated reason.
+     */
+    @Test
+    public void blankReason_throwsIllegalArgumentException() {
+        try {
+            lhuAmendmentService.applyLhuAmendment(Long.parseLong(SAMPLE_ID), ACCESSION, "");
+            fail("blank reason must throw IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // pass
+        }
+    }
+
+    /**
+     * Null reason also rejected.
+     */
+    @Test
+    public void nullReason_throwsIllegalArgumentException() {
+        try {
+            lhuAmendmentService.applyLhuAmendment(Long.parseLong(SAMPLE_ID), ACCESSION, null);
+            fail("null reason must throw IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // pass
+        }
+    }
+
+    /**
+     * certificateNumberWithAmendmentSuffix appends /Am.N when amendmentNumber >= 1.
+     */
+    @Test
+    public void certificateSuffix_appendsAmN_whenAmended() {
+        assertEquals("24-00001/Am.1", lhuAmendmentService.certificateNumberWithAmendmentSuffix("24-00001", 1));
+        assertEquals("24-00001/Am.2", lhuAmendmentService.certificateNumberWithAmendmentSuffix("24-00001", 2));
+    }
+
+    /**
+     * No suffix when amendmentNumber is null or 0.
+     */
+    @Test
+    public void certificateSuffix_noSuffix_whenNullOrZero() {
+        assertEquals("24-00001", lhuAmendmentService.certificateNumberWithAmendmentSuffix("24-00001", null));
+        assertEquals("24-00001", lhuAmendmentService.certificateNumberWithAmendmentSuffix("24-00001", 0));
+    }
+
+    /**
+     * /R revision suffix is preserved — the amendment suffix appends after it.
+     */
+    @Test
+    public void certificateSuffix_preservesRevisionSuffix() {
+        assertEquals("LHU-2026-0042/R/Am.1",
+                lhuAmendmentService.certificateNumberWithAmendmentSuffix("LHU-2026-0042/R", 1));
+    }
+
+    /**
+     * Null base returns null (defensive — callers may not have a certificate number
+     * yet).
+     */
+    @Test
+    public void certificateSuffix_nullBase_returnsNull() {
+        assertNull(lhuAmendmentService.certificateNumberWithAmendmentSuffix(null, 1));
+    }
+}

--- a/src/test/java/org/openelisglobal/compliance/service/LhuAmendmentServiceTest.java
+++ b/src/test/java/org/openelisglobal/compliance/service/LhuAmendmentServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.sample.service.SampleService;
@@ -31,6 +32,13 @@ public class LhuAmendmentServiceTest extends BaseWebContextSensitiveTest {
 
     @Autowired
     private SampleService sampleService;
+
+    @Before
+    public void setUp() throws Exception {
+        // Seed Sample#1 (accession 24-00001), which the amendment service and these
+        // assertions resolve via sampleService.get("1").
+        executeDataSetWithStateManagement("testdata/compliance-report-archive.xml");
+    }
 
     /**
      * A fresh (never-amended) order has amendmentNumber == null. Untouched orders

--- a/src/test/resources/persistence/test-persistence.xml
+++ b/src/test/resources/persistence/test-persistence.xml
@@ -183,6 +183,7 @@
         <class>org.openelisglobal.compliance.valueholder.ParameterGroup</class>
         <class>org.openelisglobal.compliance.valueholder.ComplianceThreshold</class>
         <class>org.openelisglobal.compliance.valueholder.ComplianceThresholdValueMap</class>
+        <class>org.openelisglobal.compliance.valueholder.ComplianceReportArchive</class>
         <class>org.openelisglobal.sample.valueholder.SampleComplianceStandard</class>
         <!-- Vector Surveillance entities -->
         <class>org.openelisglobal.vector.valueholder.VectorOrganismGroup</class>

--- a/src/test/resources/testdata/compliance-report-archive.xml
+++ b/src/test/resources/testdata/compliance-report-archive.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Minimal fixture for the compliance report archive / LHU amendment service
+    tests (OGC-776). Provides Sample#1 (accession 24-00001) which both ComplianceReportArchiveServiceTest
+    and LhuAmendmentServiceTest resolve via sampleService.get("1"). -->
+<dataset>
+    <sample id="1" accession_number="24-00001"
+        entered_date="2024-02-12 00:00:00" received_date="2024-02-12 00:00:00"
+        collection_date="2024-02-11 08:30:00" is_confirmation="false"
+        lastupdated="2024-02-12 12:00:00" />
+</dataset>


### PR DESCRIPTION
- Added ComplianceReportArchiveDAO and ComplianceReportArchiveDAOImpl for managing compliance report archives.
- Introduced ComplianceReportArchiveService and its implementation to handle archiving logic.
- Created LhuAmendmentService and LhuAmendmentServiceImpl for managing LHU report-level amendments.
- Enhanced Sample entity to include amendment metadata (amendsLhuNumber, amendmentNumber, amendmentReason).
- Added Liquibase changelogs for database schema updates related to compliance report archiving and sample amendment metadata.
- Developed unit tests for ComplianceReportArchiveService and LhuAmendmentService to ensure functionality and correctness.
- Implemented security tests for compliance report reissue endpoint to validate authorization logic.

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
