### PR TITLE
docs: analyzer-independent QC/results roadmap

### DIFF
--- a/specs/427-811-qc-results-entry-roadmap/checklists/requirements.md
+++ b/specs/427-811-qc-results-entry-roadmap/checklists/requirements.md
@@ -1,0 +1,53 @@
+# Requirements Checklist: Analyzer-Independent QC/Results Roadmap
+
+## Scope Integrity
+
+- [ ] Roadmap excludes analyzer profiles, analyzer mapping GUI, bridge transport,
+      ASTM/HL7, and FILE polling.
+- [ ] OGC-811 is treated as the current Results Entry authority.
+- [ ] OGC-517 is historical context only.
+- [ ] OGC-427 is the first implementation anchor.
+- [ ] OGC-817 follows Results Entry and consumes shared signals.
+- [ ] OGC-899 is used for PNG/CPHL rollup and evidence.
+
+## MVP Integrity
+
+- [ ] MVP A covers Batch Workplan persistence, lifecycle, reagent lot, QC state,
+      inline QC, NCE override, and print/preview.
+- [ ] MVP B covers Results Entry worklist, edit-state, bench controls, inline
+      NCE, sample usage, aliquots, and scoped history.
+- [ ] MVP C covers Validation risk triage, guarded release, inline NCE reject,
+      retest note, and e-sign release.
+
+## Evidence Integrity
+
+- [ ] Mock baseline commit is pinned.
+- [ ] Mock screenshots are captured before UI implementation.
+- [ ] Implementation screenshots match the same viewports.
+- [ ] Mock comparison note exists.
+- [ ] MP4 user-story proof exists.
+- [ ] MP4 was inspected.
+- [ ] Browser console logs were reviewed.
+- [ ] Playwright does not use API calls as proof.
+
+## Code-QA Integrity
+
+- [ ] Spec-code alignment is documented.
+- [ ] Tests sit at the right layer.
+- [ ] No overmocking hides product gaps.
+- [ ] Controllers do not own transactions.
+- [ ] Services compile response data inside transactions.
+- [ ] Liquibase owns schema changes.
+- [ ] React Intl is used for user-facing strings.
+- [ ] Non-English locale files are not edited.
+- [ ] Carbon is used for UI.
+- [ ] Legacy paths are removed, redirected, or tracked.
+
+## PR Readiness
+
+- [ ] Milestone tasks are checked off.
+- [ ] Local validation commands are recorded.
+- [ ] Evidence note is linked in PR body.
+- [ ] Code-qa gate summary is in PR body.
+- [ ] Mock comparison summary is in PR body.
+- [ ] Follow-ups are explicit and not hidden scope.

--- a/specs/427-811-qc-results-entry-roadmap/contracts/evidence-template.md
+++ b/specs/427-811-qc-results-entry-roadmap/contracts/evidence-template.md
@@ -1,0 +1,71 @@
+# Evidence Template
+
+Copy this file into each milestone evidence folder as `README.md` or reference
+it from the PR body.
+
+## Milestone
+
+- Milestone:
+- Branch:
+- PR:
+- Jira:
+- Mock baseline commit:
+- Mock artifacts:
+
+## Scope
+
+In scope:
+
+- <fill in>
+
+Out of scope:
+
+- Analyzer profiles, analyzer bridge, ASTM/HL7/FILE transport, and OGC-1054
+  unless explicitly approved for this milestone.
+
+## User Story Video
+
+- Playwright spec:
+- Project:
+- MP4:
+- Duration:
+- Browser console reviewed: yes/no
+- Trace reviewed: yes/no
+
+The video proves visible user behavior only. It does not use REST/API shortcuts
+as proof.
+
+## Screenshot Comparison
+
+Mock screenshots:
+
+- <fill in>
+
+Implementation screenshots:
+
+- <fill in>
+
+Comparison result:
+
+- Aligned:
+- Intentional deviations:
+- Blocking mismatches:
+
+## Validation Commands
+
+- <fill in>
+
+## Code-QA Gates
+
+- Spec-code alignment:
+- Meaningful test coverage:
+- Architecture and transaction boundaries:
+- i18n and Carbon:
+- Security and audit:
+- Legacy path:
+- Simplicity:
+- Evidence bundle:
+
+## Follow-ups
+
+- <fill in>

--- a/specs/427-811-qc-results-entry-roadmap/plan.md
+++ b/specs/427-811-qc-results-entry-roadmap/plan.md
@@ -1,0 +1,229 @@
+# Implementation Plan: Analyzer-Independent QC, Results Entry, and Validation
+
+**Branch**: `codex/qc-results-entry-roadmap`
+**Date**: 2026-06-28
+**Spec**: [spec.md](./spec.md)
+**Roadmap Index**:
+[qc-results-entry-analyzer-independent-roadmap-2026-06-28.md](../roadmaps/qc-results-entry-analyzer-independent-roadmap-2026-06-28.md)
+
+## Summary
+
+This plan sequences analyzer-independent development across OGC-427, OGC-811,
+and OGC-817. It deliberately excludes OGC-1054 analyzer profile/mapping work,
+which is already in progress on a separate branch. The implementation path is:
+
+1. Batch Workplan foundation.
+2. Shared reagent/QC/NCE contract.
+3. Inline QC, NCE override, and printable workplan.
+4. Results Entry v4 foundation.
+5. Results Entry v4 bench controls.
+6. Validation v4 risk triage and guarded release.
+7. PNG/CPHL cross-domain evidence hardening.
+
+Each milestone is one PR, starts from a clean worktree based on current
+`origin/develop`, and must include code-qa plus visual evidence before it is
+marked ready.
+
+## Technical Context
+
+**Language/Version**: Java 21 LTS; JavaScript/React 17
+**Backend**: Spring Framework 6.2 traditional MVC, Jakarta EE 9, Hibernate/JPA,
+Liquibase 4.8
+**Frontend**: React 17, Carbon Design System, React Intl, SWR, Formik/Yup where
+appropriate
+**Testing**: JUnit 4, Mockito, Spring integration tests, Vitest/RTL, Playwright
+for new E2E/video evidence
+**Target**: OpenELIS Global 2 web app on Tomcat/nginx/PostgreSQL
+**Evidence source**: `digi-uw/openelis-work` mock commit
+`6c24b6ee04aab4ecef96e8daa57dc88ae8821356`
+
+## Constitution Check
+
+- [x] **Configuration-Driven Variation**: PNG/SILNAS/domain behavior must be
+      configuration/data, not country-specific code branches.
+- [x] **Carbon First**: New UI uses `@carbon/react`, Carbon icons, Carbon grid,
+      and React Intl. No Bootstrap/Tailwind/custom framework.
+- [x] **FHIR/IHE**: External healthcare data exposure must preserve existing
+      FHIR patterns and use service transforms where applicable.
+- [x] **Layered Architecture**: Valueholder -> DAO -> Service -> Controller ->
+      Form/DTO. Transactions start in services. Controllers do not traverse lazy
+      relationships.
+- [x] **TDD and E2E Evidence**: Backend contracts get backend tests; browser
+      user stories get Playwright tests and MP4 evidence. No API-focused
+      Playwright proof.
+- [x] **Liquibase**: All schema changes via versioned Liquibase changesets.
+- [x] **i18n**: New user-facing strings in `frontend/src/languages/en.json`
+      only.
+- [x] **Security and Audit**: Role checks, input validation, audit trail, and
+      NCE/e-signature semantics are part of the milestone contract.
+- [x] **Spec-Driven Iteration**: Each milestone is one reviewable PR.
+- [x] **Legacy Removal**: When a milestone touches legacy Results or Workplan
+      routes, it must remove, redirect, or file paired removal work. No
+      duplicate long-lived path.
+
+## Mock Baseline and Evidence Contract
+
+Every UI milestone must create an evidence folder, not committed unless the
+repo's evidence convention for that milestone says otherwise:
+
+```text
+specs/427-811-qc-results-entry-roadmap/evidence/<milestone>/
++-- README.md
++-- mock-screenshots/
++-- implementation-screenshots/
++-- mock-comparison.md
++-- code-qa.md
++-- videos/
+```
+
+Required viewport captures:
+
+- Desktop: 1440 x 900
+- Tablet: 1024 x 768 when the workflow has dense tables
+- Mobile: 390 x 844 for any route expected to be usable on phones
+
+Required mock comparison checks:
+
+- Correct route and workflow surface.
+- Primary work zone matches mock ordering.
+- Context/reference sections are not above the work zone unless the mock shows
+  that.
+- No developer-only controls in lab-facing paths.
+- No blank panels, overlapping text, or hidden action buttons.
+- Carbon component usage and spacing are consistent with nearby app patterns.
+- Any deviation from the mock is explicitly justified in `mock-comparison.md`.
+
+Required video checks:
+
+- Generated with the repo Playwright demo-video project.
+- Shows the full user story with visible UI state changes.
+- Does not use `page.request` or REST shortcuts as proof.
+- Ends on a visible success state that a reviewer can understand.
+
+Required code-qa gates:
+
+- Spec-code alignment.
+- Meaningful test coverage at the correct layer.
+- Architecture and transaction-boundary review.
+- i18n and Carbon review.
+- Security/audit review.
+- Legacy-path review.
+- Simplicity review.
+- Visual evidence and MP4 review.
+
+## Milestone Plan
+
+### Table 1: Sequential MVP Roadmap
+
+| ID | Branch suffix | Scope | Jira | MVP contribution | Verification | Depends on |
+| --- | --- | --- | --- | --- | --- | --- |
+| **M0** | roadmap-spec | Roadmap/spec baseline, mock source pin, evidence checklist | OGC-427/811/817/899 | Establishes execution contract | Docs review, markdown/format checks | None |
+| **M1** | m1-batch-foundation | Unified workplan route, Pending Tests and Batches shell, batch persistence, lifecycle service | OGC-427 | Batch Workplan foundation | Backend integration tests, UI smoke, mock screenshots, MP4 route walkthrough | M0 |
+| **M2** | m2-reagent-qc-contract | Reagent lot assignment, QC validity model, shared DTO/API contract for QC/reagent/NCE signals | OGC-427, OGC-811 | Shared contract | Service tests, controller tests, contract fixtures, no UI shortcut proof | M1 |
+| **M3** | m3-inline-qc-nce-print | Inline QC entry, QC override creates NCE, auto-expand overdue/failed QC batches, printable workplan | OGC-427 | Batch Workplan MVP complete | Full UI Playwright MP4, mock comparison, backend NCE/audit tests | M2 |
+| **M4** | m4-results-worklist-edit-state | `/Results` route, worklist foundation, row expansion, v4 edit-state machine, method field, optional analyzer field | OGC-811 | Results Entry foundation | UI/component/integration tests, Results v4 mock screenshots, MP4 | M3 |
+| **M5** | m5-results-bench-controls | Combined Reagents/QC/Controls section, inline NCE, sample usage, aliquots, scoped history | OGC-811 | Results Entry MVP complete | Full Results Entry MP4, reagent-usage mock comparison, audit tests | M4 |
+| **M6** | m6-validation-risk-release | Validation queue risk chips, Needs review filters, guarded clear-lane release, inline NCE reject, retest note, e-sign final release | OGC-817 | Validation MVP | Validation v4 MP4, mock comparison, release/audit tests | M5 |
+| **M7** | m7-png-cross-domain-evidence | Cross-domain clinical/environmental/vector hardening, PNG evidence bundle, roadmap rollup | OGC-899, OGC-527 context | Program-ready evidence | Cross-domain seeded demo MP4s, code-qa final pass, PR checklist | M6 |
+
+### Table 2: Explicitly Excluded Analyzer Lane
+
+| Item | Status | Treatment |
+| --- | --- | --- |
+| OGC-1054 Analyzer Types and Mapping | Active separate PR/worktree | Reference only; do not block this roadmap |
+| Analyzer bridge and mock server | Separate ownership | Not part of these milestones |
+| ASTM/HL7/FILE result ingestion | Separate analyzer integration lane | Optional future data source |
+| Analyzer Manual QC OGC-428 | Adjacent QC story | Reuse shared QC model when ready, but do not make M1-M7 depend on analyzer UI |
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    M0["M0 Roadmap/spec baseline"] --> M1["M1 Batch foundation"]
+    M1 --> M2["M2 Reagent/QC contract"]
+    M2 --> M3["M3 Inline QC + NCE + print"]
+    M3 --> M4["M4 Results worklist + edit state"]
+    M4 --> M5["M5 Results bench controls"]
+    M5 --> M6["M6 Validation risk + release"]
+    M6 --> M7["M7 PNG cross-domain evidence"]
+
+    OGC1054["OGC-1054 analyzer mapping"]:::external -. future data source .-> M5
+    OGC428["OGC-428 analyzer manual QC"]:::external -. reuse shared QC model .-> M2
+
+    classDef external fill:#fff,stroke:#999,color:#333,stroke-dasharray: 2 2;
+```
+
+## Branch and Worktree Strategy
+
+Use a new clean worktree for each implementation milestone:
+
+```bash
+git fetch origin develop
+git worktree add /Users/pmanko/.codex/worktrees/<id>/OpenELIS-Global-2 -b feat/427-811-qc-results-mN-<desc> origin/develop
+```
+
+Rules:
+
+- Do not implement in the active OGC-1054 worktree.
+- Do not base implementation on stale `feat/ogc-517-results-entry-redesign`.
+- Do not base implementation on `stack/qc-on-madagascar`; cherry-pick only
+  after explicit review.
+- Each milestone PR targets `develop`.
+- Each milestone PR body includes the validation commands, code-qa summary,
+  mock comparison summary, and MP4 path.
+
+## Architecture Notes
+
+### Shared QC/Reagent Signal
+
+The shared contract must expose enough state for Workplan, Results Entry, and
+Validation without binding to analyzers:
+
+- Entity context: batch, sample item, analysis/result, reagent lot.
+- QC state: valid, missing, overdue, failed, overridden.
+- QC source: manual entry, imported result, control result, future analyzer
+  source.
+- Enforcement target: block print, block save, flag release, or warn only.
+- NCE link: created NCE id, disposition, reason, status.
+- Audit: actor, timestamp, reason, source screen, affected records.
+
+### Results Entry v4 Boundaries
+
+Results Entry consumes the shared contract, but must not own every upstream
+configuration problem. For MVP:
+
+- Analyzer instance is optional and nullable.
+- Method is a first-class field.
+- Reagent capture supports manual lot selection.
+- Control capture supports manual/RDT style control result entry.
+- Inline NCE is required.
+- Refer-out remains a separate action.
+- History is this-analysis scoped.
+
+### Validation v4 Boundaries
+
+Validation should not duplicate QC/NCE computation. It consumes the shared
+signals:
+
+- NCE open.
+- QC fail or override.
+- Modified.
+- Ack pending.
+- Nonconforming.
+- Critical/abnormal/invalid range.
+
+## PR Readiness Gate
+
+A milestone PR is not ready until:
+
+- Spec/task checkbox for that milestone is updated.
+- New code is formatted.
+- Relevant backend tests pass.
+- Relevant frontend tests pass.
+- Relevant Playwright story passes.
+- Demo-video MP4 exists and was inspected.
+- Mock screenshots and implementation screenshots are compared.
+- Browser console logs from the Playwright run are reviewed.
+- Code-qa note is complete.
+- Legacy/deprecated path decision is documented.
+- PR body links the evidence note and lists commands run.

--- a/specs/427-811-qc-results-entry-roadmap/quickstart.md
+++ b/specs/427-811-qc-results-entry-roadmap/quickstart.md
@@ -1,0 +1,114 @@
+# Quickstart: Running the Analyzer-Independent QC/Results Roadmap
+
+This quickstart is for the developer starting the next milestone from this
+roadmap.
+
+## 1. Start From a Clean Worktree
+
+Never use the active OGC-1054 worktree for this roadmap.
+
+```bash
+git fetch origin develop
+git worktree add /Users/pmanko/.codex/worktrees/<id>/OpenELIS-Global-2 \
+  -b feat/427-811-qc-results-m1-batch-foundation origin/develop
+cd /Users/pmanko/.codex/worktrees/<id>/OpenELIS-Global-2
+```
+
+For later milestones, replace the branch suffix with the milestone branch from
+[plan.md](./plan.md).
+
+## 2. Confirm Mock Baseline
+
+Use the pinned openelis-work commit:
+
+```bash
+OPENELIS_WORK=/Users/pmanko/code/openelis-work
+MOCK_COMMIT=6c24b6ee04aab4ecef96e8daa57dc88ae8821356
+git -C "$OPENELIS_WORK" fetch origin main
+git -C "$OPENELIS_WORK" rev-parse origin/main
+```
+
+Capture baseline screenshots from the relevant mock artifact before implementing
+UI:
+
+- M1-M3: `designs/quality/batch-workplan-reagent-qc.jsx`
+- M4-M5: `designs/results-validation/results-entry-v4.html`
+- M5: `designs/results-validation/results-page-reagent-usage-v2.1-preview.html`
+  and `designs/nce/nce-results-entry.jsx`
+- M6: `designs/results-validation/validation-page-v4.html`
+
+Store local artifacts outside git unless the milestone PR intentionally commits
+text-only evidence:
+
+```text
+specs/427-811-qc-results-entry-roadmap/evidence/<milestone>/
+```
+
+## 3. Develop With Layered Tests
+
+Use the right test layer:
+
+- Backend business rules: JUnit 4 service/controller/integration tests.
+- ORM/schema: mapping tests and Liquibase migration tests.
+- React behavior: Vitest/RTL component tests.
+- User-story proof: Playwright browser tests and MP4 video.
+
+Do not use Playwright REST calls as proof. If setup or cleanup needs API/fixture
+help, keep it outside the asserted story path and document it.
+
+## 4. Run Focused Validation
+
+Backend examples:
+
+```bash
+mvn "-Dtest=org.openelisglobal.<module>.**" -Dsurefire.failIfNoSpecifiedTests=false test
+mvn spotless:check
+```
+
+Frontend examples:
+
+```bash
+cd frontend
+npm test -- --run <focused-test-files>
+npm run pw:guard
+npm run lint -- --quiet
+npm run check-format
+```
+
+Video proof example:
+
+```bash
+cd frontend
+TEST_USER=admin TEST_PASS='adminADMIN!' \
+  npm run pw:test:core-demo-video -- \
+  playwright/tests/demo/core/<milestone-user-story>.spec.ts --workers=1
+```
+
+Review the generated screenshots, MP4, browser console logs, and trace before
+calling the milestone done.
+
+## 5. Fill Evidence Notes
+
+Each milestone must produce:
+
+- `code-qa.md`
+- `mock-comparison.md`
+- MP4 path
+- screenshot paths
+- validation command list
+
+Use [contracts/evidence-template.md](./contracts/evidence-template.md) as the
+required PR evidence shape.
+
+## 6. PR Body Minimum
+
+Every milestone PR body must include:
+
+- Scope and explicit non-scope.
+- Jira links.
+- Mock baseline commit and artifacts used.
+- Validation commands and results.
+- MP4 evidence path.
+- Screenshot comparison summary.
+- Code-qa gate summary.
+- Any legacy route/removal decision.

--- a/specs/427-811-qc-results-entry-roadmap/spec.md
+++ b/specs/427-811-qc-results-entry-roadmap/spec.md
@@ -1,0 +1,208 @@
+# Feature Specification: Analyzer-Independent QC, Reagent, Results Entry, and Validation Roadmap
+
+**Feature Branch**: `codex/qc-results-entry-roadmap`
+**Created**: 2026-06-28
+**Status**: Draft roadmap/specification
+**Jira Scope**: OGC-427, OGC-428 context only where shared QC applies, OGC-811, OGC-817, OGC-899
+**Out-of-scope reference**: OGC-1054 analyzer profiles/mapping is already in progress and is not a dependency for this roadmap.
+
+## Summary
+
+Deliver an analyzer-independent sequence for the PNG/CPHL QC, reagent
+traceability, Results Entry v4, and Validation v4 work. The sequence starts from
+the concrete OGC-427 Batch Workplan with Reagent QC story, extracts the shared
+QC/reagent/NCE contract that Results Entry v4 needs, then implements Results
+Entry and Validation slices against that contract.
+
+The roadmap explicitly avoids depending on analyzer profile work, bridge
+transport, FILE polling, ASTM/HL7 ingestion, or OGC-1054. Analyzer-derived data
+may populate these workflows later, but the MVP must work for manual bench
+workflows and regular OpenELIS worklists.
+
+## Current Authority
+
+- OGC-811 is the current Results Entry authority; its v4 block supersedes
+  conflicting OGC-517 details.
+- OGC-517 remains historical design input only.
+- OGC-427 is the first implementation anchor because it is assigned, concrete,
+  and due on 2026-07-10.
+- OGC-817 is the Validation companion epic and must consume the same QC/NCE
+  signals after Results Entry establishes them.
+- OGC-899 is the PNG/CPHL program umbrella and evidence rollup target.
+
+## Mock and Design Baseline
+
+Pin mock validation to `digi-uw/openelis-work` commit:
+
+`6c24b6ee04aab4ecef96e8daa57dc88ae8821356`
+
+Baseline artifacts:
+
+- Batch Workplan with Reagent QC:
+  `designs/quality/batch-workplan-reagent-qc.md`
+  `designs/quality/batch-workplan-reagent-qc.jsx`
+- Results Entry v4:
+  `designs/results-validation/results-entry-v4.md`
+  `designs/results-validation/results-entry-v4.html`
+  `designs/results-validation/results-entry-v4-decisions.md`
+- Results reagent usage detail:
+  `designs/results-validation/results-page-reagent-usage-v2.1-preview.html`
+  `designs/results-validation/results-page-reagent-usage-v2.1.jsx`
+- Inline NCE reference:
+  `designs/nce/nce-results-entry.md`
+  `designs/nce/nce-results-entry.jsx`
+- Validation v4:
+  `designs/results-validation/validation-page-v4.md`
+  `designs/results-validation/validation-page-v4.html`
+
+Every UI milestone must capture baseline screenshots from those mock artifacts
+and compare them against implementation screenshots before the PR is marked
+ready.
+
+## Goals
+
+- Replace fragmented batch workplan behavior with a persisted, unified batch
+  workplan flow that supports reagent lot assignment and QC verification.
+- Define a shared analyzer-independent QC/reagent/NCE contract that Batch
+  Workplan, Results Entry, and Validation consume consistently.
+- Deliver a Results Entry v4 MVP with the v4 edit-state model, inline NCE,
+  reagent/QC/control capture, sample usage, aliquoting, and scoped history.
+- Deliver a Validation v4 MVP that consumes those same signals for release
+  triage and guarded release.
+- Produce reviewer-ready evidence for every milestone: code-qa notes, focused
+  tests, MP4 user-story video, implementation screenshots, and mock comparison.
+
+## Non-Goals
+
+- No analyzer profile, analyzer type, or mapping GUI work.
+- No analyzer bridge, mock server, ASTM, HL7, or FILE transport work.
+- No OpenELIS application-side FILE poller.
+- No dependency on OGC-1054 landing first.
+- No full rewrite of every legacy Results route in the first MVP.
+- No new custom CSS framework; Carbon only.
+- No non-English locale edits; add new keys to `frontend/src/languages/en.json`
+  only.
+
+## Users and Jobs
+
+### Lab Technician
+
+Needs one work surface to group pending tests into batches, assign reagent lots,
+verify QC state, enter QC when required, print a workplan, and later enter
+results with the same reagent/QC/NCE context visible.
+
+### Validator
+
+Needs a queue that separates clear results from results requiring review because
+of NCE, QC fail, modification, nonconforming status, critical acknowledgment, or
+similar release risk.
+
+### Lab Supervisor
+
+Needs traceable proof that reagent lot use, QC overrides, NCE creation, result
+modification, and release decisions are audited consistently.
+
+## MVP Scope
+
+### MVP A: Batch Workplan and Shared QC Contract
+
+MVP A is complete when a lab user can:
+
+1. Open a unified workplan route.
+2. Filter pending tests.
+3. Create and persist a batch.
+4. Move a batch through `DRAFT`, `ACTIVE`, `COMPLETED`, and `ARCHIVED`.
+5. Assign a reagent lot to the batch.
+6. See whether required QC is valid, missing, failed, or overdue.
+7. Enter inline QC for the reagent lot.
+8. Override invalid/missing QC only by creating an NCE.
+9. Print or preview a workplan with reagent/QC state included.
+
+### MVP B: Results Entry v4 Bench Flow
+
+MVP B is complete when a lab user can:
+
+1. Use `/Results` as the unified route for a narrow initial worklist slice.
+2. Expand a row into the v4 work zone.
+3. Respect the v4 edit state: saved results are read-only until row-level Edit.
+4. Enter result value, method, notes, reagent/QC/control data, and sample usage.
+5. Open the real inline NCE form without a modal.
+6. Save with e-signature where required.
+7. See this-analysis history inline and paginated.
+8. Complete the same flow for at least one clinical and one non-clinical/domain
+   representative row where seeded data exists.
+
+### MVP C: Validation v4 Companion
+
+MVP C is complete when a validator can:
+
+1. Open a Validation queue with "check before release" signals.
+2. Filter by Needs review, NCE, QC fail, Modified, Ack pending, Critical, and
+   Abnormal.
+3. Release clear rows through a guarded confirmation list.
+4. Review and release flagged rows one at a time.
+5. Reject by filing an inline NCE.
+6. Retest with required note behavior controlled by configuration.
+7. Use e-signature for final release.
+
+## Core Requirements
+
+### Functional Requirements
+
+- **FR-001**: The Batch Workplan route must expose Pending Tests and Batches
+  surfaces.
+- **FR-002**: Batch creation must persist server-side and survive logout.
+- **FR-003**: Batch lifecycle transitions must be service-owned and audited.
+- **FR-004**: Reagent lot assignment must be explicit and visible on the batch.
+- **FR-005**: QC validity must be computed server-side for the selected reagent
+  lot and requirement frequency.
+- **FR-006**: Invalid, failed, overdue, or missing QC must be visible before
+  print or activation decisions.
+- **FR-007**: QC override must create an NCE and record actor, reason, and
+  affected batch/test context.
+- **FR-008**: Results Entry v4 must implement saved-result read-only state until
+  row-level Edit is selected.
+- **FR-009**: Method and analyzer must remain separate fields; analyzer is
+  optional in this analyzer-independent MVP.
+- **FR-010**: Results Entry must include a combined Reagents, QC, and Controls
+  section without requiring analyzer profiles.
+- **FR-011**: Inline NCE must use the real inline form pattern, not a modal.
+- **FR-012**: Refer-out must remain separate from NCE disposition.
+- **FR-013**: Sample usage must support partial amount used and mark-used-up
+  workflow where backend support exists or is added in the milestone.
+- **FR-014**: Aliquoting must be available from Results Entry using existing
+  aliquot behavior where possible.
+- **FR-015**: History must be scoped to this analysis/result and rendered inline
+  with pagination.
+- **FR-016**: Validation must consume shared QC/NCE/modification signals instead
+  of recomputing incompatible state.
+- **FR-017**: All user-facing strings must use React Intl with new keys in
+  `en.json` only.
+- **FR-018**: All schema changes must be Liquibase changesets with rollback for
+  structural changes.
+
+### Evidence Requirements
+
+- **ER-001**: Every UI milestone must include a Playwright MP4 generated by the
+  repo demo-video project.
+- **ER-002**: The MP4 must exercise the user story through visible UI behavior;
+  API calls cannot be used as proof.
+- **ER-003**: Setup/cleanup helpers may use backend fixtures only when they are
+  outside the proof path and documented.
+- **ER-004**: Every UI milestone must include baseline mock screenshots and
+  implementation screenshots at matching viewport sizes.
+- **ER-005**: Every UI milestone must include a mock comparison note describing
+  alignment, intentional deviations, and blocking mismatches.
+- **ER-006**: Every PR must include a code-qa note covering spec alignment,
+  meaningful tests, architecture, simplicity, legacy removal, i18n, security,
+  and evidence.
+
+## Success Criteria
+
+- Each milestone lands as a reviewable PR with one milestone's scope.
+- No milestone extends analyzer-owned code to finish analyzer-independent
+  workflows.
+- The shared QC/reagent/NCE contract is consumed by Batch Workplan, Results
+  Entry, and Validation without duplicate implementations.
+- UI evidence is visually comparable to the pinned mock baseline.
+- Local validation and CI evidence are included in each PR body.

--- a/specs/427-811-qc-results-entry-roadmap/tasks.md
+++ b/specs/427-811-qc-results-entry-roadmap/tasks.md
@@ -1,0 +1,189 @@
+# Tasks: Analyzer-Independent QC, Results Entry, and Validation Roadmap
+
+**Organization**: by milestone. Each milestone is one PR and one reviewable unit.
+Do not implement a later milestone until the prior milestone's PR is merged or
+explicitly approved as a stacked dependency.
+
+**Task format**:
+`- [ ] T### [P?] [Mx] [OGC-###] task -- path`
+
+`[P]` means parallelizable within the milestone.
+
+---
+
+## M0: Roadmap and Spec Baseline
+
+Status: this branch.
+
+- [x] T001 [M0] Create clean branch `codex/qc-results-entry-roadmap` from
+      `origin/develop`.
+- [x] T002 [M0] Confirm OGC-1054 is adjacent/in-progress and not the base for
+      this roadmap.
+- [x] T003 [M0] Pin mock baseline to `openelis-work`
+      `6c24b6ee04aab4ecef96e8daa57dc88ae8821356`.
+- [ ] T004 [M0] Review this spec/plan/tasks/checklist with the product owner.
+- [ ] T005 [M0] After review, open a documentation PR to `develop`.
+
+## M1: Batch Workplan Foundation
+
+Branch: `feat/427-811-qc-results-m1-batch-foundation`
+Primary Jira: OGC-427
+
+Independent proof: user can open Workplan, see Pending Tests and Batches, create
+a batch, persist it, and move through lifecycle states without reagent/QC yet.
+
+- [ ] T100 [M1] Create a clean worktree from `origin/develop`.
+- [ ] T101 [M1] Resolve current legacy workplan route inventory and removal or
+      redirect plan -- `frontend/src/**`, `src/main/java/**`.
+- [ ] T102 [M1] Draft milestone evidence plan and mock capture list against
+      `designs/quality/batch-workplan-reagent-qc.*`.
+- [ ] T103 [M1] RED backend tests for batch lifecycle service.
+- [ ] T104 [M1] RED controller tests for pending tests, batch create, batch
+      update, and archive endpoints.
+- [ ] T105 [M1] Liquibase changesets for batch persistence tables with rollback.
+- [ ] T106 [M1] Valueholder, DAO, service, controller, and DTO layers for batch
+      persistence.
+- [ ] T107 [M1] React route and Carbon UI shell for Pending Tests and Batches.
+- [ ] T108 [M1] React Intl keys in `frontend/src/languages/en.json` only.
+- [ ] T109 [M1] Focused frontend/component tests for route shell and lifecycle
+      controls.
+- [ ] T110 [M1] Playwright demo-video story for create batch and lifecycle.
+- [ ] T111 [M1] Capture mock and implementation screenshots at required
+      viewports.
+- [ ] T112 [M1] Complete `code-qa.md` and `mock-comparison.md`.
+- [ ] T113 [M1] Run relevant backend/frontend/Playwright validation and record
+      commands in PR body.
+
+## M2: Reagent Lot and Shared QC Contract
+
+Branch: `feat/427-811-qc-results-m2-reagent-qc-contract`
+Primary Jira: OGC-427; consumer Jira: OGC-811
+
+Independent proof: batch can assign a reagent lot and receive a server-computed
+QC state through a contract that Results Entry and Validation can also consume.
+
+- [ ] T200 [M2] Create a clean worktree from `origin/develop` after M1 lands.
+- [ ] T201 [M2] Inventory existing reagent lot, inventory, QC, NCE, and audit
+      entities; document reuse-first decisions.
+- [ ] T202 [M2] Define shared QC/reagent DTOs and state enum: valid, missing,
+      overdue, failed, overridden.
+- [ ] T203 [M2] RED service tests for QC validity rules and frequency behavior.
+- [ ] T204 [M2] RED controller tests for reagent lot assignment and QC state
+      response.
+- [ ] T205 [M2] Add or adapt Liquibase schema only where existing model cannot
+      support the contract.
+- [ ] T206 [M2] Implement reagent lot assignment service and shared QC signal
+      service.
+- [ ] T207 [M2] Add batch UI lot assignment and QC state summary.
+- [ ] T208 [M2] Add contract fixtures for Results Entry future consumers.
+- [ ] T209 [M2] Capture mock/implementation screenshots for lot assignment and
+      QC state.
+- [ ] T210 [M2] Complete code-qa and mock comparison notes.
+
+## M3: Inline QC, NCE Override, and Printable Workplan
+
+Branch: `feat/427-811-qc-results-m3-inline-qc-nce-print`
+Primary Jira: OGC-427
+
+Independent proof: user can enter inline QC, override invalid QC only through
+NCE, and print/preview a workplan with reagent/QC state.
+
+- [ ] T300 [M3] Create a clean worktree after M2 lands.
+- [ ] T301 [M3] RED backend tests for inline QC entry, NCE creation, and audit.
+- [ ] T302 [M3] RED frontend tests for overdue/failed auto-expand behavior.
+- [ ] T303 [M3] Implement inline QC entry service/controller/UI.
+- [ ] T304 [M3] Implement QC override flow using NCE service; no modal shortcut
+      if the mock requires inline behavior.
+- [ ] T305 [M3] Implement printable workplan preview/export.
+- [ ] T306 [M3] Add permissions checks for workplan view/create/print and QC
+      result entry/override.
+- [ ] T307 [M3] Playwright MP4 for full Batch Workplan MVP.
+- [ ] T308 [M3] Screenshot comparison against batch workplan mock.
+- [ ] T309 [M3] Complete code-qa and PR evidence package.
+
+## M4: Results Entry v4 Worklist and Edit State
+
+Branch: `feat/427-811-qc-results-m4-results-worklist-edit-state`
+Primary Jira: OGC-811
+
+Independent proof: `/Results` route renders a narrow worklist slice, expands a
+row, and enforces saved-result read-only until row-level Edit.
+
+- [ ] T400 [M4] Create a clean worktree after M3 lands.
+- [ ] T401 [M4] Resolve legacy Results routes and redirect/feature-flag plan.
+- [ ] T402 [M4] Pin Results Entry v4 and decisions mock screenshots.
+- [ ] T403 [M4] RED backend tests for worklist query DTO and save conflict
+      guard.
+- [ ] T404 [M4] RED frontend tests for row expansion and edit-state behavior.
+- [ ] T405 [M4] Implement `/Results` route foundation using Carbon components.
+- [ ] T406 [M4] Implement work zone: result value, method, optional analyzer,
+      notes, row actions.
+- [ ] T407 [M4] Implement saved-result read-only until Edit, then Save relocks.
+- [ ] T408 [M4] Add e-signature integration where required by existing service.
+- [ ] T409 [M4] Playwright MP4 for worklist/edit-state story.
+- [ ] T410 [M4] Screenshot comparison against Results Entry v4 mock.
+- [ ] T411 [M4] Complete code-qa and PR evidence package.
+
+## M5: Results Entry Bench Controls
+
+Branch: `feat/427-811-qc-results-m5-results-bench-controls`
+Primary Jira: OGC-811
+
+Independent proof: user can enter reagent/QC/control/sample-use/NCE data in
+Results Entry using the same contract introduced in M2.
+
+- [ ] T500 [M5] Create a clean worktree after M4 lands.
+- [ ] T501 [M5] RED service/controller tests for Results Entry consuming shared
+      QC/reagent/NCE signals.
+- [ ] T502 [M5] RED frontend tests for combined Reagents, QC, and Controls
+      section.
+- [ ] T503 [M5] Implement combined Reagents, QC, and Controls section.
+- [ ] T504 [M5] Implement inline NCE form and supported dispositions:
+      Cancel, Reject plus reason, Retest.
+- [ ] T505 [M5] Keep refer-out as a separate row action.
+- [ ] T506 [M5] Implement sample partial-use and mark-used-up workflow.
+- [ ] T507 [M5] Surface aliquoting from the expanded row.
+- [ ] T508 [M5] Implement this-analysis inline paginated history.
+- [ ] T509 [M5] Playwright MP4 for full Results Entry bench-controls MVP.
+- [ ] T510 [M5] Screenshot comparison against Results Entry v4, reagent-usage,
+      and NCE mocks.
+- [ ] T511 [M5] Complete code-qa and PR evidence package.
+
+## M6: Validation Risk Triage and Guarded Release
+
+Branch: `feat/427-811-qc-results-m6-validation-risk-release`
+Primary Jira: OGC-817
+
+Independent proof: validator can distinguish clear rows from needs-review rows
+and release or reject using the v4 rules.
+
+- [ ] T600 [M6] Create a clean worktree after M5 lands.
+- [ ] T601 [M6] RED backend tests for risk signal aggregation.
+- [ ] T602 [M6] RED frontend tests for Check before release chips and filters.
+- [ ] T603 [M6] Implement Validation queue risk chips and counts.
+- [ ] T604 [M6] Implement Needs review filters.
+- [ ] T605 [M6] Implement guarded release-all-clear with scannable confirm list.
+- [ ] T606 [M6] Implement per-row release for flagged results.
+- [ ] T607 [M6] Implement Reject through inline NCE.
+- [ ] T608 [M6] Implement Retest with configured note requirement.
+- [ ] T609 [M6] Integrate e-signature on final release.
+- [ ] T610 [M6] Playwright MP4 for Validation v4 MVP.
+- [ ] T611 [M6] Screenshot comparison against Validation v4 mock.
+- [ ] T612 [M6] Complete code-qa and PR evidence package.
+
+## M7: PNG/CPHL Cross-Domain Evidence and Hardening
+
+Branch: `feat/427-811-qc-results-m7-png-cross-domain-evidence`
+Primary Jira: OGC-899; context Jira: OGC-527
+
+Independent proof: clinical, environmental, and vector representative rows
+exercise the same analyzer-independent workflows without country-specific code.
+
+- [ ] T700 [M7] Create clean worktree after M6 lands.
+- [ ] T701 [M7] Define seeded clinical, environmental, and vector demo rows.
+- [ ] T702 [M7] Verify PII masking and domain-specific context behavior.
+- [ ] T703 [M7] Verify regulatory limit/reference range behavior per domain.
+- [ ] T704 [M7] Verify program/EQA fields where present.
+- [ ] T705 [M7] Record cross-domain Playwright MP4s.
+- [ ] T706 [M7] Produce final PNG/CPHL evidence bundle and rollup note.
+- [ ] T707 [M7] Complete final code-qa and roadmap status update.

--- a/specs/roadmaps/qc-results-entry-analyzer-independent-roadmap-2026-06-28.md
+++ b/specs/roadmaps/qc-results-entry-analyzer-independent-roadmap-2026-06-28.md
@@ -1,0 +1,59 @@
+# Roadmap: Analyzer-Independent QC, Results Entry, and Validation
+
+**Date**: 2026-06-28
+**Spec folder**: `specs/427-811-qc-results-entry-roadmap/`
+**Branch**: `codex/qc-results-entry-roadmap`
+
+## Decision
+
+Proceed with an analyzer-independent sequence:
+
+1. OGC-427 Batch Workplan with Reagent QC.
+2. Shared reagent/QC/NCE contract.
+3. OGC-811 Results Entry v4 MVP.
+4. OGC-817 Validation v4 companion.
+5. OGC-899 PNG/CPHL cross-domain evidence rollup.
+
+Do not fold in OGC-1054. OGC-1054 is already active analyzer profile/mapping
+work and remains a reference/future data source only.
+
+## Canonical Artifacts
+
+- [Specification](../427-811-qc-results-entry-roadmap/spec.md)
+- [Implementation Plan](../427-811-qc-results-entry-roadmap/plan.md)
+- [Tasks](../427-811-qc-results-entry-roadmap/tasks.md)
+- [Quickstart](../427-811-qc-results-entry-roadmap/quickstart.md)
+- [Evidence Template](../427-811-qc-results-entry-roadmap/contracts/evidence-template.md)
+- [Requirements Checklist](../427-811-qc-results-entry-roadmap/checklists/requirements.md)
+
+## Milestones
+
+| ID | Scope | Primary Jira |
+| --- | --- | --- |
+| M0 | Roadmap/spec baseline | OGC-427/811/817/899 |
+| M1 | Batch Workplan foundation | OGC-427 |
+| M2 | Reagent lot and shared QC contract | OGC-427, OGC-811 |
+| M3 | Inline QC, NCE override, printable workplan | OGC-427 |
+| M4 | Results Entry v4 worklist and edit-state | OGC-811 |
+| M5 | Results Entry bench controls | OGC-811 |
+| M6 | Validation risk triage and guarded release | OGC-817 |
+| M7 | PNG/CPHL cross-domain evidence | OGC-899 |
+
+## Evidence Standard
+
+Each UI milestone requires:
+
+- Pinned mock baseline from `digi-uw/openelis-work`
+  `6c24b6ee04aab4ecef96e8daa57dc88ae8821356`.
+- Mock screenshots and implementation screenshots at matching viewports.
+- A written mock-comparison note.
+- A Playwright MP4 from the repo demo-video project.
+- Code-qa validation note.
+- PR body with validation commands and evidence links.
+
+## Next Action
+
+Review M0 artifacts, then start M1 from a new clean worktree based on
+`origin/develop`:
+
+`feat/427-811-qc-results-m1-batch-foundation`


### PR DESCRIPTION
## Summary

Creates the analyzer-independent roadmap package for the QC, reagent, Results Entry v4, and Validation v4 workstream.

This is the M0 planning/spec baseline so implementation can start cleanly from `origin/develop` without reusing the active OGC-1054 analyzer worktree or stale OGC-517 branch.

## What changed

- Adds a SpecKit-style roadmap folder at `specs/427-811-qc-results-entry-roadmap/`
- Defines MVP scope and sequencing for:
  - M1 Batch Workplan foundation
  - M2 shared reagent/QC/NCE contract
  - M3 inline QC, NCE override, printable workplan
  - M4 Results Entry v4 worklist and edit-state
  - M5 Results Entry bench controls
  - M6 Validation v4 risk triage and guarded release
  - M7 PNG/CPHL cross-domain evidence
- Adds a roadmap index under `specs/roadmaps/`
- Adds an evidence template and requirements checklist for code-qa, MP4 proof, and mock screenshot comparison

## Scope boundaries

- OGC-811 is the current Results Entry authority; OGC-517 is historical context only
- OGC-1054 is explicitly reference-only and remains a separate active analyzer profile/mapping lane
- No analyzer bridge, analyzer profiles, ASTM/HL7/FILE transport, or OE app-side FILE polling in this roadmap

## Mock/evidence baseline

Pins visual validation to `digi-uw/openelis-work` commit:

`6c24b6ee04aab4ecef96e8daa57dc88ae8821356`

Every UI milestone requires:

- mock screenshots and implementation screenshots at matching viewports
- written mock comparison notes
- Playwright MP4 from the repo demo-video project
- code-qa validation notes
- PR body evidence links and validation commands

## Validation

- `git diff --cached --check` before commit - passed
- ASCII check over added Markdown files - passed
- `git diff --check HEAD~1..HEAD` after commit - passed
- Pre-commit formatter ran during commit

## Ready-to-start next step

After review, start M1 on a new clean worktree from `origin/develop`:

`feat/427-811-qc-results-m1-batch-foundation`