### PR TITLE
fix(result-page): align upload-file button with referral row and refi…

### DIFF
--- a/frontend/src/components/resultPage/AcceptUnconditionallyGuard.jsx
+++ b/frontend/src/components/resultPage/AcceptUnconditionallyGuard.jsx
@@ -53,9 +53,13 @@ const AcceptUnconditionallyGuard = ({
     return (
       <Button
         data-testid={`accept-uncond-${rowId}-trigger`}
-        kind="danger--ghost"
         size="sm"
         renderIcon={Warning}
+        style={{
+          backgroundColor: "var(--cds-support-success, #24a148)",
+          borderColor: "var(--cds-support-success, #24a148)",
+          color: "#ffffff",
+        }}
         onClick={() => {
           setArmed(true);
           setReason("");

--- a/frontend/src/components/resultPage/SearchResultForm.jsx
+++ b/frontend/src/components/resultPage/SearchResultForm.jsx
@@ -1190,12 +1190,14 @@ export function SearchResults(props) {
 
       case "accept":
         return (
-          <AcceptUnconditionallyGuard
-            rowId={row.id}
-            accepted={!!acceptAsIs[row.id]}
-            onAccept={(reason) => handleAcceptUnconditionally(row.id, reason)}
-            onUnaccept={() => handleUnacceptUnconditionally(row.id)}
-          />
+          <div style={{ paddingRight: "1.5rem", marginRight: "0.5rem" }}>
+            <AcceptUnconditionallyGuard
+              rowId={row.id}
+              accepted={!!acceptAsIs[row.id]}
+              onAccept={(reason) => handleAcceptUnconditionally(row.id, reason)}
+              onUnaccept={() => handleUnacceptUnconditionally(row.id)}
+            />
+          </div>
         );
 
       case "reject":
@@ -1629,6 +1631,13 @@ export function SearchResults(props) {
             )}
           </Column>
           <Column lg={2}>
+            <span
+              className="cds--label"
+              aria-hidden="true"
+              style={{ display: "block" }}
+            >
+              &nbsp;
+            </span>
             <Checkbox
               labelText={intl.formatMessage({ id: "results.label.refer" })}
               name={"testResult[" + data.id + "].refer"}
@@ -1715,7 +1724,7 @@ export function SearchResults(props) {
           </Column>
         </Grid>
         <Grid style={{ marginTop: "1rem" }}>
-          <Column lg={3}>
+          <Column lg={16}>
             <Button
               kind="danger--tertiary"
               size="sm"
@@ -1730,9 +1739,20 @@ export function SearchResults(props) {
               />
             </Button>
           </Column>
-          <Column lg={13}>
-            <div className="result-entry-storage-section">
-              <div className="result-entry-storage-current">
+          <Column lg={16} style={{ marginTop: "1rem" }}>
+            <div
+              className="result-entry-storage-section"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: "0.75rem",
+              }}
+            >
+              <div
+                className="result-entry-storage-current"
+                style={{ minWidth: 0, flex: "0 1 auto" }}
+              >
                 <strong>
                   <FormattedMessage
                     id="storage.location.current"
@@ -2215,6 +2235,7 @@ export function SearchResults(props) {
                 expandableRowsComponent={renderReferral}
               ></DataTable>
               <Pagination
+                style={{ marginTop: "1.5rem" }}
                 onChange={handlePageChange}
                 page={page}
                 pageSize={pageSize}

--- a/frontend/src/components/resultPage/fileUpload/FileInput.tsx
+++ b/frontend/src/components/resultPage/fileUpload/FileInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, ChangeEvent, memo } from "react";
-import { FileUploader } from "@carbon/react";
+import { FileUploaderButton } from "@carbon/react";
 import { FormattedMessage } from "react-intl";
 import { toBase64 } from "../../utils/Utils";
 
@@ -95,14 +95,22 @@ const CompactFileInput: React.FC<CompactFileInputProps> = memo(
     }, [results, data.accessionNumber]);
 
     return (
-      <FileUploader
-        buttonLabel={<FormattedMessage id="label.button.uploadfile" />}
-        filenameStatus={currentFile ? "complete" : ""}
-        accept={["image/jpeg", "image/png", "application/pdf"]}
-        multiple={false}
-        onChange={handleUpload}
-        filename={currentFile?.fileName}
-      />
+      <div className="cds--form-item">
+        <span
+          className="cds--label"
+          aria-hidden="true"
+          style={{ display: "block" }}
+        >
+          &nbsp;
+        </span>
+        <FileUploaderButton
+          labelText={<FormattedMessage id="label.button.uploadfile" />}
+          accept={["image/jpeg", "image/png", "application/pdf"]}
+          multiple={false}
+          onChange={handleUpload}
+          disableLabelChanges
+        />
+      </div>
     );
   },
 );


### PR DESCRIPTION
result-entry spacing

- Replace Carbon FileUploader with FileUploaderButton + cds--label spacer so the upload-file control matches the [label][input] structure of the Methods, Refer, Institute, and Test-to-perform fields on the referral expansion row.
- Add a label spacer above the Refer checkbox so it baseline-aligns with the surrounding Select inputs.
- Move the storage-location section onto its own full-width row below the Report NCE button (previously sat to the right of it).
- Restyle the unconditional-accept trigger as a solid success button and add right-side spacing on the accept cell so it no longer crowds the result column.
- Add top margin to the results pagination to give it breathing room.

