### PR TITLE
fix(i18n): register address.search.label so "Quick Address Search" is…

### DIFF
--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -10,6 +10,7 @@
   "add.age.range": "Add Another Age Range +",
   "add.aliquot": "Add Aliquot",
   "add.new.dictionary.menu": "Add New Dictionary Menu",
+  "address.search.label": "Quick Address Search",
   "adjustment.button": "Adjust Quantity",
   "adjustment.newQuantity": "New Quantity",
   "adjustment.notes": "Notes",


### PR DESCRIPTION
… translatable

AddressSearch.jsx already calls intl.formatMessage with id `address.search.label`, but the key was missing from en.json, so the component always rendered the hardcoded defaultMessage and could never be translated through Transifex. Adding the key to en.json lets Transifex pick it up and feed translations into the other language bundles.

