### PR TITLE
feat(OGC-949): async alert dispatch, multi-terminology FHIR codings, test-catalog name/filter polish

### DIFF
--- a/frontend/src/components/admin/testCatalog/TestCatalogList.jsx
+++ b/frontend/src/components/admin/testCatalog/TestCatalogList.jsx
@@ -75,10 +75,21 @@ const TestCatalogList = () => {
   const [domain, setDomain] = useState(initParams.get("domain") || "");
   const [status, setStatus] = useState(initParams.get("status") || "all");
   const [amr, setAmr] = useState(initParams.get("amr") || "");
+  const [sampleType, setSampleType] = useState(
+    initParams.get("sampleType") || "",
+  );
+  const [sampleTypes, setSampleTypes] = useState([]);
   const [search, setSearch] = useState(initParams.get("search") || "");
   const [debouncedSearch, setDebouncedSearch] = useState(
     initParams.get("search") || "",
   );
+
+  // Sample types for the filter dropdown — fetched once (static reference data).
+  useEffect(() => {
+    getFromOpenElisServer("/rest/test-catalog/sample-types", (res) => {
+      setSampleTypes(Array.isArray(res) ? res : []);
+    });
+  }, []);
 
   // Debounce the search box: fetch once the user pauses, not on every keystroke.
   useEffect(() => {
@@ -97,6 +108,7 @@ const TestCatalogList = () => {
     if (domain) params.set("domain", domain);
     if (status && status !== "all") params.set("status", status);
     if (amr) params.set("amr", amr);
+    if (sampleType) params.set("sampleType", sampleType);
     if (debouncedSearch) params.set("search", debouncedSearch);
     params.set("page", String(page));
     params.set("pageSize", String(pageSize));
@@ -121,7 +133,16 @@ const TestCatalogList = () => {
       controller.signal,
     );
     return () => controller.abort();
-  }, [domain, status, amr, debouncedSearch, page, pageSize, history]);
+  }, [
+    domain,
+    status,
+    amr,
+    sampleType,
+    debouncedSearch,
+    page,
+    pageSize,
+    history,
+  ]);
 
   const breadcrumbs = [
     { label: "home.label", link: "/" },
@@ -158,6 +179,16 @@ const TestCatalogList = () => {
       `/MasterListsPage/TestCatalogEditor/${testId}/${DEFAULT_SECTION}`,
     );
   };
+
+  const sampleTypeItems = [
+    {
+      id: "",
+      name: intl.formatMessage({
+        id: "label.testCatalog.list.filter.allSampleTypes",
+      }),
+    },
+    ...sampleTypes,
+  ];
 
   const tableRows = (pageData.rows || []).map((r) => ({
     id: r.testId,
@@ -237,6 +268,20 @@ const TestCatalogList = () => {
               onChange={({ selectedItem }) => {
                 setPage(1);
                 setAmr(selectedItem ? selectedItem.id : "");
+              }}
+            />
+            <Dropdown
+              id="filter-sample-type"
+              titleText={intl.formatMessage({
+                id: "label.testCatalog.list.filter.sampleType",
+              })}
+              label=""
+              items={sampleTypeItems}
+              itemToString={(item) => (item ? item.name : "")}
+              selectedItem={sampleTypeItems.find((o) => o.id === sampleType)}
+              onChange={({ selectedItem }) => {
+                setPage(1);
+                setSampleType(selectedItem ? selectedItem.id : "");
               }}
             />
             <Search

--- a/frontend/src/components/admin/testCatalog/TestCatalogList.test.jsx
+++ b/frontend/src/components/admin/testCatalog/TestCatalogList.test.jsx
@@ -91,16 +91,18 @@ describe("TestCatalogList", () => {
   });
 
   it("restores filter state from the URL and sends it to the server", async () => {
-    mockHistory.location = { search: "?amr=true&domain=CLINICAL" };
+    mockHistory.location = { search: "?amr=true&domain=CLINICAL&sampleType=2" };
     let requestedUrl = "";
     getFromOpenElisServer.mockImplementation((url, cb) => {
-      requestedUrl = url;
+      // Only the tests endpoint carries filter state; ignore the sample-types
+      // reference fetch.
+      if (url.includes("/tests")) requestedUrl = url;
       cb(pageOf([]));
     });
     renderList();
-    await waitFor(() => expect(getFromOpenElisServer).toHaveBeenCalled());
-    expect(requestedUrl).toContain("amr=true");
+    await waitFor(() => expect(requestedUrl).toContain("amr=true"));
     expect(requestedUrl).toContain("domain=CLINICAL");
+    expect(requestedUrl).toContain("sampleType=2");
   });
 
   it("aborts the previous request when filters change (stale-result guard)", () => {
@@ -108,7 +110,9 @@ describe("TestCatalogList", () => {
     try {
       const signals = [];
       getFromOpenElisServer.mockImplementation((url, cb, sig) => {
-        signals.push(sig);
+        // Track only the tests endpoint; the sample-types reference fetch is
+        // a separate, signal-less call.
+        if (url.includes("/tests")) signals.push(sig);
         cb(pageOf([]));
       });
       renderList();

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -4449,6 +4449,8 @@
   "label.testCatalog.list.filter.anyAmr": "Any",
   "label.testCatalog.list.filter.amrOnly": "AMR only",
   "label.testCatalog.list.filter.nonAmr": "Non-AMR",
+  "label.testCatalog.list.filter.sampleType": "Sample Type",
+  "label.testCatalog.list.filter.allSampleTypes": "All sample types",
   "label.testCatalog.list.amrTag": "AMR",
   "label.testCatalog.list.error": "Couldn't load the test catalog. Adjust the filters or reload to try again.",
   "label.testCatalog.list.empty": "No tests match the current filters.",

--- a/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/service/FhirTransformServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -141,6 +142,8 @@ import org.openelisglobal.test.service.TestService;
 import org.openelisglobal.test.valueholder.Test;
 import org.openelisglobal.testresult.service.TestResultService;
 import org.openelisglobal.testresult.valueholder.TestResult;
+import org.openelisglobal.testterminology.service.TestTerminologyMappingService;
+import org.openelisglobal.testterminology.valueholder.TestTerminologyMapping;
 import org.openelisglobal.typeofsample.service.TypeOfSampleService;
 import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
 import org.openelisglobal.typeoftestresult.service.TypeOfTestResultServiceImpl;
@@ -169,6 +172,8 @@ public class FhirTransformServiceImpl implements FhirTransformService {
     private AnalysisService analysisService;
     @Autowired
     private TestService testService;
+    @Autowired
+    private TestTerminologyMappingService testTerminologyMappingService;
     @Autowired
     private ResultService resultService;
     @Autowired
@@ -1141,10 +1146,85 @@ public class FhirTransformServiceImpl implements FhirTransformService {
         LogEvent.logTrace(this.getClass().getSimpleName(), "transformTestToCodeableConcept",
                 "transformTestToCodeableConcept test called");
 
+        String display = test.getLocalizedTestName() != null ? test.getLocalizedTestName().getEnglish()
+                : test.getName();
         CodeableConcept codeableConcept = new CodeableConcept();
-        codeableConcept
-                .addCoding(new Coding("http://loinc.org", test.getLoinc(), test.getLocalizedTestName().getEnglish()));
+
+        // Group the configured terminology mappings (the editor's Terminology section
+        // is the source of truth) by their FHIR system, keeping only those with a
+        // recognized system and a code. The legacy test.loinc value participates as a
+        // LOINC SAME_AS candidate — it is kept in sync with the LOINC SAME_AS mapping
+        // and also covers tests not yet migrated to the terminology editor.
+        Map<String, List<Candidate>> bySystem = new LinkedHashMap<>();
+        for (TestTerminologyMapping mapping : testTerminologyMappingService.getActiveByTestId(test.getId())) {
+            String system = terminologySystemUrl(mapping.getSource());
+            if (system == null || GenericValidator.isBlankOrNull(mapping.getCode())) {
+                continue;
+            }
+            bySystem.computeIfAbsent(system, k -> new ArrayList<>())
+                    .add(new Candidate(mapping.getCode(), "SAME_AS".equalsIgnoreCase(mapping.getRelationship())));
+        }
+        if (!GenericValidator.isBlankOrNull(test.getLoinc())) {
+            bySystem.computeIfAbsent("http://loinc.org", k -> new ArrayList<>())
+                    .add(new Candidate(test.getLoinc(), true));
+        }
+
+        // Emit one system's codings at a time. Within a system the SAME_AS mapping is
+        // the equivalent concept, so it wins; with no SAME_AS we keep the rest. A test
+        // thus maps to multiple terminology systems at once (LOINC + SNOMED + ...).
+        for (Map.Entry<String, List<Candidate>> entry : bySystem.entrySet()) {
+            String system = entry.getKey();
+            List<Candidate> candidates = entry.getValue();
+            boolean hasSameAs = candidates.stream().anyMatch(c -> c.sameAs);
+            Set<String> seenCodes = new HashSet<>();
+            for (Candidate candidate : candidates) {
+                if (hasSameAs && !candidate.sameAs) {
+                    continue;
+                }
+                if (seenCodes.add(candidate.code)) {
+                    codeableConcept.addCoding(new Coding(system, candidate.code, display));
+                }
+            }
+        }
         return codeableConcept;
+    }
+
+    /**
+     * A candidate code for one terminology system, flagged if it is a SAME_AS
+     * mapping.
+     */
+    private static final class Candidate {
+        private final String code;
+        private final boolean sameAs;
+
+        private Candidate(String code, boolean sameAs) {
+            this.code = code;
+            this.sameAs = sameAs;
+        }
+    }
+
+    /**
+     * Canonical FHIR system URI for a terminology mapping source. LOINC and SNOMED
+     * use the HL7-registered URIs already used elsewhere in this service; CIEL and
+     * OCL use their OpenConceptLab canonical URLs. Returns {@code null} for an
+     * unrecognized source so it is skipped rather than emitting a bogus system.
+     */
+    private String terminologySystemUrl(String source) {
+        if (source == null) {
+            return null;
+        }
+        switch (source.toUpperCase()) {
+        case "LOINC":
+            return "http://loinc.org";
+        case "SNOMED":
+            return "http://snomed.info/sct";
+        case "CIEL":
+            return "https://openconceptlab.org/orgs/CIEL/sources/CIEL";
+        case "OCL":
+            return "https://openconceptlab.org";
+        default:
+            return null;
+        }
     }
 
     private Specimen transformToFhirSpecimen(SampleTestCollection sampleTest) {

--- a/src/main/java/org/openelisglobal/notification/service/sender/AsyncNotificationDispatcher.java
+++ b/src/main/java/org/openelisglobal/notification/service/sender/AsyncNotificationDispatcher.java
@@ -1,0 +1,46 @@
+package org.openelisglobal.notification.service.sender;
+
+import java.util.List;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.notification.valueholder.RemoteNotification;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * Sends an already-prepared {@link RemoteNotification} through the matching
+ * {@link ClientNotificationSender} off the request thread, so SMS/Email network
+ * calls (SMTP / SMS gateway) don't block result entry — mirroring how the
+ * default test-notification flow runs its sends asynchronously.
+ *
+ * <p>
+ * Runs on a separate thread with no Hibernate session, so the notification must
+ * already carry a fully-resolved payload (plain strings); do not access lazy
+ * entity associations from here.
+ */
+@Component
+public class AsyncNotificationDispatcher {
+
+    // Optional so callers still function (no external send) when no sender is
+    // wired in the deployment.
+    @SuppressWarnings("rawtypes")
+    @Autowired(required = false)
+    private List<ClientNotificationSender> notificationSenders;
+
+    @Async
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void dispatch(RemoteNotification notification) {
+        if (notificationSenders == null) {
+            return;
+        }
+        for (ClientNotificationSender sender : notificationSenders) {
+            try {
+                if (sender.forClass().isInstance(notification)) {
+                    sender.send(notification);
+                }
+            } catch (RuntimeException e) {
+                LogEvent.logError(e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/testalertrule/service/TestAlertEvaluationServiceImpl.java
+++ b/src/main/java/org/openelisglobal/testalertrule/service/TestAlertEvaluationServiceImpl.java
@@ -2,7 +2,7 @@ package org.openelisglobal.testalertrule.service;
 
 import java.util.List;
 import org.openelisglobal.common.log.LogEvent;
-import org.openelisglobal.notification.service.sender.ClientNotificationSender;
+import org.openelisglobal.notification.service.sender.AsyncNotificationDispatcher;
 import org.openelisglobal.notification.valueholder.EmailNotification;
 import org.openelisglobal.notification.valueholder.RemoteNotification;
 import org.openelisglobal.notification.valueholder.SMSNotification;
@@ -38,10 +38,11 @@ public class TestAlertEvaluationServiceImpl implements TestAlertEvaluationServic
     @Autowired
     private SampleHumanService sampleHumanService;
 
-    // The SMS/Email senders used by the testNotificationConfig page. Optional so
-    // the processor still runs (header-only) in environments with none wired.
-    @Autowired(required = false)
-    private List<ClientNotificationSender> notificationSenders;
+    // Sends SMS/Email off the request thread so the result-entry response isn't
+    // blocked on SMTP / SMS-gateway calls (same async behavior as the default
+    // test-notification flow).
+    @Autowired
+    private AsyncNotificationDispatcher asyncNotificationDispatcher;
 
     @Override
     @Transactional
@@ -147,20 +148,10 @@ public class TestAlertEvaluationServiceImpl implements TestAlertEvaluationServic
         dispatch(mail);
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     private void dispatch(RemoteNotification notification) {
-        if (notificationSenders == null) {
-            return;
-        }
-        for (ClientNotificationSender sender : notificationSenders) {
-            try {
-                if (sender.forClass().isInstance(notification)) {
-                    sender.send(notification);
-                }
-            } catch (RuntimeException e) {
-                LogEvent.logError(e);
-            }
-        }
+        // Fire-and-forget on a separate thread; the notification already carries
+        // a fully-resolved string payload, so no Hibernate session is needed.
+        asyncNotificationDispatcher.dispatch(notification);
     }
 
     private String patientContact(Result result, boolean phone) {

--- a/src/main/java/org/openelisglobal/testcatalog/controller/rest/TestCatalogEditorRestController.java
+++ b/src/main/java/org/openelisglobal/testcatalog/controller/rest/TestCatalogEditorRestController.java
@@ -22,6 +22,7 @@ import org.openelisglobal.panelitem.valueholder.PanelItem;
 import org.openelisglobal.resultlimit.service.ResultLimitService;
 import org.openelisglobal.resultlimits.valueholder.ResultLimit;
 import org.openelisglobal.test.service.TestService;
+import org.openelisglobal.test.service.TestServiceImpl;
 import org.openelisglobal.test.valueholder.Test;
 import org.openelisglobal.testcatalog.service.RangeCoverageValidationService;
 import org.openelisglobal.testresult.service.TestResultService;
@@ -156,9 +157,19 @@ public class TestCatalogEditorRestController {
     @GetMapping(value = "/tests", produces = MediaType.APPLICATION_JSON_VALUE)
     public TestListPage listTests(@RequestParam(required = false) String domain,
             @RequestParam(required = false, defaultValue = "all") String status,
-            @RequestParam(required = false) Boolean amr, @RequestParam(required = false) String search,
-            @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "25") int pageSize) {
+            @RequestParam(required = false) Boolean amr, @RequestParam(required = false) String sampleType,
+            @RequestParam(required = false) String search, @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "25") int pageSize) {
         String searchLower = search == null ? null : search.toLowerCase(Locale.ROOT);
+        // Resolve the test ids for the requested sample type once (one query),
+        // rather than looking up each test's sample types while filtering.
+        Set<String> sampleTypeTestIds = null;
+        if (!isBlank(sampleType)) {
+            sampleTypeTestIds = new HashSet<>();
+            for (TypeOfSampleTest link : typeOfSampleTestService.getTypeOfSampleTestsForSampleType(sampleType)) {
+                sampleTypeTestIds.add(link.getTestId());
+            }
+        }
         List<TestListRow> filtered = new ArrayList<>();
         for (Test test : testService.getAll()) {
             if (domain != null && !domain.isBlank() && !domain.equals(test.getDomain())) {
@@ -173,6 +184,9 @@ public class TestCatalogEditorRestController {
             }
             boolean testAmr = Boolean.TRUE.equals(test.getAntimicrobialResistance());
             if (amr != null && amr != testAmr) {
+                continue;
+            }
+            if (sampleTypeTestIds != null && !sampleTypeTestIds.contains(test.getId())) {
                 continue;
             }
             String name = test.getName();
@@ -204,28 +218,13 @@ public class TestCatalogEditorRestController {
         int from = Math.min((result.page - 1) * result.pageSize, filtered.size());
         int to = Math.min(from + result.pageSize, filtered.size());
         result.rows = new ArrayList<>(filtered.subList(from, to));
-        // Disambiguate same-named tests by appending their sample type, e.g.
-        // "Covid-PCR (Urine)". Done on the page slice only (≤ pageSize lookups).
+        // Augment each name with its sample type — e.g. "Covid-PCR (Urine)" — using
+        // the same helper the rest of the app uses (respects augmentTestNameWithType).
+        // Done on the page slice only (≤ pageSize lookups).
         for (TestListRow row : result.rows) {
-            row.name = (row.name == null ? "" : row.name) + sampleTypeSuffix(row.testId);
+            row.name = TestServiceImpl.getLocalizedTestNameWithType(row.testId);
         }
         return result;
-    }
-
-    private String sampleTypeSuffix(String testId) {
-        List<String> sampleNames = new ArrayList<>();
-        for (TypeOfSampleTest link : typeOfSampleTestService.getTypeOfSampleTestsForTest(testId)) {
-            TypeOfSample sampleType = typeOfSampleService.getTypeOfSampleById(link.getTypeOfSampleId());
-            if (sampleType == null) {
-                continue;
-            }
-            String name = !isBlank(sampleType.getDescription()) ? sampleType.getDescription()
-                    : sampleType.getLocalAbbreviation();
-            if (!isBlank(name) && !sampleNames.contains(name)) {
-                sampleNames.add(name);
-            }
-        }
-        return sampleNames.isEmpty() ? "" : " (" + String.join("/", sampleNames) + ")";
     }
 
     public static class EditorEnvelope {
@@ -244,8 +243,9 @@ public class TestCatalogEditorRestController {
         }
         EditorEnvelope envelope = new EditorEnvelope();
         envelope.testId = test.getId();
-        // Test.getName() resolves the localized name, falling back to description.
-        envelope.name = test.getName();
+        // Name augmented with the sample type (e.g. "Covid-PCR (Urine)") so the
+        // selected test is distinguishable, matching the list view.
+        envelope.name = TestServiceImpl.getLocalizedTestNameWithType(test);
         envelope.code = test.getLocalCode();
         envelope.domain = test.getDomain();
         envelope.applicableSections = V1_SECTIONS;

--- a/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorBasicInfoIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorBasicInfoIntegrationTest.java
@@ -255,16 +255,18 @@ public class TestCatalogEditorBasicInfoIntegrationTest extends BaseWebContextSen
                     id, "ListIT-" + id, "ListIT-" + id, UUID.randomUUID().toString(), dom);
         }
 
-        TestCatalogEditorRestController.TestListPage vector = controller.listTests("VECTOR", "all", null, "ListIT-", 1,
-                25);
+        TestCatalogEditorRestController.TestListPage vector = controller.listTests("VECTOR", "all", null, null,
+                "ListIT-", 1, 25);
         assertEquals(1, vector.total);
         assertEquals("VECTOR", vector.rows.get(0).domain);
 
-        TestCatalogEditorRestController.TestListPage all = controller.listTests(null, "all", null, "ListIT-", 1, 2);
+        TestCatalogEditorRestController.TestListPage all = controller.listTests(null, "all", null, null, "ListIT-", 1,
+                2);
         assertEquals(3, all.total);
         assertEquals(2, all.rows.size()); // page size 2 of 3 total
 
-        TestCatalogEditorRestController.TestListPage page2 = controller.listTests(null, "all", null, "ListIT-", 2, 2);
+        TestCatalogEditorRestController.TestListPage page2 = controller.listTests(null, "all", null, null, "ListIT-", 2,
+                2);
         assertEquals(1, page2.rows.size());
     }
 
@@ -274,9 +276,9 @@ public class TestCatalogEditorBasicInfoIntegrationTest extends BaseWebContextSen
         seedTest(95021L, "StatusIT-active2", "CLINICAL", true, false);
         seedTest(95022L, "StatusIT-inactive", "CLINICAL", false, false);
 
-        assertEquals(3, controller.listTests(null, "all", null, "StatusIT-", 1, 25).total);
-        assertEquals(2, controller.listTests(null, "active", null, "StatusIT-", 1, 25).total);
-        assertEquals(1, controller.listTests(null, "inactive", null, "StatusIT-", 1, 25).total);
+        assertEquals(3, controller.listTests(null, "all", null, null, "StatusIT-", 1, 25).total);
+        assertEquals(2, controller.listTests(null, "active", null, null, "StatusIT-", 1, 25).total);
+        assertEquals(1, controller.listTests(null, "inactive", null, null, "StatusIT-", 1, 25).total);
     }
 
     @org.junit.Test
@@ -285,9 +287,9 @@ public class TestCatalogEditorBasicInfoIntegrationTest extends BaseWebContextSen
         seedTest(95024L, "AmrIT-no1", "CLINICAL", true, false);
         seedTest(95025L, "AmrIT-no2", "CLINICAL", true, false);
 
-        assertEquals(3, controller.listTests(null, "all", null, "AmrIT-", 1, 25).total);
-        assertEquals(1, controller.listTests(null, "all", true, "AmrIT-", 1, 25).total);
-        assertEquals(2, controller.listTests(null, "all", false, "AmrIT-", 1, 25).total);
+        assertEquals(3, controller.listTests(null, "all", null, null, "AmrIT-", 1, 25).total);
+        assertEquals(1, controller.listTests(null, "all", true, null, "AmrIT-", 1, 25).total);
+        assertEquals(2, controller.listTests(null, "all", false, null, "AmrIT-", 1, 25).total);
     }
 
     @org.junit.Test
@@ -296,9 +298,9 @@ public class TestCatalogEditorBasicInfoIntegrationTest extends BaseWebContextSen
         seedTest(95027L, "alphaSrchIT", "CLINICAL", true, false);
 
         // a lowercase query matches both mixed-case names (case-insensitive)
-        assertEquals(2, controller.listTests(null, "all", null, "srchit", 1, 25).total);
+        assertEquals(2, controller.listTests(null, "all", null, null, "srchit", 1, 25).total);
         // a distinct fragment narrows to one
-        assertEquals(1, controller.listTests(null, "all", null, "ZEBRA", 1, 25).total);
+        assertEquals(1, controller.listTests(null, "all", null, null, "ZEBRA", 1, 25).total);
     }
 
     @org.junit.Test
@@ -307,7 +309,7 @@ public class TestCatalogEditorBasicInfoIntegrationTest extends BaseWebContextSen
         seedTest(95029L, "Apple SortIT", "CLINICAL", true, false);
         seedTest(95030L, "cherry SortIT", "CLINICAL", true, false);
 
-        java.util.List<TestCatalogEditorRestController.TestListRow> rows = controller.listTests(null, "all", null,
+        java.util.List<TestCatalogEditorRestController.TestListRow> rows = controller.listTests(null, "all", null, null,
                 "SortIT", 1, 25).rows;
         assertEquals(3, rows.size());
         assertEquals("Apple SortIT", rows.get(0).name);

--- a/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
@@ -128,6 +128,15 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
                 "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
                         + " VALUES (?, ?, ?, 'Y', ?, NOW())",
                 SOURCE_ID, "SampleResultsCopySrc", "copy source", UUID.randomUUID().toString());
+        // Give the test a localized name so the shared name builder
+        // (getLocalizedTestNameWithType) resolves a name to augment with the sample
+        // type — mirrors production, where every test has a name localization.
+        Localization testNameLocalization = LocalizationServiceImpl.createNewLocalization("SampleResultsIT",
+                "SampleResultsIT", LocalizationServiceImpl.LocalizationType.TEST_NAME);
+        testNameLocalization.setSysUserId("1");
+        String testNameLocalizationId = localizationService.insert(testNameLocalization);
+        jdbc.update("UPDATE clinlims.test SET name_localization_id = ? WHERE id = ?",
+                Long.parseLong(testNameLocalizationId), TEST_ID);
         // Self-seed the dictionary entry + sample type these tests need; CI's DB does
         // not ship seed rows for them. The dictionary needs only an id; the sample
         // type needs a (cascade-managed) name localization, created via the service.
@@ -150,8 +159,21 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
     }
 
     private void cleanup() {
+        // Capture the test's name localization before the row is deleted, so it can
+        // be removed afterwards (its FK would otherwise block / orphan it).
+        java.util.List<Long> testNameLocalizationIds = jdbc
+                .queryForList("SELECT name_localization_id FROM clinlims.test WHERE id = ?", Long.class, TEST_ID);
         cleanupTest(TEST_ID);
         cleanupTest(SOURCE_ID);
+        for (Long localizationId : testNameLocalizationIds) {
+            if (localizationId != null) {
+                try {
+                    localizationService.delete(String.valueOf(localizationId), "1");
+                } catch (RuntimeException ignored) {
+                    // localization may already be gone; ignore
+                }
+            }
+        }
         jdbc.update("DELETE FROM clinlims.unit_of_measure WHERE id = ?", UOM_ID);
         // sampletype_test rows referencing the seeded sample type are removed by
         // cleanupTest (by test_id). Drop the sample type, then its name localization
@@ -546,12 +568,12 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
         jdbc.update("INSERT INTO clinlims.sampletype_test (id, sample_type_id, test_id) VALUES (?, ?, ?)", 952060L,
                 SAMPLE_TYPE_ID, TEST_ID);
 
-        TestCatalogEditorRestController.TestListPage page = controller.listTests(null, "all", null, "SampleResultsIT",
-                1, 25);
+        TestCatalogEditorRestController.TestListPage page = controller.listTests(null, "all", null, null,
+                "SampleResultsIT", 1, 25);
         TestCatalogEditorRestController.TestListRow row = page.rows.stream()
                 .filter(r -> r.testId.equals(String.valueOf(TEST_ID))).findFirst().orElseThrow();
         assertTrue("test name must be disambiguated by its sample type, got: " + row.name,
-                row.name.endsWith(" (" + SAMPLE_TYPE_DESC + ")"));
+                row.name.endsWith("(" + SAMPLE_TYPE_DESC + ")"));
     }
 
     @org.junit.Test


### PR DESCRIPTION
## Summary

Three related improvements in the Test Catalog v2 (OGC-949) area:

### 1. Async alert notifications
Test Alert SMS/Email were sent **synchronously** during result entry, freezing the page on SMTP / SMS-gateway calls. New `AsyncNotificationDispatcher` (`@Async`) performs the send off the request thread; `TestAlertEvaluationServiceImpl` resolves recipients + payload synchronously (session open, no lazy-loading on the async thread) then delegates the network send. Mirrors how the default test-notification flow already works.

### 2. Multi-terminology FHIR codings
`ServiceRequest` / `Observation` / `DiagnosticReport` previously carried only a LOINC coding from `test.loinc`. They now build the `CodeableConcept` from the **terminology mappings** (LOINC / SNOMED / CIEL / OCL) with canonical system URLs:
- **one coding per terminology system**;
- within each system the **`SAME_AS`** mapping wins (it is the equivalent concept); otherwise the system's other mappings are kept;
- legacy `test.loinc` participates as the LOINC `SAME_AS` (also covers tests not yet migrated to the terminology editor).

So a test now maps to multiple terminology systems at once (e.g. LOINC + SNOMED).

### 3. Test Catalog list / editor polish
- **Reuse** the app-wide `TestServiceImpl.getLocalizedTestNameWithType` for list rows and the editor header instead of hand-constructing the name. This shows the test's (single) sample type in brackets and respects the `augmentTestNameWithType` setting — fixing rows that previously listed *every* sample type joined by `/` (e.g. `Actin Smooth Muscle (Immunohistochemistry/Tissue.../Tissue...)`).
- **Sample Type filter** added to the list, alongside Domain / Status / AMR (backend `listTests` param + a frontend dropdown sourced from `/rest/test-catalog/sample-types`).

## Testing
- Backend full suite: 4546 run, 0 failures, 0 errors.
- Frontend full suite: 774 passed.
- `mvn spotless:apply` + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)