### PR TITLE
fix: prevent duplicate patient creation on stale ADD status

### DIFF
--- a/src/main/java/org/openelisglobal/sample/service/PatientManagementUpdate.java
+++ b/src/main/java/org/openelisglobal/sample/service/PatientManagementUpdate.java
@@ -403,6 +403,14 @@ public class PatientManagementUpdate extends ControllerUtills implements IPatien
 
         if (!GenericValidator.isBlankOrNull(patientInfo.getPatientPK())) {
             patientID = patientInfo.getPatientPK();
+
+            // A non-blank patientPK always identifies an existing patient record.
+            // Never trust an "ADD" (or missing/corrupted) status over it - doing so
+            // discards the ID and inserts a duplicate person/patient row for a
+            // patient that was already found and selected via search.
+            if (patientUpdateStatus != PatientUpdateStatus.NO_ACTION) {
+                patientUpdateStatus = PatientUpdateStatus.UPDATE;
+            }
         }
 
         // For NO_ACTION, load patient/person objects so they're available for

--- a/src/test/java/org/openelisglobal/sample/SamplePatientEntryServiceTest.java
+++ b/src/test/java/org/openelisglobal/sample/SamplePatientEntryServiceTest.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import javax.sql.DataSource;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
@@ -56,11 +60,42 @@ public class SamplePatientEntryServiceTest extends BaseWebContextSensitiveTest {
     private PatientService patientService;
 
     @Autowired
-    private PatientManagementUpdate patientManagementUpdate;
+    private DataSource dataSource;
 
     @Before
     public void setup() throws Exception {
         executeDataSetWithStateManagement("testdata/samplepatiententry.xml");
+        // Reset singleton caches to avoid stale identity type IDs from previous tests
+        org.openelisglobal.patientidentitytype.util.PatientIdentityTypeMap.reset();
+        // Ensure the address_part rows PatientManagementUpdate resolves at
+        // @PostConstruct time exist, regardless of what other test classes'
+        // fixtures have done to this shared table.
+        ensureAddressPart("department");
+        ensureAddressPart("commune");
+        ensureAddressPart("village");
+    }
+
+    private void ensureAddressPart(String partName) throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement select = conn
+                        .prepareStatement("SELECT id FROM clinlims.address_part WHERE part_name = ?")) {
+            select.setString(1, partName);
+            try (ResultSet rs = select.executeQuery()) {
+                if (rs.next()) {
+                    return;
+                }
+            }
+        }
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement insert = conn.prepareStatement(
+                        "INSERT INTO clinlims.address_part (id, part_name) VALUES (nextval('clinlims.address_part_seq'), ?)")) {
+            insert.setString(1, partName);
+            insert.executeUpdate();
+        }
+    }
+
+    private PatientManagementUpdate newPatientManagementUpdate() {
+        return webApplicationContext.getBean(PatientManagementUpdate.class);
     }
 
     @Test
@@ -149,6 +184,7 @@ public class SamplePatientEntryServiceTest extends BaseWebContextSensitiveTest {
         SamplePatientEntryForm patientEntryForm = new SamplePatientEntryForm();
         patientEntryForm.setPatientProperties(patientInfo);
 
+        PatientManagementUpdate patientManagementUpdate = newPatientManagementUpdate();
         patientManagementUpdate.setPatientUpdateStatus(patientInfo);
 
         SamplePatientUpdateData updateData = new SamplePatientUpdateData("1");

--- a/src/test/java/org/openelisglobal/sample/SamplePatientEntryServiceTest.java
+++ b/src/test/java/org/openelisglobal/sample/SamplePatientEntryServiceTest.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.sample;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -11,6 +12,7 @@ import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.login.valueholder.UserSessionData;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.patient.action.IPatientUpdate.PatientUpdateStatus;
 import org.openelisglobal.patient.action.bean.PatientManagementInfo;
 import org.openelisglobal.patient.service.PatientService;
 import org.openelisglobal.person.service.PersonService;
@@ -53,6 +55,7 @@ public class SamplePatientEntryServiceTest extends BaseWebContextSensitiveTest {
     @Autowired
     private PatientService patientService;
 
+    @Autowired
     private PatientManagementUpdate patientManagementUpdate;
 
     @Before
@@ -124,6 +127,123 @@ public class SamplePatientEntryServiceTest extends BaseWebContextSensitiveTest {
         } catch (Exception e) {
             assertNotNull("Exception should be thrown for missing patient ID", e.getMessage());
         }
+    }
+
+    private MockHttpServletRequest newRequestWithSession() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        UserSessionData usd = new UserSessionData();
+        request.getSession().setAttribute(IActionConstants.USER_SESSION_DATA, usd);
+        return request;
+    }
+
+    private SamplePatientUpdateData runPersistPatientFlow(PatientManagementInfo patientInfo,
+            MockHttpServletRequest request) throws Exception {
+        Sample sample = sampleService.getSampleByAccessionNumber("TEST001");
+        assertNotNull("Sample should exist", sample);
+
+        SampleHuman sampleHuman = new SampleHuman();
+        sampleHuman.setId("1");
+        sampleHuman.setSampleId(String.valueOf(sample.getId()));
+        sampleHumanService.getData(sampleHuman);
+
+        SamplePatientEntryForm patientEntryForm = new SamplePatientEntryForm();
+        patientEntryForm.setPatientProperties(patientInfo);
+
+        patientManagementUpdate.setPatientUpdateStatus(patientInfo);
+
+        SamplePatientUpdateData updateData = new SamplePatientUpdateData("1");
+        updateData.setSample(sample);
+        updateData.setSampleHuman(sampleHuman);
+        updateData.setSampleItemsTests(new java.util.ArrayList<>());
+        updateData.setSavePatient(patientManagementUpdate.getPatientUpdateStatus() != PatientUpdateStatus.NO_ACTION);
+
+        if (updateData.isSavePatient()) {
+            updateData.setPatientErrors(patientManagementUpdate.preparePatientData(request, patientInfo));
+        }
+
+        samplePatientEntryService.persistData(updateData, patientManagementUpdate, patientInfo, patientEntryForm,
+                request);
+        return updateData;
+    }
+
+    @Test
+    public void persistData_existingPatientPKWithAddStatus_mustNotCreateDuplicate() throws Exception {
+        long personCountBefore = personService.getAll().size();
+        long patientCountBefore = patientService.getAll().size();
+
+        // Existing patient (id=1 / person_id=4) from testdata/samplepatiententry.xml
+        PatientManagementInfo patientInfo = new PatientManagementInfo();
+        patientInfo.setPatientPK("1");
+        patientInfo.setPatientUpdateStatus(PatientUpdateStatus.ADD);
+        patientInfo.setLastName("DoeUpdated");
+        patientInfo.setFirstName("John");
+
+        runPersistPatientFlow(patientInfo, newRequestWithSession());
+
+        assertEquals("A non-blank patientPK must not result in a new person row", personCountBefore,
+                personService.getAll().size());
+        assertEquals("A non-blank patientPK must not result in a new patient row", patientCountBefore,
+                patientService.getAll().size());
+        assertEquals("The existing patientPK must be reused, not replaced by a newly generated one", "1",
+                patientInfo.getPatientPK());
+        assertEquals("The existing person's data must actually be updated, not left stale", "DoeUpdated",
+                personService.get("4").getLastName());
+    }
+
+    @Test
+    public void persistData_blankPatientPKWithAddStatus_stillCreatesNewPatient() throws Exception {
+        long personCountBefore = personService.getAll().size();
+        long patientCountBefore = patientService.getAll().size();
+
+        PatientManagementInfo patientInfo = new PatientManagementInfo();
+        patientInfo.setPatientUpdateStatus(PatientUpdateStatus.ADD);
+        patientInfo.setLastName("BrandNew");
+        patientInfo.setFirstName("Patient");
+
+        runPersistPatientFlow(patientInfo, newRequestWithSession());
+
+        assertEquals("A genuinely new patient (no patientPK) must still be inserted as a new person",
+                personCountBefore + 1, personService.getAll().size());
+        assertEquals("A genuinely new patient (no patientPK) must still be inserted as a new patient",
+                patientCountBefore + 1, patientService.getAll().size());
+    }
+
+    @Test
+    public void persistData_nullUpdateStatusWithExistingPatientPK_mustNotCreateDuplicate() throws Exception {
+        long personCountBefore = personService.getAll().size();
+        long patientCountBefore = patientService.getAll().size();
+
+        PatientManagementInfo patientInfo = new PatientManagementInfo();
+        patientInfo.setPatientPK("1");
+        // patientUpdateStatus intentionally left null.
+        patientInfo.setLastName("DoeViaNullStatus");
+
+        runPersistPatientFlow(patientInfo, newRequestWithSession());
+
+        assertEquals("A missing update-status with a valid patientPK must not create a duplicate person",
+                personCountBefore, personService.getAll().size());
+        assertEquals("A missing update-status with a valid patientPK must not create a duplicate patient",
+                patientCountBefore, patientService.getAll().size());
+        assertEquals("A missing update-status with a valid patientPK must still apply the update", "DoeViaNullStatus",
+                personService.get("4").getLastName());
+    }
+
+    @Test
+    public void persistData_noActionWithExistingPatientPK_appliesNoChanges() throws Exception {
+        long personCountBefore = personService.getAll().size();
+        long patientCountBefore = patientService.getAll().size();
+
+        PatientManagementInfo patientInfo = new PatientManagementInfo();
+        patientInfo.setPatientPK("1");
+        patientInfo.setPatientUpdateStatus(PatientUpdateStatus.NO_ACTION);
+        patientInfo.setLastName("ShouldNeverBeWritten");
+
+        runPersistPatientFlow(patientInfo, newRequestWithSession());
+
+        assertEquals("NO_ACTION must not create a new person row", personCountBefore, personService.getAll().size());
+        assertEquals("NO_ACTION must not create a new patient row", patientCountBefore, patientService.getAll().size());
+        assertEquals("NO_ACTION must not modify the existing person's data", "Doe",
+                personService.get("4").getLastName());
     }
 
 }


### PR DESCRIPTION
## Problem

The clinical order-entry workflow sometimes creates a **duplicate patient** when a user searches for and selects an existing patient instead of reusing the found record. The frontend correctly attaches the selected patient's `patientPK` to the submission, but a separate `patientUpdateStatus` flag travels alongside it and is meant to tell the backend whether to insert, update, or skip. When that flag is wrong or missing (e.g. `ADD` instead of `UPDATE`, or `null`), `PatientManagementUpdate.persistPatientData()` in `src/main/java/org/openelisglobal/sample/service/PatientManagementUpdate.java` branches purely on the status string and ignores `patientPK` entirely:

- Status `ADD` → always calls `personService.insert()` / `patientService.insert()`, creating a duplicate person + patient row with the same demographics as the one already selected.
- Status `null` (missing) → matches neither `ADD`, `UPDATE`, nor `NO_ACTION`, so the edit is silently dropped without persisting anything.

Since `patientPK` was never consulted, a perfectly valid existing ID was discarded either way.

## Solution

`PatientManagementUpdate.setPatientUpdateStatus()` now treats a non-blank `patientPK` as authoritative: if the incoming status isn't already `NO_ACTION`, it's corrected to `UPDATE`. This closes both failure modes at the single point where the client-supplied status and the patient ID are both known, regardless of which frontend code path produced the bad status.

## Test plan

Added to `SamplePatientEntryServiceTest` (DBUnit-backed, drives the same `setPatientUpdateStatus` → `preparePatientData` → `persistPatientData` sequence the real controller uses):
- [x] `persistData_existingPatientPKWithAddStatus_mustNotCreateDuplicate` — reproduces the reported bug; fails on `main` (`expected:<1> but was:<2>` person rows), passes with the fix, and also verifies the existing record's data is actually updated (not just non-duplicated).
- [x] `persistData_nullUpdateStatusWithExistingPatientPK_mustNotCreateDuplicate` — covers a missing/`null` status; without the fix this silently drops the edit instead of duplicating, which the assertion also catches.
- [x] `persistData_blankPatientPKWithAddStatus_stillCreatesNewPatient` — regression guard confirming genuine new-patient creation (no `patientPK`) still inserts.
- [x] `persistData_noActionWithExistingPatientPK_appliesNoChanges` — confirms `NO_ACTION` remains a true no-op.

Ran `mvn test -Dtest='org.openelisglobal.sample.**,org.openelisglobal.patient.**'` — 236 tests pass, no regressions.