### PR TITLE
feat(qa-overview): light up NCE Pulse tile and critical-NCE attention row (OGC-699 WS-C)

### DIFF
--- a/frontend/src/components/nonconform/common/NceDashboard.jsx
+++ b/frontend/src/components/nonconform/common/NceDashboard.jsx
@@ -34,7 +34,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer, postToOpenElisServer } from "../../utils/Utils";
 import config from "../../../config.json";
 import { NotificationContext } from "../../layout/Layout";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import "./NceDashboard.css";
 
 const STATUS_CONFIG = {
@@ -68,11 +68,17 @@ export const NceDashboard = () => {
   const [categories, setCategories] = useState([]);
   const [expandedRows, setExpandedRows] = useState({});
 
-  // Filters
+  // Filters — status/severity seed once from URL params so overview tiles
+  // can deep-link a pre-filtered register (e.g. ?severity=CRITICAL&status=Pending)
+  const location = useLocation();
   const [searchTerm, setSearchTerm] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState(
+    () => new URLSearchParams(location.search).get("status") || "",
+  );
   const [categoryFilter, setCategoryFilter] = useState("");
-  const [severityFilter, setSeverityFilter] = useState("");
+  const [severityFilter, setSeverityFilter] = useState(
+    () => new URLSearchParams(location.search).get("severity") || "",
+  );
 
   // Pagination
   const [currentPage, setCurrentPage] = useState(1);

--- a/frontend/src/components/nonconform/common/__tests__/NceDashboard.urlFilters.test.jsx
+++ b/frontend/src/components/nonconform/common/__tests__/NceDashboard.urlFilters.test.jsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import { MemoryRouter } from "react-router-dom";
+import messages from "../../../../languages/en.json";
+import { NceDashboard } from "../NceDashboard";
+import { NotificationContext } from "../../../layout/Layout";
+import { getFromOpenElisServer } from "../../../utils/Utils";
+
+vi.mock("../../../utils/Utils", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getFromOpenElisServer: vi.fn(),
+    postToOpenElisServer: vi.fn(),
+  };
+});
+
+const nce = (id, severity, status) => ({
+  id,
+  nceNumber: `NCE-2026-000${id}`,
+  title: `Event ${id}`,
+  description: "",
+  severity,
+  status,
+  dateOfEvent: "2026-07-01",
+  reportDate: "2026-07-01",
+  nameOfReporter: "Reporter",
+  assignedTo: null,
+  assignedToName: null,
+  notesCount: 0,
+  notes: [],
+  linkedSpecimens: [],
+  attachments: [],
+  history: [],
+});
+
+const NCE_LIST = [
+  nce("1", "CRITICAL", "Pending"),
+  nce("2", "MAJOR", "Pending"),
+  nce("3", "CRITICAL", "Closed"),
+];
+
+const renderAt = async (url) => {
+  await act(async () =>
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <NotificationContext.Provider
+          value={{ notificationVisible: false, addNotification: vi.fn() }}
+        >
+          <MemoryRouter initialEntries={[url]}>
+            <NceDashboard />
+          </MemoryRouter>
+        </NotificationContext.Provider>
+      </IntlProvider>,
+    ),
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getFromOpenElisServer.mockImplementation((url, callback) => {
+    if (url.includes("/rest/nce/dashboard")) {
+      callback({ nceList: NCE_LIST });
+    } else if (url.includes("/rest/nce/categories")) {
+      callback([]);
+    } else if (url.includes("/rest/nce/users")) {
+      callback([]);
+    }
+  });
+});
+
+describe("NceDashboard URL-seeded filters", () => {
+  test("without params all events are listed", async () => {
+    await renderAt("/NceDashboard");
+
+    expect(screen.getByText("NCE-2026-0001")).toBeInTheDocument();
+    expect(screen.getByText("NCE-2026-0002")).toBeInTheDocument();
+    expect(screen.getByText("NCE-2026-0003")).toBeInTheDocument();
+  });
+
+  test("?severity=CRITICAL&status=Pending seeds the filters and narrows the list", async () => {
+    await renderAt("/NceDashboard?severity=CRITICAL&status=Pending");
+
+    expect(screen.getByText("NCE-2026-0001")).toBeInTheDocument();
+    expect(screen.queryByText("NCE-2026-0002")).not.toBeInTheDocument();
+    expect(screen.queryByText("NCE-2026-0003")).not.toBeInTheDocument();
+
+    expect(document.getElementById("severity-filter")).toHaveValue("CRITICAL");
+    expect(document.getElementById("status-filter")).toHaveValue("Pending");
+  });
+});

--- a/frontend/src/components/qa/overview/AttentionRequired.jsx
+++ b/frontend/src/components/qa/overview/AttentionRequired.jsx
@@ -1,9 +1,14 @@
-import React from "react";
-import { useIntl } from "react-intl";
+import React, { useEffect, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { useHistory } from "react-router-dom";
 import ComingSoon from "./ComingSoon";
+import {
+  NCE_DRILL_URL,
+  countCriticalPending,
+  fetchNceList,
+} from "./nceOverview";
 
 const ROWS = [
-  { titleKey: "qa.overview.attention.criticalNce", ticket: "OGC-694" },
   { titleKey: "qa.overview.attention.criticalResults", ticket: "OGC-714" },
   { titleKey: "qa.overview.attention.overdueCapas", ticket: "OGC-707" },
   { titleKey: "qa.overview.attention.qcViolations", ticket: "OGC-700" },
@@ -11,6 +16,46 @@ const ROWS = [
   { titleKey: "qa.overview.attention.eqaDue", ticket: "OGC-721" },
   { titleKey: "qa.overview.attention.nceSla", ticket: "NCE v2" },
 ];
+
+// Live row (OGC-699): count of critical NCEs pending acknowledgment, linked
+// to the NCE register pre-filtered to that slice.
+const NceCriticalRow = () => {
+  const history = useHistory();
+  // undefined = loading, null = fetch yielded no data
+  const [nceList, setNceList] = useState();
+
+  useEffect(() => {
+    let mounted = true;
+    fetchNceList((list) => {
+      if (mounted) {
+        setNceList(list);
+      }
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const count = nceList ? countCriticalPending(nceList) : null;
+
+  return (
+    <button
+      type="button"
+      className={"qa-live-row" + (count > 0 ? " qa-live-row-alert" : "")}
+      onClick={() => history.push(NCE_DRILL_URL)}
+    >
+      <span className="qa-live-badge">
+        {nceList === undefined ? "…" : count != null ? count : "—"}
+      </span>
+      <span className="qa-cs-title">
+        <FormattedMessage id="qa.overview.attention.criticalNce" />
+      </span>
+      <span className="qa-live-arrow" aria-hidden="true">
+        →
+      </span>
+    </button>
+  );
+};
 
 const AttentionRequired = () => {
   const intl = useIntl();
@@ -21,6 +66,7 @@ const AttentionRequired = () => {
         <h3>{title}</h3>
       </div>
       <div className="qa-cs-rows">
+        <NceCriticalRow />
         {ROWS.map((row) => (
           <ComingSoon key={row.titleKey} variant="row" {...row} />
         ))}

--- a/frontend/src/components/qa/overview/NcePulseTile.jsx
+++ b/frontend/src/components/qa/overview/NcePulseTile.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from "react";
+import { ClickableTile, SkeletonText } from "@carbon/react";
+import { FormattedMessage } from "react-intl";
+import { useHistory } from "react-router-dom";
+import {
+  NCE_DRILL_URL,
+  countCriticalPending,
+  countInCorrectiveAction,
+  fetchNceList,
+  pulseColor,
+} from "./nceOverview";
+
+/**
+ * NCE Pulse — current-state count of critical NCEs pending acknowledgment
+ * (OGC-699). Deliberately not a trend: no sparkline. Standalone so the QI
+ * Dashboard (WS-B) can render the same tile.
+ */
+const NcePulseTile = () => {
+  const history = useHistory();
+  // undefined = loading, null = fetch yielded no data
+  const [nceList, setNceList] = useState();
+
+  useEffect(() => {
+    let mounted = true;
+    fetchNceList((list) => {
+      if (mounted) {
+        setNceList(list);
+      }
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const count = nceList ? countCriticalPending(nceList) : null;
+
+  return (
+    <ClickableTile
+      className="qa-live-tile"
+      onClick={() => history.push(NCE_DRILL_URL)}
+    >
+      <div className="qa-cs-title">
+        <FormattedMessage id="qa.overview.tile.ncePulse" />
+      </div>
+      {nceList === undefined ? (
+        <SkeletonText heading width="40%" />
+      ) : (
+        <>
+          <div
+            className={
+              "qa-live-count" +
+              (count != null ? ` qa-live-${pulseColor(count)}` : "")
+            }
+          >
+            {count != null ? count : "—"}
+          </div>
+          <div className="qa-live-caption">
+            <FormattedMessage id="qa.overview.ncePulse.criticalPending" />
+          </div>
+          {nceList && (
+            <div className="qa-live-caption">
+              <FormattedMessage
+                id="qa.overview.ncePulse.inCorrectiveAction"
+                values={{ count: countInCorrectiveAction(nceList) }}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </ClickableTile>
+  );
+};
+
+export default NcePulseTile;

--- a/frontend/src/components/qa/overview/QAOverview.css
+++ b/frontend/src/components/qa/overview/QAOverview.css
@@ -85,6 +85,75 @@
   min-height: 6.5rem;
 }
 
+/* Live (wired) tiles and rows */
+.qa-live-tile.cds--tile {
+  min-height: 6.5rem;
+  cursor: pointer;
+}
+
+.qa-live-count {
+  font-size: 1.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.qa-live-green {
+  color: #198038;
+}
+
+.qa-live-amber {
+  color: #b28600;
+}
+
+.qa-live-red {
+  color: #da1e28;
+}
+
+.qa-live-caption {
+  color: #525252;
+  font-size: 0.75rem;
+}
+
+.qa-live-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  border: none;
+  border-left: 3px solid #c6c6c6;
+  background: #ffffff;
+  padding: 0.625rem 1rem;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.qa-live-row-alert {
+  border-left-color: #da1e28;
+}
+
+.qa-live-row-alert .qa-live-badge {
+  background: #da1e28;
+  color: #ffffff;
+}
+
+.qa-live-badge {
+  min-width: 1.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background: #e0e0e0;
+  color: #161616;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.qa-live-arrow {
+  margin-left: auto;
+  color: #525252;
+}
+
 .qa-cs-stat.cds--tile {
   min-height: 4.5rem;
   padding: 0.75rem 1rem;

--- a/frontend/src/components/qa/overview/TodayTiles.jsx
+++ b/frontend/src/components/qa/overview/TodayTiles.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import ComingSoon from "./ComingSoon";
+import NcePulseTile from "./NcePulseTile";
 
 const TILES = [
   { titleKey: "qa.overview.tile.tat", ticket: "OGC-696" },
   { titleKey: "qa.overview.tile.rejectionRate", ticket: "OGC-697" },
   { titleKey: "qa.overview.tile.amendmentRate", ticket: "OGC-698" },
   { titleKey: "qa.overview.tile.criticalCallback", ticket: "OGC-714" },
-  { titleKey: "qa.overview.tile.ncePulse", ticket: "OGC-699" },
 ];
 
 const TodayTiles = () => {
@@ -22,6 +22,7 @@ const TodayTiles = () => {
         {TILES.map((tile) => (
           <ComingSoon key={tile.titleKey} variant="tile" {...tile} />
         ))}
+        <NcePulseTile />
       </div>
     </section>
   );

--- a/frontend/src/components/qa/overview/__tests__/NcePulseTile.test.jsx
+++ b/frontend/src/components/qa/overview/__tests__/NcePulseTile.test.jsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import { MemoryRouter, Route } from "react-router-dom";
+import messages from "../../../../languages/en.json";
+import NcePulseTile from "../NcePulseTile";
+import { getFromOpenElisServer } from "../../../utils/Utils";
+
+vi.mock("../../../utils/Utils", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getFromOpenElisServer: vi.fn(),
+  };
+});
+
+const nce = (id, severity, status) => ({
+  id,
+  nceNumber: `NCE-${id}`,
+  severity,
+  status,
+});
+
+const mockNceList = (list) => {
+  getFromOpenElisServer.mockImplementation((url, callback) => {
+    if (url.includes("/rest/nce/dashboard")) {
+      callback({ nceList: list });
+    }
+  });
+};
+
+let testLocation;
+const renderTile = async () => {
+  testLocation = undefined;
+  await act(async () =>
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <MemoryRouter initialEntries={["/qa/overview"]}>
+          <NcePulseTile />
+          <Route
+            path="*"
+            render={({ location }) => {
+              testLocation = location;
+              return null;
+            }}
+          />
+        </MemoryRouter>
+      </IntlProvider>,
+    ),
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("NcePulseTile", () => {
+  test("counts only CRITICAL + Pending events and shows corrective-action line (amber band)", async () => {
+    mockNceList([
+      nce("1", "CRITICAL", "Pending"),
+      nce("2", "CRITICAL", "Pending"),
+      nce("3", "CRITICAL", "Closed"),
+      nce("4", "MAJOR", "Pending"),
+      nce("5", "CRITICAL", "Corrective Action"),
+      nce("6", "MINOR", "Corrective Action"),
+    ]);
+    await renderTile();
+
+    const count = screen.getByText("2");
+    expect(count).toHaveClass("qa-live-count", "qa-live-amber");
+    expect(screen.getByText("critical pending")).toBeInTheDocument();
+    expect(screen.getByText("2 in corrective action")).toBeInTheDocument();
+  });
+
+  test("zero critical pending renders green, five or more renders red", async () => {
+    mockNceList([nce("1", "MAJOR", "Pending"), nce("2", "CRITICAL", "Closed")]);
+    await renderTile();
+    expect(screen.getByText("0")).toHaveClass("qa-live-green");
+
+    mockNceList(
+      ["1", "2", "3", "4", "5"].map((id) => nce(id, "CRITICAL", "Pending")),
+    );
+    await renderTile();
+    expect(screen.getByText("5")).toHaveClass("qa-live-red");
+  });
+
+  test("shows an em dash without a color band when the endpoint returns no data", async () => {
+    getFromOpenElisServer.mockImplementation((url, callback) => callback());
+    await renderTile();
+
+    const count = screen.getByText("—");
+    expect(count).toHaveClass("qa-live-count");
+    expect(count).not.toHaveClass("qa-live-green", "qa-live-amber");
+  });
+
+  test("click drills through to the NCE register pre-filtered to critical + pending", async () => {
+    mockNceList([nce("1", "CRITICAL", "Pending")]);
+    await renderTile();
+
+    fireEvent.click(screen.getByText("NCE Pulse"));
+    expect(testLocation.pathname).toBe("/NceDashboard");
+    expect(testLocation.search).toBe("?severity=CRITICAL&status=Pending");
+  });
+});

--- a/frontend/src/components/qa/overview/__tests__/QAOverview.test.jsx
+++ b/frontend/src/components/qa/overview/__tests__/QAOverview.test.jsx
@@ -1,29 +1,59 @@
 import React from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import { MemoryRouter } from "react-router-dom";
 import messages from "../../../../languages/en.json";
 import QAOverview from "../QAOverview";
+import { getFromOpenElisServer } from "../../../utils/Utils";
+
+vi.mock("../../../utils/Utils", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getFromOpenElisServer: vi.fn(),
+  };
+});
+
+// 3 critical+Pending, plus noise the predicates must ignore
+const NCE_LIST = [
+  { id: "1", severity: "CRITICAL", status: "Pending" },
+  { id: "2", severity: "CRITICAL", status: "Pending" },
+  { id: "3", severity: "CRITICAL", status: "Pending" },
+  { id: "4", severity: "CRITICAL", status: "Closed" },
+  { id: "5", severity: "MAJOR", status: "Pending" },
+  { id: "6", severity: "MINOR", status: "Corrective Action" },
+];
 
 // Rendering with the real en.json also fails loudly if a referenced i18n key
 // is missing (react-intl falls back to the raw key, breaking text assertions).
-const renderPage = () =>
-  render(
-    <IntlProvider locale="en" messages={messages}>
-      <MemoryRouter>
-        <QAOverview />
-      </MemoryRouter>
-    </IntlProvider>,
-  );
+const renderPage = async () => {
+  let view;
+  await act(async () => {
+    view = render(
+      <IntlProvider locale="en" messages={messages}>
+        <MemoryRouter>
+          <QAOverview />
+        </MemoryRouter>
+      </IntlProvider>,
+    );
+  });
+  return view;
+};
 
 beforeEach(() => {
   sessionStorage.clear();
+  vi.clearAllMocks();
+  getFromOpenElisServer.mockImplementation((url, callback) => {
+    if (url.includes("/rest/nce/dashboard")) {
+      callback({ nceList: NCE_LIST });
+    }
+  });
 });
 
 describe("QAOverview shell", () => {
-  test("renders page title and the six sections with the expected placeholder slots", () => {
-    renderPage();
+  test("renders page title and the six sections with the expected placeholder slots", async () => {
+    await renderPage();
 
     expect(
       screen.getByRole("heading", { name: "QA Overview" }),
@@ -32,9 +62,10 @@ describe("QAOverview shell", () => {
       screen.getByText(/Daily snapshot for the QA Officer/),
     ).toBeInTheDocument();
 
+    // NCE slots are live (WS-C); the counts below are the remaining placeholders
     const slotCounts = {
-      "Attention Required": 7,
-      Today: 5,
+      "Attention Required": 6,
+      Today: 4,
       "This Week": 8,
       "Pillar Status": 4,
       "Recent Activity": 1,
@@ -43,10 +74,13 @@ describe("QAOverview shell", () => {
       const region = screen.getByRole("region", { name });
       expect(within(region).getAllByText("Coming soon")).toHaveLength(slots);
     });
+
+    // Tile + attention row mount together but share one deduped request
+    expect(getFromOpenElisServer).toHaveBeenCalledTimes(1);
   });
 
-  test("Today tiles carry the KPI titles and light-up tickets from the delivery plan", () => {
-    renderPage();
+  test("Today tiles carry the KPI titles, tickets, and the live NCE Pulse count", async () => {
+    await renderPage();
     const today = screen.getByRole("region", { name: "Today" });
 
     [
@@ -58,22 +92,29 @@ describe("QAOverview shell", () => {
     ].forEach((title) => {
       expect(within(today).getByText(title)).toBeInTheDocument();
     });
-    ["OGC-696", "OGC-697", "OGC-698", "OGC-714", "OGC-699"].forEach(
-      (ticket) => {
-        expect(within(today).getByText(ticket)).toBeInTheDocument();
-      },
-    );
+    ["OGC-696", "OGC-697", "OGC-698", "OGC-714"].forEach((ticket) => {
+      expect(within(today).getByText(ticket)).toBeInTheDocument();
+    });
+    // NCE Pulse is live: no ticket tag, real counts from the mocked payload
+    expect(within(today).queryByText("OGC-699")).not.toBeInTheDocument();
+    expect(within(today).getByText("3")).toHaveClass("qa-live-amber");
+    expect(
+      within(today).getByText("1 in corrective action"),
+    ).toBeInTheDocument();
   });
 
-  test("attention rows and pillars are ticket-annotated", () => {
-    renderPage();
+  test("attention section shows the live critical-NCE row plus ticket-annotated placeholders", async () => {
+    await renderPage();
 
     const attention = screen.getByRole("region", {
       name: "Attention Required",
     });
-    expect(
-      within(attention).getByText("Critical NCEs pending acknowledgment"),
-    ).toBeInTheDocument();
+    const liveRow = within(attention).getByRole("button", {
+      name: /Critical NCEs pending acknowledgment/,
+    });
+    expect(within(liveRow).getByText("3")).toBeInTheDocument();
+    expect(liveRow).toHaveClass("qa-live-row-alert");
+
     // Overdue CAPAs + effectiveness reviews both light up via OGC-707
     expect(within(attention).getAllByText("OGC-707")).toHaveLength(2);
     expect(within(attention).getByText("NCE v2")).toBeInTheDocument();
@@ -89,8 +130,8 @@ describe("QAOverview shell", () => {
     });
   });
 
-  test("inspector readiness is collapsed by default and open state sticks across a remount", () => {
-    const view = renderPage();
+  test("inspector readiness is collapsed by default and open state sticks across a remount", async () => {
+    const view = await renderPage();
     const heading = screen.getByRole("button", {
       name: /Inspector readiness/,
     });
@@ -109,7 +150,7 @@ describe("QAOverview shell", () => {
     ).toBeInTheDocument();
 
     view.unmount();
-    renderPage();
+    await renderPage();
     expect(
       screen.getByRole("button", { name: /Inspector readiness/ }),
     ).toHaveAttribute("aria-expanded", "true");

--- a/frontend/src/components/qa/overview/nceOverview.js
+++ b/frontend/src/components/qa/overview/nceOverview.js
@@ -1,0 +1,47 @@
+import { getFromOpenElisServer } from "../../utils/Utils";
+
+/**
+ * Shared NCE client-filter util for the QA Overview (OGC-699 WS-C).
+ *
+ * There is no acknowledgment column on nce_event: acknowledging an NCE
+ * transitions status "Pending" -> "Under Investigation" (NceEnhancement
+ * REST controller), so "critical pending acknowledgment" is exactly
+ * severity CRITICAL + status Pending. WS-F reuses these predicates for
+ * the QMS pillar chip and This-Week counters.
+ */
+
+export const NCE_DRILL_URL = "/NceDashboard?severity=CRITICAL&status=Pending";
+
+// Deduped fetch: overview slots mounting together share one request; the
+// cache clears on resolve so a fresh mount refetches current data.
+let inflight = null;
+export const fetchNceList = (callback) => {
+  if (!inflight) {
+    const request = new Promise((resolve) => {
+      getFromOpenElisServer("/rest/nce/dashboard", (data) =>
+        resolve(data && Array.isArray(data.nceList) ? data.nceList : null),
+      );
+    });
+    inflight = request;
+    // Clear after settle (identity-guarded) so the reset survives callbacks
+    // that fire synchronously, e.g. cached responses or test mocks.
+    request.then(() => {
+      if (inflight === request) {
+        inflight = null;
+      }
+    });
+  }
+  inflight.then(callback);
+};
+
+export const countCriticalPending = (list) =>
+  list.filter((nce) => nce.severity === "CRITICAL" && nce.status === "Pending")
+    .length;
+
+export const countInCorrectiveAction = (list) =>
+  list.filter((nce) => nce.status === "Corrective Action").length;
+
+// ponytail: v1 hard-coded thresholds (0 green, 1-4 amber, >=5 red) per
+// OGC-699; per-lab configuration arrives with QI config in v8.
+export const pulseColor = (count) =>
+  count === 0 ? "green" : count < 5 ? "amber" : "red";

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -4672,6 +4672,8 @@
   "qa.overview.week.auditEntries": "Audit log entries",
   "qa.overview.week.signatureEvents": "Signature events",
   "qa.overview.activity.feed": "Attested actions across all pillars",
+  "qa.overview.ncePulse.criticalPending": "critical pending",
+  "qa.overview.ncePulse.inCorrectiveAction": "{count} in corrective action",
   "qa.overview.inspector.q1": "Are runs in control?",
   "qa.overview.inspector.q2": "How did EQA perform last cycle?",
   "qa.overview.inspector.q3": "Are QIs on target?",


### PR DESCRIPTION
## Summary

WS-C of the QA Overview MVP delivery plan (OGC-683 A.2) — the first **live** slots on the Overview shell (#3830), frontend-only over the existing `/rest/nce/dashboard` endpoint.

**Key data-model insight:** `nc_event` has no acknowledgment column — acknowledging transitions `status Pending → Under Investigation`. So *critical pending acknowledgment* ⇔ `severity=CRITICAL AND status=Pending`, computed client-side; no new endpoint or SQL (supersedes the ticket's older `NCEPulseTileService` idea per the delivery plan).

- **`nceOverview.js`** — shared NCE client-filter util: deduped fetch (two consumers, one request — asserted in tests), count predicates, drill URL, v1 hard-coded thresholds (`0→green, 1–4→amber, ≥5→red`)
- **`NcePulseTile`** — current-state count + color band + "N in corrective action"; deliberately no sparkline (not a trend). Standalone so WS-B drops it onto the QI Dashboard with one import
- **Live attention row** — same count, red accent when non-zero, replaces the `ComingSoon` slot
- **Drill-through** — tile/row → `/NceDashboard?severity=CRITICAL&status=Pending`; `NceDashboard` now seeds its severity/status filters from URL params (~10 lines). Note: `/qa/qms/nce-register` (`ViewNonConformingEvent`) is a single-record lookup form and cannot render a filtered list, so `/NceDashboard` is the drill target

## Test plan

- [x] `npx vitest run` — 123 files, 792 passed / 13 skipped. New: NcePulseTile suite (exact counts vs a mixed payload, all three threshold bands, em-dash fallback, drill-through location), NceDashboard URL-filter seeding suite, updated QAOverview shell suite (slot counts 5→4 / 7→6, live counts, request dedupe)
- [x] `npm run format`
- [x] Live-verified on the dev stack with seeded data: amber (3 critical pending / 2 in corrective action), red (6), drill-through landing pre-filtered showing exactly the 6 matching events

## Notes for reviewers

- Pre-existing quirk (untouched): the NCE dashboard's own CRITICAL summary card counts **all** criticals incl. Closed; the tile counts unacknowledged only — the definitions intentionally differ
- The QMS pillar chip and inspector Q4 slots (tagged OGC-699 on the shell) light up in WS-F, which reuses `nceOverview.js`
- `NceEnhancementRestController` has no `@PreAuthorize` (relies on default authenticated-session security) — flagged for a backend hardening follow-up, out of this frontend-only scope

Refs OGC-699 · Part of OGC-683 Phase A.2 · Follows #3830

🤖 Generated with [Claude Code](https://claude.com/claude-code)