### PR TITLE
feat(qa-overview): light up Average TAT Today tile (OGC-696 WS-G)

### DIFF
--- a/frontend/src/components/qa/overview/TatTile.jsx
+++ b/frontend/src/components/qa/overview/TatTile.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from "react";
+import { ClickableTile, SkeletonText } from "@carbon/react";
+import { FormattedMessage } from "react-intl";
+import { useHistory } from "react-router-dom";
+import { formatTat } from "../../reports/tat/tatUtils";
+import { fetchTatRollup } from "./overviewData";
+
+// tatDelta tone → the shared qa-live color classes (faster TAT is good/green).
+const DELTA_COLOR = { good: "qa-live-green", bad: "qa-live-amber" };
+const TAT_DRILL_URL = "/qa/qi/dashboard";
+
+/**
+ * Average TAT — 30-day mean receipt-to-validation with its prior-window delta
+ * (OGC-696). Rides the deduped fetchTatRollup already fetched by the QI pillar
+ * chip / inspector Q3, so it adds no request. Drills to the QI Dashboard (its
+ * detail /qa/qi/tat is RESULTS/REPORTS-gated, narrower than this audience).
+ */
+const TatTile = () => {
+  const history = useHistory();
+  // undefined = loading, null = fetch yielded no runs
+  const [tat, setTat] = useState();
+
+  useEffect(() => {
+    let mounted = true;
+    fetchTatRollup((data) => mounted && setTat(data));
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return (
+    <ClickableTile
+      className="qa-live-tile"
+      onClick={() => history.push(TAT_DRILL_URL)}
+    >
+      <div className="qa-cs-title">
+        <FormattedMessage id="qa.overview.tile.tat" />
+      </div>
+      {tat === undefined ? (
+        <SkeletonText heading width="40%" />
+      ) : tat === null ? (
+        <>
+          <div className="qa-live-count">—</div>
+          <div className="qa-live-caption">
+            <FormattedMessage id="qa.overview.pillar.qi.noData" />
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="qa-live-count">{formatTat(tat.mean)}</div>
+          <div className="qa-live-caption">
+            {tat.arrow && tat.text ? (
+              <span className={DELTA_COLOR[tat.tone] || ""}>
+                {tat.arrow} {tat.text}{" "}
+              </span>
+            ) : null}
+            <FormattedMessage
+              id="qa.qi.dashboard.tile.tat.vsPriorDays"
+              values={{ days: 30 }}
+            />
+          </div>
+        </>
+      )}
+    </ClickableTile>
+  );
+};
+
+export default TatTile;

--- a/frontend/src/components/qa/overview/TodayTiles.jsx
+++ b/frontend/src/components/qa/overview/TodayTiles.jsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import ComingSoon from "./ComingSoon";
 import AmendmentRateTile from "./AmendmentRateTile";
 import NcePulseTile from "./NcePulseTile";
+import TatTile from "./TatTile";
 
 const TodayTiles = () => {
   const intl = useIntl();
@@ -13,11 +14,7 @@ const TodayTiles = () => {
         <h3>{title}</h3>
       </div>
       <div className="qa-cs-grid qa-cs-grid-tiles">
-        <ComingSoon
-          variant="tile"
-          titleKey="qa.overview.tile.tat"
-          ticket="OGC-696"
-        />
+        <TatTile />
         <ComingSoon
           variant="tile"
           titleKey="qa.overview.tile.rejectionRate"

--- a/frontend/src/components/qa/overview/__tests__/QAOverview.test.jsx
+++ b/frontend/src/components/qa/overview/__tests__/QAOverview.test.jsx
@@ -146,11 +146,11 @@ describe("QAOverview", () => {
     ).toBeInTheDocument();
 
     // WS-F lit This Week / Pillars / Activity and the QC/EQA attention rows;
-    // WS-E lit the Today Amendment tile (NCE Pulse already live via WS-C).
-    // These placeholders remain.
+    // WS-E lit the Today Amendment tile, WS-G the Average TAT tile (NCE Pulse
+    // already live via WS-C). These placeholders remain.
     const slotCounts = {
       "Attention Required": 4,
-      Today: 3,
+      Today: 2,
       "This Week": 1,
       "Pillar Status": 1,
       "Recent Activity": 0,
@@ -165,7 +165,7 @@ describe("QAOverview", () => {
     expect(getFromOpenElisServer).toHaveBeenCalledTimes(5);
   });
 
-  test("Today tiles carry the KPI titles, tickets, and the live NCE Pulse count", async () => {
+  test("Today tiles carry the KPI titles, tickets, and the live TAT/Amendment/NCE values", async () => {
     await renderPage();
     const today = screen.getByRole("region", { name: "Today" });
 
@@ -178,9 +178,17 @@ describe("QAOverview", () => {
     ].forEach((title) => {
       expect(within(today).getByText(title)).toBeInTheDocument();
     });
-    ["OGC-696", "OGC-697", "OGC-714"].forEach((ticket) => {
+    ["OGC-697", "OGC-714"].forEach((ticket) => {
       expect(within(today).getByText(ticket)).toBeInTheDocument();
     });
+    // Average TAT is live (WS-G): value + prior-window delta, no ticket
+    expect(within(today).queryByText("OGC-696")).not.toBeInTheDocument();
+    const tatTile = within(today)
+      .getByText("Average TAT")
+      .closest(".cds--tile");
+    expect(within(tatTile).getByText("33h 20m")).toBeInTheDocument();
+    expect(tatTile).toHaveTextContent("↓ 6h 40m");
+    expect(within(tatTile).getByText(/vs prior 30 days/)).toBeInTheDocument();
     // NCE Pulse is live: no ticket tag, real counts from the mocked payload
     expect(within(today).queryByText("OGC-699")).not.toBeInTheDocument();
     expect(within(today).getByText("3")).toHaveClass("qa-live-amber");


### PR DESCRIPTION
## What

Lights up the QA Overview's **Average TAT** Today tile — the last v1-LIVE cell in the delivery plan (§02, OGC-696 leftover; WS-B built the QI Dashboard's TAT tile, this is the Overview's).

New `TatTile.jsx` rides the **deduped `fetchTatRollup`** already fetched by the QI pillar chip / inspector Q3 → **zero new requests, no backend, no liquibase, no CSS**. It shows the 30-day mean receipt-to-validation TAT with its prior-window delta and drills to the role-safe `/qa/qi/dashboard` (the `/qa/qi/tat` detail is RESULTS/REPORTS-gated, narrower than the overview audience).

Reuses `formatTat`, the `qa-live-*` styles, and existing i18n keys — **zero new i18n keys**.

## Changes
- **New** `TatTile.jsx` — live tile over `fetchTatRollup`.
- `TodayTiles.jsx` — `<TatTile/>` replaces the OGC-696 ComingSoon slot.
- `QAOverview.test.jsx` — Today coming-soon `3 → 2`, OGC-696 tag gone, asserts `33h 20m` / `↓ 6h 40m` / "vs prior 30 days".

## Coordination
Rebased on **WS-E** (#3837, merged): WS-E lit Amendment Rate and rewrote `TodayTiles.jsx`; this re-decrements the shared coming-soon count. Today now: 2 coming-soon (Rejection OGC-697, Critical Callback OGC-714) + 3 live (TAT, Amendment, NCE Pulse).

## Testing
- vitest: qa suite 31/31, `QAOverview` 7/7.
- Live-verified at `/qa/overview`: tile renders `33h 20m · ↓ 6h 40m vs prior 30 days` (green delta, no ticket tag); drill → `/qa/qi/dashboard` with no access-denied; value matches the seeded dataset WS-B verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)