### PR TITLE
feat(test-catalog): is_primary component flag + runtime multi-component result entry + config-loader bridges (OGC-949)

### DIFF
--- a/frontend/src/components/admin/testCatalog/sections/SampleResultsSection.jsx
+++ b/frontend/src/components/admin/testCatalog/sections/SampleResultsSection.jsx
@@ -296,20 +296,52 @@ const SampleResultsSection = ({ testId }) => {
     setComponents((prev) => [
       ...prev,
       {
-        code: "",
+        // The first (only) component is the primary; its code is fixed to
+        // PRIMARY (mirrored to the legacy test columns).
+        code: prev.length === 0 ? "PRIMARY" : "",
         label: "",
         displayOrder: prev.length + 1,
         resultType: "N",
         significantDigits: null,
         defaultResult: "",
         allowMultipleReadings: false,
+        isPrimary: prev.length === 0,
         options: [],
         interpretations: [],
       },
     ]);
 
+  // Exactly one component is primary. While one is marked, the other
+  // components' Primary toggles are disabled — the current primary must be
+  // unmarked first. Marking fixes the code to PRIMARY (and disables it);
+  // unmarking frees the code back to the component's label.
+  const togglePrimary = (ci, checked) =>
+    setComponents((prev) =>
+      prev.map((c, i) => {
+        if (i !== ci) {
+          return c;
+        }
+        if (checked) {
+          return { ...c, isPrimary: true, code: "PRIMARY" };
+        }
+        return {
+          ...c,
+          isPrimary: false,
+          code: c.code === "PRIMARY" ? c.label || "" : c.code,
+        };
+      }),
+    );
+
   const removeComponent = (ci) =>
-    setComponents((prev) => prev.filter((_, i) => i !== ci));
+    setComponents((prev) => {
+      const removed = prev[ci];
+      const next = prev.filter((_, i) => i !== ci);
+      // Removing the primary promotes the first remaining component.
+      if (removed && removed.isPrimary && next.length > 0) {
+        next[0] = { ...next[0], isPrimary: true, code: "PRIMARY" };
+      }
+      return next;
+    });
 
   const moveComponent = (ci, dir) =>
     setComponents((prev) => {
@@ -573,12 +605,24 @@ const SampleResultsSection = ({ testId }) => {
                     onClick={() => moveComponent(ci, 1)}
                   />
                 </div>
+                <Toggle
+                  id={`comp-primary-${ci}`}
+                  labelText={intl.formatMessage({
+                    id: "label.testCatalog.sampleResults.isPrimary",
+                  })}
+                  labelA={intl.formatMessage({ id: "label.no" })}
+                  labelB={intl.formatMessage({ id: "label.yes" })}
+                  toggled={!!c.isPrimary}
+                  disabled={!c.isPrimary && components.some((x) => x.isPrimary)}
+                  onToggle={(checked) => togglePrimary(ci, checked)}
+                />
                 <TextInput
                   id={`comp-code-${ci}`}
                   labelText={intl.formatMessage({
                     id: "label.testCatalog.sampleResults.code",
                   })}
-                  value={c.code || ""}
+                  value={c.isPrimary ? "PRIMARY" : c.code || ""}
+                  disabled={!!c.isPrimary}
                   onChange={(e) => patchComponent(ci, { code: e.target.value })}
                 />
                 <TextInput

--- a/frontend/src/components/admin/testCatalog/sections/SampleResultsSection.jsx
+++ b/frontend/src/components/admin/testCatalog/sections/SampleResultsSection.jsx
@@ -397,7 +397,7 @@ const SampleResultsSection = ({ testId }) => {
                 {
                   value: item.id,
                   valueName: item.name,
-                  resultType: "D",
+                  resultType: c.resultType,
                   sortOrder: c.options.length + 1,
                   normal: false,
                 },

--- a/frontend/src/components/admin/testCatalog/sections/SampleResultsSection.test.jsx
+++ b/frontend/src/components/admin/testCatalog/sections/SampleResultsSection.test.jsx
@@ -201,6 +201,63 @@ describe("SampleResultsSection", () => {
     expect(components[1].code).toBe("Diastolic");
   });
 
+  it("marks a component primary: code fixed to PRIMARY + disabled, other toggles locked", async () => {
+    getFromOpenElisServer.mockImplementation((url, cb) => {
+      if (url === "/rest/test-list" || url === "/rest/uom") {
+        cb([]);
+      } else {
+        cb(clone(TWO_COMPONENTS));
+      }
+    });
+    const { container } = renderSection();
+    await screen.findByDisplayValue("SYS");
+
+    // No primary yet → both toggles enabled; mark the first.
+    fireEvent.click(container.querySelector("#comp-primary-0"));
+
+    // Its code is forced to PRIMARY and the field is disabled.
+    const code0 = container.querySelector("#comp-code-0");
+    expect(code0.value).toBe("PRIMARY");
+    expect(code0).toBeDisabled();
+    // The other component can no longer be marked primary.
+    expect(container.querySelector("#comp-primary-1")).toBeDisabled();
+
+    fireEvent.click(saveButton());
+    const components = savedPayload().components;
+    expect(components[0].isPrimary).toBe(true);
+    expect(components[0].code).toBe("PRIMARY");
+    expect(components[1].isPrimary).toBeFalsy();
+  });
+
+  it("unmarking the primary frees its code and unlocks the other toggles", async () => {
+    getFromOpenElisServer.mockImplementation((url, cb) => {
+      if (url === "/rest/test-list" || url === "/rest/uom") {
+        cb([]);
+      } else {
+        const data = clone(TWO_COMPONENTS);
+        data.components[0].isPrimary = true;
+        data.components[0].code = "PRIMARY";
+        cb(data);
+      }
+    });
+    const { container } = renderSection();
+    await screen.findByDisplayValue("PRIMARY");
+
+    // Second toggle starts locked while the first is primary.
+    expect(container.querySelector("#comp-primary-1")).toBeDisabled();
+
+    // Unmark the primary → code falls back to its label, other toggle unlocks.
+    fireEvent.click(container.querySelector("#comp-primary-0"));
+    expect(container.querySelector("#comp-code-0").value).toBe("Systolic");
+    expect(container.querySelector("#comp-code-0")).not.toBeDisabled();
+    expect(container.querySelector("#comp-primary-1")).not.toBeDisabled();
+
+    // Now the second component can take the designation.
+    fireEvent.click(container.querySelector("#comp-primary-1"));
+    expect(container.querySelector("#comp-code-1").value).toBe("PRIMARY");
+    expect(container.querySelector("#comp-code-1")).toBeDisabled();
+  });
+
   it("shows result types as primary cards with the legacy types behind a disclosure (FR-28)", async () => {
     renderSection();
     await screen.findByDisplayValue("SYS");

--- a/frontend/src/components/common/cascadingMultiSelect.jsx
+++ b/frontend/src/components/common/cascadingMultiSelect.jsx
@@ -31,7 +31,23 @@ export default function CascadingMultiSelect({
     }
   };
 
-  const [cascades, setCascades] = useState(() => parseValue(value));
+  // Selections are derived from the value prop so saved results display and
+  // edits round-trip through the parent form state. Empty cascades are
+  // stripped from the emitted JSON, so newly added (still empty) rows live in
+  // local state until they get a selection.
+  const savedCascades = useMemo(() => parseValue(value), [value]);
+  const [draftKeys, setDraftKeys] = useState([]);
+
+  const cascades = useMemo(() => {
+    const merged = {};
+    draftKeys.forEach((k) => {
+      merged[k] = [];
+    });
+    Object.keys(savedCascades).forEach((k) => {
+      merged[k] = savedCascades[k];
+    });
+    return merged;
+  }, [savedCascades, draftKeys]);
 
   const cascadeKeys = Object.keys(cascades)
     .map(Number)
@@ -50,26 +66,26 @@ export default function CascadingMultiSelect({
 
   const addCascade = () => {
     const nextKey = cascadeKeys.length ? Math.max(...cascadeKeys) + 1 : 0;
-
-    const updated = { ...cascades, [nextKey]: [] };
-    setCascades(updated);
-    emitChange(updated);
+    setDraftKeys([...draftKeys, nextKey]);
   };
 
   const removeCascade = (key) => {
+    setDraftKeys(draftKeys.filter((k) => k !== key));
+
     const updated = { ...cascades };
     delete updated[key];
-    setCascades(updated);
     emitChange(updated);
   };
 
   const updateCascade = (key, selectedItems) => {
-    const updated = {
+    if (!draftKeys.includes(key)) {
+      setDraftKeys([...draftKeys, key]);
+    }
+
+    emitChange({
       ...cascades,
       [key]: selectedItems.map((i) => i.id),
-    };
-    setCascades(updated);
-    emitChange(updated);
+    });
   };
 
   return (
@@ -82,32 +98,35 @@ export default function CascadingMultiSelect({
             );
 
             return (
-              <div
-                key={key}
-                style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}
-              >
-                <Column lg={16} sm={4} md={8}>
-                  <MultiSelect
-                    id={`${id}_${key}`}
-                    items={items}
-                    selectedItems={selectedItems}
-                    itemToString={(item) => item?.label || ""}
-                    onChange={({ selectedItems }) =>
-                      updateCascade(key, selectedItems)
-                    }
-                    label=""
-                    selectionFeedback="top-after-reopen"
-                    style={{ minWidth: "250px" }}
+              <div key={key} style={{ marginBottom: "0.5rem" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    marginBottom: "-0.5rem",
+                  }}
+                >
+                  <Button
+                    kind="ghost"
+                    size="sm"
+                    hasIconOnly
+                    renderIcon={TrashCan}
+                    iconDescription="Remove"
+                    onClick={() => removeCascade(key)}
                   />
-                </Column>
+                </div>
 
-                <Button
-                  kind="ghost"
-                  size="sm"
-                  hasIconOnly
-                  renderIcon={TrashCan}
-                  iconDescription="Remove"
-                  onClick={() => removeCascade(key)}
+                <MultiSelect
+                  id={`${id}_${key}`}
+                  items={items}
+                  selectedItems={selectedItems}
+                  itemToString={(item) => item?.label || ""}
+                  onChange={({ selectedItems }) =>
+                    updateCascade(key, selectedItems)
+                  }
+                  label=""
+                  selectionFeedback="top-after-reopen"
+                  style={{ minWidth: "250px" }}
                 />
               </div>
             );

--- a/frontend/src/components/resultPage/SearchResultForm.jsx
+++ b/frontend/src/components/resultPage/SearchResultForm.jsx
@@ -1391,7 +1391,32 @@ export function SearchResults(props) {
       case "currentResult":
         switch (row.resultType) {
           case "M":
-          case "C":
+          case "C": {
+            const labelFor = (dictId) =>
+              row.dictionaryResults?.find((result) => result.id == dictId)
+                ?.value || dictId;
+            let groups;
+            try {
+              groups = JSON.parse(row.multiSelectResultValues || "{}");
+            } catch {
+              groups = {};
+            }
+            const lines = Object.keys(groups)
+              .sort((a, b) => Number(a) - Number(b))
+              .map((k) =>
+                groups[k].split(",").filter(Boolean).map(labelFor).join(", "),
+              )
+              .filter(Boolean);
+            return (
+              <>
+                {lines.map((line, index) => (
+                  <div key={index}>
+                    {row.resultType === "C" ? `[ ${line} ]` : line}
+                  </div>
+                ))}
+              </>
+            );
+          }
           case "D":
             return (
               <>

--- a/frontend/src/components/resultPage/SearchResultForm.jsx
+++ b/frontend/src/components/resultPage/SearchResultForm.jsx
@@ -858,6 +858,10 @@ export function SearchResults(props) {
   const [storageModalRow, setStorageModalRow] = useState(null);
 
   const componentMounted = useRef(false);
+  // Saved multiselect values per row, frozen once the user starts editing so
+  // the Current Result column keeps showing what is persisted, not the
+  // in-progress selection (multiSelectResultValues is the editable field).
+  const savedMultiSelectValues = useRef({});
 
   useEffect(() => {
     componentMounted.current = true;
@@ -1395,9 +1399,16 @@ export function SearchResults(props) {
             const labelFor = (dictId) =>
               row.dictionaryResults?.find((result) => result.id == dictId)
                 ?.value || dictId;
+            const snapshotKey = `${row.analysisId}_${row.testResultComponentId || ""}`;
+            if (row.isModified !== "true") {
+              savedMultiSelectValues.current[snapshotKey] =
+                row.multiSelectResultValues || "{}";
+            }
             let groups;
             try {
-              groups = JSON.parse(row.multiSelectResultValues || "{}");
+              groups = JSON.parse(
+                savedMultiSelectValues.current[snapshotKey] || "{}",
+              );
             } catch {
               groups = {};
             }
@@ -1408,13 +1419,13 @@ export function SearchResults(props) {
               )
               .filter(Boolean);
             return (
-              <>
+              <div style={{ display: "flex", flexDirection: "column" }}>
                 {lines.map((line, index) => (
                   <div key={index}>
                     {row.resultType === "C" ? `[ ${line} ]` : line}
                   </div>
                 ))}
-              </>
+              </div>
             );
           }
           case "D":

--- a/frontend/src/components/validation/Validation.jsx
+++ b/frontend/src/components/validation/Validation.jsx
@@ -378,7 +378,32 @@ const Validation = (props) => {
       case "result":
         switch (row.resultType) {
           case "M":
-          case "C":
+          case "C": {
+            const labelFor = (dictId) =>
+              row.dictionaryResults?.find((result) => result.id == dictId)
+                ?.value || dictId;
+            let groups;
+            try {
+              groups = JSON.parse(row.multiSelectResultValues || "{}");
+            } catch {
+              groups = {};
+            }
+            const lines = Object.keys(groups)
+              .sort((a, b) => Number(a) - Number(b))
+              .map((k) =>
+                groups[k].split(",").filter(Boolean).map(labelFor).join(", "),
+              )
+              .filter(Boolean);
+            return (
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                {lines.map((line, index) => (
+                  <div key={index}>
+                    {row.resultType === "C" ? `[ ${line} ]` : line}
+                  </div>
+                ))}
+              </div>
+            );
+          }
           case "D":
             return (
               <>

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -4291,6 +4291,7 @@
   "label.testCatalog.sampleResults.empty": "No result components yet. Add one to define how this test's results are captured.",
   "label.testCatalog.sampleResults.newComponent": "(new component)",
   "label.testCatalog.sampleResults.code": "Component code",
+  "label.testCatalog.sampleResults.isPrimary": "Primary component",
   "label.testCatalog.sampleResults.label": "Component label",
   "label.testCatalog.sampleResults.resultType": "Result type",
   "label.testCatalog.sampleResults.resultType.N": "Numeric",

--- a/src/main/java/org/openelisglobal/common/services/ResultSaveService.java
+++ b/src/main/java/org/openelisglobal/common/services/ResultSaveService.java
@@ -85,7 +85,24 @@ public class ResultSaveService {
                 try {
                     JSONObject jsonResult = (JSONObject) parser.parse(serviceBean.getMultiSelectResultValues());
 
-                    List<Result> existingResults = resultService.getResultsByAnalysis(analysis);
+                    // Only this item's own multiselect selections may be reconciled
+                    // (and leftovers deleted). A multi-component analysis also holds
+                    // the other components' results — deleting those here orphans
+                    // their rows mid-save and their own update then fails.
+                    List<Result> existingResults = new ArrayList<>();
+                    for (Result existingResult : resultService.getResultsByAnalysis(analysis)) {
+                        if (!TypeOfTestResultServiceImpl.ResultType
+                                .isMultiSelectVariant(existingResult.getResultType())) {
+                            continue;
+                        }
+                        String existingComponentId = existingResult.getTestResult() == null ? null
+                                : existingResult.getTestResult().getComponentId();
+                        if (serviceBean.getTestResultComponentId() != null && existingComponentId != null
+                                && !serviceBean.getTestResultComponentId().equals(existingComponentId)) {
+                            continue;
+                        }
+                        existingResults.add(existingResult);
+                    }
                     for (Object key : jsonResult.keySet()) {
                         getResultsForMultiSelect(results, existingResults, serviceBean, (String) key,
                                 (String) jsonResult.get(key), isQualifiedResult);

--- a/src/main/java/org/openelisglobal/common/services/ResultSaveService.java
+++ b/src/main/java/org/openelisglobal/common/services/ResultSaveService.java
@@ -122,10 +122,24 @@ public class ResultSaveService {
                 // result
             } else {
                 List<TestResult> testResultList = testResultService.getActiveTestResultsByTest(serviceBean.getTestId());
-                // we are assuming there is only one testResult for a numeric
-                // type result
-                if (!testResultList.isEmpty()) {
-                    result.setTestResult(testResultList.get(0));
+                // Multi-component tests post one bean per component; bind the result
+                // to that component's test_result row so it stays attributable to
+                // its component. Single-component tests keep the historic
+                // first-row assumption.
+                TestResult boundTestResult = null;
+                if (!GenericValidator.isBlankOrNull(serviceBean.getTestResultComponentId())) {
+                    for (TestResult testResult : testResultList) {
+                        if (serviceBean.getTestResultComponentId().equals(testResult.getComponentId())) {
+                            boundTestResult = testResult;
+                            break;
+                        }
+                    }
+                }
+                if (boundTestResult == null && !testResultList.isEmpty()) {
+                    boundTestResult = testResultList.get(0);
+                }
+                if (boundTestResult != null) {
+                    result.setTestResult(boundTestResult);
                 }
             }
 

--- a/src/main/java/org/openelisglobal/common/services/ResultSaveService.java
+++ b/src/main/java/org/openelisglobal/common/services/ResultSaveService.java
@@ -152,11 +152,10 @@ public class ResultSaveService {
                         }
                     }
                 }
-                if (boundTestResult == null && !testResultList.isEmpty()) {
-                    boundTestResult = testResultList.get(0);
-                }
                 if (boundTestResult != null) {
                     result.setTestResult(boundTestResult);
+                } else if (result.getTestResult() == null && !testResultList.isEmpty()) {
+                    result.setTestResult(testResultList.get(0));
                 }
             }
 

--- a/src/main/java/org/openelisglobal/common/services/beanAdapters/ResultSaveBeanAdapter.java
+++ b/src/main/java/org/openelisglobal/common/services/beanAdapters/ResultSaveBeanAdapter.java
@@ -29,6 +29,7 @@ public class ResultSaveBeanAdapter {
         bean.setResultType(item.getResultType());
         bean.setMultiSelectResultValues(item.getMultiSelectResultValues());
         bean.setTestId(item.getTestId());
+        bean.setTestResultComponentId(item.getTestResultComponentId());
         bean.setQualifiedResultId(item.getQualifiedResultId());
         bean.setQualifiedResultValue(item.getQualifiedResultValue());
         bean.setQualifiedDictionaryId(item.getQualifiedDictionaryId());

--- a/src/main/java/org/openelisglobal/common/services/beanAdapters/ResultSaveBeanAdapter.java
+++ b/src/main/java/org/openelisglobal/common/services/beanAdapters/ResultSaveBeanAdapter.java
@@ -50,6 +50,7 @@ public class ResultSaveBeanAdapter {
         bean.setResultType(item.getResultType());
         bean.setMultiSelectResultValues(item.getMultiSelectResultValues());
         bean.setTestId(item.getTestId());
+        bean.setTestResultComponentId(item.getTestResultComponentId());
         bean.setQualifiedResultId(item.getQualifiedResultId());
         bean.setQualifiedResultValue(item.getQualifiedResultValue());
         bean.setQualifiedDictionaryId(item.getQualifiedDictionaryId());

--- a/src/main/java/org/openelisglobal/common/services/serviceBeans/ResultSaveBean.java
+++ b/src/main/java/org/openelisglobal/common/services/serviceBeans/ResultSaveBean.java
@@ -22,6 +22,9 @@ public class ResultSaveBean {
     private String resultType;
     private String multiSelectResultValues;
     private String testId;
+    // Result component this value belongs to (multi-component tests post one
+    // bean per component); null for single-component tests.
+    private String testResultComponentId;
     private String qualifiedResultId;
     private String qualifiedResultValue;
     private String qualifiedDictionaryId;
@@ -62,6 +65,14 @@ public class ResultSaveBean {
 
     public void setTestId(String testId) {
         this.testId = testId;
+    }
+
+    public String getTestResultComponentId() {
+        return testResultComponentId;
+    }
+
+    public void setTestResultComponentId(String testResultComponentId) {
+        this.testResultComponentId = testResultComponentId;
     }
 
     public String getQualifiedResultId() {

--- a/src/main/java/org/openelisglobal/reports/action/implementation/PatientReport.java
+++ b/src/main/java/org/openelisglobal/reports/action/implementation/PatientReport.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IllegalFormatException;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -90,6 +91,8 @@ import org.openelisglobal.systemuser.service.UserService;
 import org.openelisglobal.test.service.TestService;
 import org.openelisglobal.test.service.TestServiceImpl;
 import org.openelisglobal.test.valueholder.Test;
+import org.openelisglobal.testresultcomponent.service.TestResultComponentService;
+import org.openelisglobal.testresultcomponent.valueholder.TestResultComponent;
 import org.openelisglobal.typeoftestresult.service.TypeOfTestResultServiceImpl;
 
 public abstract class PatientReport extends Report {
@@ -703,6 +706,13 @@ public abstract class PatientReport extends Report {
         String reportResult = "";
         if (!resultList.isEmpty()) {
 
+            List<TestResultComponent> activeComponents = SpringContext.getBean(TestResultComponentService.class)
+                    .getActiveComponentsByTestId(analysisService.getTest(currentAnalysis).getId());
+            if (activeComponents.size() > 1) {
+                data.setResult(buildMultiComponentResult(resultList, activeComponents));
+                return;
+            }
+
             // If only one result just get it and get out
             if (resultList.size() == 1) {
                 Result result = resultList.get(0);
@@ -817,6 +827,85 @@ public abstract class PatientReport extends Report {
             }
         }
         data.setResult(reportResult);
+    }
+
+    /**
+     * A multi-component analysis reports one labeled line per component, each
+     * formatted by its component's own type. Results whose test_result row has no
+     * component (legacy rows) belong to the primary component.
+     */
+    private String buildMultiComponentResult(List<Result> resultList, List<TestResultComponent> components) {
+        ResultService resultResultService = SpringContext.getBean(ResultService.class);
+        StringBuilder reportBuilder = new StringBuilder();
+        for (TestResultComponent component : components) {
+            List<Result> componentResults = new ArrayList<>();
+            for (Result result : resultList) {
+                if (result.getParentResult() != null) {
+                    continue;
+                }
+                String componentId = result.getTestResult() == null ? null : result.getTestResult().getComponentId();
+                if (componentId == null ? component.getIsPrimary() : component.getId().equals(componentId)) {
+                    componentResults.add(result);
+                }
+            }
+            if (componentResults.isEmpty()) {
+                continue;
+            }
+            String componentValue = formatComponentResults(component, componentResults, resultResultService);
+            if (GenericValidator.isBlankOrNull(componentValue)) {
+                continue;
+            }
+            reportBuilder.append(component.getLabel()).append(": ").append(componentValue).append("\n");
+        }
+        if (reportBuilder.length() > 0) {
+            reportBuilder.setLength(reportBuilder.length() - 1);
+        }
+        return reportBuilder.toString();
+    }
+
+    private String formatComponentResults(TestResultComponent component, List<Result> componentResults,
+            ResultService resultResultService) {
+        if (TypeOfTestResultServiceImpl.ResultType.isMultiSelectVariant(component.getResultType())) {
+            Collections.sort(componentResults, new Comparator<Result>() {
+                @Override
+                public int compare(Result o1, Result o2) {
+                    if (o1.getGrouping() == o2.getGrouping()) {
+                        return Integer.parseInt(o1.getId()) - Integer.parseInt(o2.getId());
+                    }
+                    return o1.getGrouping() - o2.getGrouping();
+                }
+            });
+            Map<Integer, List<String>> namesByGroup = new LinkedHashMap<>();
+            for (Result result : componentResults) {
+                Dictionary dictionary = new Dictionary();
+                dictionary.setId(result.getValue());
+                dictionaryService.getData(dictionary);
+                if (dictionary.getId() != null) {
+                    namesByGroup.computeIfAbsent(result.getGrouping(), k -> new ArrayList<>())
+                            .add(dictionary.getLocalizedName());
+                }
+            }
+            List<String> groups = new ArrayList<>();
+            for (List<String> names : namesByGroup.values()) {
+                groups.add(String.join(", ", names));
+            }
+            if (groups.isEmpty()) {
+                return "";
+            }
+            if (TypeOfTestResultServiceImpl.ResultType.CASCADING_MULTISELECT.matches(component.getResultType())) {
+                return "[ " + String.join(" ] [ ", groups) + " ]";
+            }
+            return String.join(", ", groups);
+        }
+
+        Result result = componentResults.get(0);
+        if (TypeOfTestResultServiceImpl.ResultType.isDictionaryVariant(result.getResultType())) {
+            Dictionary dictionary = new Dictionary();
+            dictionary.setId(result.getValue());
+            dictionaryService.getData(dictionary);
+            return dictionary.getId() != null ? dictionary.getLocalizedName() : "";
+        }
+        return resultResultService.getResultValue(result, true);
     }
 
     protected void setCollectionTime(Set<SampleItem> sampleSet, List<ClinicalPatientData> currentSampleReportItems,

--- a/src/main/java/org/openelisglobal/result/action/util/ResultUtil.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultUtil.java
@@ -217,10 +217,27 @@ public class ResultUtil {
         return !GenericValidator.isBlankOrNull(item.getForceTechApproval());
     }
 
+    /**
+     * Multi-component analyses post one TestResultItem per component, all sharing
+     * the same analysisId. The same detached Analysis instance must be reused
+     * across those items so the analysis is registered for update (and later
+     * merged) only once per save; merging a second detached copy after the first
+     * merge flushes fails the optimistic lock on lastupdated and rolls back the
+     * whole transaction.
+     */
+    public static Analysis resolveModifiedAnalysis(ResultsUpdateDataSet actionDataSet, String analysisId) {
+        Analysis analysis = actionDataSet.findModifiedAnalysis(analysisId);
+        if (analysis == null) {
+            analysis = analysisService.get(analysisId);
+            actionDataSet.getModifiedAnalysis().add(analysis);
+        }
+        return analysis;
+    }
+
     public static void createAnalysisOnlyUpdates(ResultsUpdateDataSet actionDataSet, HttpServletRequest request) {
         for (TestResultItem testResultItem : actionDataSet.getAnalysisOnlyChangeResults()) {
 
-            Analysis analysis = analysisService.get(testResultItem.getAnalysisId());
+            Analysis analysis = resolveModifiedAnalysis(actionDataSet, testResultItem.getAnalysisId());
             analysis.setSysUserId(ControllerUtills.getSysUserId(request));
             analysis.setCompletedDate(DateUtil.convertStringDateToTimestampLenient(testResultItem.getTestDate()));
             if (testResultItem.getAnalysisMethod() != null) {
@@ -235,7 +252,6 @@ public class ResultUtil {
                     analysis.setResultFile(resultFile);
                 }
             }
-            actionDataSet.getModifiedAnalysis().add(analysis);
         }
     }
 
@@ -257,15 +273,16 @@ public class ResultUtil {
             }
         }
 
+        Set<String> correctedFlagComputedIds = new HashSet<>();
+
         for (TestResultItem testResultItem : actionDataSet.getModifiedItems()) {
 
-            Analysis analysis = analysisService.get(testResultItem.getAnalysisId());
+            Analysis analysis = resolveModifiedAnalysis(actionDataSet, testResultItem.getAnalysisId());
             analysis.setStatusId(getStatusForTestResult(testResultItem, alwaysValidate));
             analysis.setSysUserId(ControllerUtills.getSysUserId(request));
             if (!GenericValidator.isBlankOrNull(testResultItem.getTestMethod())) {
                 analysis.setMethod(methodService.get(testResultItem.getTestMethod()));
             }
-            actionDataSet.getModifiedAnalysis().add(analysis);
 
             actionDataSet.addToNoteList(noteService.createSavableNote(analysis, NoteType.INTERNAL,
                     testResultItem.getNote(), RESULT_SUBJECT, ControllerUtills.getSysUserId(request)));
@@ -299,8 +316,13 @@ public class ResultUtil {
             List<Result> results = resultSaveService.createResultsFromTestResultItem(bean,
                     actionDataSet.getDeletableResults());
 
-            analysis.setCorrectedSincePatientReport(
-                    resultSaveService.isUpdatedResult() && analysisService.patientReportHasBeenDone(analysis));
+            boolean correctedSinceReport = resultSaveService.isUpdatedResult()
+                    && analysisService.patientReportHasBeenDone(analysis);
+            if (correctedFlagComputedIds.add(analysis.getId())) {
+                analysis.setCorrectedSincePatientReport(correctedSinceReport);
+            } else if (correctedSinceReport) {
+                analysis.setCorrectedSincePatientReport(true);
+            }
 
             if (analysisService.hasBeenCorrectedSinceLastPatientReport(analysis)) {
                 Note note = noteService.createSavableNote(analysis, NoteType.EXTERNAL,

--- a/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
@@ -94,6 +94,7 @@ import org.openelisglobal.testreflex.action.util.TestReflexUtil;
 import org.openelisglobal.testreflex.valueholder.TestReflex;
 import org.openelisglobal.testresult.service.TestResultService;
 import org.openelisglobal.testresult.valueholder.TestResult;
+import org.openelisglobal.testresultcomponent.valueholder.TestResultComponent;
 import org.openelisglobal.typeofsample.service.TypeOfSampleService;
 import org.openelisglobal.typeoftestresult.service.TypeOfTestResultServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -158,6 +159,10 @@ public class ResultsLoadUtility {
     private TestResultService testResultService;
     @Autowired
     private SampleEQAService sampleEQAService;
+    @Autowired
+    private org.openelisglobal.testresultcomponent.service.TestResultComponentService testResultComponentService;
+    @Autowired
+    private org.openelisglobal.unitofmeasure.service.UnitOfMeasureService unitOfMeasureService;
 
     private final StatusRules statusRules = new StatusRules();
 
@@ -437,6 +442,16 @@ public class ResultsLoadUtility {
             resultList.add(null);
         }
 
+        // Multi-component tests (v2.4 FRS §Result Components) render one result
+        // field per active component: existing results are bucketed to their
+        // component via their test_result row, and components not yet recorded get
+        // a blank placeholder row appended.
+        Test analysisTest = analysisService.getTest(analysis);
+        List<TestResultComponent> activeComponents = analysisTest == null ? new ArrayList<>()
+                : testResultComponentService.getActiveComponentsByTestId(analysisTest.getId());
+        boolean multiComponent = activeComponents.size() > 1;
+        Set<String> coveredComponentIds = new HashSet<>();
+
         boolean multiSelectionResult = false;
         for (Result result : resultList) {
             // If the parentResult has a value then this result was handled with
@@ -464,6 +479,12 @@ public class ResultsLoadUtility {
                         .isMultiSelectVariant(result.getResultType());
             }
 
+            TestResultComponent component = null;
+            if (multiComponent) {
+                component = result == null ? activeComponents.get(0) : resolveComponent(result, activeComponents);
+                coveredComponentIds.add(component.getId());
+            }
+
             String initialConditions = getInitialSampleConditionString(sampleItem);
             NoteType[] noteTypes = { NoteType.EXTERNAL, NoteType.INTERNAL, NoteType.REJECTION_REASON,
                     NoteType.NON_CONFORMITY };
@@ -473,7 +494,8 @@ public class ResultsLoadUtility {
             TestResultItem resultItem = createTestResultItem(analysis, testKit, notes, sampleItem.getSortOrder(),
                     result, sampleItem.getSample().getAccessionNumber(), patientName, patientInfo, techSignature,
                     techSignatureId, initialConditions, SpringContext.getBean(TypeOfSampleService.class)
-                            .getTypeOfSampleNameForId(sampleItem.getTypeOfSampleId()));
+                            .getTypeOfSampleNameForId(sampleItem.getTypeOfSampleId()),
+                    component);
             resultItem.setNationalId(nationalId);
             testResultList.add(resultItem);
 
@@ -482,7 +504,60 @@ public class ResultsLoadUtility {
             }
         }
 
+        // Blank placeholder rows for components without a recorded result yet.
+        if (multiComponent) {
+            String initialConditions = getInitialSampleConditionString(sampleItem);
+            NoteType[] noteTypes = { NoteType.EXTERNAL, NoteType.INTERNAL, NoteType.REJECTION_REASON,
+                    NoteType.NON_CONFORMITY };
+            String notes = SpringContext.getBean(NoteService.class).getNotesAsString(analysis, true, true, "<br/>",
+                    noteTypes, false);
+            for (TestResultComponent component : activeComponents) {
+                if (coveredComponentIds.contains(component.getId())) {
+                    continue;
+                }
+                TestResultItem resultItem = createTestResultItem(analysis, null, notes, sampleItem.getSortOrder(), null,
+                        sampleItem.getSample().getAccessionNumber(), patientName, patientInfo, techSignature,
+                        techSignatureId, initialConditions, SpringContext.getBean(TypeOfSampleService.class)
+                                .getTypeOfSampleNameForId(sampleItem.getTypeOfSampleId()),
+                        component);
+                resultItem.setNationalId(nationalId);
+                testResultList.add(resultItem);
+            }
+        }
+
         return testResultList;
+    }
+
+    /**
+     * The component an existing result belongs to: via its test_result row's
+     * component_id, defaulting to the primary component (NULL component_id rows are
+     * legacy rows owned by the primary).
+     */
+    private TestResultComponent resolveComponent(Result result, List<TestResultComponent> components) {
+        String componentId = result.getTestResult() == null ? null : result.getTestResult().getComponentId();
+        if (componentId != null) {
+            for (TestResultComponent component : components) {
+                if (componentId.equals(component.getId())) {
+                    return component;
+                }
+            }
+        }
+        for (TestResultComponent component : components) {
+            if (component.getIsPrimary()) {
+                return component;
+            }
+        }
+        return components.get(0);
+    }
+
+    /** The component's own unit of measure (blank when it has none). */
+    private String componentUomName(TestResultComponent component) {
+        if (component.getUomId() == null) {
+            return "";
+        }
+        org.openelisglobal.unitofmeasure.valueholder.UnitOfMeasure uom = unitOfMeasureService
+                .getUnitOfMeasureById(component.getUomId());
+        return uom == null || uom.getUnitOfMeasureName() == null ? "" : uom.getUnitOfMeasureName();
     }
 
     private String getInitialSampleConditionString(SampleItem sampleItem) {
@@ -638,7 +713,8 @@ public class ResultsLoadUtility {
 
     private TestResultItem createTestResultItem(Analysis analysis, ResultInventory testKit, String notes,
             String sequenceNumber, Result result, String accessionNumber, String patientName, String patientInfo,
-            String techSignature, String techSignatureId, String initialSampleConditions, String sampleType) {
+            String techSignature, String techSignatureId, String initialSampleConditions, String sampleType,
+            TestResultComponent component) {
 
         TestService testService = SpringContext.getBean(TestService.class);
         Test test = analysisService.getTest(analysis);
@@ -663,6 +739,19 @@ public class ResultsLoadUtility {
         String receivedDate = currSample == null ? getCurrentDate() : currSample.getReceivedDateForDisplay();
         String testMethodName = testService.getTestMethodName(test);
         List<TestResult> testResults = testService.getPossibleTestResults(test);
+        // Multi-component rows see only their component's test_result rows so the
+        // widget type, dictionary options and significant digits are per component
+        // (NULL component_id rows are legacy rows owned by the primary).
+        if (component != null) {
+            List<TestResult> componentRows = new ArrayList<>();
+            for (TestResult testResult : testResults) {
+                if (component.getId().equals(testResult.getComponentId())
+                        || (component.getIsPrimary() && testResult.getComponentId() == null)) {
+                    componentRows.add(testResult);
+                }
+            }
+            testResults = componentRows;
+        }
 
         String testKitId = null;
         String testKitInventoryId = null;
@@ -694,6 +783,11 @@ public class ResultsLoadUtility {
             }
         }
 
+        if (component != null && !isConclusion && !isCD4Conclusion
+                && !GenericValidator.isBlankOrNull(component.getLabel())) {
+            displayTestName += " — " + component.getLabel();
+        }
+
         String referralId = null;
         String referralReasonId = null;
         boolean referralCanceled = false;
@@ -709,6 +803,9 @@ public class ResultsLoadUtility {
         }
 
         String uom = testService.getUOM(test, isCD4Conclusion);
+        if (component != null) {
+            uom = componentUomName(component);
+        }
 
         String testDate;
         Timestamp completedTs = analysis.getCompletedDate();
@@ -747,6 +844,9 @@ public class ResultsLoadUtility {
         testItem.setReceivedDate(receivedDate);
         testItem.setTestName(displayTestName);
         testItem.setTestId(test.getId());
+        if (component != null) {
+            testItem.setTestResultComponentId(component.getId());
+        }
         setResultLimitDependencies(resultLimit, testItem, testResults);
         testItem.setPatientName(patientName);
         testItem.setPatientInfo(patientInfo);
@@ -772,7 +872,9 @@ public class ResultsLoadUtility {
         // for eventual test-configuration cleanup.
         // - For new rows (no stored result) we must use the test's configured
         // type, because that's the only signal available for widget choice.
-        String configuredType = testService.getResultType(test);
+        String configuredType = component != null && !GenericValidator.isBlankOrNull(component.getResultType())
+                ? component.getResultType()
+                : testService.getResultType(test);
         if (result != null && !GenericValidator.isBlankOrNull(result.getResultType())
                 && !GenericValidator.isBlankOrNull(result.getValue())
                 && !result.getResultType().equals(configuredType)) {

--- a/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
@@ -451,6 +451,7 @@ public class ResultsLoadUtility {
                 : testResultComponentService.getActiveComponentsByTestId(analysisTest.getId());
         boolean multiComponent = activeComponents.size() > 1;
         Set<String> coveredComponentIds = new HashSet<>();
+        Set<String> multiSelectComponentIds = new HashSet<>();
 
         boolean multiSelectionResult = false;
         for (Result result : resultList) {
@@ -483,6 +484,13 @@ public class ResultsLoadUtility {
             if (multiComponent) {
                 component = result == null ? activeComponents.get(0) : resolveComponent(result, activeComponents);
                 coveredComponentIds.add(component.getId());
+                // A multiselect result set collapses into a single row per
+                // component (the values travel as JSON in
+                // multiSelectResultValues), while other components' results
+                // must still get their own rows.
+                if (multiSelectionResult && !multiSelectComponentIds.add(component.getId())) {
+                    continue;
+                }
             }
 
             String initialConditions = getInitialSampleConditionString(sampleItem);
@@ -499,7 +507,7 @@ public class ResultsLoadUtility {
             resultItem.setNationalId(nationalId);
             testResultList.add(resultItem);
 
-            if (multiSelectionResult) {
+            if (multiSelectionResult && !multiComponent) {
                 break;
             }
         }

--- a/src/main/java/org/openelisglobal/result/action/util/ResultsUpdateDataSet.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultsUpdateDataSet.java
@@ -78,6 +78,15 @@ public class ResultsUpdateDataSet implements IResultSaveService {
         return modifiedAnalysis;
     }
 
+    public Analysis findModifiedAnalysis(String analysisId) {
+        for (Analysis analysis : modifiedAnalysis) {
+            if (analysis.getId() != null && analysis.getId().equals(analysisId)) {
+                return analysis;
+            }
+        }
+        return null;
+    }
+
     public List<Result> getDeletableResults() {
         return deletableResults;
     }

--- a/src/main/java/org/openelisglobal/result/controller/LogbookResultsController.java
+++ b/src/main/java/org/openelisglobal/result/controller/LogbookResultsController.java
@@ -8,8 +8,10 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.validator.GenericValidator;
@@ -514,7 +516,7 @@ public class LogbookResultsController extends LogbookResultsBaseController {
     private void createAnalysisOnlyUpdates(ResultsUpdateDataSet actionDataSet) {
         for (TestResultItem testResultItem : actionDataSet.getAnalysisOnlyChangeResults()) {
 
-            Analysis analysis = analysisService.get(testResultItem.getAnalysisId());
+            Analysis analysis = ResultUtil.resolveModifiedAnalysis(actionDataSet, testResultItem.getAnalysisId());
             analysis.setSysUserId(getSysUserId(request));
             analysis.setCompletedDate(DateUtil.convertStringDateToTimestampLenient(testResultItem.getTestDate()));
             if (testResultItem.getAnalysisMethod() != null) {
@@ -523,22 +525,22 @@ public class LogbookResultsController extends LogbookResultsBaseController {
             if (!GenericValidator.isBlankOrNull(testResultItem.getTestMethod())) {
                 analysis.setMethod(methodService.get(testResultItem.getTestMethod()));
             }
-            actionDataSet.getModifiedAnalysis().add(analysis);
         }
     }
 
     private void createResultsFromItems(ResultsUpdateDataSet actionDataSet, boolean supportReferrals,
             boolean alwaysValidate, boolean useTechnicianName, String statusRuleSet) {
 
+        Set<String> correctedFlagComputedIds = new HashSet<>();
+
         for (TestResultItem testResultItem : actionDataSet.getModifiedItems()) {
 
-            Analysis analysis = analysisService.get(testResultItem.getAnalysisId());
+            Analysis analysis = ResultUtil.resolveModifiedAnalysis(actionDataSet, testResultItem.getAnalysisId());
             analysis.setStatusId(getStatusForTestResult(testResultItem, alwaysValidate));
             analysis.setSysUserId(getSysUserId(request));
             if (!GenericValidator.isBlankOrNull(testResultItem.getTestMethod())) {
                 analysis.setMethod(methodService.get(testResultItem.getTestMethod()));
             }
-            actionDataSet.getModifiedAnalysis().add(analysis);
 
             actionDataSet.addToNoteList(noteService.createSavableNote(analysis, NoteType.INTERNAL,
                     testResultItem.getNote(), RESULT_SUBJECT, getSysUserId(request)));
@@ -560,8 +562,13 @@ public class LogbookResultsController extends LogbookResultsBaseController {
             List<Result> results = resultSaveService.createResultsFromTestResultItem(bean,
                     actionDataSet.getDeletableResults());
 
-            analysis.setCorrectedSincePatientReport(
-                    resultSaveService.isUpdatedResult() && analysisService.patientReportHasBeenDone(analysis));
+            boolean correctedSinceReport = resultSaveService.isUpdatedResult()
+                    && analysisService.patientReportHasBeenDone(analysis);
+            if (correctedFlagComputedIds.add(analysis.getId())) {
+                analysis.setCorrectedSincePatientReport(correctedSinceReport);
+            } else if (correctedSinceReport) {
+                analysis.setCorrectedSincePatientReport(true);
+            }
 
             if (analysisService.hasBeenCorrectedSinceLastPatientReport(analysis)) {
                 Note note = noteService.createSavableNote(analysis, NoteType.EXTERNAL,

--- a/src/main/java/org/openelisglobal/resultvalidation/bean/AnalysisItem.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/bean/AnalysisItem.java
@@ -77,6 +77,9 @@ public class AnalysisItem implements Serializable {
     @Pattern(regexp = ValidationHelper.ID_REGEX, groups = { ResultValidationForm.ResultValidation.class })
     private String resultId;
 
+    @SafeHtml(level = SafeHtml.SafeListLevel.NONE, groups = { ResultValidationForm.ResultValidation.class })
+    private String testResultComponentId;
+
     private double lowerCritical;
     private double higherCritical;
     private String normalRange;
@@ -602,6 +605,14 @@ public class AnalysisItem implements Serializable {
 
     public String getResultId() {
         return resultId;
+    }
+
+    public String getTestResultComponentId() {
+        return testResultComponentId;
+    }
+
+    public void setTestResultComponentId(String testResultComponentId) {
+        this.testResultComponentId = testResultComponentId;
     }
 
     public void setResultType(String resultType) {

--- a/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
@@ -565,15 +565,18 @@ public class ResultsValidationUtility {
         List<IdValuePair> values = null;
         Dictionary dictionary;
 
-        if (testResults != null && testResults.size() > 0
-                && TypeOfTestResultServiceImpl.ResultType.isDictionaryVariant(testResults.get(0).getTestResultType())) {
-            values = new ArrayList<>();
-            values.add(new IdValuePair("0", ""));
-
+        if (testResults != null) {
             for (TestResult testResult : testResults) {
                 // Note: result group use to be a criteria but was removed, if
                 // results are not as expected investigate
+                // A multi-component test mixes row types, so dictionary options
+                // are collected from any dictionary-variant row rather than
+                // gating on the first row's type.
                 if (TypeOfTestResultServiceImpl.ResultType.isDictionaryVariant(testResult.getTestResultType())) {
+                    if (values == null) {
+                        values = new ArrayList<>();
+                        values.add(new IdValuePair("0", ""));
+                    }
                     dictionary = dictionaryService.getDataForId(testResult.getValue());
                     String displayValue = dictionary.getLocalizedName();
 

--- a/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
@@ -106,6 +106,8 @@ public class ResultsValidationUtility {
     protected AnalysisService analysisService;
     @Autowired
     protected ResultLimitService resultLimitService;
+    @Autowired
+    protected org.openelisglobal.testresultcomponent.service.TestResultComponentService testResultComponentService;
 
     private Patient currentPatient;
     protected String SAMPLE_STATUS_OBSERVATION_HISTORY_TYPE_ID;
@@ -364,6 +366,29 @@ public class ResultsValidationUtility {
         return valid;
     }
 
+    /**
+     * For a multi-component test, label the row with its component so validators
+     * can tell the values apart (the component is resolved via the result's
+     * test_result row).
+     */
+    protected String appendComponentLabel(String displayTestName, Result result, Test test) {
+        if (result == null || result.getTestResult() == null || result.getTestResult().getComponentId() == null) {
+            return displayTestName;
+        }
+        List<org.openelisglobal.testresultcomponent.valueholder.TestResultComponent> components = testResultComponentService
+                .getActiveComponentsByTestId(test.getId());
+        if (components.size() < 2) {
+            return displayTestName;
+        }
+        for (org.openelisglobal.testresultcomponent.valueholder.TestResultComponent component : components) {
+            if (component.getId().equals(result.getTestResult().getComponentId())
+                    && !GenericValidator.isBlankOrNull(component.getLabel())) {
+                return displayTestName + " — " + component.getLabel();
+            }
+        }
+        return displayTestName;
+    }
+
     public final List<ResultValidationItem> getResultItemFromAnalysis(Analysis analysis) throws LIMSRuntimeException {
         List<ResultValidationItem> testResultList = new ArrayList<>();
 
@@ -418,6 +443,7 @@ public class ResultsValidationUtility {
         List<TestResult> testResults = getPossibleResultsForTest(test);
 
         String displayTestName = TestServiceImpl.getLocalizedTestNameWithType(test);
+        displayTestName = appendComponentLabel(displayTestName, result, test);
         // displayTestName = augmentTestNameWithRange(displayTestName, result);
 
         ResultLimit resultLimit = SpringContext.getBean(ResultLimitService.class).getResultLimitForTestAndPatient(test,

--- a/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
@@ -459,7 +459,14 @@ public class ResultsValidationUtility {
         testItem.setAnalysisMethod(analysis.getAnalysisType());
         testItem.setResult(result);
         testItem.setDictionaryResults(getAnyDictonaryValues(testResults));
-        testItem.setResultType(getTestResultType(testResults));
+        // The test-level type is the first test_result row's, which for a
+        // multi-component test is the primary's; an entered result knows its
+        // own component's type, so prefer the stored one.
+        if (result != null && !GenericValidator.isBlankOrNull(result.getResultType())) {
+            testItem.setResultType(result.getResultType());
+        } else {
+            testItem.setResultType(getTestResultType(testResults));
+        }
         testItem.setTestSortNumber(test.getSortOrder());
         testItem.setReflexGroup(analysis.getTriggeredReflex());
         testItem.setChildReflex(analysis.getTriggeredReflex() && isConclusion(result, analysis));
@@ -598,34 +605,34 @@ public class ResultsValidationUtility {
 
         /*
          * The issue with multiselect results is that each selection is one
-         * ResultValidationItem but they all need to be condensed into one AnalysisItem.
-         * There is a many to one mapping. The first multiselect result we have gets
-         * rolled into one AnalysisItem and the rest are skipped but we want to capture
-         * any qualified results
+         * ResultValidationItem but they all need to be condensed into one AnalysisItem
+         * (whose multiSelectResultValues carries every selection as JSON). The
+         * condensing is scoped per analysis: other results of the same accession —
+         * other analyses, or other components of a multi-component analysis — must
+         * still get their own rows. Qualified results found among an analysis's
+         * multiselect selections are captured onto its condensed item.
          */
-        boolean multiResultEntered = false;
-        String currentAccession = null;
-        AnalysisItem currentMultiSelectAnalysisItem = null;
+        Map<String, AnalysisItem> condensedMultiSelectByAnalysis = new HashMap<>();
         for (ResultValidationItem testResultItem : testResultList) {
-            if (!testResultItem.getAccessionNumber().equals(currentAccession)) {
-                currentAccession = testResultItem.getAccessionNumber();
-                currentMultiSelectAnalysisItem = null;
-                multiResultEntered = false;
-            }
-            if (!multiResultEntered) {
+            String analysisId = testResultItem.getAnalysis().getId();
+            boolean multiSelect = TypeOfTestResultServiceImpl.ResultType
+                    .isMultiSelectVariant(testResultItem.getResultType());
+
+            if (!multiSelect || !condensedMultiSelectByAnalysis.containsKey(analysisId)) {
                 AnalysisItem convertedItem = testResultItemToAnalysisItem(testResultItem);
                 analysisResultList.add(convertedItem);
-                if (TypeOfTestResultServiceImpl.ResultType.isMultiSelectVariant(testResultItem.getResultType())) {
-                    multiResultEntered = true;
-                    currentMultiSelectAnalysisItem = convertedItem;
+                if (multiSelect) {
+                    condensedMultiSelectByAnalysis.put(analysisId, convertedItem);
                 }
             }
-            if (currentMultiSelectAnalysisItem != null && testResultItem.isHasQualifiedResult()) {
-                currentMultiSelectAnalysisItem.setQualifiedResultValue(testResultItem.getQualifiedResultValue());
-                currentMultiSelectAnalysisItem.setQualifiedDictionaryId(testResultItem.getQualifiedDictionaryId());
-                currentMultiSelectAnalysisItem.setHasQualifiedResult(true);
-                currentMultiSelectAnalysisItem.setNormalRange(testResultItem.getNormalRange());
-                currentMultiSelectAnalysisItem.setPatientName(testResultItem.getPatientName());
+
+            AnalysisItem condensedItem = condensedMultiSelectByAnalysis.get(analysisId);
+            if (condensedItem != null && testResultItem.isHasQualifiedResult()) {
+                condensedItem.setQualifiedResultValue(testResultItem.getQualifiedResultValue());
+                condensedItem.setQualifiedDictionaryId(testResultItem.getQualifiedDictionaryId());
+                condensedItem.setHasQualifiedResult(true);
+                condensedItem.setNormalRange(testResultItem.getNormalRange());
+                condensedItem.setPatientName(testResultItem.getPatientName());
             }
         }
 

--- a/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
@@ -685,6 +685,9 @@ public class ResultsValidationUtility {
         analysisResultItem.setAnalysisId(testResultItem.getAnalysis().getId());
         analysisResultItem.setPastNotes(testResultItem.getPastNotes());
         analysisResultItem.setResultId(testResultItem.getResultId());
+        if (result != null && result.getTestResult() != null) {
+            analysisResultItem.setTestResultComponentId(result.getTestResult().getComponentId());
+        }
         analysisResultItem.setResultType(testResultItem.getResultType());
         analysisResultItem.setTestId(testResultItem.getTestId());
         analysisResultItem.setTestSortNumber(sortOrder);

--- a/src/main/java/org/openelisglobal/test/beanItems/TestResultItem.java
+++ b/src/main/java/org/openelisglobal/test/beanItems/TestResultItem.java
@@ -103,6 +103,12 @@ public class TestResultItem implements ResultItem, Serializable {
     @Pattern(regexp = ValidationHelper.ID_REGEX, groups = { LogbookResultsForm.LogbookResults.class })
     private String testId;
 
+    // Which result component of the test this row records (multi-component tests
+    // render one row per component). Component UUID; null for single-component
+    // tests.
+    @SafeHtml(level = SafeHtml.SafeListLevel.NONE, groups = { LogbookResultsForm.LogbookResults.class })
+    private String testResultComponentId;
+
     @SafeHtml(level = SafeHtml.SafeListLevel.NONE, groups = { LogbookResultsForm.LogbookResults.class })
     private String testKit1InventoryId;
 
@@ -565,6 +571,14 @@ public class TestResultItem implements ResultItem, Serializable {
 
     public void setTestId(String testId) {
         this.testId = testId;
+    }
+
+    public String getTestResultComponentId() {
+        return testResultComponentId;
+    }
+
+    public void setTestResultComponentId(String testResultComponentId) {
+        this.testResultComponentId = testResultComponentId;
     }
 
     public String getResultValue() {

--- a/src/main/java/org/openelisglobal/test/service/TestConfigurationHandler.java
+++ b/src/main/java/org/openelisglobal/test/service/TestConfigurationHandler.java
@@ -18,6 +18,8 @@ import org.openelisglobal.localization.service.LocalizationValueService;
 import org.openelisglobal.localization.valueholder.Localization;
 import org.openelisglobal.test.valueholder.Test;
 import org.openelisglobal.test.valueholder.TestSection;
+import org.openelisglobal.testresultcomponent.service.TestResultComponentService;
+import org.openelisglobal.testterminology.service.TestTerminologyMappingService;
 import org.openelisglobal.typeofsample.service.TypeOfSampleService;
 import org.openelisglobal.typeofsample.service.TypeOfSampleTestService;
 import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
@@ -82,6 +84,15 @@ public class TestConfigurationHandler implements DomainConfigurationHandler {
 
     @Autowired
     private UnitOfMeasureService unitOfMeasureService;
+
+    // Bridge loaded tests into the new editor model (PRIMARY component under
+    // Sample & Results, LOINC under Terminology) — config-loaded tests otherwise
+    // exist only in the legacy shape.
+    @Autowired
+    private TestResultComponentService testResultComponentService;
+
+    @Autowired
+    private TestTerminologyMappingService terminologyMappingService;
 
     @Override
     public String getDomainName() {
@@ -149,6 +160,20 @@ public class TestConfigurationHandler implements DomainConfigurationHandler {
             } catch (Exception e) {
                 LogEvent.logError(this.getClass().getSimpleName(), "processConfiguration",
                         "Error processing line " + lineNumber + " in file " + fileName + ": " + e.getMessage());
+            }
+        }
+
+        // Bridge each loaded test into the new editor model: a PRIMARY result
+        // component under Sample & Results and its LOINC as a terminology mapping.
+        for (Test loaded : processedTests) {
+            try {
+                testResultComponentService.syncPrimaryComponentFromLegacy(loaded.getId(), "1");
+                if (loaded.getLoinc() != null && !loaded.getLoinc().trim().isEmpty()) {
+                    terminologyMappingService.syncLegacyLoinc(loaded.getId(), loaded.getLoinc(), "1");
+                }
+            } catch (Exception e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "processConfiguration",
+                        "Failed to bridge test " + loaded.getId() + " to the new editor model: " + e.getMessage());
             }
         }
 

--- a/src/main/java/org/openelisglobal/testcatalog/controller/rest/TestCatalogEditorRestController.java
+++ b/src/main/java/org/openelisglobal/testcatalog/controller/rest/TestCatalogEditorRestController.java
@@ -615,6 +615,9 @@ public class TestCatalogEditorRestController {
         public Integer significantDigits;
         public String defaultResult;
         public Boolean allowMultipleReadings;
+        // Exactly one component per test is primary — the one mirrored to the
+        // legacy test columns. The service normalizes to a single primary.
+        public Boolean isPrimary;
         public List<InterpretationDto> interpretations = new ArrayList<>();
         public List<OptionDto> options = new ArrayList<>();
     }
@@ -670,6 +673,7 @@ public class TestCatalogEditorRestController {
             e.setSignificantDigits(c.significantDigits);
             e.setDefaultResult(c.defaultResult);
             e.setAllowMultipleReadings(Boolean.TRUE.equals(c.allowMultipleReadings));
+            e.setIsPrimary(Boolean.TRUE.equals(c.isPrimary));
             desired.add(e);
 
             List<TestResultInterpretation> interps = new ArrayList<>();
@@ -730,6 +734,7 @@ public class TestCatalogEditorRestController {
             dto.significantDigits = c.getSignificantDigits();
             dto.defaultResult = c.getDefaultResult();
             dto.allowMultipleReadings = c.getAllowMultipleReadings();
+            dto.isPrimary = c.getIsPrimary();
             for (TestResultInterpretation i : interpretationService.getActiveByComponentId(c.getId())) {
                 InterpretationDto idto = new InterpretationDto();
                 idto.id = i.getId();

--- a/src/main/java/org/openelisglobal/testcatalog/controller/rest/TestCatalogEditorRestController.java
+++ b/src/main/java/org/openelisglobal/testcatalog/controller/rest/TestCatalogEditorRestController.java
@@ -700,7 +700,10 @@ public class TestCatalogEditorRestController {
                 tr.setValue(o.value);
                 tr.setSortOrder(o.sortOrder != null ? String.valueOf(o.sortOrder) : null);
                 tr.setIsNormal(Boolean.TRUE.equals(o.normal));
-                tr.setTestResultType(o.resultType != null ? o.resultType : c.resultType);
+                // Option rows must carry the component's type ('D'/'M'/'C') —
+                // result entry derives the widget from them, so a stale
+                // per-option type would render the wrong control.
+                tr.setTestResultType(c.resultType != null ? c.resultType : o.resultType);
                 opts.add(tr);
             }
             optionsByCode.put(c.code, opts);

--- a/src/main/java/org/openelisglobal/testresult/daoimpl/TestResultDAOImpl.java
+++ b/src/main/java/org/openelisglobal/testresult/daoimpl/TestResultDAOImpl.java
@@ -185,8 +185,8 @@ public class TestResultDAOImpl extends BaseDAOImpl<TestResult, String> implement
         if (StringUtil.isInteger(result)) {
             List<TestResult> list;
             try {
-                String sql = "from TestResult t where  t.testResultType in ('D','M','Q') and t.test.id = :testId and"
-                        + " t.value = :testValue";
+                String sql = "from TestResult t where  t.testResultType in ('D','M','Q','C') and t.test.id = :testId"
+                        + " and t.value = :testValue";
                 Query<TestResult> query = entityManager.unwrap(Session.class).createQuery(sql, TestResult.class);
                 query.setParameter("testId", testId);
                 query.setParameter("testValue", result);

--- a/src/main/java/org/openelisglobal/testresult/service/TestResultConfigurationHandler.java
+++ b/src/main/java/org/openelisglobal/testresult/service/TestResultConfigurationHandler.java
@@ -5,7 +5,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.DisplayListService;
 import org.openelisglobal.configuration.service.DomainConfigurationHandler;
@@ -14,6 +16,8 @@ import org.openelisglobal.dictionary.valueholder.Dictionary;
 import org.openelisglobal.test.service.TestService;
 import org.openelisglobal.test.valueholder.Test;
 import org.openelisglobal.testresult.valueholder.TestResult;
+import org.openelisglobal.testresultcomponent.service.TestResultComponentService;
+import org.openelisglobal.testterminology.service.TestTerminologyMappingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +59,17 @@ public class TestResultConfigurationHandler implements DomainConfigurationHandle
 
     @Autowired
     private DictionaryService dictionaryService;
+
+    // The config loader writes tests/test_results in the legacy shape; these bridge
+    // that to the new editor's model so loaded tests appear correctly under Sample
+    // &
+    // Results (components), Ranges (result_limits repointed to the PRIMARY
+    // component) and Terminology (LOINC mapping).
+    @Autowired
+    private TestResultComponentService testResultComponentService;
+
+    @Autowired
+    private TestTerminologyMappingService terminologyMappingService;
 
     @Override
     public String getDomainName() {
@@ -102,6 +117,9 @@ public class TestResultConfigurationHandler implements DomainConfigurationHandle
         int skippedRows = 0;
         int dataRows = 0;
         int totalResultsCreated = 0;
+        // Tests whose legacy results were loaded — bridged to the new editor model
+        // once, after all rows for the file are in.
+        Set<String> touchedTestIds = new LinkedHashSet<>();
 
         while ((line = reader.readLine()) != null) {
             lineNumber++;
@@ -115,7 +133,7 @@ public class TestResultConfigurationHandler implements DomainConfigurationHandle
                 String[] values = parseCsvLine(line);
                 int resultsCreated = processCsvLine(values, testNameIndex, resultTypeIndex, resultValueIndex,
                         dictionaryCategoryIndex, sortOrderIndex, isQuantifiableIndex, isActiveIndex, isNormalIndex,
-                        significantDigitsIndex, flagsIndex, lineNumber, fileName);
+                        significantDigitsIndex, flagsIndex, lineNumber, fileName, touchedTestIds);
                 if (resultsCreated > 0) {
                     totalResultsCreated += resultsCreated;
                 } else {
@@ -125,6 +143,22 @@ public class TestResultConfigurationHandler implements DomainConfigurationHandle
                 skippedRows++;
                 LogEvent.logError(this.getClass().getSimpleName(), "processConfiguration",
                         "Error processing line " + lineNumber + " in file " + fileName + ": " + e.getMessage());
+            }
+        }
+
+        // Bridge every loaded test to the new editor model: create/refresh its
+        // PRIMARY result component (Sample & Results) + repoint its options and
+        // ranges onto that component, and sync its LOINC into a terminology mapping.
+        for (String testId : touchedTestIds) {
+            try {
+                testResultComponentService.syncPrimaryComponentFromLegacy(testId, "1");
+                Test test = testService.getTestById(testId);
+                if (test != null && test.getLoinc() != null && !test.getLoinc().trim().isEmpty()) {
+                    terminologyMappingService.syncLegacyLoinc(testId, test.getLoinc(), "1");
+                }
+            } catch (Exception e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "processConfiguration",
+                        "Failed to bridge test " + testId + " to the new editor model: " + e.getMessage());
             }
         }
 
@@ -207,7 +241,8 @@ public class TestResultConfigurationHandler implements DomainConfigurationHandle
      */
     private int processCsvLine(String[] values, int testNameIndex, int resultTypeIndex, int resultValueIndex,
             int dictionaryCategoryIndex, int sortOrderIndex, int isQuantifiableIndex, int isActiveIndex,
-            int isNormalIndex, int significantDigitsIndex, int flagsIndex, int lineNumber, String fileName) {
+            int isNormalIndex, int significantDigitsIndex, int flagsIndex, int lineNumber, String fileName,
+            Set<String> touchedTestIds) {
 
         String testName = getValueOrEmpty(values, testNameIndex);
         String resultType = getValueOrEmpty(values, resultTypeIndex);
@@ -304,6 +339,7 @@ public class TestResultConfigurationHandler implements DomainConfigurationHandle
                 LogEvent.logDebug(this.getClass().getSimpleName(), "processCsvLine",
                         "Created new test result for test: " + test.getDescription());
             }
+            touchedTestIds.add(test.getId());
             resultsCreated++;
         }
 

--- a/src/main/java/org/openelisglobal/testresultcomponent/service/TestResultComponentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/testresultcomponent/service/TestResultComponentServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.testresultcomponent.service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -138,6 +139,7 @@ public class TestResultComponentServiceImpl extends AuditableBaseObjectServiceIm
                 }
             }
         }
+        ensureSinglePrimary(testId, sysUserId);
         return baseObjectDAO.getActiveComponentsByTestId(testId);
     }
 
@@ -264,6 +266,7 @@ public class TestResultComponentServiceImpl extends AuditableBaseObjectServiceIm
             primary.setUomId(uomId);
             primary.setSignificantDigits(significantDigits);
             primary.setIsActive("Y");
+            primary.setIsPrimary(true);
             primary.setSysUserId(sysUserId);
             insert(primary);
         } else {
@@ -292,19 +295,58 @@ public class TestResultComponentServiceImpl extends AuditableBaseObjectServiceIm
                 resultLimitService.update(rl);
             }
         }
+        ensureSinglePrimary(testId, sysUserId);
     }
 
     private TestResultComponent findPrimaryComponent(String testId) {
         List<TestResultComponent> components = baseObjectDAO.getActiveComponentsByTestId(testId);
-        if (components.isEmpty()) {
+        return pickPrimary(components);
+    }
+
+    /**
+     * The primary component: the explicit is_primary flag first, then the legacy
+     * PRIMARY code, then the lowest-display-order component (defensive fallback for
+     * data predating the flag).
+     */
+    private TestResultComponent pickPrimary(List<TestResultComponent> components) {
+        if (components == null || components.isEmpty()) {
             return null;
+        }
+        for (TestResultComponent c : components) {
+            if (c.getIsPrimary()) {
+                return c;
+            }
         }
         for (TestResultComponent c : components) {
             if (PRIMARY_CODE.equals(c.getCode())) {
                 return c;
             }
         }
-        return components.get(0);
+        return components.stream()
+                .min(Comparator
+                        .comparingInt(c -> c.getDisplayOrder() == null ? Integer.MAX_VALUE : c.getDisplayOrder()))
+                .orElse(components.get(0));
+    }
+
+    /**
+     * Guarantee exactly one active component carries is_primary. Called after any
+     * component-set change so the flag stays consistent even though the editor DTO
+     * doesn't send it.
+     */
+    private void ensureSinglePrimary(String testId, String sysUserId) {
+        List<TestResultComponent> components = baseObjectDAO.getActiveComponentsByTestId(testId);
+        TestResultComponent primary = pickPrimary(components);
+        if (primary == null) {
+            return;
+        }
+        for (TestResultComponent c : components) {
+            boolean shouldBePrimary = c.getId().equals(primary.getId());
+            if (c.getIsPrimary() != shouldBePrimary) {
+                c.setIsPrimary(shouldBePrimary);
+                c.setSysUserId(sysUserId);
+                update(c);
+            }
+        }
     }
 
     private static String latestResultType(List<TestResult> newestFirst) {
@@ -398,5 +440,6 @@ public class TestResultComponentServiceImpl extends AuditableBaseObjectServiceIm
             }
             testResultService.saveOptionsForComponent(target, copy.getId(), optionCopies, sysUserId);
         }
+        ensureSinglePrimary(targetTestId, sysUserId);
     }
 }

--- a/src/main/java/org/openelisglobal/testresultcomponent/service/TestResultComponentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/testresultcomponent/service/TestResultComponentServiceImpl.java
@@ -100,6 +100,7 @@ public class TestResultComponentServiceImpl extends AuditableBaseObjectServiceIm
                 match.setSignificantDigits(d.getSignificantDigits());
                 match.setDefaultResult(d.getDefaultResult());
                 match.setAllowMultipleReadings(d.getAllowMultipleReadings());
+                match.setIsPrimary(d.getIsPrimary());
                 match.setSysUserId(sysUserId);
                 update(match);
                 keptIds.add(match.getId());
@@ -116,6 +117,7 @@ public class TestResultComponentServiceImpl extends AuditableBaseObjectServiceIm
                     dead.setSignificantDigits(d.getSignificantDigits());
                     dead.setDefaultResult(d.getDefaultResult());
                     dead.setAllowMultipleReadings(d.getAllowMultipleReadings());
+                    dead.setIsPrimary(d.getIsPrimary());
                     dead.setIsActive("Y");
                     dead.setSysUserId(sysUserId);
                     update(dead);
@@ -439,6 +441,7 @@ public class TestResultComponentServiceImpl extends AuditableBaseObjectServiceIm
             copy.setSignificantDigits(src.getSignificantDigits());
             copy.setDefaultResult(src.getDefaultResult());
             copy.setAllowMultipleReadings(src.getAllowMultipleReadings());
+            copy.setIsPrimary(src.getIsPrimary());
             copy.setIsActive("Y");
             copy.setSysUserId(sysUserId);
             insert(copy);

--- a/src/main/java/org/openelisglobal/testresultcomponent/service/TestResultComponentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/testresultcomponent/service/TestResultComponentServiceImpl.java
@@ -200,42 +200,68 @@ public class TestResultComponentServiceImpl extends AuditableBaseObjectServiceIm
         test.setSysUserId(sysUserId);
         testService.update(test);
 
-        String significantDigits = primary.getSignificantDigits() == null ? null
-                : String.valueOf(primary.getSignificantDigits());
+        // Every non-dictionary component gets its own test_result row (typed per
+        // component, linked via component_id) so result entry can bind one Result
+        // field per component. Dictionary components get their rows from their
+        // select-list options. Rows with a NULL component_id are legacy rows and
+        // belong to the primary.
+        List<TestResultComponent> components = baseObjectDAO.getActiveComponentsByTestId(testId);
         List<TestResult> testResults = testResultService.getAllActiveTestResultsPerTest(test);
-        if (testResults.isEmpty()) {
-            // A test created in the new editor has no legacy test_result row yet, so
-            // getResultType() would fall back to ALPHA. For non-dictionary types
-            // (numeric / free text / titer / alpha) seed a single row carrying the
-            // component's result type; dictionary types get their rows from options.
-            String resultType = primary.getResultType();
-            if (resultType != null && !TypeOfTestResultServiceImpl.ResultType.isDictionaryVariant(resultType)) {
-                TestResult tr = new TestResult();
-                tr.setTest(test);
-                tr.setTestResultType(resultType);
-                tr.setSortOrder("1");
-                tr.setIsActive(true);
-                tr.setSignificantDigits(significantDigits);
-                tr.setSysUserId(sysUserId);
-                testResultService.insert(tr);
-            }
-        } else {
-            boolean dictionary = primary.getResultType() != null
-                    && TypeOfTestResultServiceImpl.ResultType.isDictionaryVariant(primary.getResultType());
+        for (TestResultComponent component : components) {
+            boolean isPrimaryComponent = component.getId().equals(primary.getId());
+            List<TestResult> componentRows = new ArrayList<>();
             for (TestResult tr : testResults) {
-                boolean hasValue = tr.getValue() != null && !tr.getValue().trim().isEmpty();
-                if (dictionary && !hasValue) {
-                    tr.setIsActive(false);
+                if (component.getId().equals(tr.getComponentId())
+                        || (isPrimaryComponent && tr.getComponentId() == null)) {
+                    componentRows.add(tr);
+                }
+            }
+            String resultType = component.getResultType();
+            String significantDigits = component.getSignificantDigits() == null ? null
+                    : String.valueOf(component.getSignificantDigits());
+            boolean dictionary = resultType != null
+                    && TypeOfTestResultServiceImpl.ResultType.isDictionaryVariant(resultType);
+
+            if (dictionary) {
+                // Option rows carry their own type + dictionary value; a value-less
+                // row here is a stale placeholder from a previous non-dictionary
+                // type — deactivate it rather than leaving a broken dictionary row.
+                for (TestResult tr : componentRows) {
+                    boolean hasValue = tr.getValue() != null && !tr.getValue().trim().isEmpty();
+                    if (!hasValue) {
+                        tr.setIsActive(false);
+                        tr.setSysUserId(sysUserId);
+                        testResultService.update(tr);
+                    }
+                }
+                continue;
+            }
+
+            if (componentRows.isEmpty()) {
+                if (resultType != null) {
+                    TestResult tr = new TestResult();
+                    tr.setTest(test);
+                    tr.setTestResultType(resultType);
+                    tr.setSortOrder(
+                            String.valueOf(component.getDisplayOrder() == null ? 1 : component.getDisplayOrder() + 1));
+                    tr.setIsActive(true);
+                    tr.setSignificantDigits(significantDigits);
+                    tr.setComponentId(component.getId());
+                    tr.setSysUserId(sysUserId);
+                    testResultService.insert(tr);
+                }
+            } else {
+                for (TestResult tr : componentRows) {
+                    tr.setSignificantDigits(significantDigits);
+                    if (resultType != null) {
+                        tr.setTestResultType(resultType);
+                    }
+                    if (tr.getComponentId() == null) {
+                        tr.setComponentId(component.getId());
+                    }
                     tr.setSysUserId(sysUserId);
                     testResultService.update(tr);
-                    continue;
                 }
-                tr.setSignificantDigits(significantDigits);
-                if (primary.getResultType() != null) {
-                    tr.setTestResultType(primary.getResultType());
-                }
-                tr.setSysUserId(sysUserId);
-                testResultService.update(tr);
             }
         }
     }

--- a/src/main/java/org/openelisglobal/testresultcomponent/valueholder/TestResultComponent.java
+++ b/src/main/java/org/openelisglobal/testresultcomponent/valueholder/TestResultComponent.java
@@ -61,6 +61,12 @@ public class TestResultComponent extends BaseObject<String> {
     @Column(name = "allow_multiple_readings", nullable = false)
     private boolean allowMultipleReadings = false;
 
+    // Exactly one active component per test is the primary — the one mirrored back
+    // to the legacy test / test_result columns. An explicit flag (not the code) so
+    // renaming a component's code can't silently move the primary designation.
+    @Column(name = "is_primary", nullable = false)
+    private boolean isPrimary = false;
+
     @Column(name = "is_active", nullable = false, length = 2)
     private String isActive = "Y";
 
@@ -109,6 +115,14 @@ public class TestResultComponent extends BaseObject<String> {
 
     public void setDisplayOrder(Integer displayOrder) {
         this.displayOrder = displayOrder;
+    }
+
+    public boolean getIsPrimary() {
+        return isPrimary;
+    }
+
+    public void setIsPrimary(boolean isPrimary) {
+        this.isPrimary = isPrimary;
     }
 
     public String getResultType() {

--- a/src/main/resources/liquibase/3.5.x.x/052-component-is-primary.xml
+++ b/src/main/resources/liquibase/3.5.x.x/052-component-is-primary.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!-- OGC-949: mark the PRIMARY result component with an explicit boolean instead
+         of relying on the magic code='PRIMARY'. The legacy→component backfill (041)
+         creates the migrated single component as PRIMARY, so it defaults to true. -->
+    <changeSet author="openelis" id="component-add-is-primary">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists schemaName="clinlims" tableName="test_result_component" columnName="is_primary" />
+            </not>
+        </preConditions>
+        <comment>Add is_primary boolean to test_result_component and seed it from the PRIMARY code.</comment>
+        <addColumn schemaName="clinlims" tableName="test_result_component">
+            <column name="is_primary" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+        <!-- Migrated legacy tests: the backfilled single component is the primary. -->
+        <sql>UPDATE clinlims.test_result_component SET is_primary = true WHERE code = 'PRIMARY'</sql>
+        <!-- Robustness: any test with active components but no primary yet gets its
+             lowest-display-order active component marked primary, so every test has
+             exactly one primary regardless of how its components were coded. -->
+        <sql>
+            UPDATE clinlims.test_result_component c SET is_primary = true
+            WHERE c.is_active = 'Y'
+              AND NOT EXISTS (
+                SELECT 1 FROM clinlims.test_result_component p
+                WHERE p.test_id = c.test_id AND p.is_active = 'Y' AND p.is_primary = true)
+              AND c.id = (
+                SELECT c2.id FROM clinlims.test_result_component c2
+                WHERE c2.test_id = c.test_id AND c2.is_active = 'Y'
+                ORDER BY c2.display_order, c2.id LIMIT 1)
+        </sql>
+        <rollback>
+            <dropColumn schemaName="clinlims" tableName="test_result_component" columnName="is_primary" />
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -138,4 +138,7 @@
   <!-- OGC-749 / OGC-963 (FR-29): code + UCUM columns for the inline unit-create form -->
   <include relativeToChangelogFile="true" file="051-uom-code-ucum.xml"/>
 
+  <!-- OGC-949: explicit is_primary boolean on result components -->
+  <include relativeToChangelogFile="true" file="052-component-is-primary.xml"/>
+
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/configuration/service/TestResultConfigLoaderBridgeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/configuration/service/TestResultConfigLoaderBridgeIntegrationTest.java
@@ -1,0 +1,95 @@
+package org.openelisglobal.configuration.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.testresultcomponent.service.TestResultComponentService;
+import org.openelisglobal.testresultcomponent.valueholder.TestResultComponent;
+import org.openelisglobal.testterminology.service.TestTerminologyMappingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * The config loader writes tests/test_results in the legacy shape; this
+ * verifies it now also bridges a loaded test into the new editor model — a
+ * PRIMARY result component (Sample &amp; Results) and a LOINC terminology
+ * mapping.
+ */
+public class TestResultConfigLoaderBridgeIntegrationTest extends BaseWebContextSensitiveTest {
+
+    private static final long TEST_ID = 95601L;
+    private static final String TEST_NAME = "ConfigBridgeIT";
+
+    // The handler is a @Transactional JDK proxy, so inject it by its interface.
+    @Autowired
+    @Qualifier("testResultConfigurationHandler")
+    private DomainConfigurationHandler handler;
+
+    @Autowired
+    private TestResultComponentService componentService;
+
+    @Autowired
+    private TestTerminologyMappingService terminologyService;
+
+    @Autowired
+    private javax.sql.DataSource dataSource;
+
+    private JdbcTemplate jdbc;
+
+    @Before
+    public void setUp() {
+        jdbc = new JdbcTemplate(dataSource);
+        cleanup();
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, loinc, lastupdated)"
+                        + " VALUES (?, ?, ?, 'Y', ?, '1558-6', NOW())",
+                TEST_ID, TEST_NAME, TEST_NAME, UUID.randomUUID().toString());
+    }
+
+    @After
+    public void tearDown() {
+        cleanup();
+    }
+
+    private void cleanup() {
+        try {
+            jdbc.update("DELETE FROM clinlims.test_terminology_mapping WHERE test_id = ?", TEST_ID);
+            // test_result.component_id references test_result_component, so delete the
+            // results before the components.
+            jdbc.update("DELETE FROM clinlims.test_result WHERE test_id = ?", TEST_ID);
+            jdbc.update("DELETE FROM clinlims.test_result_component WHERE test_id = ?", TEST_ID);
+        } catch (Exception ignored) {
+            // tables may be absent in a degenerate schema
+        }
+        jdbc.update("DELETE FROM clinlims.test WHERE id = ?", TEST_ID);
+    }
+
+    @Test
+    public void loadingTestResults_bridgesToPrimaryComponentAndTerminology() throws Exception {
+        String csv = "testName,resultType,resultValue,sortOrder,isQuantifiable,isActive,isNormal,"
+                + "significantDigits,flags\n" + TEST_NAME + ",N,,1,Y,Y,N,2,\n";
+        handler.processConfiguration(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)),
+                "test-results.csv");
+
+        // Sample & Results: a PRIMARY component was created from the legacy result.
+        List<TestResultComponent> components = componentService.getActiveComponentsByTestId(String.valueOf(TEST_ID));
+        assertFalse("a component must be created for the loaded test", components.isEmpty());
+        TestResultComponent primary = components.get(0);
+        assertTrue("the component is flagged primary", primary.getIsPrimary());
+        assertEquals("N", primary.getResultType());
+
+        // Terminology: the test's LOINC became a mapping.
+        assertFalse("a LOINC terminology mapping must be created",
+                terminologyService.getActiveByTestId(String.valueOf(TEST_ID)).isEmpty());
+    }
+}

--- a/src/test/java/org/openelisglobal/result/MultiComponentResultEntryIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/result/MultiComponentResultEntryIntegrationTest.java
@@ -1,0 +1,91 @@
+package org.openelisglobal.result;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.result.action.util.ResultsLoadUtility;
+import org.openelisglobal.test.beanItems.TestResultItem;
+import org.openelisglobal.testresultcomponent.service.TestResultComponentService;
+import org.openelisglobal.testresultcomponent.valueholder.TestResultComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * v2.4 FRS §Result Components runtime behavior: ordering one multi-component
+ * test yields one result-entry field per active component ("User orders one
+ * test; result entry shows N component fields"), each bound to its component.
+ */
+public class MultiComponentResultEntryIntegrationTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private ResultsLoadUtility resultsLoadUtility;
+
+    @Autowired
+    private TestResultComponentService componentService;
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Before
+    public void init() throws Exception {
+        executeDataSetWithStateManagement("testdata/analysis.xml");
+    }
+
+    private TestResultComponent component(String code, String label, int order, String type) {
+        TestResultComponent c = new TestResultComponent();
+        c.setCode(code);
+        c.setLabel(label);
+        c.setDisplayOrder(order);
+        c.setResultType(type);
+        return c;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<TestResultItem> loadItems(Analysis analysis) throws Exception {
+        Method loader = ResultsLoadUtility.class.getDeclaredMethod("getTestResultItemFromAnalysis", Analysis.class,
+                String.class, String.class, String.class);
+        loader.setAccessible(true);
+        return (List<TestResultItem>) loader.invoke(resultsLoadUtility, analysis, " ", " ", "");
+    }
+
+    @Test
+    public void multiComponentTest_rendersOneResultFieldPerComponent() throws Exception {
+        // Test 1 (dataset) gains two numeric components: PRIMARY + DIA. The save
+        // also seeds one test_result row per component (component-typed).
+        componentService.saveSampleResults("1",
+                List.of(component("PRIMARY", "Systolic", 0, "N"), component("DIA", "Diastolic", 1, "N")), null, null,
+                "1");
+
+        Analysis analysis = analysisService.get("1");
+        List<TestResultItem> items = loadItems(analysis);
+
+        assertEquals("one result-entry field per active component", 2, items.size());
+        assertNotNull(items.get(0).getTestResultComponentId());
+        assertNotNull(items.get(1).getTestResultComponentId());
+        assertNotEquals("each field is bound to its own component", items.get(0).getTestResultComponentId(),
+                items.get(1).getTestResultComponentId());
+        assertTrue("rows are labeled with their component",
+                items.stream().anyMatch(i -> i.getTestName().contains("Systolic")));
+        assertTrue(items.stream().anyMatch(i -> i.getTestName().contains("Diastolic")));
+        assertEquals("N", items.get(0).getResultType());
+        assertEquals("N", items.get(1).getResultType());
+    }
+
+    @Test
+    public void singleComponentTest_keepsSingleResultField() throws Exception {
+        componentService.saveSampleResults("1", List.of(component("PRIMARY", "Primary", 0, "N")), null, null, "1");
+
+        Analysis analysis = analysisService.get("1");
+        List<TestResultItem> items = loadItems(analysis);
+
+        assertEquals("single-component tests are unchanged", 1, items.size());
+    }
+}

--- a/src/test/java/org/openelisglobal/result/MultiComponentResultEntryIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/result/MultiComponentResultEntryIntegrationTest.java
@@ -3,6 +3,7 @@ package org.openelisglobal.result;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
@@ -12,7 +13,9 @@ import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.result.action.util.ResultUtil;
 import org.openelisglobal.result.action.util.ResultsLoadUtility;
+import org.openelisglobal.result.action.util.ResultsUpdateDataSet;
 import org.openelisglobal.test.beanItems.TestResultItem;
 import org.openelisglobal.testresultcomponent.service.TestResultComponentService;
 import org.openelisglobal.testresultcomponent.valueholder.TestResultComponent;
@@ -77,6 +80,23 @@ public class MultiComponentResultEntryIntegrationTest extends BaseWebContextSens
         assertTrue(items.stream().anyMatch(i -> i.getTestName().contains("Diastolic")));
         assertEquals("N", items.get(0).getResultType());
         assertEquals("N", items.get(1).getResultType());
+    }
+
+    /**
+     * Saving values for several components of one analysis in one POST must not
+     * register the analysis for update more than once: a second detached copy fails
+     * the optimistic lock (lastupdated) when merged after the first copy's merge
+     * has flushed, rolling back the whole save.
+     */
+    @Test
+    public void resolveModifiedAnalysis_reusesOneInstancePerAnalysis() {
+        ResultsUpdateDataSet dataSet = new ResultsUpdateDataSet("1");
+
+        Analysis first = ResultUtil.resolveModifiedAnalysis(dataSet, "1");
+        Analysis second = ResultUtil.resolveModifiedAnalysis(dataSet, "1");
+
+        assertSame("component rows of one analysis must share a single detached instance", first, second);
+        assertEquals("the analysis is registered for update exactly once", 1, dataSet.getModifiedAnalysis().size());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
@@ -265,6 +265,24 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
     }
 
     @org.junit.Test
+    public void saveSampleResults_roundTripsThePrimaryFlag_exactlyOnePrimary() {
+        // Mark the second component primary; the save must persist the flag and the
+        // read must return exactly one primary.
+        ResultComponentDto sys = comp(null, "SYS", "Systolic", 1);
+        ResultComponentDto primary = comp(null, "PRIMARY", "Diastolic", 2);
+        primary.isPrimary = true;
+        controller.saveSampleResults(String.valueOf(TEST_ID), body(sys, primary), authedRequest());
+
+        SampleResults loaded = controller.getSampleResults(String.valueOf(TEST_ID)).getBody();
+        assertEquals(2, loaded.components.size());
+        long primaries = loaded.components.stream().filter(c -> Boolean.TRUE.equals(c.isPrimary)).count();
+        assertEquals("exactly one primary", 1L, primaries);
+        ResultComponentDto flagged = loaded.components.stream().filter(c -> Boolean.TRUE.equals(c.isPrimary))
+                .findFirst().get();
+        assertEquals("PRIMARY", flagged.code);
+    }
+
+    @org.junit.Test
     public void saveSampleResults_updatesExistingComponentById_withoutCreatingARow() {
         controller.saveSampleResults(String.valueOf(TEST_ID), body(comp(null, "SYS", "Systolic", 1)), authedRequest());
         SampleResults loaded = controller.getSampleResults(String.valueOf(TEST_ID)).getBody();

--- a/src/test/java/org/openelisglobal/testresultcomponent/TestResultComponentServiceIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testresultcomponent/TestResultComponentServiceIntegrationTest.java
@@ -113,6 +113,26 @@ public class TestResultComponentServiceIntegrationTest extends BaseWebContextSen
         assertNull(loaded.getDefaultResult());
         // BOOLEAN NOT NULL DEFAULT false
         assertFalse(loaded.getAllowMultipleReadings());
+        assertFalse("is_primary defaults false", loaded.getIsPrimary());
+    }
+
+    @Test
+    public void saveComponentsForTest_marksExactlyOneActivePrimary() {
+        TestResultComponent primary = new TestResultComponent();
+        primary.setCode("PRIMARY");
+        primary.setLabel("Primary");
+        primary.setDisplayOrder(0);
+        TestResultComponent second = new TestResultComponent();
+        second.setCode("DIA");
+        second.setLabel("Diastolic");
+        second.setDisplayOrder(1);
+
+        componentService.saveComponentsForTest(String.valueOf(TEST_ID), List.of(primary, second), "1");
+
+        List<TestResultComponent> active = componentService.getActiveComponentsByTestId(String.valueOf(TEST_ID));
+        long primaries = active.stream().filter(TestResultComponent::getIsPrimary).count();
+        assertEquals("exactly one component is flagged primary", 1L, primaries);
+        assertEquals("PRIMARY", active.stream().filter(TestResultComponent::getIsPrimary).findFirst().get().getCode());
     }
 
     @Test

--- a/volume/properties/common.properties
+++ b/volume/properties/common.properties
@@ -80,7 +80,7 @@ org.openelisglobal.odoo.database=
 org.openelisglobal.odoo.username=
 org.openelisglobal.odoo.password=
 
-#Loading configurationss
+#Loading configurations
 org.openelisglobal.configuration.autocreate=true
 org.openelisglobal.configuration.dir=/var/lib/openelis-global/configuration/backend
 


### PR DESCRIPTION
## Summary

Makes the result-component model robust and **real at runtime**, per the v2.4 FRS §Result Components and decision D-02. Umbrella **OGC-949**. Three commits:

## 1 — Explicit `is_primary` flag (`533662191`)
The primary component (mirrored to the legacy `test`/`test_result` columns) was identified by the magic `code='PRIMARY'` — fragile. Now:
- Liquibase **052** adds `test_result_component.is_primary`, backfills existing `PRIMARY` components to `true`, and guarantees every test exactly one primary.
- Primary resolution + legacy⇄component sync use the flag (code is a last-resort fallback); every save re-asserts a single primary.
- The `test-results` config loader bridges loaded tests into the new editor model (PRIMARY component, options/ranges repointed, LOINC → Terminology).

## 2 — Runtime multi-component result entry (`7082b3d45`)
Implements *"User orders one test; result entry shows N component fields"* + D-02:
- `syncLegacyTestFields` seeds one typed, `component_id`-linked `test_result` row **per non-dictionary component**, with per-component type/sig-digit scoping.
- `ResultsLoadUtility` expands a multi-component analysis into **one result-entry row per active component** — existing results bucket to their component; missing ones get blank placeholders. Each row carries its component's result type, dictionary options, unit, significant digits, and a labeled name (`Test — Component`). Single-component tests unchanged.
- `TestResultItem`/`ResultSaveBean` carry `testResultComponentId` (round-trips through the React form via Jackson — zero frontend changes); `ResultSaveService` binds each posted value to its component's `test_result` row.
- Validation rows are component-labeled. **FHIR needs no change**: one `Observation` per `Result` row already → N component results = N Observations, no `Observation.component[]` (D-02).
- The `tests`-domain config loader also bridges loaded tests (PRIMARY component + LOINC mapping).

## 3 — Primary toggle in the editor UI (`147d4a7b4`)
- Each component gets a **"Primary component" toggle**; exactly one can be marked — the others' toggles are disabled until the current primary is unmarked.
- Marking auto-fills the code with **`PRIMARY` and disables the field**; unmarking frees the code back to the label. First component of a new test defaults primary; removing the primary promotes the next.
- Migrated tests load pre-marked (052 backfill). API: `ResultComponentDto.isPrimary` on GET/PUT; server still normalizes to exactly one.

## Tests
- New `MultiComponentResultEntryIntegrationTest`: 2-component analysis → 2 fields with distinct component bindings + labels; single-component unchanged.
- SampleResults IT **22/22** (isPrimary round-trip), component IT 5/5 (single-primary invariant), config-loader ITs green.
- Frontend suite **790 passed** (toggle mark/unmark coverage); backend full suite green at `7082b3d45` (4556) — final run for the UI commit in CI.
- Spotless + prettier clean. Migration is additive/idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)