### PR TITLE
fix(i18n): unblock Transifex push — empty source string in en.json

### DIFF
--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -1071,7 +1071,7 @@
   "notificationtrigger.column.trigger": "Trigger",
   "notificationtrigger.config.subtitle": "Enable or disable notification triggers, select delivery channels, and configure recipient types per event.",
   "notificationtrigger.config.title": "Notification Trigger Configuration",
-  "notificationtrigger.disabled.hint": "",
+  "notificationtrigger.disabled.hint": "Enable this trigger to configure its channels and recipients.",
   "notificationtrigger.override.comingsoon": "Per-lab-unit override is not available yet.",
   "notificationtrigger.override.configure": "Configure",
   "notificationtrigger.recipient.coccontact": "CoC Contact",


### PR DESCRIPTION
## Summary

The **Transifex push** CI (`tx-push.yml`) has failed on every push to `develop` since #3848, which added a new key with an **empty source string**:

```json
"notificationtrigger.disabled.hint": "",
```

Transifex's `KEYVALUEJSON` uploader rejects empty source strings, so `tx push` fails with `failed to upload of resource 'openelis-1:r:enjson'` — blocking the translation sync for the whole team on every subsequent push.

## Fix

Populate the key (currently unreferenced in the frontend) with a non-empty value:

```json
"notificationtrigger.disabled.hint": "Enable this trigger to configure its channels and recipients.",
```

It's now the only exactly-empty source string, so this restores a clean `tx push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)