### PR TITLE
chore(i18n): key reuse tooling — i18n:find, warn-only CI checks, Claude Code hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node frontend/scripts/i18n-check.js --hook"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -70,3 +70,25 @@ jobs:
               sys.exit(1)
           print('i18n source-of-truth OK — only en.json modified')
           "
+
+  check-duplicate-values:
+    name: Duplicate value check (warn-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Warn when new keys duplicate existing English values
+        run: |
+          git show origin/${{ github.base_ref }}:frontend/src/languages/en.json > /tmp/base-en.json
+          node frontend/scripts/i18n-check.js --duplicates /tmp/base-en.json
+
+  check-missing-keys:
+    name: Missing key check (warn-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Warn for ids referenced in code but missing from en.json
+        run: node frontend/scripts/i18n-check.js --missing

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,8 @@
     "yup": "^0.29.2"
   },
   "scripts": {
+    "i18n:find": "node scripts/i18n-find.js",
+    "i18n:check": "node scripts/i18n-check.js",
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/frontend/scripts/i18n-check.js
+++ b/frontend/scripts/i18n-check.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * i18n-check: duplicate-value and missing-key checks for en.json.
+ * Constitution Principle VII (Key Reuse & Hygiene).
+ *
+ * Modes:
+ *   --duplicates <base-en.json>  Warn for keys added (vs base) whose value
+ *                                already exists under another key. common.*
+ *                                keys are exempt (they are the canonical
+ *                                targets duplicates get consolidated onto).
+ *   --missing                    Warn for ids referenced at react-intl call
+ *                                sites in src/ that do not exist in en.json.
+ *   --hook                       Claude Code PostToolUse hook: reads the hook
+ *                                JSON from stdin; if the edited file is
+ *                                en.json, runs the duplicate check against
+ *                                the git develop version and reports via
+ *                                exit code 2 (feedback to the agent).
+ *
+ * All modes are WARN-ONLY for CI right now (exit 0) except --hook, which
+ * exits 2 on findings so the agent self-corrects. Flip WARN_ONLY to false
+ * once the consolidation baseline lands.
+ */
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const WARN_ONLY = true;
+const FRONTEND = path.join(__dirname, "..");
+const EN_PATH = path.join(FRONTEND, "src", "languages", "en.json");
+const EN_REL = "frontend/src/languages/en.json";
+
+const norm = (s) =>
+  s
+    .toLowerCase()
+    .replace(/[:*.…]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+function loadJson(p) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function duplicateFindings(baseEn, headEn) {
+  const valueIndex = new Map(); // norm(value) -> [existing keys]
+  for (const [k, v] of Object.entries(headEn)) {
+    if (typeof v !== "string") continue;
+    const n = norm(v);
+    if (!valueIndex.has(n)) valueIndex.set(n, []);
+    valueIndex.get(n).push(k);
+  }
+  const findings = [];
+  for (const [k, v] of Object.entries(headEn)) {
+    if (k in baseEn) continue; // only newly added keys
+    if (k.startsWith("common.")) continue; // canonical targets are exempt
+    if (typeof v !== "string" || !v.trim()) continue;
+    const others = (valueIndex.get(norm(v)) || []).filter((o) => o !== k);
+    if (others.length) {
+      const canonical = others.find((o) => o.startsWith("common."));
+      findings.push({
+        key: k,
+        value: v,
+        reuse: canonical || others.sort((a, b) => a.length - b.length)[0],
+        others: others.length,
+      });
+    }
+  }
+  return findings;
+}
+
+function missingFindings(en) {
+  const ids = new Set();
+  const walk = (dir) => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (/\.(jsx?|tsx?)$/.test(e.name)) {
+        const txt = fs.readFileSync(p, "utf8");
+        for (const m of txt.matchAll(
+          /formatMessage\(\s*\{\s*id:\s*["']([^"']+)["']/g,
+        ))
+          ids.add(m[1]);
+        for (const m of txt.matchAll(
+          /<FormattedMessage[^>]{0,200}?id=["']([^"']+)["']/gs,
+        ))
+          ids.add(m[1]);
+      }
+    }
+  };
+  walk(path.join(FRONTEND, "src"));
+  return [...ids]
+    .filter(
+      (i) =>
+        !(i in en) && i.includes(".") && !/\s/.test(i) && !/^[\d.]+$/.test(i),
+    )
+    .sort();
+}
+
+const mode = process.argv[2];
+
+if (mode === "--duplicates") {
+  const base = loadJson(process.argv[3]);
+  const head = loadJson(EN_PATH);
+  const findings = duplicateFindings(base, head);
+  for (const f of findings)
+    console.log(
+      `::warning file=${EN_REL}::New key "${f.key}" duplicates existing value "${f.value}" — reuse "${f.reuse}" instead (${f.others} existing key(s) share this value). Run: npm run i18n:find -- "${f.value}"`,
+    );
+  console.log(`i18n duplicate-value check: ${findings.length} finding(s).`);
+  process.exit(findings.length && !WARN_ONLY ? 1 : 0);
+} else if (mode === "--missing") {
+  const en = loadJson(EN_PATH);
+  const missing = missingFindings(en);
+  for (const k of missing)
+    console.log(
+      `::warning::id "${k}" is referenced at a react-intl call site but missing from en.json (renders as raw id / untranslatable).`,
+    );
+  console.log(`i18n missing-key check: ${missing.length} finding(s).`);
+  process.exit(missing.length && !WARN_ONLY ? 1 : 0);
+} else if (mode === "--hook") {
+  let input = "";
+  try {
+    input = fs.readFileSync(0, "utf8");
+  } catch (e) {
+    process.exit(0);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(input);
+  } catch (e) {
+    process.exit(0);
+  }
+  const file = (payload.tool_input && payload.tool_input.file_path) || "";
+  if (!file.endsWith("languages/en.json")) process.exit(0);
+  let baseRaw;
+  try {
+    baseRaw = execSync(`git show develop:${EN_REL}`, {
+      cwd: path.join(FRONTEND, ".."),
+      maxBuffer: 64 * 1024 * 1024,
+    }).toString();
+  } catch (e) {
+    process.exit(0); // no base available; stay silent
+  }
+  let head;
+  try {
+    head = loadJson(EN_PATH);
+  } catch (e) {
+    console.error(`en.json is not valid JSON after this edit: ${e.message}`);
+    process.exit(2);
+  }
+  const findings = duplicateFindings(JSON.parse(baseRaw), head);
+  if (findings.length) {
+    console.error(
+      `i18n Key Reuse violation (Constitution VII): ${findings.length} newly added key(s) duplicate existing English values. REUSE the existing keys instead of minting new ones:`,
+    );
+    for (const f of findings.slice(0, 20))
+      console.error(`  - "${f.key}" = "${f.value}" -> reuse "${f.reuse}"`);
+    console.error(
+      `If a duplicate is intentional (different translation context), record it in frontend/src/languages/i18n-context-exceptions.json and say so in the PR.`,
+    );
+    process.exit(2);
+  }
+  process.exit(0);
+} else {
+  console.error(
+    "Usage: i18n-check.js --duplicates <base-en.json> | --missing | --hook",
+  );
+  process.exit(1);
+}

--- a/frontend/scripts/i18n-find.js
+++ b/frontend/scripts/i18n-find.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * i18n-find: search en.json for existing keys matching an English string.
+ * Usage: npm run i18n:find -- "collection date"
+ * Per Constitution Principle VII (Key Reuse): run this BEFORE adding any
+ * new key. If a canonical (common.*) key matches, reuse it. If the value
+ * exists only under a feature-scoped key, promote it to common.* instead
+ * of referencing another feature's key.
+ */
+const fs = require("fs");
+const path = require("path");
+
+const query = process.argv.slice(2).join(" ").trim();
+if (!query) {
+  console.error('Usage: npm run i18n:find -- "<english text>"');
+  process.exit(1);
+}
+
+const enPath = path.join(__dirname, "..", "src", "languages", "en.json");
+const en = JSON.parse(fs.readFileSync(enPath, "utf8"));
+
+const norm = (s) =>
+  s
+    .toLowerCase()
+    .replace(/[:*.…]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const bigrams = (s) => {
+  const set = new Set();
+  const t = ` ${s} `;
+  for (let i = 0; i < t.length - 1; i++) set.add(t.slice(i, i + 2));
+  return set;
+};
+
+const dice = (a, b) => {
+  const A = bigrams(a);
+  const B = bigrams(b);
+  let inter = 0;
+  for (const g of A) if (B.has(g)) inter++;
+  return (2 * inter) / (A.size + B.size);
+};
+
+const q = norm(query);
+const results = [];
+for (const [key, value] of Object.entries(en)) {
+  if (typeof value !== "string") continue;
+  const v = norm(value);
+  let score;
+  if (v === q) score = 1;
+  else if (v.includes(q) || q.includes(v)) score = 0.9;
+  else score = dice(q, v) * 0.89;
+  if (score >= 0.6) results.push({ key, value, score });
+}
+
+results.sort(
+  (a, b) =>
+    b.score - a.score ||
+    (b.key.startsWith("common.") ? 1 : 0) -
+      (a.key.startsWith("common.") ? 1 : 0) ||
+    a.key.length - b.key.length,
+);
+
+// canonical keys first within equal scores
+const canonical = results.filter((r) => r.key.startsWith("common."));
+const rest = results.filter((r) => !r.key.startsWith("common."));
+
+if (!results.length) {
+  console.log(`No match for "${query}" — a new key is justified.`);
+  console.log("Namespace it by domain (e.g. qc.controlLot.field.expiry).");
+  process.exit(0);
+}
+
+if (canonical.length) {
+  console.log("CANONICAL (reuse these):");
+  for (const r of canonical.slice(0, 5))
+    console.log(
+      `  ${(r.score * 100).toFixed(0).padStart(3)}%  ${r.key} = "${r.value}"`,
+    );
+}
+if (rest.length) {
+  console.log(
+    "Feature-scoped matches (do NOT cross-reference — promote to common.* if you need one):",
+  );
+  for (const r of rest.slice(0, 10))
+    console.log(
+      `  ${(r.score * 100).toFixed(0).padStart(3)}%  ${r.key} = "${r.value}"`,
+    );
+}


### PR DESCRIPTION
## Summary

Tooling for the i18n Key Reuse & Hygiene workstream (#3862, constitution PR #3861). Everything here is **warn-only / advisory** — no CI job fails, no behavior changes, zero risk to existing translations.

**`npm run i18n:find -- "<text>"`** — fuzzy-searches `en.json` values and prints matching keys, canonical `common.*` matches first. The "search before minting" tool the amendment mandates.

**`npm run i18n:check`** (`frontend/scripts/i18n-check.js`) — shared checker used by CI and the agent hook:

- `--duplicates <base>`: newly added keys whose English value already exists under another key (`common.*` exempt)
- `--missing`: ids referenced at react-intl call sites but absent from `en.json`
- `--hook`: Claude Code PostToolUse mode — feedback lands *while the agent edits* `en.json`, not after the PR is open

**CI** — two new warn-only jobs in `i18n-check.yml` (duplicate-value, missing-key). They annotate PRs with `::warning` and always pass. Flip `WARN_ONLY` in the script to enforce once the `common.*` consolidation baseline lands.

**`.claude/settings.json`** — repo-level PostToolUse hook wiring `i18n-check.js --hook`, so Claude Code sessions get key-reuse violations as immediate feedback. (`.claude/commands|skills|logs` remain gitignored; only `settings.json` is shared. Local `settings.local.json` files are unaffected.)

## Screenshots

N/A — developer tooling only. Example output:

```
$ npm run i18n:find -- "collection date"
CANONICAL (reuse these):
  100%  common.collectionDate = "Collection Date"
Feature-scoped matches (do NOT cross-reference — promote to common.* if you need one):
  100%  collection.date = "Collection Date"
  100%  sample.collection.date = "Collection Date"
```

## Related Issue

#3862 (constitution amendment proposal; PR #3861).

## Other

Verified locally: find ranks canonical keys first; missing-check reports 0 after the missing-keys PR; duplicate-check correctly flags value duplication; hook exits silently for non-en.json edits and degrades gracefully without a git base.
