### PR TITLE
test: fix order-dependent person_pk flake in PatientDAORedirectIntegrationTest

### DIFF
--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -344,6 +344,23 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
     }
 
     /**
+     * Resync a Postgres sequence to {@code MAX(id)+1} of its table. DBUnit fixture
+     * loads insert rows with explicit ids without advancing the sequence, so a
+     * later sequence-backed insert can collide with a seeded id depending on test
+     * order (e.g. {@code person_pk id=2 already exists}). Call this before
+     * sequence-backed inserts into a fixture-seeded table.
+     */
+    protected void resyncSequence(String sequence, String table) {
+        try (Connection conn = dataSource.getConnection(); Statement st = conn.createStatement()) {
+            // id columns are numeric(10); setval needs a bigint.
+            st.execute("SELECT setval('" + sequence + "', (SELECT COALESCE(MAX(id), 0) + 1 FROM " + table
+                    + ")::bigint, false)");
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to resync sequence " + sequence + " from " + table, e);
+        }
+    }
+
+    /**
      * Idempotently ensure the audit user {@code system_user.id=1} ("admin") exists,
      * inserting it via raw JDBC (no audit emission) if absent. Audit-emitting
      * service calls stamp history with {@code sys_user_id=1}

--- a/src/test/java/org/openelisglobal/patient/daoimpl/PatientDAORedirectIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/patient/daoimpl/PatientDAORedirectIntegrationTest.java
@@ -39,6 +39,11 @@ public class PatientDAORedirectIntegrationTest extends BaseWebContextSensitiveTe
     @Before
     public void setUp() throws Exception {
         ensureReferenceTables("PERSON", "PATIENT");
+        // Sibling tests seed person/patient rows with explicit ids (DBUnit
+        // fixtures) without advancing the sequences; resync so the inserts below
+        // can't collide with a seeded id (order-dependent person_pk flake).
+        resyncSequence("clinlims.person_seq", "clinlims.person");
+        resyncSequence("clinlims.patient_seq", "clinlims.patient");
         // Create persons for test patients
         primaryPerson = new Person();
         primaryPerson.setFirstName("John");


### PR DESCRIPTION
## Summary

Fixes the intermittent develop-branch CI failure in `PatientDAORedirectIntegrationTest.testGetDataByPrimaryKey_NonMergedPatient_ReturnsSelf` (e.g. [this Transifex-merge run](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/29537651420/job/87752654857)).

**Root cause:** DBUnit fixture datasets insert `person`/`patient` rows with explicit ids without advancing the Postgres sequences. When this test later inserts a Person through the sequence, the sequence hands out an already-taken id → `person_pk id=2 already exists`. Failure depends purely on surefire test order, which is why it appears intermittently on merges but not on every PR.

**Fix:** a reusable `resyncSequence(sequence, table)` helper on `BaseWebContextSensitiveTest` (`setval` to `MAX(id)+1`, bigint-cast for the numeric id columns), called in this test's `setUp` for `person_seq`/`patient_seq`. Any other test inserting into fixture-seeded tables can use the same helper.

**Verification:** reproduced the failing order deterministically (`SearchResultsServiceTest → PatientDAORedirectIntegrationTest` = 8/8 errors), then 36/36 green with the fix.

Cherry-picked from #3859 (`aa50e9d0d`) so develop stops failing on unrelated merges before that PR lands; merging both is harmless (identical change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)