### PR TITLE
test(qa): fix full-suite test isolation (audit sysUserId + person/patient PK leaks)

### DIFF
--- a/src/test/java/org/openelisglobal/analyzerresults/AnalyzerResultsServiceTest.java
+++ b/src/test/java/org/openelisglobal/analyzerresults/AnalyzerResultsServiceTest.java
@@ -109,6 +109,7 @@ public class AnalyzerResultsServiceTest extends BaseWebContextSensitiveTest {
         sample.setEnteredDate(Date.valueOf("2025-07-01"));
         sample.setReceivedDate(Date.valueOf("2025-07-01"));
         sample.setIsConfirmation(true);
+        sample.setSysUserId(TEST_SYS_USER_ID);
         sampleGrouping.sample = sample;
 
         SampleItem sampleItem = new SampleItem();
@@ -116,18 +117,22 @@ public class AnalyzerResultsServiceTest extends BaseWebContextSensitiveTest {
         sampleItem.setSample(sample);
         sampleItem.setLastupdated(Timestamp.valueOf("2025-02-01 12:00:00"));
         sampleItem.setStatusId("401");
+        sampleItem.setSysUserId(TEST_SYS_USER_ID);
         sampleGrouping.sampleItem = sampleItem;
 
+        Person person = new Person();
+        person.setSysUserId(TEST_SYS_USER_ID);
         Patient patient = new Patient();
-        patient.setPerson(new Person());
+        patient.setPerson(person);
         patient.setRace("Red");
         patient.setBirthDate(Timestamp.valueOf("2014-03-20 12:00:00"));
+        patient.setSysUserId(TEST_SYS_USER_ID);
         sampleGrouping.patient = patient;
 
         List<Note> notes = noteService.getAll();
         noteService.deleteAll(notes);
         Note note = new Note();
-        note.setSysUserId("2001");
+        note.setSysUserId(TEST_SYS_USER_ID);
         note.setReferenceId("3001");
         note.setReferenceTableId("1");
         note.setNoteType("G");
@@ -141,6 +146,7 @@ public class AnalyzerResultsServiceTest extends BaseWebContextSensitiveTest {
         analysis.setSampleItem(sampleItem);
         analysis.setAnalysisType("Endoscopy");
         analysis.setStartedDate(Date.valueOf("2024-06-17"));
+        analysis.setSysUserId(TEST_SYS_USER_ID);
         List<Analysis> analysisList = new ArrayList<>();
         analysisList.add(analysis);
         sampleGrouping.analysisList = analysisList;
@@ -150,6 +156,7 @@ public class AnalyzerResultsServiceTest extends BaseWebContextSensitiveTest {
         result.setIsReportable("Y");
         result.setResultType("N");
         result.setLastupdated(Timestamp.valueOf("2025-11-16 10:00:00"));
+        result.setSysUserId(TEST_SYS_USER_ID);
         List<Result> resultList = new ArrayList<>();
         resultList.add(result);
         sampleGrouping.resultList = resultList;

--- a/src/test/java/org/openelisglobal/patient/daoimpl/PatientDAORedirectIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/patient/daoimpl/PatientDAORedirectIntegrationTest.java
@@ -39,6 +39,11 @@ public class PatientDAORedirectIntegrationTest extends BaseWebContextSensitiveTe
     @Before
     public void setUp() throws Exception {
         ensureReferenceTables("PERSON", "PATIENT");
+        // Test isolation: earlier fixtures load explicit person/patient ids via
+        // named sequences that TRUNCATE ... RESTART IDENTITY does not reset, so
+        // leftover rows collide with our sequence-generated inserts. Empty the
+        // tables first so the collision cannot occur regardless of run order.
+        cleanRowsInCurrentConnection(new String[] { "patient", "person" });
         // Create persons for test patients
         primaryPerson = new Person();
         primaryPerson.setFirstName("John");

--- a/src/test/java/org/openelisglobal/result/ResultServiceTest.java
+++ b/src/test/java/org/openelisglobal/result/ResultServiceTest.java
@@ -517,9 +517,11 @@ public class ResultServiceTest extends BaseWebContextSensitiveTest {
     public void deleteAll_shouldDeleteAllResults() {
 
         List<ResultSignature> signatures = resultSignatureService.getAll();
+        signatures.forEach(s -> s.setSysUserId(TEST_SYS_USER_ID));
         resultSignatureService.deleteAll(signatures);
         List<Result> results1 = resultService.getAll();
         results1.sort((r1, r2) -> Long.compare(Long.parseLong(r2.getId()), Long.parseLong(r1.getId())));
+        results1.forEach(r -> r.setSysUserId(TEST_SYS_USER_ID));
         resultService.deleteAll(results1);
         List<Result> results2 = resultService.getAll();
         assertEquals(0, results2.size());
@@ -530,10 +532,11 @@ public class ResultServiceTest extends BaseWebContextSensitiveTest {
     public void deleteAllGivenList_shouldDeleteAllResults() {
 
         List<ResultSignature> signatures = resultSignatureService.getAll();
+        signatures.forEach(s -> s.setSysUserId(TEST_SYS_USER_ID));
         resultSignatureService.deleteAll(signatures);
 
         List<String> resultIds = List.of("4", "3");
-        resultService.deleteAll(resultIds, "");
+        resultService.deleteAll(resultIds, TEST_SYS_USER_ID);
         List<Result> results = resultService.getAll();
         assertEquals(0, results.size());
     }
@@ -541,9 +544,11 @@ public class ResultServiceTest extends BaseWebContextSensitiveTest {
     @Test
     public void delete_shouldDeleteAResult() {
         List<ResultSignature> signatures = resultSignatureService.getAll();
+        signatures.forEach(s -> s.setSysUserId(TEST_SYS_USER_ID));
         resultSignatureService.deleteAll(signatures);
         Result result = resultService.get("4");
         assertNotNull(result);
+        result.setSysUserId(TEST_SYS_USER_ID);
         resultService.delete(result);
         List<Result> results = resultService.getAll();
         assertEquals(1, results.size());
@@ -559,15 +564,18 @@ public class ResultServiceTest extends BaseWebContextSensitiveTest {
     @Test
     public void save_shouldSaveResult() {
         List<ResultSignature> signatures = resultSignatureService.getAll();
+        signatures.forEach(s -> s.setSysUserId(TEST_SYS_USER_ID));
         resultSignatureService.deleteAll(signatures);
         List<Result> results1 = resultService.getAll();
         results1.sort((r1, r2) -> Long.compare(Long.parseLong(r2.getId()), Long.parseLong(r1.getId())));
+        results1.forEach(r -> r.setSysUserId(TEST_SYS_USER_ID));
         resultService.deleteAll(results1);
         Result result = new Result();
         result.setValue("90.0");
         result.setAnalysis(analysisService.get("1"));
         result.setTestResult(testResultService.get("1"));
         result.setAnalyte(analyteService.get("3"));
+        result.setSysUserId(TEST_SYS_USER_ID);
         Result result1 = resultService.save(result);
         List<Result> results2 = resultService.getAll();
         assertNotNull(result1);
@@ -579,15 +587,18 @@ public class ResultServiceTest extends BaseWebContextSensitiveTest {
     @Test
     public void insert_shouldInsertResult() {
         List<ResultSignature> signatures = resultSignatureService.getAll();
+        signatures.forEach(s -> s.setSysUserId(TEST_SYS_USER_ID));
         resultSignatureService.deleteAll(signatures);
         List<Result> results1 = resultService.getAll();
         results1.sort((r1, r2) -> Long.compare(Long.parseLong(r2.getId()), Long.parseLong(r1.getId())));
+        results1.forEach(r -> r.setSysUserId(TEST_SYS_USER_ID));
         resultService.deleteAll(results1);
         Result result = new Result();
         result.setValue("90.0");
         result.setAnalysis(analysisService.get("1"));
         result.setTestResult(testResultService.get("1"));
         result.setAnalyte(analyteService.get("3"));
+        result.setSysUserId(TEST_SYS_USER_ID);
         String result1 = resultService.insert(result);
         List<Result> results2 = resultService.getAll();
         assertNotNull(result1);
@@ -601,6 +612,7 @@ public class ResultServiceTest extends BaseWebContextSensitiveTest {
     public void update_shouldUpdateResult() {
         Result result = resultService.get("3");
         result.setValue("95.0");
+        result.setSysUserId(TEST_SYS_USER_ID);
         Result updatedResult = resultService.update(result);
         assertNotNull(updatedResult);
         assertEquals("95.0", updatedResult.getValue());

--- a/src/test/java/org/openelisglobal/result/service/LogBookPersistServiceTest.java
+++ b/src/test/java/org/openelisglobal/result/service/LogBookPersistServiceTest.java
@@ -126,11 +126,14 @@ public class LogBookPersistServiceTest extends BaseWebContextSensitiveTest {
         Sample sample = analysis.getSampleItem().getSample();
         sample.setStatusId(sampleTestingStartedId);
         List<ResultInventory> invResults = resultInventoryService.getAll();
+        invResults.forEach(i -> i.setSysUserId(TEST_SYS_USER_ID));
         resultInventoryService.deleteAll(invResults);
         List<ResultSignature> sigs = resultSigService.getAll();
+        sigs.forEach(s -> s.setSysUserId(TEST_SYS_USER_ID));
         resultSigService.deleteAll(sigs);
         List<Result> existingResults = resultService.getAll();
         existingResults.sort((r1, r2) -> Long.compare(Long.parseLong(r2.getId()), Long.parseLong(r1.getId())));
+        existingResults.forEach(r -> r.setSysUserId(TEST_SYS_USER_ID));
         resultService.deleteAll(existingResults);
 
         ResultsUpdateDataSet dataSet = new ResultsUpdateDataSet("");


### PR DESCRIPTION
## Problem

Several integration tests pass in isolation but fail in the **full CI suite** (`Build + Test`) due to **pre-existing cross-test contamination**. They surface on any PR that touches core files (e.g. `Test.java`) and thus triggers the whole backend suite:

- `ResultServiceTest` (delete/deleteAll/insert/save/update)
- `AnalyzerResultsServiceTest.persistAnalyzerResults_*`
- `LogBookPersistServiceTest.saveNewResult_*`
- `PatientDAORedirectIntegrationTest.setUp`

## Root causes (both proven by local reproduction)

**1. Audit `sysUserId` null.** `ResultServiceImpl`/`AnalyzerResultsServiceImpl` set `auditTrailLog=true` unconditionally. Audit is gated on `reference_tables.keep_history`, which is **cached in-memory** — in the full-suite JVM a prior test populates the cache with `'Y'`, turning audit ON. The victim tests persisted/deleted audited entities **without a `sysUserId`**, so `AuditTrailServiceImpl` throws *"System User ID is null"*. (Not reproducible in isolation: the cache loads the seed `'N'`, so audit stays off.)

**2. `person`/`patient` PK collision.** Those ids come from **named sequences** (`person_seq`) that `TRUNCATE … RESTART IDENTITY` does **not** reset. Fixture-loaded explicit ids from an earlier test survive and collide with sequence-generated inserts → `duplicate key … person_pk`/`pat_pk`.

## Fix — make each test self-sufficient / order-independent

- Set a **valid** `sysUserId` (`TEST_SYS_USER_ID`) on every persisted/deleted/updated entity; replace the empty-string `sysUserId` in `deleteAll`. (Using a real user matters — a non-existent id violates `sample_sysuser_fk`.)
- `PatientDAORedirectIntegrationTest` empties `person`/`patient` in `setUp` so the sequence collision cannot occur regardless of run order.

No production code changed — test-only hardening. All four classes pass locally; the audit-ON path (cache-gated) is validated by this CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)