### PR TITLE
fix(ci): apply spotless formatting to SECURITY.md (unblock develop build)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,11 @@ settings. Protecting patient data and laboratory operations is a core project
 priority. This document explains how to report security vulnerabilities in
 OpenELIS Global 2 and what to expect from the maintainers.
 
-**Steward:** [DIGI](https://openelis-global.org/about/) (Digital Initiatives Group at the
-University of Washington).
+**Steward:** [DIGI](https://openelis-global.org/about/) (Digital Initiatives
+Group at the University of Washington).
 
-**Primary repository:** [DIGI-UW/OpenELIS-Global-2](https://github.com/DIGI-UW/OpenELIS-Global-2)
+**Primary repository:**
+[DIGI-UW/OpenELIS-Global-2](https://github.com/DIGI-UW/OpenELIS-Global-2)
 
 For general community conduct, see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). For
 functional bugs and feature requests, use
@@ -19,18 +20,18 @@ this process.
 
 ## Supported versions
 
-Security fixes are provided for supported lines below. Version numbers follow the
-project release scheme (for example `3.2.1.9`). See
+Security fixes are provided for supported lines below. Version numbers follow
+the project release scheme (for example `3.2.1.9`). See
 [Releases](https://github.com/DIGI-UW/OpenELIS-Global-2/releases) for tags and
 installer assets.
 
-| Version / line | Supported | Notes |
-| -------------- | --------- | ----- |
-| Latest [GitHub Release](https://github.com/DIGI-UW/OpenELIS-Global-2/releases) (current `3.2.x` patch) | Yes | Production deployments should run a current release tag or installer build. |
-| `main` | Yes | Production release branch; receives security backports from `develop`. |
-| `develop` | Yes | Integration branch; fixes land here first, then are backported to `main` for release. |
-| Older `3.2.x` patches superseded by a newer release | Best effort | Upgrade to the latest `3.2.x` release when possible. |
-| `2.x` and earlier major versions | No | End of life; no security support unless explicitly listed in a release notice. |
+| Version / line                                                                                         | Supported   | Notes                                                                                 |
+| ------------------------------------------------------------------------------------------------------ | ----------- | ------------------------------------------------------------------------------------- |
+| Latest [GitHub Release](https://github.com/DIGI-UW/OpenELIS-Global-2/releases) (current `3.2.x` patch) | Yes         | Production deployments should run a current release tag or installer build.           |
+| `main`                                                                                                 | Yes         | Production release branch; receives security backports from `develop`.                |
+| `develop`                                                                                              | Yes         | Integration branch; fixes land here first, then are backported to `main` for release. |
+| Older `3.2.x` patches superseded by a newer release                                                    | Best effort | Upgrade to the latest `3.2.x` release when possible.                                  |
+| `2.x` and earlier major versions                                                                       | No          | End of life; no security support unless explicitly listed in a release notice.        |
 
 If you are unsure whether your deployment is supported, include your **release
 tag**, **installer version**, or **`git describe` output** when you report.
@@ -44,9 +45,9 @@ tag**, **installer version**, or **`git describe` output** when you report.
 Vulnerabilities in software maintained for OpenELIS Global 2, including when
 reasonably exercised in supported deployments:
 
-- This repository (`OpenELIS-Global-2`): application server (Java/Spring),
-  React UI, REST APIs, authentication/authorization, session handling, and
-  bundled configuration shipped here.
+- This repository (`OpenELIS-Global-2`): application server (Java/Spring), React
+  UI, REST APIs, authentication/authorization, session handling, and bundled
+  configuration shipped here.
 - **Analyzer bridge** when used with OpenELIS Global:
   [DIGI-UW/openelis-analyzer-bridge](https://github.com/DIGI-UW/openelis-analyzer-bridge)
   (report bridge-specific issues to that repository, or note the bridge in your
@@ -88,7 +89,8 @@ data at risk before a fix is available.
    for this repository (Security → Advisories → **Report a vulnerability**).
 2. Provide as much detail as you can (see [What to include](#what-to-include)).
 
-Maintainers use [GitHub Security Advisories](https://github.com/DIGI-UW/OpenELIS-Global-2/security/advisories)
+Maintainers use
+[GitHub Security Advisories](https://github.com/DIGI-UW/OpenELIS-Global-2/security/advisories)
 for coordinated disclosure when appropriate.
 
 ### Alternative: OpenELIS contact form
@@ -112,29 +114,33 @@ For community questions that are not security-sensitive, see
 
 Help us triage quickly:
 
-1. **Affected component** — OpenELIS app, analyzer bridge, FHIR path, plugin, etc.
-2. **Version** — release tag (for example `v3.2.1.9`), installer version, or commit SHA on `develop` / `main`.
-3. **Environment** — Docker vs installer, optional modules, bridge enabled or not.
+1. **Affected component** — OpenELIS app, analyzer bridge, FHIR path, plugin,
+   etc.
+2. **Version** — release tag (for example `v3.2.1.9`), installer version, or
+   commit SHA on `develop` / `main`.
+3. **Environment** — Docker vs installer, optional modules, bridge enabled or
+   not.
 4. **Description** — what is wrong and why it is security-relevant.
 5. **Reproduction** — minimal steps or proof of concept.
-6. **Impact** — confidentiality, integrity, availability; whether authenticated access is required.
+6. **Impact** — confidentiality, integrity, availability; whether authenticated
+   access is required.
 7. **Suggested fix** (optional).
 
 ### Protected health information (PHI)
 
 OpenELIS processes laboratory and patient data. **Never** include real patient
-records, accession numbers from production, or live database dumps in a
-report. Use synthetic data, local test fixtures, or redacted screenshots only.
+records, accession numbers from production, or live database dumps in a report.
+Use synthetic data, local test fixtures, or redacted screenshots only.
 
 ---
 
 ## What to expect
 
-| Stage | Target |
-| ----- | ------ |
-| Acknowledgement | Within **3 business days** |
-| Initial triage / severity | Within **10 business days** when possible |
-| Fix and advisory | Depends on severity; we aim for **coordinated disclosure** |
+| Stage                     | Target                                                     |
+| ------------------------- | ---------------------------------------------------------- |
+| Acknowledgement           | Within **3 business days**                                 |
+| Initial triage / severity | Within **10 business days** when possible                  |
+| Fix and advisory          | Depends on severity; we aim for **coordinated disclosure** |
 
 We follow coordinated disclosure: we work with you on a reasonable timeline
 before publishing details, typically up to **90 days** from acknowledgement,
@@ -152,9 +158,10 @@ When a fix is ready, we may:
 
 ## Good-faith research
 
-We appreciate good-faith security research conducted against **test environments**
-without real patient data. Please follow this policy, use local or non-production
-deployments where possible, and avoid impacting live laboratory operations.
+We appreciate good-faith security research conducted against **test
+environments** without real patient data. Please follow this policy, use local
+or non-production deployments where possible, and avoid impacting live
+laboratory operations.
 
 ---
 
@@ -162,20 +169,21 @@ deployments where possible, and avoid impacting live laboratory operations.
 
 - **Product security overview:**
   [Security and privacy (openelis-global.org)](https://openelis-global.org/about/security-is-critical-to-our-mission/)
-- **Administrator security:** [OpenELIS documentation](https://docs.openelis-global.org/)
-- **Engineering principles (RBAC, audit, transport):** Constitution Principle VIII in
-  [.specify/memory/constitution.md](.specify/memory/constitution.md)
+- **Administrator security:**
+  [OpenELIS documentation](https://docs.openelis-global.org/)
+- **Engineering principles (RBAC, audit, transport):** Constitution Principle
+  VIII in [.specify/memory/constitution.md](.specify/memory/constitution.md)
 - **Contributing (non-security):** [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ---
 
 ## Related repositories
 
-| Repository | Report here when |
-| ---------- | ---------------- |
-| [DIGI-UW/OpenELIS-Global-2](https://github.com/DIGI-UW/OpenELIS-Global-2) | Core LIMS application (this policy). |
-| [DIGI-UW/openelis-analyzer-bridge](https://github.com/DIGI-UW/openelis-analyzer-bridge) | Analyzer bridge service and its security boundary. |
-| [DIGI-UW/openelis-docker](https://github.com/DIGI-UW/openelis-docker) | Published compose/images **only** if the vulnerability is in those artifacts; otherwise report via OpenELIS Global 2 if the root cause is application code. |
+| Repository                                                                              | Report here when                                                                                                                                            |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [DIGI-UW/OpenELIS-Global-2](https://github.com/DIGI-UW/OpenELIS-Global-2)               | Core LIMS application (this policy).                                                                                                                        |
+| [DIGI-UW/openelis-analyzer-bridge](https://github.com/DIGI-UW/openelis-analyzer-bridge) | Analyzer bridge service and its security boundary.                                                                                                          |
+| [DIGI-UW/openelis-docker](https://github.com/DIGI-UW/openelis-docker)                   | Published compose/images **only** if the vulnerability is in those artifacts; otherwise report via OpenELIS Global 2 if the root cause is application code. |
 
 If a flaw spans multiple repositories, report once via OpenELIS Global 2 private
 reporting and mention all affected components.


### PR DESCRIPTION
## What

Applies the required spotless/prettier formatting to `SECURITY.md`, which is currently **breaking the `develop` build**.

## Why the develop build is red

`SECURITY.md` was added in #2779. The post-merge `develop` build fails on the backend **check formatting** step (`mvn spotless:check`) because the file was never run through spotless (`prettier` with `proseWrap: always` + table-column padding).

**Why the PR itself passed but merge failed:** `backend.yml` gates the `Build + Test` job (which contains `mvn spotless:check`) behind a `dorny/paths-filter`. That filter matches `src/**`, `pom.xml`, `plugins/**`, etc. — **not `*.md`**. So a docs-only PR resolves `backend=false` and **skips Build + Test entirely** (the PR's check-runs show `Build + Test: skipped`), meaning the formatting check never ran. On `push` to `develop` the filter step is skipped and the `|| 'true'` fallback forces a full build, so `spotless:check` runs there for the first time — and fails.

## The change

Formatting-only. Prose word-stream, links, and document structure are unchanged; only line-wrapping, markdown table padding, and the trailing newline differ. Verified `mvn spotless:check` passes cold (cache cleared).

## Follow-up (not in this PR)

Consider adding `- '**/*.md'` to the backend paths-filter (or a lightweight always-on formatting job) so markdown formatting is validated on PRs, not only after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)