### PR TITLE
fix(ci): opt into fork-PR checkout in E2E executor (allow-unsafe-pr-checkout)

### DIFF
--- a/.github/workflows/e2e-cypress-deprecated.yml
+++ b/.github/workflows/e2e-cypress-deprecated.yml
@@ -86,6 +86,11 @@ jobs:
           repository: ${{github.repository}}
           submodules: recursive
           persist-credentials: false
+          # actions/checkout@v6 (retagged 2026-07-20) refuses fork-PR checkout in
+          # a workflow_run context. This executor intentionally runs PR specs to
+          # validate them, so opt back in. Follow-up: harden so fork code never
+          # runs with base secrets, then this flag can be removed.
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/e2e-playwright-reusable.yml
+++ b/.github/workflows/e2e-playwright-reusable.yml
@@ -76,6 +76,11 @@ jobs:
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
+          # actions/checkout@v6 (retagged 2026-07-20) refuses fork-PR checkout in
+          # a workflow_run context. This executor intentionally runs PR specs to
+          # validate them, so opt back in. Follow-up: harden so fork code never
+          # runs with base secrets, then this flag can be removed.
+          allow-unsafe-pr-checkout: true
 
       - name: Restore Playwright browser cache
         id: pw-cache
@@ -135,6 +140,11 @@ jobs:
           ref: ${{ inputs.checkout_ref || github.sha }}
           submodules: recursive
           persist-credentials: false
+          # actions/checkout@v6 (retagged 2026-07-20) refuses fork-PR checkout in
+          # a workflow_run context. This executor intentionally runs PR specs to
+          # validate them, so opt back in. Follow-up: harden so fork code never
+          # runs with base secrets, then this flag can be removed.
+          allow-unsafe-pr-checkout: true
 
       - name: Configure swap for OOM resilience
         run: |
@@ -446,6 +456,11 @@ jobs:
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
+          # actions/checkout@v6 (retagged 2026-07-20) refuses fork-PR checkout in
+          # a workflow_run context. This executor intentionally runs PR specs to
+          # validate them, so opt back in. Follow-up: harden so fork code never
+          # runs with base secrets, then this flag can be removed.
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Problem

All **fork-PR** E2E runs started failing around **2026-07-20 15:14 UTC** at the checkout step, before any test runs:

> Refusing to check out fork pull request code from a 'workflow_run' workflow. … set `allow-unsafe-pr-checkout: true` …

Nothing changed on our side — the E2E workflow files were last edited 2026-05-12. **GitHub retagged the moving `actions/checkout@v6` tag** to a newer build that adds this guard:

| Run | Time (UTC) | `@v6` resolved to | Result |
|-----|-----------|-------------------|--------|
| 29753946171 | 15:10 | `df4cb1c0…` | ✅ pass |
| 29757353357 | 15:55 | `d23441a4…` | ❌ fail |

The "Authoritative E2E Executor" runs via `workflow_run` (trusted context with base secrets) and checks out the fork PR's ref to run the PR's own Playwright/Cypress specs — exactly what the new guard blocks.

## Fix

Add `allow-unsafe-pr-checkout: true` to the **4 fork-ref checkout steps**, staying on `@v6` (so we keep future checkout fixes). This is GitHub's documented opt-in and restores the behavior we had this morning:

- `e2e-playwright-reusable.yml` — Playwright Core + Harness (3 steps)
- `e2e-cypress-deprecated.yml` — Cypress (1 step)

`persist-credentials: false` is already set on these steps, limiting token exposure. The executor deliberately runs the PR's specs to validate them, so opting in matches intent.

## Heads-up: this PR's own E2E will be red

`workflow_run` workflow definitions are always loaded from the **default branch**, not the PR. So while this PR's E2E runs, it uses develop's still-unpatched checkout and fails at checkout — the very bug being fixed. Backend/frontend/shared-build are green. **This needs a maintainer merge/admin-override**; once on develop, all subsequent fork-PR E2E passes.

## Follow-up (separate, for @pmanko)

Harden the executor so fork code never executes with base secrets (build the fork image in an untrusted job; run tests in the trusted job against **base** specs). After that, this flag can be removed and we can adopt the guarded checkout safely. Also worth pinning all `actions/checkout` usages by SHA for supply-chain hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)