### PR TITLE
feat(qa-qi): QI disable cascade — tiles, detail routes, alerts (OGC-711)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,7 @@ import QAPlaceholder from "./components/qa/QAPlaceholder";
 import QAOverview from "./components/qa/overview/QAOverview";
 import QIDashboard from "./components/qa/qi/QIDashboard";
 import QIConfigList from "./components/qa/qi/QIConfigList";
+import QIEnabledRoute from "./components/qa/qi/QIEnabledRoute";
 import AmendmentReport from "./components/qa/qi/AmendmentReport";
 import ESignatureLog from "./components/qa/qms/ESignatureLog";
 import CapaRegister from "./components/qa/qms/CapaRegister";
@@ -834,13 +835,21 @@ export default function App() {
                 <SecureRoute
                   path="/qa/qi/tat"
                   exact
-                  component={() => <TATReport breadcrumbs={qaTatBreadcrumbs} />}
+                  component={() => (
+                    <QIEnabledRoute indicator="TAT">
+                      <TATReport breadcrumbs={qaTatBreadcrumbs} />
+                    </QIEnabledRoute>
+                  )}
                   role={[Roles.RESULTS, Roles.REPORTS]}
                 />
                 <SecureRoute
                   path="/qa/qi/amendment"
                   exact
-                  component={() => <AmendmentReport />}
+                  component={() => (
+                    <QIEnabledRoute indicator="AMENDMENT">
+                      <AmendmentReport />
+                    </QIEnabledRoute>
+                  )}
                   role={[Roles.RESULTS, Roles.REPORTS]}
                 />
                 <SecureRoute

--- a/frontend/src/components/qa/overview/AttentionRequired.jsx
+++ b/frontend/src/components/qa/overview/AttentionRequired.jsx
@@ -4,6 +4,7 @@ import { useHistory } from "react-router-dom";
 import { CheckmarkOutline } from "@carbon/icons-react";
 import ComingSoon from "./ComingSoon";
 import QAEmptyState from "../common/QAEmptyState";
+import { getFromOpenElisServer } from "../../utils/Utils";
 import {
   NCE_DRILL_URL,
   countCriticalPending,
@@ -43,11 +44,18 @@ const AttentionRequired = () => {
   // undefined = loading, null = fetch yielded no data
   const [nceList, setNceList] = useState();
   const [summary, setSummary] = useState();
+  // OGC-711: hide the critical-NCE row when the NCE indicator is disabled.
+  // Fail-open — default true until/unless resolve says enabled === false.
+  const [nceEnabled, setNceEnabled] = useState(true);
 
   useEffect(() => {
     let mounted = true;
     fetchNceList((list) => mounted && setNceList(list));
     fetchOverviewSummary((data) => mounted && setSummary(data));
+    getFromOpenElisServer(
+      "/rest/qi-config/resolve?indicator=NCE",
+      (res) => mounted && res && setNceEnabled(res.enabled !== false),
+    );
     return () => {
       mounted = false;
     };
@@ -59,7 +67,8 @@ const AttentionRequired = () => {
 
   // All live queues loaded and empty — surface a calm "all clear" above the
   // rows (placeholders still render below).
-  const allClear = criticalNce === 0 && qcViolations === 0 && eqaDue === 0;
+  const allClear =
+    (!nceEnabled || criticalNce === 0) && qcViolations === 0 && eqaDue === 0;
 
   return (
     <section className="qa-overview-section" aria-label={title}>
@@ -75,12 +84,14 @@ const AttentionRequired = () => {
             subheadKey="qa.empty.attention.subhead"
           />
         )}
-        <LiveRow
-          count={criticalNce}
-          labelKey="qa.overview.attention.criticalNce"
-          alert={criticalNce > 0}
-          onClick={() => history.push(NCE_DRILL_URL)}
-        />
+        {nceEnabled && (
+          <LiveRow
+            count={criticalNce}
+            labelKey="qa.overview.attention.criticalNce"
+            alert={criticalNce > 0}
+            onClick={() => history.push(NCE_DRILL_URL)}
+          />
+        )}
         <ComingSoon
           variant="row"
           titleKey="qa.overview.attention.criticalResults"

--- a/frontend/src/components/qa/overview/__tests__/QAOverview.test.jsx
+++ b/frontend/src/components/qa/overview/__tests__/QAOverview.test.jsx
@@ -160,9 +160,10 @@ describe("QAOverview", () => {
       expect(within(region).queryAllByText("Coming soon")).toHaveLength(slots);
     });
 
-    // One shared NCE fetch, one overview summary, two TAT windows, plus the
-    // Amendment tile's own summary fetch
-    expect(getFromOpenElisServer).toHaveBeenCalledTimes(5);
+    // One shared NCE fetch, one overview summary, two TAT windows, the
+    // Amendment tile's own summary fetch, plus AttentionRequired's NCE
+    // enabled-config resolve (OGC-711)
+    expect(getFromOpenElisServer).toHaveBeenCalledTimes(6);
   });
 
   test("Today tiles carry the KPI titles, tickets, and the live TAT/Amendment/NCE values", async () => {

--- a/frontend/src/components/qa/qi/QIDashboard.jsx
+++ b/frontend/src/components/qa/qi/QIDashboard.jsx
@@ -17,6 +17,7 @@ import { Renew } from "@carbon/icons-react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../../utils/Utils";
 import PageBreadCrumb from "../../common/PageBreadCrumb";
+import { AlertDialog } from "../../common/CustomNotification";
 import { formatTat, tatDelta } from "../../reports/tat/tatUtils";
 import {
   NCE_DRILL_URL,
@@ -76,6 +77,9 @@ const QIDashboard = () => {
   const [tat, setTat] = useState({ loading: true });
   const [amendment, setAmendment] = useState({ loading: true });
   const [nce, setNce] = useState({ loading: true });
+  // OGC-711 disable cascade: per-indicator enabled flag from qi_config.
+  // Fail-open — an indicator absent from the map renders (config fetch failed).
+  const [enabledMap, setEnabledMap] = useState({});
   const [lastRefreshed, setLastRefreshed] = useState(null);
   const [refreshDisabled, setRefreshDisabled] = useState(false);
   const [, setTick] = useState(0); // re-render so "last refreshed" stays fresh
@@ -143,10 +147,31 @@ const QIDashboard = () => {
     });
   }, []);
 
+  // OGC-711: resolve each indicator's enabled flag (default config, no override).
+  // REJECTION is a data-less "coming soon" tile — gate it when OGC-697 lights up.
+  const fetchConfig = useCallback(() => {
+    ["TAT", "AMENDMENT", "NCE"].forEach((key) =>
+      getFromOpenElisServer(
+        `/rest/qi-config/resolve?indicator=${key}`,
+        (res) => {
+          if (res && typeof res.enabled === "boolean") {
+            setEnabledMap((m) => ({ ...m, [key]: res.enabled }));
+          }
+        },
+      ),
+    );
+  }, []);
+
+  const isEnabled = (key) => enabledMap[key] !== false; // fail-open
+
   useEffect(() => {
     fetchTat();
     fetchAmendment();
   }, [fetchTat, fetchAmendment]);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
 
   useEffect(() => {
     fetchNce();
@@ -169,6 +194,7 @@ const QIDashboard = () => {
     fetchTat();
     fetchAmendment();
     fetchNce();
+    fetchConfig();
     setRefreshDisabled(true);
     cooldownRef.current = setTimeout(
       () => setRefreshDisabled(false),
@@ -258,6 +284,7 @@ const QIDashboard = () => {
 
   return (
     <div className="adminPageContent qi-dashboard" data-testid="qi-dashboard">
+      <AlertDialog />
       <PageBreadCrumb breadcrumbs={breadcrumbs} />
       <h2>
         <FormattedMessage id="qa.qi.dashboard.title" />
@@ -313,73 +340,79 @@ const QIDashboard = () => {
         </div>
       </div>
       <div className="qi-dashboard__tiles">
-        <QITile
-          testId="qi-tile-tat"
-          titleKey="qa.qi.dashboard.tile.tat.label"
-          tooltipKey="qa.qi.dashboard.tile.tat.tooltip"
-          accent="blue"
-          loading={tat.loading}
-          primary={formatTat(tatData?.mean)}
-          delta={delta}
-          targetLine={
-            windowId === "ytd"
-              ? intl.formatMessage({
-                  id: "qa.qi.dashboard.tile.tat.vsPriorPeriod",
-                })
-              : intl.formatMessage(
-                  { id: "qa.qi.dashboard.tile.tat.vsPriorDays" },
-                  { days: win.days },
-                )
-          }
-          secondary={tatSecondary}
-          message={tatMessage}
-          detailPath="/qa/qi/tat"
-        />
+        {isEnabled("TAT") && (
+          <QITile
+            testId="qi-tile-tat"
+            titleKey="qa.qi.dashboard.tile.tat.label"
+            tooltipKey="qa.qi.dashboard.tile.tat.tooltip"
+            accent="blue"
+            loading={tat.loading}
+            primary={formatTat(tatData?.mean)}
+            delta={delta}
+            targetLine={
+              windowId === "ytd"
+                ? intl.formatMessage({
+                    id: "qa.qi.dashboard.tile.tat.vsPriorPeriod",
+                  })
+                : intl.formatMessage(
+                    { id: "qa.qi.dashboard.tile.tat.vsPriorDays" },
+                    { days: win.days },
+                  )
+            }
+            secondary={tatSecondary}
+            message={tatMessage}
+            detailPath="/qa/qi/tat"
+          />
+        )}
         <QITile
           testId="qi-tile-rejection"
           titleKey="qa.qi.dashboard.tile.rejection.label"
           comingSoonTicket="OGC-697"
         />
-        <QITile
-          testId="qi-tile-amendment"
-          titleKey="qa.qi.dashboard.tile.amendment.label"
-          tooltipKey="qa.qi.dashboard.tile.amendment.tooltip"
-          accent="blue"
-          loading={amendment.loading}
-          primary={
-            amendmentData?.ratePercent != null
-              ? `${amendmentData.ratePercent.toFixed(2)}%`
-              : ""
-          }
-          delta={amendmentDelta}
-          targetLine={
-            windowId === "ytd"
-              ? intl.formatMessage({
-                  id: "qa.qi.dashboard.tile.amendment.vsPriorPeriod",
-                })
-              : intl.formatMessage(
-                  { id: "qa.qi.dashboard.tile.amendment.vsPriorDays" },
-                  { days: win.days },
-                )
-          }
-          secondary={amendmentSecondary}
-          message={amendmentMessage}
-          detailPath="/qa/qi/amendment"
-        />
-        <QITile
-          testId="qi-tile-nce-pulse"
-          titleKey="qa.qi.dashboard.tile.ncePulse.label"
-          tooltipKey="qa.qi.dashboard.tile.ncePulse.tooltip"
-          accent={nceCount != null ? pulseColor(nceCount) : "blue"}
-          loading={nce.loading}
-          primary={nceCount != null ? String(nceCount) : ""}
-          targetLine={intl.formatMessage({
-            id: "qa.qi.dashboard.tile.ncePulse.criticalPending",
-          })}
-          secondary={nceSecondary}
-          message={nceMessage}
-          detailPath={NCE_DRILL_URL}
-        />
+        {isEnabled("AMENDMENT") && (
+          <QITile
+            testId="qi-tile-amendment"
+            titleKey="qa.qi.dashboard.tile.amendment.label"
+            tooltipKey="qa.qi.dashboard.tile.amendment.tooltip"
+            accent="blue"
+            loading={amendment.loading}
+            primary={
+              amendmentData?.ratePercent != null
+                ? `${amendmentData.ratePercent.toFixed(2)}%`
+                : ""
+            }
+            delta={amendmentDelta}
+            targetLine={
+              windowId === "ytd"
+                ? intl.formatMessage({
+                    id: "qa.qi.dashboard.tile.amendment.vsPriorPeriod",
+                  })
+                : intl.formatMessage(
+                    { id: "qa.qi.dashboard.tile.amendment.vsPriorDays" },
+                    { days: win.days },
+                  )
+            }
+            secondary={amendmentSecondary}
+            message={amendmentMessage}
+            detailPath="/qa/qi/amendment"
+          />
+        )}
+        {isEnabled("NCE") && (
+          <QITile
+            testId="qi-tile-nce-pulse"
+            titleKey="qa.qi.dashboard.tile.ncePulse.label"
+            tooltipKey="qa.qi.dashboard.tile.ncePulse.tooltip"
+            accent={nceCount != null ? pulseColor(nceCount) : "blue"}
+            loading={nce.loading}
+            primary={nceCount != null ? String(nceCount) : ""}
+            targetLine={intl.formatMessage({
+              id: "qa.qi.dashboard.tile.ncePulse.criticalPending",
+            })}
+            secondary={nceSecondary}
+            message={nceMessage}
+            detailPath={NCE_DRILL_URL}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/qa/qi/QIEnabledRoute.jsx
+++ b/frontend/src/components/qa/qi/QIEnabledRoute.jsx
@@ -1,0 +1,56 @@
+/**
+ * QIEnabledRoute (OGC-711)
+ *
+ * Detail-route guard for the QI cascade. Resolves an indicator's qi_config
+ * (GET /rest/qi-config/resolve, gated qa.view.qi) and, if it is disabled,
+ * redirects to the dashboard with a warning toast. Fail-open: a failed/absent
+ * config fetch renders the detail page normally.
+ */
+
+import React, { useContext, useEffect, useState } from "react";
+import { Redirect } from "react-router-dom";
+import { Loading } from "@carbon/react";
+import { useIntl } from "react-intl";
+import { getFromOpenElisServer } from "../../utils/Utils";
+import { NotificationContext } from "../../layout/Layout";
+import { NotificationKinds } from "../../common/CustomNotification";
+
+const QIEnabledRoute = ({ indicator, children }) => {
+  const intl = useIntl();
+  const { addNotification, setNotificationVisible } =
+    useContext(NotificationContext);
+  // "loading" | "enabled" | "disabled"
+  const [state, setState] = useState("loading");
+
+  useEffect(() => {
+    getFromOpenElisServer(
+      `/rest/qi-config/resolve?indicator=${indicator}`,
+      (res) => {
+        if (res && res.enabled === false) {
+          // Fire the toast here, not in a state-driven effect: the <Redirect>
+          // below unmounts this guard in a layout effect that runs before a
+          // useEffect would, so a deferred toast would never show.
+          addNotification({
+            kind: NotificationKinds.warning,
+            title: intl.formatMessage({ id: "qa.qi.disabled.toast.title" }),
+            message: intl.formatMessage({ id: "qa.qi.disabled.toast.message" }),
+          });
+          setNotificationVisible(true);
+          setState("disabled");
+        } else {
+          setState("enabled");
+        }
+      },
+    );
+  }, [indicator]);
+
+  if (state === "loading") {
+    return <Loading small withOverlay={false} />;
+  }
+  if (state === "disabled") {
+    return <Redirect to="/qa/qi/dashboard" />;
+  }
+  return children;
+};
+
+export default QIEnabledRoute;

--- a/frontend/src/components/qa/qi/__tests__/QIDashboard.test.jsx
+++ b/frontend/src/components/qa/qi/__tests__/QIDashboard.test.jsx
@@ -6,6 +6,7 @@ import { IntlProvider } from "react-intl";
 import { MemoryRouter } from "react-router-dom";
 import messages from "../../../../languages/en.json";
 import QIDashboard from "../QIDashboard";
+import { NotificationContext } from "../../../layout/Layout";
 
 vi.mock("../../../utils/Utils", () => ({
   getFromOpenElisServer: vi.fn(),
@@ -13,14 +14,26 @@ vi.mock("../../../utils/Utils", () => ({
 
 import { getFromOpenElisServer } from "../../../utils/Utils";
 
+// The dashboard mounts <AlertDialog/> (for the OGC-711 disabled-route redirect
+// toast), which reads NotificationContext — provided by Layout in the app.
+const notificationValue = {
+  notifications: [],
+  addNotification: vi.fn(),
+  removeNotification: vi.fn(),
+  setNotificationVisible: vi.fn(),
+  notificationVisible: false,
+};
+
 // Rendering with the real en.json fails loudly if a referenced i18n key
 // is missing (react-intl falls back to the raw key, breaking assertions).
 const renderPage = () =>
   render(
     <IntlProvider locale="en" messages={messages}>
-      <MemoryRouter>
-        <QIDashboard />
-      </MemoryRouter>
+      <NotificationContext.Provider value={notificationValue}>
+        <MemoryRouter>
+          <QIDashboard />
+        </MemoryRouter>
+      </NotificationContext.Provider>
     </IntlProvider>,
   );
 
@@ -80,6 +93,8 @@ const mockApis = ({
       callback(amendCall++ === 0 ? amendCurrent : amendPrior);
     } else if (url.includes("/rest/nce/dashboard")) {
       callback(nce === null ? undefined : { nceList: nce });
+    } else if (url.includes("/rest/qi-config/resolve")) {
+      callback({ enabled: true });
     }
   });
 };
@@ -214,12 +229,13 @@ describe("QIDashboard", () => {
   test("refresh refetches every indicator and rate-limits the button", async () => {
     mockApis();
     renderPage();
-    // TAT + Amendment fire current+prior (2 each); NCE Pulse fires once
-    expect(getFromOpenElisServer).toHaveBeenCalledTimes(5);
+    // TAT + Amendment fire current+prior (2 each); NCE Pulse once; plus the
+    // OGC-711 enabled-config resolve for TAT/AMENDMENT/NCE (3) = 8
+    expect(getFromOpenElisServer).toHaveBeenCalledTimes(8);
 
     const refresh = screen.getByTestId("qi-dashboard-refresh");
     fireEvent.click(refresh);
-    expect(getFromOpenElisServer).toHaveBeenCalledTimes(10);
+    expect(getFromOpenElisServer).toHaveBeenCalledTimes(16);
     expect(refresh).toBeDisabled();
   });
 });

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -4729,6 +4729,8 @@
   "qa.qi.dashboard.viewDetail": "View detail",
   "qa.qi.dashboard.tileInfo": "What does this tile measure?",
   "qa.qi.dashboard.comingSoon": "Coming soon — {ticket}",
+  "qa.qi.disabled.toast.title": "Indicator disabled",
+  "qa.qi.disabled.toast.message": "This quality indicator is disabled in QI Configuration; its detail page is unavailable.",
   "qa.qi.dashboard.tile.tat.label": "Average TAT",
   "qa.qi.dashboard.tile.tat.tooltip": "Average turnaround time from sample receipt to result validation, across all completed test orders in the reporting window.",
   "qa.qi.dashboard.tile.tat.vsPriorDays": "vs prior {days} days",


### PR DESCRIPTION
## OGC-711 — QI disable cascade

Makes the QI dashboard actually honour `qi_config.enabled` (shipped by OGC-709). Until now the config spine existed but nothing consumed it — disabling an indicator had no visible effect. Frontend-only.

### What changed
- **`QIDashboard.jsx`** — each indicator tile (TAT / AMENDMENT / NCE) renders only when its config resolves `enabled`. Also mounts `<AlertDialog/>` so a redirect toast can surface here.
- **`QIEnabledRoute.jsx`** (new) — route guard for the TAT + Amendment detail pages: a disabled indicator redirects to the dashboard with a warning toast. The toast is fired in the resolve callback (before the `<Redirect>` render) because `<Redirect>` unmounts the guard in a layout effect that would run before a `useEffect` — a deferred toast would never show.
- **`App.jsx`** — wraps the `/qa/qi/tat` and `/qa/qi/amendment` routes in `<QIEnabledRoute>`.
- **`AttentionRequired.jsx`** — suppresses the critical-NCE alert row when NCE is disabled.
- **`en.json`** — two toast i18n keys.

### Read contract
Reads `GET /rest/qi-config/resolve?indicator=<KEY>` (gated `qa.view.qi`, which dashboard viewers hold). The `/rest/qi-config` list endpoint is deliberately **not** used — it is gated `qa.manage.qi` and would 403 for RESULTS/VALIDATION dashboard users. **Fail-open:** a failed/absent config fetch renders everything.

### Scope notes
- The `REJECTION` "coming soon" tile is left ungated (no data yet — gate it when OGC-697 lights it up).
- The `/qa/overview` duplicate tiles (`TatTile`/`AmendmentRateTile`/`NcePulseTile`) still show informationally when disabled; the route guard already blocks reaching a disabled detail page from either surface. Honouring `enabled` on those tiles is a consistency follow-up.
- Tile **coloring** against config thresholds is out of scope here — that's OGC-710.

### Verification
Driven end-to-end on the dev app (Playwright): disabling NCE hides its tile; disabling AMENDMENT hides its tile and `/qa/qi/amendment` redirects to the dashboard with the warning toast (toast text captured via MutationObserver); an enabled indicator (TAT) passes through the guard; the overview critical-NCE alert row is suppressed. Two bugs were found and fixed during verification (toast-vs-redirect effect ordering; missing `AlertDialog` mount on the landing page).

Base: `feat/qa-next`.
