### PR TITLE
feat(qa-qi): extend QI disable cascade to the QA Overview (OGC-711 follow-up)

### DIFF
--- a/frontend/src/components/qa/overview/AttentionRequired.jsx
+++ b/frontend/src/components/qa/overview/AttentionRequired.jsx
@@ -4,7 +4,7 @@ import { useHistory } from "react-router-dom";
 import { CheckmarkOutline } from "@carbon/icons-react";
 import ComingSoon from "./ComingSoon";
 import QAEmptyState from "../common/QAEmptyState";
-import { getFromOpenElisServer } from "../../utils/Utils";
+import useQiEnabled from "../qi/useQiEnabled";
 import {
   NCE_DRILL_URL,
   countCriticalPending,
@@ -45,17 +45,13 @@ const AttentionRequired = () => {
   const [nceList, setNceList] = useState();
   const [summary, setSummary] = useState();
   // OGC-711: hide the critical-NCE row when the NCE indicator is disabled.
-  // Fail-open — default true until/unless resolve says enabled === false.
-  const [nceEnabled, setNceEnabled] = useState(true);
+  const { isEnabled } = useQiEnabled(["NCE"]);
+  const nceEnabled = isEnabled("NCE");
 
   useEffect(() => {
     let mounted = true;
     fetchNceList((list) => mounted && setNceList(list));
     fetchOverviewSummary((data) => mounted && setSummary(data));
-    getFromOpenElisServer(
-      "/rest/qi-config/resolve?indicator=NCE",
-      (res) => mounted && res && setNceEnabled(res.enabled !== false),
-    );
     return () => {
       mounted = false;
     };

--- a/frontend/src/components/qa/overview/PillarStatus.jsx
+++ b/frontend/src/components/qa/overview/PillarStatus.jsx
@@ -114,7 +114,7 @@ const PillarStatus = () => {
   // OGC-711: the QI pillar is sourced from the TAT indicator, so disabling TAT
   // must stop it lighting the chip. (QC/EQA/QMS are other pillars — not gated on
   // a QI indicator's toggle.)
-  const isEnabled = useQiEnabled(["TAT"]);
+  const { isEnabled } = useQiEnabled(["TAT"]);
   const tatEnabled = isEnabled("TAT");
 
   useEffect(() => {

--- a/frontend/src/components/qa/overview/PillarStatus.jsx
+++ b/frontend/src/components/qa/overview/PillarStatus.jsx
@@ -10,6 +10,7 @@ import {
   fetchNceList,
 } from "./nceOverview";
 import { fetchOverviewSummary, fetchTatRollup } from "./overviewData";
+import useQiEnabled from "../qi/useQiEnabled";
 
 export const STATUS_ICON = { green: "✓", amber: "⚠", red: "✗" };
 
@@ -110,6 +111,11 @@ const PillarStatus = () => {
   const [summary, setSummary] = useState();
   const [nceList, setNceList] = useState();
   const [tat, setTat] = useState();
+  // OGC-711: the QI pillar is sourced from the TAT indicator, so disabling TAT
+  // must stop it lighting the chip. (QC/EQA/QMS are other pillars — not gated on
+  // a QI indicator's toggle.)
+  const isEnabled = useQiEnabled(["TAT"]);
+  const tatEnabled = isEnabled("TAT");
 
   useEffect(() => {
     let mounted = true;
@@ -122,7 +128,12 @@ const PillarStatus = () => {
   }, []);
 
   const qc = qcPillar(intl, summary);
-  const qi = qiPillar(intl, tat);
+  const qi = tatEnabled
+    ? qiPillar(intl, tat)
+    : {
+        status: null,
+        text: intl.formatMessage({ id: "qa.overview.pillar.qi.disabled" }),
+      };
   const qms = qmsPillar(intl, nceList);
 
   return (
@@ -141,7 +152,7 @@ const PillarStatus = () => {
         <ComingSoon titleKey="banner.menu.eqa" ticket="OGC-721" />
         <PillarChip
           titleKey="sideNav.label.qa.qi"
-          loading={tat === undefined}
+          loading={tatEnabled && tat === undefined}
           status={qi.status}
           text={qi.text}
           onClick={() => history.push("/qa/qi/dashboard")}

--- a/frontend/src/components/qa/overview/TodayTiles.jsx
+++ b/frontend/src/components/qa/overview/TodayTiles.jsx
@@ -4,29 +4,35 @@ import ComingSoon from "./ComingSoon";
 import AmendmentRateTile from "./AmendmentRateTile";
 import NcePulseTile from "./NcePulseTile";
 import TatTile from "./TatTile";
+import useQiEnabled from "../qi/useQiEnabled";
+
+// OGC-711 disable cascade — reach the Overview's QI-indicator tiles too, so a
+// disabled indicator vanishes here the same way it does on the QI Dashboard.
+const GATED_INDICATORS = ["TAT", "AMENDMENT", "NCE"];
 
 const TodayTiles = () => {
   const intl = useIntl();
   const title = intl.formatMessage({ id: "qa.overview.section.today" });
+  const isEnabled = useQiEnabled(GATED_INDICATORS);
   return (
     <section className="qa-overview-section" aria-label={title}>
       <div className="qa-sec-head">
         <h3>{title}</h3>
       </div>
       <div className="qa-cs-grid qa-cs-grid-tiles">
-        <TatTile />
+        {isEnabled("TAT") && <TatTile />}
         <ComingSoon
           variant="tile"
           titleKey="qa.overview.tile.rejectionRate"
           ticket="OGC-697"
         />
-        <AmendmentRateTile />
+        {isEnabled("AMENDMENT") && <AmendmentRateTile />}
         <ComingSoon
           variant="tile"
           titleKey="qa.overview.tile.criticalCallback"
           ticket="OGC-714"
         />
-        <NcePulseTile />
+        {isEnabled("NCE") && <NcePulseTile />}
       </div>
     </section>
   );

--- a/frontend/src/components/qa/overview/TodayTiles.jsx
+++ b/frontend/src/components/qa/overview/TodayTiles.jsx
@@ -13,7 +13,7 @@ const GATED_INDICATORS = ["TAT", "AMENDMENT", "NCE"];
 const TodayTiles = () => {
   const intl = useIntl();
   const title = intl.formatMessage({ id: "qa.overview.section.today" });
-  const isEnabled = useQiEnabled(GATED_INDICATORS);
+  const { isEnabled } = useQiEnabled(GATED_INDICATORS);
   return (
     <section className="qa-overview-section" aria-label={title}>
       <div className="qa-sec-head">

--- a/frontend/src/components/qa/overview/__tests__/QAOverview.test.jsx
+++ b/frontend/src/components/qa/overview/__tests__/QAOverview.test.jsx
@@ -130,6 +130,8 @@ beforeEach(() => {
       callback(++tatCalls === 1 ? TAT_CURRENT : TAT_PRIOR);
     } else if (url.includes("/rest/reports/amendment/summary")) {
       callback({ amendedCount: 8, releasedCount: 2580, ratePercent: 0.31 });
+    } else if (url.includes("/rest/qi-config/resolve")) {
+      callback({ enabled: true });
     }
   });
 });
@@ -161,9 +163,10 @@ describe("QAOverview", () => {
     });
 
     // One shared NCE fetch, one overview summary, two TAT windows, the
-    // Amendment tile's own summary fetch, plus AttentionRequired's NCE
-    // enabled-config resolve (OGC-711)
-    expect(getFromOpenElisServer).toHaveBeenCalledTimes(6);
+    // Amendment tile's own summary fetch, plus the OGC-711 enabled-config
+    // resolves: AttentionRequired (NCE), TodayTiles (TAT/AMENDMENT/NCE),
+    // PillarStatus (TAT) = 1 + 1 + 2 + 1 + 1 + 3 + 1 = 10
+    expect(getFromOpenElisServer).toHaveBeenCalledTimes(10);
   });
 
   test("Today tiles carry the KPI titles, tickets, and the live TAT/Amendment/NCE values", async () => {

--- a/frontend/src/components/qa/qi/QIDashboard.jsx
+++ b/frontend/src/components/qa/qi/QIDashboard.jsx
@@ -26,7 +26,11 @@ import {
   pulseColor,
 } from "../overview/nceOverview";
 import QITile from "./QITile";
+import useQiEnabled from "./useQiEnabled";
 import "./QIDashboard.css";
+
+// REJECTION is a data-less "coming soon" tile — gate it when OGC-697 lights up.
+const GATED_INDICATORS = ["TAT", "AMENDMENT", "NCE"];
 
 const WINDOW_STORAGE_KEY = "qa.qi.dashboard.window";
 const REFRESH_COOLDOWN_MS = 30000;
@@ -77,9 +81,8 @@ const QIDashboard = () => {
   const [tat, setTat] = useState({ loading: true });
   const [amendment, setAmendment] = useState({ loading: true });
   const [nce, setNce] = useState({ loading: true });
-  // OGC-711 disable cascade: per-indicator enabled flag from qi_config.
-  // Fail-open — an indicator absent from the map renders (config fetch failed).
-  const [enabledMap, setEnabledMap] = useState({});
+  // OGC-711 disable cascade: shared hook resolves each indicator's enabled flag.
+  const { isEnabled, refetch: refetchConfig } = useQiEnabled(GATED_INDICATORS);
   const [lastRefreshed, setLastRefreshed] = useState(null);
   const [refreshDisabled, setRefreshDisabled] = useState(false);
   const [, setTick] = useState(0); // re-render so "last refreshed" stays fresh
@@ -147,31 +150,10 @@ const QIDashboard = () => {
     });
   }, []);
 
-  // OGC-711: resolve each indicator's enabled flag (default config, no override).
-  // REJECTION is a data-less "coming soon" tile — gate it when OGC-697 lights up.
-  const fetchConfig = useCallback(() => {
-    ["TAT", "AMENDMENT", "NCE"].forEach((key) =>
-      getFromOpenElisServer(
-        `/rest/qi-config/resolve?indicator=${key}`,
-        (res) => {
-          if (res && typeof res.enabled === "boolean") {
-            setEnabledMap((m) => ({ ...m, [key]: res.enabled }));
-          }
-        },
-      ),
-    );
-  }, []);
-
-  const isEnabled = (key) => enabledMap[key] !== false; // fail-open
-
   useEffect(() => {
     fetchTat();
     fetchAmendment();
   }, [fetchTat, fetchAmendment]);
-
-  useEffect(() => {
-    fetchConfig();
-  }, [fetchConfig]);
 
   useEffect(() => {
     fetchNce();
@@ -194,7 +176,7 @@ const QIDashboard = () => {
     fetchTat();
     fetchAmendment();
     fetchNce();
-    fetchConfig();
+    refetchConfig();
     setRefreshDisabled(true);
     cooldownRef.current = setTimeout(
       () => setRefreshDisabled(false),

--- a/frontend/src/components/qa/qi/useQiEnabled.js
+++ b/frontend/src/components/qa/qi/useQiEnabled.js
@@ -1,35 +1,47 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getFromOpenElisServer } from "../../utils/Utils";
 
 /**
  * Resolves the enabled flag for one or more QI indicators from qi_config
- * (GET /rest/qi-config/resolve, gated qa.view.qi). Returns an `isEnabled(key)`
- * predicate. Fail-open: an indicator reads as enabled unless resolve explicitly
- * returns enabled === false (a failed/absent config fetch never hides a tile).
+ * (GET /rest/qi-config/resolve, gated qa.view.qi). Returns:
+ *   - isEnabled(key): predicate, fail-open — an indicator reads as enabled
+ *     unless resolve explicitly returns enabled === false (a failed/absent
+ *     config fetch never hides a surface).
+ *   - refetch(): re-resolve on demand (e.g. a dashboard Refresh button).
  *
- * Shared by the QI-indicator surfaces on the QA Overview so the disable cascade
- * (OGC-711) reaches them the same way it reaches the QI Dashboard.
+ * Single source of truth for the OGC-711 disable cascade across the QI
+ * Dashboard and the QA Overview, so the surfaces can't drift apart.
  */
 export default function useQiEnabled(indicators) {
   const [enabledMap, setEnabledMap] = useState({});
+  // Capture the indicator list once. Call sites pass a stable set (a module
+  // const or a fixed literal), so refetch can read it from the ref without
+  // making the mount effect depend on the array's identity (which would re-run
+  // every render for an inline literal).
+  const indicatorsRef = useRef(indicators);
+  const mountedRef = useRef(true);
 
-  useEffect(() => {
-    let mounted = true;
-    indicators.forEach((key) =>
+  const refetch = useCallback(() => {
+    indicatorsRef.current.forEach((key) =>
       getFromOpenElisServer(
         `/rest/qi-config/resolve?indicator=${key}`,
         (res) => {
-          if (mounted && res && typeof res.enabled === "boolean") {
+          if (mountedRef.current && res && typeof res.enabled === "boolean") {
             setEnabledMap((m) => ({ ...m, [key]: res.enabled }));
           }
         },
       ),
     );
-    return () => {
-      mounted = false;
-    };
-    // indicators is a stable literal at each call site; resolve once on mount.
   }, []);
 
-  return (key) => enabledMap[key] !== false;
+  useEffect(() => {
+    mountedRef.current = true;
+    refetch();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [refetch]);
+
+  const isEnabled = (key) => enabledMap[key] !== false;
+  return { isEnabled, refetch };
 }

--- a/frontend/src/components/qa/qi/useQiEnabled.js
+++ b/frontend/src/components/qa/qi/useQiEnabled.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { getFromOpenElisServer } from "../../utils/Utils";
+
+/**
+ * Resolves the enabled flag for one or more QI indicators from qi_config
+ * (GET /rest/qi-config/resolve, gated qa.view.qi). Returns an `isEnabled(key)`
+ * predicate. Fail-open: an indicator reads as enabled unless resolve explicitly
+ * returns enabled === false (a failed/absent config fetch never hides a tile).
+ *
+ * Shared by the QI-indicator surfaces on the QA Overview so the disable cascade
+ * (OGC-711) reaches them the same way it reaches the QI Dashboard.
+ */
+export default function useQiEnabled(indicators) {
+  const [enabledMap, setEnabledMap] = useState({});
+
+  useEffect(() => {
+    let mounted = true;
+    indicators.forEach((key) =>
+      getFromOpenElisServer(
+        `/rest/qi-config/resolve?indicator=${key}`,
+        (res) => {
+          if (mounted && res && typeof res.enabled === "boolean") {
+            setEnabledMap((m) => ({ ...m, [key]: res.enabled }));
+          }
+        },
+      ),
+    );
+    return () => {
+      mounted = false;
+    };
+    // indicators is a stable literal at each call site; resolve once on mount.
+  }, []);
+
+  return (key) => enabledMap[key] !== false;
+}

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -4835,6 +4835,7 @@
   "qa.overview.pillar.qc.noData": "No QC data yet",
   "qa.overview.pillar.qi.text": "Avg TAT {tat}",
   "qa.overview.pillar.qi.noData": "No TAT data yet",
+  "qa.overview.pillar.qi.disabled": "Not currently tracked",
   "qa.overview.pillar.qms.text": "{critical} critical pending · {capa} in corrective action",
   "qa.overview.activity.viewAudit": "View full audit trail",
   "qa.overview.activity.empty": "No activity in the last 24 hours",


### PR DESCRIPTION
## OGC-711 follow-up — extend the QI disable cascade to the QA Overview

711 made the QI **Dashboard** honor `qi_config.enabled` (tiles omitted, detail routes redirected, one AttentionRequired NCE row suppressed). But the **QA Overview** (`/qa/overview`) has its own indicator widgets that never checked `enabled` — so a disabled indicator vanished from `/qa/qi/dashboard` yet stayed fully live on the QA Officer's daily Overview. A gap sweep confirmed this. This PR closes it for the QI-indicator surfaces.

### Changes
- **`useQiEnabled.js`** (new) — small shared hook: resolves one or more indicators' `enabled` flag via `GET /rest/qi-config/resolve` (gated `qa.view.qi`), returns an `isEnabled(key)` predicate. **Fail-open** — an indicator reads as enabled unless resolve explicitly returns `enabled === false`. Shared so the Dashboard and Overview can't drift apart again.
- **`TodayTiles.jsx`** — the TAT / Amendment / NCE-Pulse tiles are omitted when their indicator is disabled (same as the Dashboard).
- **`PillarStatus.jsx`** — the QI pillar chip is sourced from the TAT indicator, so when TAT is disabled it shows **"Not currently tracked"** instead of a live TAT-based status.
- **`en.json`** — one key, `qa.overview.pillar.qi.disabled`.
- **`QAOverview.test.jsx`** — mock now stubs the resolve URL; fetch-count assertion updated (→10). 7/7 pass.

### Deliberately NOT gated
The **QMS pillar** and **This-Week NCE counters** are QMS-domain aggregates that merely reuse NCE data — they are *not* the QI "NCE Pulse" indicator. Disabling the QI NCE indicator must not blank cross-pillar QMS reporting, so those are left as-is.

### Verification
Driven on the dev app with TAT disabled: the Today "Average TAT" tile disappeared and the QI pillar chip read "Not currently tracked," while the QMS pillar and weekly NCE counters correctly kept reporting. Restored afterward.

Base: `feat/qa-next`.
