### PR TITLE
fix(3891): trim trailing newlines and carriage returns in CreateAdminUserTask

### DIFF
--- a/src/main/java/org/openelisglobal/config/CreateAdminUserTask.java
+++ b/src/main/java/org/openelisglobal/config/CreateAdminUserTask.java
@@ -76,13 +76,15 @@ public class CreateAdminUserTask {
         return login;
     }
 
-    private String processPassword(String password) {
-        // strip password marker at beginning of line and newline character at end
-        if (password.startsWith(PASSWORD_MARKER)) {
-            password = password.substring(PASSWORD_MARKER.length());
+    String processPassword(String password) {
+        if (password == null) {
+            return "";
         }
-        if (password.endsWith("\n")) {
-            password = password.substring(0, password.length() - 1);
+        password = password.trim();
+        // strip password marker at beginning of line and newline/carriage return
+        // characters
+        if (password.startsWith(PASSWORD_MARKER)) {
+            password = password.substring(PASSWORD_MARKER.length()).trim();
         }
         if (password.startsWith("$2y")) {
             password = password.replace("$2y", "$2a");

--- a/src/test/java/org/openelisglobal/config/CreateAdminUserTaskTest.java
+++ b/src/test/java/org/openelisglobal/config/CreateAdminUserTaskTest.java
@@ -31,8 +31,24 @@ public class CreateAdminUserTaskTest {
     }
 
     @Test
+    public void processPassword_withAdminPrefixAndCR_stripsMarkerAndConvertsPrefix() {
+        String input = "admin:$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W\r";
+        String expected = "$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W";
+        String actual = task.processPassword(input);
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void processPassword_withoutAdminPrefix_convertsBcryptPrefixAndTrims() {
         String input = "$2y$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W\r\n";
+        String expected = "$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W";
+        String actual = task.processPassword(input);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void processPassword_noTrailingLineEnding_isUnchanged() {
+        String input = "$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W";
         String expected = "$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W";
         String actual = task.processPassword(input);
         assertEquals(expected, actual);

--- a/src/test/java/org/openelisglobal/config/CreateAdminUserTaskTest.java
+++ b/src/test/java/org/openelisglobal/config/CreateAdminUserTaskTest.java
@@ -1,0 +1,46 @@
+package org.openelisglobal.config;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class CreateAdminUserTaskTest {
+
+    private CreateAdminUserTask task;
+
+    @Before
+    public void setUp() {
+        task = new CreateAdminUserTask();
+    }
+
+    @Test
+    public void processPassword_withAdminPrefixAndCRLF_stripsMarkerAndConvertsPrefix() {
+        String input = "admin:$2y$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W\r\n";
+        String expected = "$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W";
+        String actual = task.processPassword(input);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void processPassword_withAdminPrefixAndLF_stripsMarkerAndConvertsPrefix() {
+        String input = "admin:$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W\n";
+        String expected = "$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W";
+        String actual = task.processPassword(input);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void processPassword_withoutAdminPrefix_convertsBcryptPrefixAndTrims() {
+        String input = "$2y$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W\r\n";
+        String expected = "$2a$12$G.ie.iZuxFu7DKVtIkvpyu/jg9dulZIsgfu6EfY5E05OWJnvOhC6W";
+        String actual = task.processPassword(input);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void processPassword_nullAndEmptyInput_returnsEmptyString() {
+        assertEquals("", task.processPassword(null));
+        assertEquals("", task.processPassword("   "));
+    }
+}


### PR DESCRIPTION
## Description
Closes #3891

This PR fixes a bug where default admin user creation fails silently during initial startup on fresh clones when `adminPassword.txt` contains CRLF line endings (`\r\n`).

## Cause & Fix
- **Root Cause**: `processPassword()` stripped `\n` but left trailing `\r` carriage returns on CRLF line endings. The extra character caused `LoginUserService.isHashedPassword()`'s regex matcher to fail. The task then incorrectly attempted to validate the bcrypt hash string as a plaintext password candidate, throwing a complexity validation exception and aborting admin user creation silently.
- **Fix**: Updated `processPassword()` to perform `password.trim()`, safely stripping all leading/trailing whitespace, `\r`, and `\n` characters before checking BCrypt patterns.
- **Null Safety**: Added explicit null checks to prevent `NullPointerException`s.
- **Unit Tests**: Added `CreateAdminUserTaskTest.java` to test password parsing across `\r\n`, `\n`, `\r`, `admin:` prefix markers, un-terminated hash inputs, and null/whitespace inputs.

## Verification Done
- `mvn test -Dtest=CreateAdminUserTaskTest`: **BUILD SUCCESS** (6 tests run, 0 failures, 0 errors).
- `mvn spotless:apply`: **BUILD SUCCESS** (Code formatted).

## Checklist
- [x] Target branch is `develop`
- [x] Code formatted with `mvn spotless:apply`
- [x] Unit tests added and passing locally
- [x] Surgical, minimal diff

