### PR TITLE
fix(ui): restore sidenav pin control — pinned persistent nav vs on-demand drawer on desktop

### DIFF
--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -585,6 +585,13 @@ button {
   }
 }
 
+/* Pin/unpin control at the top of the sidenav (desktop only) */
+.sidenav-pin-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.25rem 0.5rem 0;
+}
+
 /* Allow sidenav to scroll long menus (e.g. Admin) while hiding scrollbar */
 .cds--side-nav {
   overflow-y: auto !important;

--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -592,6 +592,22 @@ button {
   padding: 0.25rem 0.5rem 0;
 }
 
+/* Both sidenavs are white, but only the main nav remaps Carbon's icon tokens
+   (the admin nav hard-codes colors on its own selectors instead), so without
+   this the ghost button inherits the blue header theme's light icon color and
+   renders white-on-white in the admin nav. Match the main nav's icon grey. */
+.sidenav-pin-row .cds--btn--ghost {
+  --cds-icon-primary: #525252;
+  color: #525252;
+}
+
+.sidenav-pin-row .cds--btn--ghost:hover,
+.sidenav-pin-row .cds--btn--ghost:focus {
+  --cds-icon-primary: #161616;
+  color: #161616;
+  background-color: #f4f4f4;
+}
+
 /* Allow sidenav to scroll long menus (e.g. Admin) while hiding scrollbar */
 .cds--side-nav {
   overflow-y: auto !important;

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -7,8 +7,10 @@ import {
   UserAvatarFilledAlt,
   LocationFilled,
   Menu,
+  Pin,
+  PinFilled,
 } from "@carbon/icons-react";
-import { Select, SelectItem } from "@carbon/react";
+import { IconButton, Select, SelectItem } from "@carbon/react";
 import HelpMenu from "./HelpMenu";
 import AdminSideNav from "../admin/AdminSideNav";
 import React, { createRef, useContext, useEffect, useState } from "react";
@@ -43,6 +45,9 @@ function OEHeader({
   onChangeLanguage,
   navOpen = true,
   isDesktop = true,
+  navPinned = true,
+  navPersistent = isDesktop && navPinned,
+  toggleNavPinned,
   toggleSideNav,
   closeSideNav,
   storageKeyPrefix = "main",
@@ -244,9 +249,10 @@ function OEHeader({
     return () => window.clearTimeout(timer);
   }, []);
 
-  // Click-outside handler: close the drawer on small viewports
+  // Click-outside handler: close the drawer whenever the nav is an overlay
+  // (small viewports, or desktop with the nav unpinned)
   useEffect(() => {
-    if (isDesktop || !navOpen) return;
+    if (navPersistent || !navOpen) return;
 
     const handleClickOutside = (event) => {
       const sideNav = document.querySelector(".cds--side-nav");
@@ -266,7 +272,7 @@ function OEHeader({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [isDesktop, navOpen, closeSideNav]);
+  }, [navPersistent, navOpen, closeSideNav]);
 
   const panelSwitchIcon = () => {
     return userSessionDetails.authenticated ? (
@@ -662,7 +668,7 @@ function OEHeader({
           }}
         >
           <Header id="mainHeader" className="mainHeader" aria-label="">
-            {userSessionDetails.authenticated && !isDesktop && (
+            {userSessionDetails.authenticated && !navPersistent && (
               <button
                 id="sidenav-menu-button"
                 data-cy="menuButton"
@@ -851,11 +857,36 @@ function OEHeader({
                     navContext === "admin" ? "admin-shell-side-nav" : undefined
                   }
                   expanded={navOpen}
-                  // Desktop: always-rendered fixed nav; small viewports: overlay drawer
-                  isFixedNav={isDesktop}
-                  isPersistent={isDesktop}
+                  // Pinned desktop: always-rendered fixed nav;
+                  // unpinned desktop + small viewports: overlay drawer
+                  isFixedNav={navPersistent}
+                  isPersistent={navPersistent}
                   isChildOfHeader={true}
                 >
+                  {isDesktop && (
+                    <div className="sidenav-pin-row">
+                      <IconButton
+                        id="sidenav-pin-toggle"
+                        data-cy="sidenavPinToggle"
+                        data-testid="sidenav-pin-toggle"
+                        kind="ghost"
+                        size="sm"
+                        align="right"
+                        label={intl.formatMessage({
+                          id: navPinned
+                            ? "header.icon.menu.unpin"
+                            : "header.icon.menu.pin",
+                        })}
+                        onClick={toggleNavPinned}
+                      >
+                        {navPinned ? (
+                          <PinFilled size={16} />
+                        ) : (
+                          <Pin size={16} />
+                        )}
+                      </IconButton>
+                    </div>
+                  )}
                   {navContext === "admin" ? (
                     <AdminSideNav
                       isTrainingInstallation={isTrainingInstallation}

--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -28,6 +28,18 @@ const isAdminNavRoute = (pathname) =>
 // Must match the .content-nav-locked media query in Style.css
 const DESKTOP_MEDIA_QUERY = "(min-width: 1024px)";
 
+// User preference: whether the desktop sidenav is pinned open (pushing
+// content) or collapsed into an on-demand overlay drawer.
+const NAV_PINNED_STORAGE_KEY = "sideNavPinned";
+
+const readNavPinnedPreference = () => {
+  try {
+    return localStorage.getItem(NAV_PINNED_STORAGE_KEY) !== "false";
+  } catch {
+    return true;
+  }
+};
+
 /**
  * True when the viewport is desktop-sized.
  * On desktop the sidenav is always rendered; below it collapses into a
@@ -79,21 +91,40 @@ export default function Layout(props) {
         ? "analyzer"
         : "main";
 
-  // Nav is always rendered on desktop; below the breakpoint it's an
-  // ephemeral hamburger-opened drawer, closed on navigation.
+  // Nav on desktop: pinned (default) renders it persistently and pushes
+  // content; unpinned turns it into the same hamburger-opened overlay drawer
+  // used below the breakpoint, closed on navigation.
   const isDesktop = useIsDesktop();
+  const [navPinned, setNavPinned] = useState(readNavPinnedPreference);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const navOpen = isDesktop || drawerOpen;
+  const navPersistent = isDesktop && navPinned;
+  const navOpen = navPersistent || drawerOpen;
 
   const closeSideNav = useCallback(() => setDrawerOpen(false), []);
+
+  const toggleNavPinned = useCallback(() => {
+    setNavPinned((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(NAV_PINNED_STORAGE_KEY, String(next));
+      } catch {
+        // preference simply won't survive a reload
+      }
+      return next;
+    });
+    // Unpinning keeps the nav visible as a drawer (instead of vanishing
+    // mid-interaction); pinning hands visibility back to the persistent nav.
+    setDrawerOpen(navPinned);
+  }, [navPinned]);
 
   useEffect(() => {
     closeSideNav();
   }, [location.pathname, closeSideNav]);
 
-  // Only push content when sidenav is actually present (authenticated UX).
-  // Unauthenticated pages like /login have no sidenav to make room for.
-  const isLocked = userSessionDetails.authenticated && isDesktop;
+  // Only push content when the persistent sidenav is actually present
+  // (authenticated desktop UX with the nav pinned). Unauthenticated pages
+  // like /login have no sidenav to make room for.
+  const isLocked = userSessionDetails.authenticated && navPersistent;
 
   const addNotification = (notificationBody) => {
     setNotifications([...notifications, notificationBody]);
@@ -180,6 +211,9 @@ export default function Layout(props) {
             onChangeLanguage={props.onChangeLanguage}
             navOpen={navOpen}
             isDesktop={isDesktop}
+            navPinned={navPinned}
+            navPersistent={navPersistent}
+            toggleNavPinned={toggleNavPinned}
             toggleSideNav={() => setDrawerOpen((open) => !open)}
             closeSideNav={closeSideNav}
             storageKeyPrefix={storageKeyPrefix}

--- a/frontend/src/components/layout/Layout.test.jsx
+++ b/frontend/src/components/layout/Layout.test.jsx
@@ -473,6 +473,99 @@ describe("Layout", () => {
     });
   });
 
+  describe("sidenav pin preference", () => {
+    /**
+     * The desktop nav is pinned by default (persistent, pushing content), but
+     * the pin toggle at the top of the sidenav lets the user unpin it into an
+     * on-demand overlay drawer. The preference persists via localStorage.
+     */
+    test("testLayout_Desktop_PinToggleRendered", () => {
+      renderWithProviders(
+        <Layout>
+          <div>Content</div>
+        </Layout>,
+      );
+
+      expect(screen.getByTestId("sidenav-pin-toggle")).toBeInTheDocument();
+    });
+
+    test("testLayout_SmallViewport_NoPinToggle", () => {
+      viewportIsDesktop = false;
+
+      renderWithProviders(
+        <Layout>
+          <div>Content</div>
+        </Layout>,
+      );
+
+      expect(screen.queryByTestId("sidenav-pin-toggle")).toBeNull();
+    });
+
+    test("testLayout_Desktop_UnpinConvertsNavToOverlayDrawer", () => {
+      const { container } = renderWithProviders(
+        <Layout>
+          <div>Content</div>
+        </Layout>,
+      );
+
+      fireEvent.click(screen.getByTestId("sidenav-pin-toggle"));
+
+      // Nav stays visible mid-interaction, but as an overlay drawer:
+      // content is no longer pushed and the hamburger appears.
+      const sideNav = container.querySelector(".cds--side-nav");
+      expect(sideNav).toHaveClass("cds--side-nav--expanded");
+      expect(sideNav).toHaveClass("cds--side-nav--hidden");
+      expect(screen.getByTestId("content-wrapper")).not.toHaveClass(
+        "content-nav-locked",
+      );
+      expect(container.querySelector("#sidenav-menu-button")).not.toBeNull();
+      expect(window.localStorage.getItem("sideNavPinned")).toBe("false");
+    });
+
+    test("testLayout_Desktop_UnpinnedPreferenceRestoredOnLoad", () => {
+      window.localStorage.setItem("sideNavPinned", "false");
+
+      const { container } = renderWithProviders(
+        <Layout>
+          <div>Content</div>
+        </Layout>,
+      );
+
+      // Unpinned desktop behaves like the small-viewport drawer
+      const sideNav = container.querySelector(".cds--side-nav");
+      expect(sideNav).not.toHaveClass("cds--side-nav--expanded");
+      expect(screen.getByTestId("content-wrapper")).not.toHaveClass(
+        "content-nav-locked",
+      );
+
+      fireEvent.click(container.querySelector("#sidenav-menu-button"));
+      expect(container.querySelector(".cds--side-nav")).toHaveClass(
+        "cds--side-nav--expanded",
+      );
+    });
+
+    test("testLayout_Desktop_RepinRestoresPersistentNav", () => {
+      window.localStorage.setItem("sideNavPinned", "false");
+
+      const { container } = renderWithProviders(
+        <Layout>
+          <div>Content</div>
+        </Layout>,
+      );
+
+      fireEvent.click(screen.getByTestId("sidenav-pin-toggle"));
+
+      const sideNav = container.querySelector(".cds--side-nav");
+      expect(sideNav).toHaveClass("cds--side-nav--expanded");
+      expect(sideNav).not.toHaveClass("cds--side-nav--hidden");
+      expect(screen.getByTestId("content-wrapper")).toHaveClass(
+        "content-nav-locked",
+      );
+      expect(container.querySelector("#sidenav-menu-button")).toBeNull();
+      expect(window.localStorage.getItem("sideNavPinned")).toBe("true");
+    });
+  });
+
   describe("onChangeLanguage wiring", () => {
     /**
      * Test: onChangeLanguage prop is accepted by Layout

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -2537,6 +2537,7 @@
   "header.icon.menu.close": "Close menu",
   "header.icon.menu.open": "Open menu",
   "header.icon.menu.pin": "Pin menu",
+  "header.icon.menu.unpin": "Unpin menu",
   "header.icon.notifications": "Notifications",
   "header.icon.search": "Search",
   "header.icon.user": "User",


### PR DESCRIPTION
## Summary

#3879's responsive sidenav rework made the desktop nav unconditionally persistent, dropping the previous ability to control whether the main nav sticks or not. This restores that control as a **pin/unpin icon at the top of the sidenav**, layered on top of the responsive improvements (which are fully preserved).

## Behavior

- **Pin toggle (desktop ≥1024px only):** `PinFilled`/`Pin` icon button at the top of the menu, with "Pin menu"/"Unpin menu" tooltips.
- **Pinned (default):** exactly the current behavior — persistent fixed nav, content pushed (`content-nav-locked`). Nothing changes for anyone until they choose to unpin.
- **Unpinned:** the desktop nav becomes the same hamburger-opened overlay drawer used on small viewports — hamburger appears in the header, drawer closes on navigation/outside-click, content gets the full width. Unpinning keeps the nav open as a drawer so it doesn't vanish mid-interaction.
- **Preference persists** across sessions via `localStorage` (`sideNavPinned`).
- **Small viewports unchanged:** no pin control below the breakpoint; the drawer behavior from #3879 is untouched.

## Implementation

- `Layout.jsx` — `navPinned` state + localStorage persistence; `navPersistent = isDesktop && navPinned` now drives content locking.
- `Header.jsx` — hamburger visibility, click-outside close, and `SideNav` `isFixedNav`/`isPersistent` keyed on `navPersistent` instead of `isDesktop`; pin `IconButton` rendered inside the SideNav (desktop only).
- `en.json` — added `header.icon.menu.unpin` (the `pin` key already existed).
- `Style.css` — `.sidenav-pin-row` alignment.

## Testing

- 5 new tests in `Layout.test.jsx`: toggle rendered on desktop / absent on small viewports, unpin → overlay drawer + unlocked content + hamburger + persisted preference, preference restored on load, re-pin restores the persistent nav.
- Full frontend suite: 122 files, 803 tests passing. `npm run format` clean.

Regression introduced by #3879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)