### PR TITLE
fix: spotless formatting failure on develop (code-qa submodule + md fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,102 +1,160 @@
 # Changelog
 
-Human-readable release notes for OpenELIS Global, written for three audiences: decision-makers, implementers & admins, and lab users. This file is generated from the OpenELIS features inventory (do not hand-edit).
+Human-readable release notes for OpenELIS Global, written for three audiences:
+decision-makers, implementers & admins, and lab users. This file is generated
+from the OpenELIS features inventory (do not hand-edit).
 
-See also: the live product roadmap (https://uwdigi.atlassian.net/wiki/spaces/oeg/pages/640319495), the per-audience release-notes page (https://uwdigi.atlassian.net/wiki/spaces/oeg/pages/1412136974), and earlier releases v3.0/v2.7/v2.6 (https://uwdigi.atlassian.net/wiki/spaces/OG/pages/645005332).
+See also: the live product roadmap
+(https://uwdigi.atlassian.net/wiki/spaces/oeg/pages/640319495), the per-audience
+release-notes page
+(https://uwdigi.atlassian.net/wiki/spaces/oeg/pages/1412136974), and earlier
+releases v3.0/v2.7/v2.6
+(https://uwdigi.atlassian.net/wiki/spaces/OG/pages/645005332).
 
 ## v3.2 (beta stream — 3.2.1.x, pilot / UAT)
 
-
 ## 3.2.1.10
+
 ### For decision-makers
-- Full two-way instrument integration reduces manual order entry at the bench. (OGC-773) — *Outbound order dispatch*
+
+- Full two-way instrument integration reduces manual order entry at the bench.
+  (OGC-773) — _Outbound order dispatch_
 
 ### For implementers & admins
-- New live log screen and logging configuration, including under SSO login. — *System monitoring & logs*
-- Bidirectional ASTM/HL7 order dispatch via the analyzer bridge. (OGC-773) — *Outbound order dispatch*
+
+- New live log screen and logging configuration, including under SSO login. —
+  _System monitoring & logs_
+- Bidirectional ASTM/HL7 order dispatch via the analyzer bridge. (OGC-773) —
+  _Outbound order dispatch_
 
 ### For lab users
-- Orders can now be sent to instruments automatically, not just received. (OGC-773) — *Outbound order dispatch*
 
+- Orders can now be sent to instruments automatically, not just received.
+  (OGC-773) — _Outbound order dispatch_
 
 ## 3.2.1.9
+
 ### For decision-makers
-- Operational visibility into data exchange reliability. — *Automatic result sharing (FHIR)*
+
+- Operational visibility into data exchange reliability. — _Automatic result
+  sharing (FHIR)_
 
 ### For implementers & admins
-- See and act on FHIR data-export retry health from admin. — *Automatic result sharing (FHIR)*
-- Filter and manage test notifications more easily. — *Test notifications & SMS gateways*
 
+- See and act on FHIR data-export retry health from admin. — _Automatic result
+  sharing (FHIR)_
+- Filter and manage test notifications more easily. — _Test notifications & SMS
+  gateways_
 
 ## 3.2.1.8
-### For lab users
-- Patient identifiers now show in the modify-order header. — *Patient & order enhancements*
-- Entered date/time now persists on result entry. — *Results entry*
 
+### For lab users
+
+- Patient identifiers now show in the modify-order header. — _Patient & order
+  enhancements_
+- Entered date/time now persists on result entry. — _Results entry_
 
 ## 3.2.1.7
+
 ### For decision-makers
-- Supports consent-tracking compliance for patient testing. (OGC-557, OGC-558) — *Informed consent capture*
-- Stronger quality control supports accreditation readiness. (OGC-41) — *Westgard QC rules & dashboard*
-- Modernized, faster UI foundation. — *Modernized user interface*
+
+- Supports consent-tracking compliance for patient testing. (OGC-557, OGC-558) —
+  _Informed consent capture_
+- Stronger quality control supports accreditation readiness. (OGC-41) —
+  _Westgard QC rules & dashboard_
+- Modernized, faster UI foundation. — _Modernized user interface_
 
 ### For implementers & admins
-- Manual consent recording fields configurable on patient orders. (OGC-557, OGC-558) — *Informed consent capture*
-- FHIR-based QC pipeline with automated rule evaluation. (OGC-41) — *Westgard QC rules & dashboard*
-- Create file-based analyzers from profiles with two-way bridge sync. — *Analyzer file import*
-- Breaking change to query translation — review analyzer query configuration on upgrade. **[breaking]** (OGC-346) — *Analyzer integration framework*
+
+- Manual consent recording fields configurable on patient orders. (OGC-557,
+  OGC-558) — _Informed consent capture_
+- FHIR-based QC pipeline with automated rule evaluation. (OGC-41) — _Westgard QC
+  rules & dashboard_
+- Create file-based analyzers from profiles with two-way bridge sync. —
+  _Analyzer file import_
+- Breaking change to query translation — review analyzer query configuration on
+  upgrade. **[breaking]** (OGC-346) — _Analyzer integration framework_
 
 ### For lab users
-- Record patient informed consent against an order. (OGC-557, OGC-558) — *Informed consent capture*
-- QC results are evaluated automatically against Westgard rules. (OGC-41) — *Westgard QC rules & dashboard*
-- Cleaner, faster storage screens. — *Sample storage management*
 
+- Record patient informed consent against an order. (OGC-557, OGC-558) —
+  _Informed consent capture_
+- QC results are evaluated automatically against Westgard rules. (OGC-41) —
+  _Westgard QC rules & dashboard_
+- Cleaner, faster storage screens. — _Sample storage management_
 
 ## 3.2.1.6
-### For lab users
-- Attach patient ID documents to records. — *Patient & order enhancements*
 
+### For lab users
+
+- Attach patient ID documents to records. — _Patient & order enhancements_
 
 ## 3.2.1.5
+
 ### For decision-makers
-- Chain-of-custody for sample referral networks. (OGC-62) — *Sample shipment & referral*
-- Audit trail supports accreditation and data integrity. — *System-level audit trail*
-- 21 CFR Part 11-aligned electronic signatures. — *Electronic signatures*
-- Structured CAPA supports quality management. — *Non-conforming events (NCE) & CAPA*
-- Security hardening across the REST API. **[security]** (OGC-150) — *Strengthened data security*
-- TAT monitoring surfaces lab performance. (OGC-306, OGC-307) — *Turnaround time report & dashboard*
-- Expanded FHIR R4 surface for interoperability. — *FHIR R4 API*
-- Supports multilingual deployments. (OGC-349) — *Standardized terminology*
-- Broader instrument coverage. (OGC-344, OGC-417, OGC-418) — *Analyzer file import*
+
+- Chain-of-custody for sample referral networks. (OGC-62) — _Sample shipment &
+  referral_
+- Audit trail supports accreditation and data integrity. — _System-level audit
+  trail_
+- 21 CFR Part 11-aligned electronic signatures. — _Electronic signatures_
+- Structured CAPA supports quality management. — _Non-conforming events (NCE) &
+  CAPA_
+- Security hardening across the REST API. **[security]** (OGC-150) —
+  _Strengthened data security_
+- TAT monitoring surfaces lab performance. (OGC-306, OGC-307) — _Turnaround time
+  report & dashboard_
+- Expanded FHIR R4 surface for interoperability. — _FHIR R4 API_
+- Supports multilingual deployments. (OGC-349) — _Standardized terminology_
+- Broader instrument coverage. (OGC-344, OGC-417, OGC-418) — _Analyzer file
+  import_
 
 ### For implementers & admins
-- System-wide audit trail of configuration and data changes. — *System-level audit trail*
-- Project-wide CSRF and REST @PreAuthorize hardening — re-test custom integrations. **[security]** (OGC-150) — *Strengthened data security*
-- Metadata can be translated into any language. (OGC-349) — *Standardized terminology*
-- Added flat-file import for additional instruments. (OGC-344, OGC-417, OGC-418) — *Analyzer file import*
+
+- System-wide audit trail of configuration and data changes. — _System-level
+  audit trail_
+- Project-wide CSRF and REST @PreAuthorize hardening — re-test custom
+  integrations. **[security]** (OGC-150) — _Strengthened data security_
+- Metadata can be translated into any language. (OGC-349) — _Standardized
+  terminology_
+- Added flat-file import for additional instruments. (OGC-344, OGC-417, OGC-418)
+  — _Analyzer file import_
 
 ### For lab users
-- Create electronic shipment manifests for referred samples. (OGC-62) — *Sample shipment & referral*
-- Sign results and reports electronically. — *Electronic signatures*
-- Track non-conforming events with history and assignment. — *Non-conforming events (NCE) & CAPA*
-- Monitor turnaround times; manage the lab calendar. (OGC-306, OGC-307) — *Turnaround time report & dashboard*
-- Order entry and sample collection are now separate steps. (OGC-356) — *Order & sample entry*
 
+- Create electronic shipment manifests for referred samples. (OGC-62) — _Sample
+  shipment & referral_
+- Sign results and reports electronically. — _Electronic signatures_
+- Track non-conforming events with history and assignment. — _Non-conforming
+  events (NCE) & CAPA_
+- Monitor turnaround times; manage the lab calendar. (OGC-306, OGC-307) —
+  _Turnaround time report & dashboard_
+- Order entry and sample collection are now separate steps. (OGC-356) — _Order &
+  sample entry_
 
 ## 3.2.1.4
+
 ### For decision-makers
-- Connect instruments without custom code. (OGC-325, OGC-492) — *Analyzer integration framework*
-- Validated TB/HIV/COVID instrument support. (OGC-335) — *Validated instrument library*
-- Patient/provider SMS notifications in more regions. — *Test notifications & SMS gateways*
-- Brings EQA into the LIS for accreditation. — *EQA / proficiency testing*
-- Foundation for flexible, self-service reporting. — *Custom data export*
+
+- Connect instruments without custom code. (OGC-325, OGC-492) — _Analyzer
+  integration framework_
+- Validated TB/HIV/COVID instrument support. (OGC-335) — _Validated instrument
+  library_
+- Patient/provider SMS notifications in more regions. — _Test notifications &
+  SMS gateways_
+- Brings EQA into the LIS for accreditation. — _EQA / proficiency testing_
+- Foundation for flexible, self-service reporting. — _Custom data export_
 
 ### For implementers & admins
-- Generic, bridge-mandatory analyzer framework with per-analyzer mappings. (OGC-325, OGC-492) — *Analyzer integration framework*
-- Cepheid GeneXpert ASTM adapter. (OGC-335) — *Validated instrument library*
-- Configure Twilio or Africa's Talking for SMS. — *Test notifications & SMS gateways*
+
+- Generic, bridge-mandatory analyzer framework with per-analyzer mappings.
+  (OGC-325, OGC-492) — _Analyzer integration framework_
+- Cepheid GeneXpert ASTM adapter. (OGC-335) — _Validated instrument library_
+- Configure Twilio or Africa's Talking for SMS. — _Test notifications & SMS
+  gateways_
 
 ### For lab users
-- Control how many barcode labels print. (OGC-284) — *Barcode label management*
-- Begin managing proficiency-testing events in OpenELIS. — *EQA / proficiency testing*
 
+- Control how many barcode labels print. (OGC-284) — _Barcode label management_
+- Begin managing proficiency-testing events in OpenELIS. — _EQA / proficiency
+  testing_

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,11 +1,16 @@
 # Security Documentation
 
-This section collects the security-related guidance for OpenELIS Global 2 in one place so that administrators, developers, and reviewers can find the right reference quickly.
+This section collects the security-related guidance for OpenELIS Global 2 in one
+place so that administrators, developers, and reviewers can find the right
+reference quickly.
 
 ## Primary references
 
-- [Security policy](https://github.com/DIGI-UW/OpenELIS-Global-2/blob/develop/SECURITY.md) - vulnerability reporting process, supported versions, and disclosure expectations.
-- [Module authentication interceptor fail-closed rollout](module-auth-interceptor-fail-closed-rollout.md) - implementation notes and rollout plan for hardening authentication behavior.
+- [Security policy](https://github.com/DIGI-UW/OpenELIS-Global-2/blob/develop/SECURITY.md) -
+  vulnerability reporting process, supported versions, and disclosure
+  expectations.
+- [Module authentication interceptor fail-closed rollout](module-auth-interceptor-fail-closed-rollout.md) -
+  implementation notes and rollout plan for hardening authentication behavior.
 
 ## When to use this section
 
@@ -13,4 +18,5 @@ This section collects the security-related guidance for OpenELIS Global 2 in one
 - Review hardening work that affects authentication and authorization behavior.
 - Find security-related documentation without searching across the repository.
 
-For broader project documentation, return to the [documentation home](../index.md).
+For broader project documentation, return to the
+[documentation home](../index.md).

--- a/pom.xml
+++ b/pom.xml
@@ -952,6 +952,7 @@
                                 <exclude>tools/Liquibase-Outdated/**</exclude>
                                 <exclude>tools/openelis-analyzer-bridge/**</exclude>
                                 <exclude>tools/analyzer-mock-server/**</exclude>
+                                <exclude>tools/code-qa/**</exclude>
                                 <exclude>dataexport/**</exclude>
                                 <exclude>plugins/**</exclude>
                             </excludes>
@@ -972,6 +973,7 @@
                                 <exclude>tools/Liquibase-Outdated/**</exclude>
                                 <exclude>tools/openelis-analyzer-bridge/**</exclude>
                                 <exclude>tools/analyzer-mock-server/**</exclude>
+                                <exclude>tools/code-qa/**</exclude>
                                 <exclude>dataexport/**</exclude>
                                 <exclude>plugins/**</exclude>
                                 <exclude>frontend/**</exclude>


### PR DESCRIPTION
## Summary
- Fixes the failing `check formatting` step on `develop` (run 30388975295).
- Excludes the newly wired `tools/code-qa` submodule from both spotless format blocks in `pom.xml`, matching how the other submodules are excluded — its markdown files were being prettier-checked by the parent repo in CI, where submodules are initialized.
- Applies pending prettier fixes to `CHANGELOG.md` and `docs/security/index.md`.

## Test plan
- `rm -rf target/spotless-* && mvn spotless:check` passes on a cold cache locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)