### PR TITLE
Update AlertAcknowledgedEvent.java

### DIFF
--- a/src/main/java/org/openelisglobal/alert/event/AlertAcknowledgedEvent.java
+++ b/src/main/java/org/openelisglobal/alert/event/AlertAcknowledgedEvent.java
@@ -7,14 +7,43 @@ import org.springframework.context.ApplicationEvent;
 
 @Getter
 public class AlertAcknowledgedEvent extends ApplicationEvent {
+
     private final Alert alert;
+
+    // Convenience field so listeners don't have to inspect the Alert object
+    private final String alertId;
+
+    // User who acknowledged the alert
     private final Long acknowledgedByUserId;
+
+    // When the acknowledgement occurred
     private final OffsetDateTime acknowledgedAt;
 
-    public AlertAcknowledgedEvent(Object source, Alert alert, Long acknowledgedByUserId) {
+    // Optional reason supplied by the user
+    private final String acknowledgementReason;
+
+    // Previous and current status for auditing
+    private final String previousStatus;
+    private final String currentStatus;
+
+    public AlertAcknowledgedEvent(
+            Object source,
+            Alert alert,
+            Long acknowledgedByUserId,
+            String acknowledgementReason,
+            String previousStatus,
+            String currentStatus,
+            OffsetDateTime acknowledgedAt) {
+
         super(source);
+
         this.alert = alert;
+        this.alertId = alert != null ? String.valueOf(alert.getId()) : null;
         this.acknowledgedByUserId = acknowledgedByUserId;
-        this.acknowledgedAt = OffsetDateTime.now();
+        this.acknowledgementReason = acknowledgementReason;
+        this.previousStatus = previousStatus;
+        this.currentStatus = currentStatus;
+        this.acknowledgedAt =
+                acknowledgedAt != null ? acknowledgedAt : OffsetDateTime.now();
     }
 }


### PR DESCRIPTION
# Enhance `AlertAcknowledgedEvent` with Additional Audit Metadata

## Description

The current `AlertAcknowledgedEvent` only contains the acknowledged `Alert`, the user ID of the acknowledger, and the acknowledgement timestamp. While this is sufficient for basic event publishing, downstream consumers (such as audit logging, notifications, and analytics) may require additional contextual information without needing to query the database.

Enhancing the event payload will make it more useful for future integrations and reduce coupling between event publishers and listeners.

## Proposed Changes

Add the following optional fields to `AlertAcknowledgedEvent`:

* `alertId` – Provides direct access to the alert identifier.
* `acknowledgementReason` – Stores the reason provided when acknowledging an alert (if applicable).
* `previousStatus` – Represents the alert status before acknowledgement.
* `currentStatus` – Represents the alert status after acknowledgement.
* Allow `acknowledgedAt` to be passed through the constructor while defaulting to `OffsetDateTime.now()` if not provided.

## Benefits

* Improves audit logging capabilities.
* Provides richer context for event listeners.
* Reduces the need for additional database lookups.
* Makes the event more extensible for future notification and reporting features.
* Improves testability by allowing a configurable acknowledgement timestamp.

## Acceptance Criteria

* [ ] Add the proposed fields to `AlertAcknowledgedEvent`.
* [ ] Maintain backward compatibility where possible.
* [ ] Update constructors and any event publishers accordingly.
* [ ] Update or add unit tests covering the new fields.
* [ ] Ensure existing event listeners continue to function correctly.

## Additional Notes

The new fields should be optional where appropriate to avoid breaking existing implementations. If the project already has conventions for event payloads, the implementation should follow those conventions.

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

