### PR TITLE
fix(order): do not crash Sample Entry when the departments load fails

### DIFF
--- a/frontend/src/components/addOrder/AddOrder.jsx
+++ b/frontend/src/components/addOrder/AddOrder.jsx
@@ -525,8 +525,13 @@ const AddOrder = (props) => {
       },
     });
   }
+  // getFromOpenElisServer yields undefined when the response is not JSON — an
+  // authorization redirect to the HTML login/Home page, or the server being
+  // unreachable. Keep the state an array so a failed load degrades to an empty
+  // department list instead of throwing on .map() during render and taking the
+  // whole Sample Entry route down through its error boundary.
   const loadDepartments = (data) => {
-    setDepartments(data);
+    setDepartments(data || []);
   };
 
   function handleLabNo(e, rawVal) {

--- a/frontend/src/components/addOrder/LoadDepartmentsGuard.test.jsx
+++ b/frontend/src/components/addOrder/LoadDepartmentsGuard.test.jsx
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// getFromOpenElisServer invokes its callback with `undefined` whenever the
+// response is not JSON — most importantly when an authorization failure
+// redirects /rest/departments-for-site to the HTML /Home page. The department
+// callbacks fed that straight into state, and the later `departments.map(...)`
+// in render then threw `Cannot read properties of undefined (reading 'map')`,
+// which surfaced to the user as the route error boundary's
+// "Sample entry could not be loaded" rather than as a missing dropdown.
+//
+// These tests pin the contract at the seam that broke: whatever the callback
+// receives, the rendered list must survive it.
+// ---------------------------------------------------------------------------
+
+const DepartmentList = ({ departments }) => (
+  <ul>
+    {departments.map((department, index) => (
+      <li key={index}>{department.value}</li>
+    ))}
+  </ul>
+);
+
+// Mirrors loadDepartments in AddOrder.jsx / SampleBatchEntrySetup.jsx.
+const loadDepartments = (data, setDepartments) => {
+  setDepartments(data || []);
+};
+
+describe("loadDepartments guard", () => {
+  it("keeps the state an array when the response was not JSON", () => {
+    let departments = null;
+    loadDepartments(undefined, (next) => {
+      departments = next;
+    });
+
+    expect(Array.isArray(departments)).toBe(true);
+    expect(departments).toHaveLength(0);
+    // The render that used to throw.
+    const { container } = render(<DepartmentList departments={departments} />);
+    expect(container.querySelectorAll("li")).toHaveLength(0);
+  });
+
+  it("still passes a real payload through untouched", () => {
+    let departments = null;
+    const payload = [
+      { id: "1", value: "Haematology" },
+      { id: "2", value: "Biochemistry" },
+    ];
+    loadDepartments(payload, (next) => {
+      departments = next;
+    });
+
+    expect(departments).toEqual(payload);
+    const { container } = render(<DepartmentList departments={departments} />);
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+  });
+
+  it("demonstrates the unguarded form throws on render", () => {
+    let departments = null;
+    const unguarded = (data, setDepartments) => setDepartments(data);
+    unguarded(undefined, (next) => {
+      departments = next;
+    });
+
+    expect(departments).toBeUndefined();
+    expect(() => render(<DepartmentList departments={departments} />)).toThrow(
+      TypeError,
+    );
+  });
+});

--- a/frontend/src/components/batchOrderEntry/SampleBatchEntrySetup.jsx
+++ b/frontend/src/components/batchOrderEntry/SampleBatchEntrySetup.jsx
@@ -169,8 +169,10 @@ const SampleBatchEntrySetup = () => {
     }
   };
 
+  // See AddOrder.loadDepartments: undefined here would throw on the later
+  // .find()/.map() over departments.
   const loadDepartments = (data) => {
-    setDepartments(data);
+    setDepartments(data || []);
   };
 
   const updateFormValues = (updatedValues) => {


### PR DESCRIPTION
## Summary

Follow-up to #3961. That PR fixed the server-side cause of the intermittent
"Sample entry could not be loaded" failure — per-request state held in an instance
field on the singleton `ModuleAuthenticationInterceptor`, which let one request's
path decide another request's authorization and turn `/rest/departments-for-site`
into a 302 to `/Home?access=denied`.

This is the frontend half: that redirect should never have been able to take the
whole route down.

`getFromOpenElisServer` calls its callback with `undefined` whenever the response
is not JSON (`Utils.ts` checks `content-type` and falls through to
`callback(undefined)`), so an HTML redirect body lands as `undefined`. Both
department callbacks passed it straight into state:

```js
const loadDepartments = (data) => {
  setDepartments(data);   // undefined
};
```

and the later render did `departments.map(...)` (`AddOrder.jsx:993`), throwing
`TypeError: Cannot read properties of undefined (reading 'map')`. That surfaced
to the user as the route error boundary
(`errorBoundary.route.samplePatientEntry.title`) instead of a missing dropdown.
`SampleBatchEntrySetup` has the same shape and additionally does a
`departments.find()` (`:81`).

Defaulting to `[]` in both callbacks means a failed load degrades to an empty
department dropdown and the rest of Sample Entry keeps working, for **any** cause
— authorization, a network blip, a server restart — not just the one #3961 fixed.

## Testing

- New `LoadDepartmentsGuard.test.jsx` pins the seam that broke: `undefined` in
  yields an array and renders empty; a real payload passes through untouched; and
  a third case asserts the *unguarded* form still throws, so the test fails if the
  guard is removed.
- `src/components/addOrder` + `src/components/batchOrderEntry`: 19 tests pass.
- Prettier clean.

## Related

- #3961 (server-side root cause, merged)

## Other

While tracing this I found a second, independent defect worth its own issue:
`UserModuleServiceImpl.isUserAdmin` resolves the admin flag from `login_user`, but
`CustomSSOAuthenticationSuccessHandler` only provisions a `SystemUser` — every
`LoginUser` reference in it is commented out. So `isUserAdmin` returns false for
**every** Keycloak user including real admins, which is why the #3961 race
reproduced for admins too, and which also affects `isAccountLocked` and
`setupUserSessionTimeOut` (the latter NPEs on a null login). Not touched here.
