### PR TITLE
fix(dev): use nginx 1.27 for the dev proxy so it runs on arm64

### DIFF
--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -132,7 +132,11 @@ services:
         tty: true
 
     proxy:
-        image: nginx:1.15-alpine
+        # nginx 1.15 (2018) predates arm64 alpine builds that run on Apple Silicon:
+        # its worker dies with SIGILL (illegal instruction) on every request, so the
+        # whole app is unreachable through the proxy on an arm64 host. 1.27-alpine is
+        # already used by projects/analyzer-harness/docker-compose.dev.yml.
+        image: nginx:1.27-alpine
         # build:
         #     context: ./nginx-proxy
         #     dockerfile: Dockerfile


### PR DESCRIPTION
One-line dev-compose fix.

`nginx:1.15-alpine` (2018) dies with **SIGILL** on Apple Silicon — the worker exits on every request, so `https://localhost` is unreachable and the app is only usable by hitting Tomcat directly on `:8443`. It also blocks Playwright, whose `baseURL` is the proxy.

Bumped to `nginx:1.27-alpine`, already used by `projects/analyzer-harness/docker-compose.dev.yml`. The proxy config needs nothing newer — it declares `ssl_protocols TLSv1.2 TLSv1.3` and has no `listen … http2` directive, so the 1.25+ http2 deprecation does not apply. Dev compose only; no production compose references this image.

**Verified on an arm64 host.** Before: `GET /` through the proxy failed to connect, log showed `worker process exited on signal 4`. After: `/` and `/api/OpenELIS-Global/LoginPage` both **200**, zero crashes.