### PR TITLE
fix: free-text catalog options break every dictionary-id consumer (500 on calculatedValue master list)

### DIFF
--- a/src/main/java/org/openelisglobal/dictionary/daoimpl/DictionaryDAOImpl.java
+++ b/src/main/java/org/openelisglobal/dictionary/daoimpl/DictionaryDAOImpl.java
@@ -249,10 +249,10 @@ public class DictionaryDAOImpl extends BaseDAOImpl<Dictionary, String> implement
     }
 
     /**
-     * The id column is numeric, so a non-numeric id can never match a row. Malformed
-     * callers pass raw result text here (e.g. a legacy free-text select-list
-     * option); that is treated as not-found instead of letting the id parse blow up
-     * the whole request.
+     * The id column is numeric, so a non-numeric id can never match a row.
+     * Malformed callers pass raw result text here (e.g. a legacy free-text
+     * select-list option); that is treated as not-found instead of letting the id
+     * parse blow up the whole request.
      */
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/org/openelisglobal/dictionary/daoimpl/DictionaryDAOImpl.java
+++ b/src/main/java/org/openelisglobal/dictionary/daoimpl/DictionaryDAOImpl.java
@@ -18,6 +18,7 @@ package org.openelisglobal.dictionary.daoimpl;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
@@ -247,9 +248,20 @@ public class DictionaryDAOImpl extends BaseDAOImpl<Dictionary, String> implement
         }
     }
 
+    /**
+     * The id column is numeric, so a non-numeric id can never match a row. Malformed
+     * callers pass raw result text here (e.g. a legacy free-text select-list
+     * option); that is treated as not-found instead of letting the id parse blow up
+     * the whole request.
+     */
     @Override
     @Transactional(readOnly = true)
     public Dictionary getDictionaryById(String dictionaryId) throws LIMSRuntimeException {
+        if (dictionaryId == null || !StringUtils.isNumeric(dictionaryId.trim())) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "getDictionaryById",
+                    "non-numeric dictionary id ignored: " + dictionaryId);
+            return null;
+        }
         try {
             return entityManager.unwrap(Session.class).get(Dictionary.class, dictionaryId);
         } catch (RuntimeException e) {

--- a/src/main/java/org/openelisglobal/testresult/service/TestResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/testresult/service/TestResultServiceImpl.java
@@ -13,6 +13,7 @@ import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.service.AuditableBaseObjectServiceImpl;
 import org.openelisglobal.dictionary.service.DictionaryService;
 import org.openelisglobal.dictionary.valueholder.Dictionary;
+import org.openelisglobal.dictionarycategory.service.DictionaryCategoryService;
 import org.openelisglobal.test.valueholder.Test;
 import org.openelisglobal.testanalyte.valueholder.TestAnalyte;
 import org.openelisglobal.testresult.dao.TestResultDAO;
@@ -25,11 +26,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TestResultServiceImpl extends AuditableBaseObjectServiceImpl<TestResult, String>
         implements TestResultService {
+
+    /**
+     * Dictionary category that result select-list options belong to — the same one
+     * the legacy select-list admin page assigns (see
+     * ResultSelectListServiceImpl.addResultSelectList) and that DisplayListService
+     * builds the "Test Result" display list from.
+     */
+    public static final String RESULT_OPTION_DICTIONARY_CATEGORY = "Test Result";
+
     @Autowired
     protected TestResultDAO baseObjectDAO;
 
     @Autowired
     private DictionaryService dictionaryService;
+
+    @Autowired
+    private DictionaryCategoryService dictionaryCategoryService;
 
     TestResultServiceImpl() {
         super(TestResult.class);
@@ -131,10 +144,11 @@ public class TestResultServiceImpl extends AuditableBaseObjectServiceImpl<TestRe
      * Dictionary-variant option rows must hold a numeric dictionary id in VALUE —
      * every consumer resolves it via {@code getDictionaryById}. A free-text option
      * typed in the Test Catalog Editor (FR-83) arrives here as raw text, so it is
-     * materialized into the dictionary master list (reusing an active entry with
-     * the same name if one exists) and the row repointed at the entry's id. A
-     * numeric value that already resolves to an entry is kept as-is; a numeric
-     * value that resolves to nothing is treated as free text too.
+     * materialized into the dictionary master list under the "Test Result" category
+     * (reusing an active entry with the same name if one exists) and the row
+     * repointed at the entry's id. A numeric value that already resolves to an
+     * entry is kept as-is; a numeric value that resolves to nothing is treated as
+     * free text too.
      */
     private void resolveDictionaryValue(TestResult option, String sysUserId) {
         if (!TypeOfTestResultServiceImpl.ResultType.isDictionaryVariant(option.getTestResultType())) {
@@ -159,6 +173,9 @@ public class TestResultServiceImpl extends AuditableBaseObjectServiceImpl<TestRe
         Dictionary dictionary = new Dictionary();
         dictionary.setDictEntry(value);
         dictionary.setIsActive(IActionConstants.YES);
+        dictionary.setSortOrder(1);
+        dictionary.setDictionaryCategory(
+                dictionaryCategoryService.getDictionaryCategoryByName(RESULT_OPTION_DICTIONARY_CATEGORY));
         dictionary.setSysUserId(sysUserId);
         option.setValue(dictionaryService.insert(dictionary));
     }

--- a/src/main/java/org/openelisglobal/testresult/service/TestResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/testresult/service/TestResultServiceImpl.java
@@ -8,7 +8,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.service.AuditableBaseObjectServiceImpl;
+import org.openelisglobal.dictionary.service.DictionaryService;
+import org.openelisglobal.dictionary.valueholder.Dictionary;
 import org.openelisglobal.test.valueholder.Test;
 import org.openelisglobal.testanalyte.valueholder.TestAnalyte;
 import org.openelisglobal.testresult.dao.TestResultDAO;
@@ -23,6 +27,9 @@ public class TestResultServiceImpl extends AuditableBaseObjectServiceImpl<TestRe
         implements TestResultService {
     @Autowired
     protected TestResultDAO baseObjectDAO;
+
+    @Autowired
+    private DictionaryService dictionaryService;
 
     TestResultServiceImpl() {
         super(TestResult.class);
@@ -91,6 +98,7 @@ public class TestResultServiceImpl extends AuditableBaseObjectServiceImpl<TestRe
         }
         Set<String> keptIds = new HashSet<>();
         for (TestResult d : desired) {
+            resolveDictionaryValue(d, sysUserId);
             TestResult match = d.getId() == null ? null : existingById.get(d.getId());
             if (match != null) {
                 match.setValue(d.getValue());
@@ -117,6 +125,42 @@ public class TestResultServiceImpl extends AuditableBaseObjectServiceImpl<TestRe
             }
         }
         return getActiveOptionsByComponentId(componentId);
+    }
+
+    /**
+     * Dictionary-variant option rows must hold a numeric dictionary id in VALUE —
+     * every consumer resolves it via {@code getDictionaryById}. A free-text option
+     * typed in the Test Catalog Editor (FR-83) arrives here as raw text, so it is
+     * materialized into the dictionary master list (reusing an active entry with
+     * the same name if one exists) and the row repointed at the entry's id. A
+     * numeric value that already resolves to an entry is kept as-is; a numeric
+     * value that resolves to nothing is treated as free text too.
+     */
+    private void resolveDictionaryValue(TestResult option, String sysUserId) {
+        if (!TypeOfTestResultServiceImpl.ResultType.isDictionaryVariant(option.getTestResultType())) {
+            return;
+        }
+        String value = option.getValue() == null ? "" : option.getValue().trim();
+        if (value.isEmpty()) {
+            return;
+        }
+        if (StringUtils.isNumeric(value) && dictionaryService.getDictionaryById(value) != null) {
+            return;
+        }
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("dictEntry", value);
+        properties.put("isActive", IActionConstants.YES);
+        List<Dictionary> matches = dictionaryService.getAllMatching(properties);
+        if (!matches.isEmpty()) {
+            matches.sort(Comparator.comparingInt(d -> Integer.parseInt(d.getId())));
+            option.setValue(matches.get(0).getId());
+            return;
+        }
+        Dictionary dictionary = new Dictionary();
+        dictionary.setDictEntry(value);
+        dictionary.setIsActive(IActionConstants.YES);
+        dictionary.setSysUserId(sysUserId);
+        option.setValue(dictionaryService.insert(dictionary));
     }
 
     @Override

--- a/src/main/resources/liquibase/3.5.x.x/068-repair-free-text-dictionary-options.xml
+++ b/src/main/resources/liquibase/3.5.x.x/068-repair-free-text-dictionary-options.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!-- The Test Catalog Editor's inline custom option (FR-83, OGC-1142) stored
+         the typed text verbatim in TEST_RESULT.VALUE. Dictionary-variant rows
+         (types D/M/C) must hold a numeric dictionary id there: every consumer
+         resolves VALUE via getDictionaryById, and the id parse throws on raw
+         text, turning pages like MasterListsPage/calculatedValue into 500s.
+         Repair: materialize each distinct raw text as a dictionary entry
+         (reusing an active entry with the same name), then repoint the rows.
+         The save path now does this resolution up front, so this only cleans
+         rows written before the fix. -->
+    <changeSet id="repair-free-text-dictionary-options" author="OGC">
+        <sql>
+            INSERT INTO clinlims.dictionary (id, is_active, dict_entry, lastupdated)
+            SELECT nextval('clinlims.dictionary_seq'), 'Y', v.value, now()
+            FROM (SELECT DISTINCT trim(tr.value) AS value
+                  FROM clinlims.test_result tr
+                  WHERE tr.tst_rslt_type IN ('D', 'M', 'C')
+                    AND tr.value IS NOT NULL
+                    AND trim(tr.value) &lt;&gt; ''
+                    AND trim(tr.value) !~ '^[0-9]+$') v
+            WHERE NOT EXISTS (
+                SELECT 1 FROM clinlims.dictionary d
+                WHERE trim(d.dict_entry) = v.value AND d.is_active = 'Y');
+
+            UPDATE clinlims.test_result tr
+            SET value = (SELECT d.id::text FROM clinlims.dictionary d
+                         WHERE trim(d.dict_entry) = trim(tr.value)
+                           AND d.is_active = 'Y'
+                         ORDER BY d.id LIMIT 1)
+            WHERE tr.tst_rslt_type IN ('D', 'M', 'C')
+              AND tr.value IS NOT NULL
+              AND trim(tr.value) &lt;&gt; ''
+              AND trim(tr.value) !~ '^[0-9]+$';
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/068-repair-free-text-dictionary-options.xml
+++ b/src/main/resources/liquibase/3.5.x.x/068-repair-free-text-dictionary-options.xml
@@ -11,13 +11,17 @@
          resolves VALUE via getDictionaryById, and the id parse throws on raw
          text, turning pages like MasterListsPage/calculatedValue into 500s.
          Repair: materialize each distinct raw text as a dictionary entry
-         (reusing an active entry with the same name), then repoint the rows.
-         The save path now does this resolution up front, so this only cleans
-         rows written before the fix. -->
+         under the "Test Result" category — the one the legacy select-list
+         admin assigns to result options — reusing an active entry with the
+         same name, then repoint the rows. The save path now does this
+         resolution up front, so this only cleans rows written before the
+         fix. -->
     <changeSet id="repair-free-text-dictionary-options" author="OGC">
         <sql>
-            INSERT INTO clinlims.dictionary (id, is_active, dict_entry, lastupdated)
-            SELECT nextval('clinlims.dictionary_seq'), 'Y', v.value, now()
+            INSERT INTO clinlims.dictionary (id, is_active, dict_entry, sort_order, dictionary_category_id, lastupdated)
+            SELECT nextval('clinlims.dictionary_seq'), 'Y', v.value, 1,
+                   (SELECT min(dc.id) FROM clinlims.dictionary_category dc WHERE dc.name = 'Test Result'),
+                   now()
             FROM (SELECT DISTINCT trim(tr.value) AS value
                   FROM clinlims.test_result tr
                   WHERE tr.tst_rslt_type IN ('D', 'M', 'C')

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -177,4 +177,8 @@
   <include relativeToChangelogFile="true" file="066-sample-type-domain-enum-migration.xml"/>
   <include relativeToChangelogFile="true" file="067-sample-type-disposal-instructions.xml"/>
 
+  <!-- OGC-1142 FR-83 follow-up: dictionary-variant TEST_RESULT rows written with raw
+      free-text values instead of dictionary ids broke every getDictionaryById consumer -->
+  <include relativeToChangelogFile="true" file="068-repair-free-text-dictionary-options.xml"/>
+
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/dictionary/service/DictionaryServiceTest.java
+++ b/src/test/java/org/openelisglobal/dictionary/service/DictionaryServiceTest.java
@@ -82,6 +82,18 @@ public class DictionaryServiceTest extends BaseWebContextSensitiveTest {
         assertEquals("Y", dictionary.getIsActive());
     }
 
+    /**
+     * Regression for the 500 on /rest/test-display-beans-map: legacy TEST_RESULT
+     * rows can carry raw text where a dictionary id belongs, and the lookup used to
+     * propagate the id-parse failure as LIMSRuntimeException, taking down every
+     * page that resolves result values. Non-numeric ids must read as not-found.
+     */
+    @Test
+    public void getDictionaryById_shouldReturnNullForNonNumericId() {
+        assertNull(dictionaryService.getDictionaryById("HIV1"));
+        assertNull(dictionaryService.getDictionaryById("  "));
+    }
+
     @Test
     public void getDictionaryEntrysByNameAndCategoryDescription_shouldGetDictionaryEntrysByNameAndCategoryDescription() {
         Dictionary dictionary = dictionaryService.getDictionaryEntrysByNameAndCategoryDescription("Dictionary Entry 1",

--- a/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
@@ -192,6 +192,20 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
             }
         }
         jdbc.update("DELETE FROM clinlims.dictionary WHERE id = ?", DICT_ID);
+        // Dictionary entries materialized from free-text options (SRIT- prefix),
+        // plus the localization rows their insert auto-created.
+        java.util.List<Long> materializedLocalizations = jdbc.queryForList(
+                "SELECT name_localization_id FROM clinlims.dictionary"
+                        + " WHERE dict_entry LIKE 'SRIT-%' AND name_localization_id IS NOT NULL",
+                Long.class);
+        jdbc.update("DELETE FROM clinlims.dictionary WHERE dict_entry LIKE 'SRIT-%'");
+        for (Long localizationId : materializedLocalizations) {
+            try {
+                localizationService.delete(String.valueOf(localizationId), "1");
+            } catch (RuntimeException ignored) {
+                // localization may already be gone; ignore
+            }
+        }
     }
 
     private void cleanupTest(long id) {
@@ -383,36 +397,83 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
 
     @org.junit.Test
     public void saveSampleResults_persistsOptionsPerComponent_andSoftDeletesOnOmit() {
+        // Free-text option values are materialized into dictionary entries on save,
+        // so the round-trip exposes the id in value and the text in valueName.
         ResultComponentDto sex = comp(null, "SEX", "Sex", 1);
         sex.resultType = "D";
-        sex.options.add(opt(null, "Male", 1));
-        sex.options.add(opt(null, "Female", 2));
+        sex.options.add(opt(null, "SRIT-Male", 1));
+        sex.options.add(opt(null, "SRIT-Female", 2));
         controller.saveSampleResults(String.valueOf(TEST_ID), body(sex), authedRequest());
 
         SampleResults loaded = controller.getSampleResults(String.valueOf(TEST_ID)).getBody();
         ResultComponentDto loadedSex = loaded.components.get(0);
         assertEquals(2, loadedSex.options.size());
         // ordered by sortOrder
-        assertEquals("Male", loadedSex.options.get(0).value);
+        assertEquals("SRIT-Male", loadedSex.options.get(0).valueName);
+        assertTrue("value must hold a numeric dictionary id, got: " + loadedSex.options.get(0).value,
+                loadedSex.options.get(0).value.matches("\\d+"));
         assertEquals(Integer.valueOf(1), loadedSex.options.get(0).sortOrder);
-        assertEquals("Female", loadedSex.options.get(1).value);
+        assertEquals("SRIT-Female", loadedSex.options.get(1).valueName);
 
-        // Re-PUT keeping only "Male" (by id) → "Female" is soft-deleted.
+        // Re-PUT keeping only "SRIT-Male" (by id) → "SRIT-Female" is soft-deleted.
         ResultComponentDto edit = comp(loadedSex.id, "SEX", "Sex", 1);
         edit.resultType = "D";
-        OptionDto keep = loadedSex.options.stream().filter(o -> "Male".equals(o.value)).findFirst().get();
+        OptionDto keep = loadedSex.options.stream().filter(o -> "SRIT-Male".equals(o.valueName)).findFirst().get();
         edit.options.add(opt(keep.id, keep.value, keep.sortOrder));
         controller.saveSampleResults(String.valueOf(TEST_ID), body(edit), authedRequest());
 
         SampleResults after = controller.getSampleResults(String.valueOf(TEST_ID)).getBody();
         assertEquals(1, after.components.get(0).options.size());
-        assertEquals("Male", after.components.get(0).options.get(0).value);
-        // "Female" soft-deleted, not hard-deleted: a TEST_RESULT row remains
-        // is_active=false.
-        Long inactive = jdbc
-                .queryForObject("SELECT count(*) FROM clinlims.test_result WHERE test_id = ? AND value = 'Female'"
-                        + " AND is_active = false", Long.class, TEST_ID);
+        assertEquals("SRIT-Male", after.components.get(0).options.get(0).valueName);
+        // "SRIT-Female" soft-deleted, not hard-deleted: a TEST_RESULT row remains
+        // is_active=false, still pointing at the materialized dictionary entry.
+        Long femaleDictId = jdbc.queryForObject("SELECT min(id) FROM clinlims.dictionary WHERE dict_entry = ?",
+                Long.class, "SRIT-Female");
+        Long inactive = jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.test_result WHERE test_id = ? AND value = ? AND is_active = false",
+                Long.class, TEST_ID, String.valueOf(femaleDictId));
         assertEquals(Long.valueOf(1L), inactive);
+    }
+
+    @org.junit.Test
+    public void saveSampleResults_freeTextOptionMaterializesADictionaryEntry() {
+        // OGC-1142 FR-83 regression: a typed custom option must land in the
+        // dictionary master list, never as raw text in TEST_RESULT.VALUE — raw text
+        // there blows up every getDictionaryById consumer (500 on
+        // MasterListsPage/calculatedValue via /rest/test-display-beans-map).
+        ResultComponentDto virus = comp(null, "VIRUS", "Virus", 1);
+        virus.resultType = "D";
+        virus.options.add(opt(null, "SRIT-HIV1", 1));
+        controller.saveSampleResults(String.valueOf(TEST_ID), body(virus), authedRequest());
+
+        OptionDto saved = controller.getSampleResults(String.valueOf(TEST_ID)).getBody().components.get(0).options
+                .get(0);
+        assertTrue("free text must be replaced by a numeric dictionary id, got: " + saved.value,
+                saved.value.matches("\\d+"));
+        assertEquals("SRIT-HIV1", saved.valueName);
+        Long entries = jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.dictionary WHERE dict_entry = ? AND is_active = 'Y'", Long.class,
+                "SRIT-HIV1");
+        assertEquals("the typed text becomes an active dictionary entry", Long.valueOf(1L), entries);
+        Long rawRows = jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.test_result WHERE test_id = ? AND value = 'SRIT-HIV1'", Long.class,
+                TEST_ID);
+        assertEquals("no test_result row may keep the raw text", Long.valueOf(0L), rawRows);
+    }
+
+    @org.junit.Test
+    public void saveSampleResults_freeTextOptionReusesAnExistingActiveDictionaryEntry() {
+        ResultComponentDto res = comp(null, "RES", "Result", 1);
+        res.resultType = "D";
+        res.options.add(opt(null, DICT_ENTRY, 1));
+        controller.saveSampleResults(String.valueOf(TEST_ID), body(res), authedRequest());
+
+        OptionDto saved = controller.getSampleResults(String.valueOf(TEST_ID)).getBody().components.get(0).options
+                .get(0);
+        assertEquals("text matching an active entry must reuse its id", String.valueOf(DICT_ID), saved.value);
+        Long entries = jdbc.queryForObject("SELECT count(*) FROM clinlims.dictionary WHERE dict_entry = ?", Long.class,
+                DICT_ENTRY);
+        assertEquals("no duplicate dictionary entry may be created", Long.valueOf(1L), entries);
     }
 
     @org.junit.Test
@@ -420,8 +481,8 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
         // Seed the source test's config via the controller.
         ResultComponentDto srcComp = comp(null, "SEX", "Sex", 1);
         srcComp.resultType = "D";
-        srcComp.options.add(opt(null, "Male", 1));
-        srcComp.interpretations.add(interp(null, "Male", "Boy", "NORMAL"));
+        srcComp.options.add(opt(null, "SRIT-Male", 1));
+        srcComp.interpretations.add(interp(null, "SRIT-Male", "Boy", "NORMAL"));
         controller.saveSampleResults(String.valueOf(SOURCE_ID), body(srcComp), authedRequest());
 
         // Copy onto the (empty) target test.
@@ -433,7 +494,7 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
         assertEquals(1, target.components.size());
         assertEquals("SEX", target.components.get(0).code);
         assertEquals(1, target.components.get(0).options.size());
-        assertEquals("Male", target.components.get(0).options.get(0).value);
+        assertEquals("SRIT-Male", target.components.get(0).options.get(0).valueName);
         assertEquals(1, target.components.get(0).interpretations.size());
         assertEquals("Boy", target.components.get(0).interpretations.get(0).text);
     }

--- a/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
@@ -49,6 +49,12 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
 
     private static final String SAMPLE_TYPE_DESC = "UrineIT";
 
+    private static final long FALLBACK_CATEGORY_ID = 952080L;
+
+    private Long testResultCategoryId;
+
+    private boolean createdTestResultCategory;
+
     @Autowired
     private TestService testService;
 
@@ -143,6 +149,16 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
         jdbc.update(
                 "INSERT INTO clinlims.dictionary (id, dict_entry, is_active, lastupdated) VALUES (?, ?, 'Y', NOW())",
                 DICT_ID, DICT_ENTRY);
+        // Free-text options materialize under the "Test Result" category; CI's DB
+        // may not ship it, so seed it when absent (and drop it again in cleanup).
+        testResultCategoryId = jdbc.queryForObject("SELECT min(id) FROM clinlims.dictionary_category WHERE name = ?",
+                Long.class, "Test Result");
+        if (testResultCategoryId == null) {
+            jdbc.update("INSERT INTO clinlims.dictionary_category (id, name, description, lastupdated)"
+                    + " VALUES (?, 'Test Result', 'General test result', NOW())", FALLBACK_CATEGORY_ID);
+            testResultCategoryId = FALLBACK_CATEGORY_ID;
+            createdTestResultCategory = true;
+        }
         Localization nameLocalization = LocalizationServiceImpl.createNewLocalization(SAMPLE_TYPE_DESC,
                 SAMPLE_TYPE_DESC, LocalizationServiceImpl.LocalizationType.TEST_NAME);
         nameLocalization.setSysUserId("1");
@@ -194,10 +210,9 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
         jdbc.update("DELETE FROM clinlims.dictionary WHERE id = ?", DICT_ID);
         // Dictionary entries materialized from free-text options (SRIT- prefix),
         // plus the localization rows their insert auto-created.
-        java.util.List<Long> materializedLocalizations = jdbc.queryForList(
-                "SELECT name_localization_id FROM clinlims.dictionary"
-                        + " WHERE dict_entry LIKE 'SRIT-%' AND name_localization_id IS NOT NULL",
-                Long.class);
+        java.util.List<Long> materializedLocalizations = jdbc
+                .queryForList("SELECT name_localization_id FROM clinlims.dictionary"
+                        + " WHERE dict_entry LIKE 'SRIT-%' AND name_localization_id IS NOT NULL", Long.class);
         jdbc.update("DELETE FROM clinlims.dictionary WHERE dict_entry LIKE 'SRIT-%'");
         for (Long localizationId : materializedLocalizations) {
             try {
@@ -205,6 +220,10 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
             } catch (RuntimeException ignored) {
                 // localization may already be gone; ignore
             }
+        }
+        if (createdTestResultCategory) {
+            jdbc.update("DELETE FROM clinlims.dictionary_category WHERE id = ?", FALLBACK_CATEGORY_ID);
+            createdTestResultCategory = false;
         }
     }
 
@@ -455,6 +474,10 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
                 "SELECT count(*) FROM clinlims.dictionary WHERE dict_entry = ? AND is_active = 'Y'", Long.class,
                 "SRIT-HIV1");
         assertEquals("the typed text becomes an active dictionary entry", Long.valueOf(1L), entries);
+        Long categoryId = jdbc.queryForObject(
+                "SELECT dictionary_category_id FROM clinlims.dictionary" + " WHERE dict_entry = ? AND is_active = 'Y'",
+                Long.class, "SRIT-HIV1");
+        assertEquals("materialized entries belong to the Test Result category", testResultCategoryId, categoryId);
         Long rawRows = jdbc.queryForObject(
                 "SELECT count(*) FROM clinlims.test_result WHERE test_id = ? AND value = 'SRIT-HIV1'", Long.class,
                 TEST_ID);


### PR DESCRIPTION
## Problem

On the testing server, `MasterListsPage/calculatedValue` fails to load because
`GET /rest/test-display-beans-map?samplesTypes=2,2,2,2` returns **500**:

```
NumberFormatException: For input string: "HIV1"
  at LIMSStringNumberUserType.nullSafeSet
  at ... DictionaryDAOImpl.getDictionaryById
```

## Root cause

The Test Catalog Editor's **inline custom option** (FR-83, OGC-1142 / #3859) lets an admin type a free-text select-list option on a Dictionary-type result component. The save path wrote that text **verbatim** into `TEST_RESULT.VALUE` — but dictionary-variant rows (`D`/`M`/`C`) must hold a **numeric dictionary id** there. Every consumer (`DisplayListController`, results entry, validation, reports) resolves the value via `getDictionaryById`, whose id parse throws on raw text, so one bad row 500s entire pages. On testing, someone typed `HIV1` as a custom option; the row poisoned the whole sample-type-2 test list.

Typing free text remains a supported feature — the bug was that the text was never materialized into the dictionary master list (the same principle the OGC-949 spec applies to units: *inline-add writes to the master list*).

## Fix (three layers)

1. **Write path** — `TestResultServiceImpl.saveOptionsForComponent` now resolves free-text option values for dictionary variants: reuse the lowest-id active dictionary entry with the same name, else create one, and store its id. FR-83 UX is unchanged.
2. **Read path** — `DictionaryDAOImpl.getDictionaryById` treats non-numeric ids as not-found (warn + `null`) instead of propagating `NumberFormatException`, so malformed legacy rows can never take down a page again.
3. **Data repair** — Liquibase changeset `068-repair-free-text-dictionary-options` creates/reuses dictionary entries for existing raw-text rows and repoints them. This fixes the testing server's data automatically on next deploy.

## Testing

- Full backend suite: **4820 tests, 0 failures**.
- Integration tests updated (they had encoded the raw-text round-trip contract) + new coverage: free-text materialization, reuse of an existing active entry, non-numeric-id guard.
- Migration SQL verified against fixtures: trailing whitespace, existing entries (reused, no duplicate), numeric values (untouched), non-dictionary types (untouched), blank/NULL (untouched), inactive rows (repaired too).
- **Live-tested on the dev compose stack**: seeded the exact testing-server condition (`HIV1` on sample type 2) → reproduced the 500 on stock develop → with this build, changeset 068 repaired the row on startup, the endpoint returned 200 with the option correctly labeled, and a freshly inserted raw row no longer 500s (guard logs and skips it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)