### PR TITLE
feat: make requester fields optional by default on Add Order, admin-c…

### DIFF
--- a/frontend/src/components/addOrder/AddOrder.jsx
+++ b/frontend/src/components/addOrder/AddOrder.jsx
@@ -1023,7 +1023,9 @@ const AddOrder = (props) => {
                 label={
                   <>
                     <FormattedMessage id="order.search.requester.label" />{" "}
-                    <span className="requiredlabel">*</span>
+                    {configurationProperties.REQUESTER_REQUIRED === "true" && (
+                      <span className="requiredlabel">*</span>
+                    )}
                   </>
                 }
                 style={{ width: "!important 100%" }}
@@ -1031,7 +1033,9 @@ const AddOrder = (props) => {
                   <FormattedMessage id="order.invalid.requester.name.label" />
                 }
                 suggestions={providers.length > 0 ? providers : []}
-                required
+                required={
+                  configurationProperties.REQUESTER_REQUIRED === "true"
+                }
               />
             </Column>
             <Column lg={8} md={4} sm={4}>
@@ -1066,8 +1070,10 @@ const AddOrder = (props) => {
                 })}
                 labelText={
                   <>
-                    <FormattedMessage id="order.requester.firstName.label" />
-                    <span className="requiredlabel">*</span>
+                    <FormattedMessage id="order.requester.firstName.label" />{" "}
+                    {configurationProperties.REQUESTER_REQUIRED === "true" && (
+                      <span className="requiredlabel">*</span>
+                    )}
                   </>
                 }
                 disabled={
@@ -1098,8 +1104,10 @@ const AddOrder = (props) => {
                 })}
                 labelText={
                   <>
-                    <FormattedMessage id="order.requester.lastName.label" />
-                    <span className="requiredlabel">*</span>
+                    <FormattedMessage id="order.requester.lastName.label" />{" "}
+                    {configurationProperties.REQUESTER_REQUIRED === "true" && (
+                      <span className="requiredlabel">*</span>
+                    )}
                   </>
                 }
                 disabled={

--- a/frontend/src/components/formModel/validationSchema/OrderEntryValidationSchema.js
+++ b/frontend/src/components/formModel/validationSchema/OrderEntryValidationSchema.js
@@ -3,8 +3,17 @@ import { createPatientValidationSchema } from "./CreatePatientValidationShema";
 
 export const createOrderEntryValidationSchema = (
   configurationProperties = {},
-) =>
-  Yup.object().shape({
+) => {
+  const requesterRequired =
+    configurationProperties.REQUESTER_REQUIRED === "true";
+  const providerFirstNameSchema = requesterRequired
+    ? Yup.string().required("Requester First Name is required")
+    : Yup.string();
+  const providerLastNameSchema = requesterRequired
+    ? Yup.string().required("Requester Last Name is required")
+    : Yup.string();
+
+  return Yup.object().shape({
     sampleXML: Yup.string().required("Sample is required"),
     patientProperties: createPatientValidationSchema(configurationProperties),
     sampleOrderItems: Yup.object()
@@ -12,12 +21,8 @@ export const createOrderEntryValidationSchema = (
         labNo: Yup.string().required("Sample Lab Number is required"),
         referringSiteName: Yup.string(),
         referringSiteId: Yup.string(),
-        providerLastName: Yup.string().required(
-          "Requester Last Name is required",
-        ),
-        providerFirstName: Yup.string().required(
-          "Requester First Name is required",
-        ),
+        providerLastName: providerLastNameSchema,
+        providerFirstName: providerFirstNameSchema,
         providerEmail: Yup.string().email("Invalid Email"),
       })
       .test(
@@ -29,3 +34,4 @@ export const createOrderEntryValidationSchema = (
         },
       ),
   });
+};

--- a/frontend/src/components/formModel/validationSchema/OrderEntryValidationSchema.test.js
+++ b/frontend/src/components/formModel/validationSchema/OrderEntryValidationSchema.test.js
@@ -115,4 +115,39 @@ describe("createOrderEntryValidationSchema", () => {
 
     await expect(schema.isValid(minimalOrderValues)).resolves.toBe(false);
   });
+
+  test("accepts empty requester first/last name when REQUESTER_REQUIRED is false (default)", async () => {
+    const schema = createOrderEntryValidationSchema({
+      PATIENT_NATIONAL_ID_REQUIRED: "false",
+    });
+
+    const valuesWithoutRequester = {
+      ...minimalOrderValues,
+      sampleOrderItems: {
+        ...minimalOrderValues.sampleOrderItems,
+        providerFirstName: "",
+        providerLastName: "",
+      },
+    };
+
+    await expect(schema.isValid(valuesWithoutRequester)).resolves.toBe(true);
+  });
+
+  test("rejects empty requester first/last name when REQUESTER_REQUIRED is true", async () => {
+    const schema = createOrderEntryValidationSchema({
+      PATIENT_NATIONAL_ID_REQUIRED: "false",
+      REQUESTER_REQUIRED: "true",
+    });
+
+    const valuesWithoutRequester = {
+      ...minimalOrderValues,
+      sampleOrderItems: {
+        ...minimalOrderValues.sampleOrderItems,
+        providerFirstName: "",
+        providerLastName: "",
+      },
+    };
+
+    await expect(schema.isValid(valuesWithoutRequester)).resolves.toBe(false);
+  });
 });

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -2651,6 +2651,7 @@
   "instructions.copy.labnum": "Copy Lab Number",
   "label.validation.viewPatient": "View Patient",
   "instructions.order.entry.eqa.enabled": "When enabled, a checkbox will appear on the Order Entry screen allowing staff to mark a sample as an EQA (External Quality Assurance) sample. Patient demographics will be auto-populated with N/A and locked.",
+  "instructions.order.entry.requester": "When enabled, Search Requester and Requester First Name and Requester Last Name become required fields on the Add Order screen. When disabled (default), all three fields are optional.",
   "instructions.test.activation": "Active Tests: a checked box indicates an already active test. To activate a test, check the box; to deactivate, uncheck the box. Any sample types without an existing active test are deactivated and appear at the bottom, under 'Inactive Sample Types'. If one of the tests is activated, the sample type will be activated.",
   "instructions.test.activation.confirm": "Verify that these are the changes you want to make. If correct then save. If not correct use the back button to make the correct changes",
   "instructions.test.activation.sort": "Display Order: Lists of sample types which have newly activated tests. Sort the tests to indicate how they will be displayed in the order entry screen. Sorting can be done by dragging items to the desired position.",

--- a/src/main/java/org/openelisglobal/common/rest/DisplayListController.java
+++ b/src/main/java/org/openelisglobal/common/rest/DisplayListController.java
@@ -343,6 +343,8 @@ public class DisplayListController extends BaseRestController {
                 ConfigurationProperties.getInstance().getPropertyValue(Property.PATIENT_ID_DOCUMENTS_LABEL));
         configs.put(Property.RESULTS_ENTRY_UNIFIED_ROUTE.toString(),
                 ConfigurationProperties.getInstance().getPropertyValue(Property.RESULTS_ENTRY_UNIFIED_ROUTE));
+        configs.put(Property.REQUESTER_REQUIRED.toString(),
+                ConfigurationProperties.getInstance().getPropertyValue(Property.REQUESTER_REQUIRED));
         return configs;
     }
 

--- a/src/main/java/org/openelisglobal/common/util/ConfigurationProperties.java
+++ b/src/main/java/org/openelisglobal/common/util/ConfigurationProperties.java
@@ -301,7 +301,8 @@ public abstract class ConfigurationProperties {
                                                                      // "Environmental", or "Both"
         ELECTRONIC_SIGNATURE_ENABLED("electronicSignatureEnabled", "text"), // 21 CFR Part 11 e-signatures
         ESIG_SESSION_TIMEOUT_MINUTES("esigSessionTimeoutMinutes", "text"), // signing session inactivity timeout
-        RESULTS_ENTRY_UNIFIED_ROUTE("resultsEntryUnifiedRoute", "text"); // OGC-1020 R1: unified /Results worklist
+        RESULTS_ENTRY_UNIFIED_ROUTE("resultsEntryUnifiedRoute", "text"), // OGC-1020 R1: unified /Results worklist
+        REQUESTER_REQUIRED("requesterRequired", "text");
 
         // visible on
         // the ui

--- a/src/main/resources/liquibase/3.5.x.x/069-requester-required-config.xml
+++ b/src/main/resources/liquibase/3.5.x.x/069-requester-required-config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet author="herbert" id="REQUESTER-REQUIRED-001">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from clinlims.site_information where name = 'requesterRequired';</sqlCheck>
+        </preConditions>
+        <comment>Add requesterRequired configuration to site_information (Sample Entry Config). When true, Search Requester and Requester First/Last Name are required on Order Entry; when false (default), all three are optional.</comment>
+        <insert schemaName="clinlims" tableName="site_information">
+            <column name="id" valueSequenceNext="site_information_seq" />
+            <column name="name" value="requesterRequired" />
+            <column name="lastupdated" valueComputed="${now}" />
+            <column name="description" value="If true, Search Requester and Requester First/Last Name are required on Order Entry. Default false makes them optional." />
+            <column name="value" value="false" />
+            <column name="encrypted" value="false" />
+            <column name="domain_id" valueComputed="(SELECT id FROM site_information_domain WHERE name = 'sampleEntryConfig')" />
+            <column name="value_type" value="boolean" />
+            <column name="instruction_key" value="instructions.order.entry.requester" />
+            <column name="group" value="0" />
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -181,4 +181,7 @@
       free-text values instead of dictionary ids broke every getDictionaryById consumer -->
   <include relativeToChangelogFile="true" file="068-repair-free-text-dictionary-options.xml"/>
 
+  <!-- Sample Entry Config: requesterRequired toggle for Search Requester + First/Last Name -->
+  <include relativeToChangelogFile="true" file="069-requester-required-config.xml"/>
+
 </databaseChangeLog>


### PR DESCRIPTION
Search Requester, Requester First Name, and Requester Last Name are now optional by default. Admins can require all three together via Home > Admin Management > Sample Entry Configuration > requesterRequired.

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
