### PR TITLE
Fix: Create Patient (Initial/Double Entry) forms blank due to EL PropertyNotFoundException on disease Pair lists

### DIFF
--- a/src/main/webapp/pages/patient/CI/arvFollowupStudy.jsp
+++ b/src/main/webapp/pages/patient/CI/arvFollowupStudy.jsp
@@ -403,15 +403,15 @@ farv = new ArvFollowupProjectChecker();
 				<c:out value="${disease.value}" />
 			</td>
 			<td>
-				<form:select path='observations.${disease.name}'
-					onchange="makeDirty();compareAllObservationHistoryFields(true)"					
-					id='farv.${disease.name}'
+				<form:select path='observations.${disease.key}'
+					onchange="makeDirty();compareAllObservationHistoryFields(true)"
+					id='farv.${disease.key}'
 					>
 					<option value=""></option>
 					<form:options items="${form.dictionaryLists.YES_NO.list}" itemLabel="localizedName"
 						itemValue="id" />
 				</form:select>
-				<div id="farv.${disease.name}.Message" class="blank"></div>
+				<div id="farv.${disease.key}.Message" class="blank"></div>
 			</td>
 		</tr>
 	</c:forEach>

--- a/src/main/webapp/pages/patient/CI/arvInitialStudy.jsp
+++ b/src/main/webapp/pages/patient/CI/arvInitialStudy.jsp
@@ -432,15 +432,15 @@ iarv = new ArvInitialProjectChecker();
 				<c:out value="${disease.value}" />
 			</td>
 			<td>
-				<form:select path='observations.${disease.name}'
-					onchange="makeDirty();compareAllObservationHistoryFields(true)"					
-					id="${disease.name}${iter.index}"
+				<form:select path='observations.${disease.key}'
+					onchange="makeDirty();compareAllObservationHistoryFields(true)"
+					id="${disease.key}${iter.index}"
 					>
 					<form:option value=""/>
 					<form:options items="${form.dictionaryLists.YES_NO.list}" itemLabel="localizedName"
 						itemValue="id" />
 				</form:select>
-				<div id="${disease.name}.Message${iter.index}" class="blank" ></div>
+				<div id="${disease.key}.Message${iter.index}" class="blank" ></div>
 			</td>
 		</tr>
 	</c:forEach> 
@@ -633,15 +633,15 @@ iarv = new ArvInitialProjectChecker();
 				<c:out value="${disease.value}" />
 			</td>
 			<td>
-				<form:select path='observations.${disease.name}'
-					onchange="makeDirty();compareAllObservationHistoryFields(true)"					
-					id="${disease.name}${iter.index}"
+				<form:select path='observations.${disease.key}'
+					onchange="makeDirty();compareAllObservationHistoryFields(true)"
+					id="${disease.key}${iter.index}"
 					>
 					<form:option value=""/>
 					<form:options items="${form.dictionaryLists.YES_NO.list}" itemLabel="localizedName"
 						itemValue="id" />
 				</form:select>
-				<div id="${disease.name}.Message${iter.index}" class="blank" ></div>
+				<div id="${disease.key}.Message${iter.index}" class="blank" ></div>
 			</td>
 		</tr>
 	</c:forEach>

--- a/src/main/webapp/pages/patient/CI/rtnStudy.jsp
+++ b/src/main/webapp/pages/patient/CI/rtnStudy.jsp
@@ -322,13 +322,13 @@ rtn = new RtnProjectChecker();
 				<c:out value="${disease.value}" />
 			</td>
 			<td>
-				<form:select path='observations.${disease.name}'
+				<form:select path='observations.${disease.key}'
 					onchange="makeDirty();compareAllObservationHistoryFields(true)"
-					id='rtn.${disease.name}'>
+					id='rtn.${disease.key}'>
 					<option value=""></option>
 					<form:options items="${form.dictionaryLists['YES_NO_UNKNOWN_NA_NOTSPEC'].list}" itemLabel="localizedName" itemValue="id" />
 				</form:select>
-				<div id='rtn.${disease.name}.Message' class="blank"></div>
+				<div id='rtn.${disease.key}.Message' class="blank"></div>
 			</td>
 		</tr>
 	</c:forEach>
@@ -341,13 +341,13 @@ rtn = new RtnProjectChecker();
 				<c:out value="${disease.value}" />
 			</td>
 			<td>
-				<form:select path='observations.${disease.name}'
+				<form:select path='observations.${disease.key}'
 					onchange="makeDirty();compareAllObservationHistoryFields(true)"
-					id='rtn.${disease.name}'>
+					id='rtn.${disease.key}'>
 					<option value=""></option>
 					<form:options items="${form.dictionaryLists['YES_NO_UNKNOWN_NA_NOTSPEC'].list}" itemLabel="localizedName" itemValue="id" />
 				</form:select>
-				<div id='rtn.${disease.name}.Message' class="blank"></div>
+				<div id='rtn.${disease.key}.Message' class="blank"></div>
 			</td>
 		</tr>
 	</c:forEach>


### PR DESCRIPTION
## Fix

Three JSP fragments (`arvInitialStudy.jsp`, `arvFollowupStudy.jsp`, `rtnStudy.jsp`) referenced `${disease.name}` on `org.apache.commons.lang3.tuple.Pair<String, String>` objects, which only expose `.key`/`.value` (aliasing `getLeft()`/`getRight()`) — not `.name`. This threw a `jakarta.el.PropertyNotFoundException` server-side, which truncated the HTTP response mid-stream and left the Create Patient (Initial Entry / Double Entry) pages completely blank below the "Form" dropdown.

Changed `${disease.name}` → `${disease.key}` in all 15 occurrences across the three files — `Pair.getKey()` delegates to `getLeft()`, which holds the value the JSP originally expected from `.name`.

Fixes #4001

## Verification

Rebuilt the WAR and recreated the container locally, then confirmed both pages render fully with a clean browser console.

**Initial Entry (after fix):**

<img width="1911" height="852" alt="Screenshot 2026-08-06 120106" src="https://github.com/user-attachments/assets/fd2344e3-d7f3-4508-a737-acf4179fa3a9" />

**Double Entry (after fix):**

<img width="1908" height="945" alt="Screenshot 2026-08-06 120336" src="https://github.com/user-attachments/assets/52e9437c-f25b-45b3-af5b-50eb6dd02e75" />


Note: the two remaining "Permissions policy violation: unload is not allowed" warnings are pre-existing and unrelated to this fix (from legacy `overlibmws.js`/`prototype-1.5.1.js`, not the code path this bug touched).