### PR TITLE
fix(test-catalog): scope free-text option lookup to the Test Result category

### DIFF
--- a/src/main/java/org/openelisglobal/testresult/service/TestResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/testresult/service/TestResultServiceImpl.java
@@ -161,9 +161,15 @@ public class TestResultServiceImpl extends AuditableBaseObjectServiceImpl<TestRe
         if (StringUtils.isNumeric(value) && dictionaryService.getDictionaryById(value) != null) {
             return;
         }
+        // Scoped to the result-option category. Matching on the name alone reused
+        // whatever active entry happened to have the lowest id — "Negative" and
+        // "Invalid" exist several times over across unrelated categories, so an
+        // option could end up sharing a demographic entry, and renaming that entry
+        // would silently rename the option. The category is part of the identity.
         Map<String, Object> properties = new HashMap<>();
         properties.put("dictEntry", value);
         properties.put("isActive", IActionConstants.YES);
+        properties.put("dictionaryCategory.categoryName", RESULT_OPTION_DICTIONARY_CATEGORY);
         List<Dictionary> matches = dictionaryService.getAllMatching(properties);
         if (!matches.isEmpty()) {
             matches.sort(Comparator.comparingInt(d -> Integer.parseInt(d.getId())));

--- a/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorSampleResultsIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.testcatalog.controller;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;
@@ -50,6 +51,18 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
     private static final String SAMPLE_TYPE_DESC = "UrineIT";
 
     private static final long FALLBACK_CATEGORY_ID = 952080L;
+
+    /**
+     * A category that is NOT "Test Result", plus an entry inside it that shares a
+     * name with a free-text option. Option lookup must not bind to it.
+     */
+    private static final long OTHER_CATEGORY_ID = 952081L;
+
+    private static final String OTHER_CATEGORY_NAME = "ScopingIT Demographics";
+
+    private static final long OTHER_CATEGORY_DICT_ID = 952082L;
+
+    private static final String SHARED_ENTRY_NAME = "SharedNameIT";
 
     private Long testResultCategoryId;
 
@@ -146,11 +159,10 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
         // Self-seed the dictionary entry + sample type these tests need; CI's DB does
         // not ship seed rows for them. The dictionary needs only an id; the sample
         // type needs a (cascade-managed) name localization, created via the service.
-        jdbc.update(
-                "INSERT INTO clinlims.dictionary (id, dict_entry, is_active, lastupdated) VALUES (?, ?, 'Y', NOW())",
-                DICT_ID, DICT_ENTRY);
         // Free-text options materialize under the "Test Result" category; CI's DB
         // may not ship it, so seed it when absent (and drop it again in cleanup).
+        // Resolved before the entry below, which has to live inside that category —
+        // option lookup is scoped to it.
         testResultCategoryId = jdbc.queryForObject("SELECT min(id) FROM clinlims.dictionary_category WHERE name = ?",
                 Long.class, "Test Result");
         if (testResultCategoryId == null) {
@@ -159,6 +171,17 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
             testResultCategoryId = FALLBACK_CATEGORY_ID;
             createdTestResultCategory = true;
         }
+        jdbc.update("INSERT INTO clinlims.dictionary"
+                + " (id, dict_entry, is_active, dictionary_category_id, lastupdated) VALUES (?, ?, 'Y', ?, NOW())",
+                DICT_ID, DICT_ENTRY, testResultCategoryId);
+        // A same-named entry in an unrelated category: option lookup must ignore it.
+        jdbc.update(
+                "INSERT INTO clinlims.dictionary_category (id, name, description, lastupdated)"
+                        + " VALUES (?, ?, 'Unrelated category for scoping test', NOW())",
+                OTHER_CATEGORY_ID, OTHER_CATEGORY_NAME);
+        jdbc.update("INSERT INTO clinlims.dictionary"
+                + " (id, dict_entry, is_active, dictionary_category_id, lastupdated) VALUES (?, ?, 'Y', ?, NOW())",
+                OTHER_CATEGORY_DICT_ID, SHARED_ENTRY_NAME, OTHER_CATEGORY_ID);
         Localization nameLocalization = LocalizationServiceImpl.createNewLocalization(SAMPLE_TYPE_DESC,
                 SAMPLE_TYPE_DESC, LocalizationServiceImpl.LocalizationType.TEST_NAME);
         nameLocalization.setSysUserId("1");
@@ -208,6 +231,8 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
             }
         }
         jdbc.update("DELETE FROM clinlims.dictionary WHERE id = ?", DICT_ID);
+        jdbc.update("DELETE FROM clinlims.dictionary WHERE dict_entry = ?", SHARED_ENTRY_NAME);
+        jdbc.update("DELETE FROM clinlims.dictionary_category WHERE id = ?", OTHER_CATEGORY_ID);
         // Dictionary entries materialized from free-text options (SRIT- prefix),
         // plus the localization rows their insert auto-created.
         java.util.List<Long> materializedLocalizations = jdbc
@@ -497,6 +522,30 @@ public class TestCatalogEditorSampleResultsIntegrationTest extends BaseWebContex
         Long entries = jdbc.queryForObject("SELECT count(*) FROM clinlims.dictionary WHERE dict_entry = ?", Long.class,
                 DICT_ENTRY);
         assertEquals("no duplicate dictionary entry may be created", Long.valueOf(1L), entries);
+    }
+
+    /**
+     * A same-named active entry in another category must not be reused. Names
+     * repeat across categories — "Negative", "Invalid" and "Positive" all exist
+     * several times over — so matching on the name alone bound an option to an
+     * unrelated concept, and renaming that entry would silently rename the option.
+     */
+    @org.junit.Test
+    public void saveSampleResults_freeTextOptionIgnoresASameNamedEntryInAnotherCategory() {
+        ResultComponentDto res = comp(null, "RES", "Result", 1);
+        res.resultType = "D";
+        res.options.add(opt(null, SHARED_ENTRY_NAME, 1));
+        controller.saveSampleResults(String.valueOf(TEST_ID), body(res), authedRequest());
+
+        OptionDto saved = controller.getSampleResults(String.valueOf(TEST_ID)).getBody().components.get(0).options
+                .get(0);
+        assertNotEquals("must not bind to the entry in the unrelated category", String.valueOf(OTHER_CATEGORY_DICT_ID),
+                saved.value);
+
+        Long categoryId = jdbc.queryForObject("SELECT dictionary_category_id FROM clinlims.dictionary WHERE id = ?",
+                Long.class, Long.parseLong(saved.value));
+        assertEquals("the option must resolve to an entry in the Test Result category", testResultCategoryId,
+                categoryId);
     }
 
     @org.junit.Test


### PR DESCRIPTION
Follow-up to #3993. That PR made the editor's free-text option (FR-83) materialize into a dictionary entry so `TEST_RESULT.VALUE` always holds an id. The **insert** assigned the "Test Result" category; the **lookup** matched on name + active flag only and took the lowest id. Create and reuse therefore disagreed about what identifies an option.

## Why that matters

Entry names repeat across categories. On a real instance:

| `dict_entry` | rows |
|---|---|
| Invalid | 4 |
| Indeterminate | 3 |
| Negative | 3 |
| Positive | 2 |

So typing `Negative` bound the option to whichever active `Negative` had the lowest id — possibly one belonging to a demographic category. The label rendered correctly, which is what made it easy to miss; the damage is that the option now *shares* an entry with an unrelated concept, and renaming that entry renames the option.

## The change

One property on the existing lookup:

```java
properties.put("dictionaryCategory.categoryName", RESULT_OPTION_DICTIONARY_CATEGORY);
```

Deliberately **not** switched to `getDictionaryEntryByNameAndCategoryName` — that drops the `isActive` filter and, being `getMatch`, returns empty when duplicates exist, which would create yet another duplicate. Keeping `getAllMatching` preserves active-only filtering and the deterministic lowest-id tie-break, and just adds the category.

**Blast radius is the free-text path only.** `addDictionaryOption` (the "Search dictionary" combo) passes the picked entry's id; that resolves and returns early, so options in `HL`, `HIVResult`, `PosNegIndInv` etc. keep their own categories untouched. Only `addCustomOption` — deliberately typing a new option — goes through this resolver.

## No repair migration, and why

I checked the real distribution before deciding. Of 205 active dictionary-variant option rows:

| category | rows |
|---|---|
| HL | 77 |
| *(entry has no category)* | 57 |
| HIVResult | 41 |
| PosNegIndInv | 19 |
| *(unresolved / raw text)* | 5 |
| HIV1NInd | 2 |
| **Test Result** | **2** |
| haitDepartments / EID Type of Clinic | 1 each |

"Test Result" is the home for **ad-hoc typed** options, not the canonical category for every option. A retroactive "everything must be Test Result" repoint would move 200+ working rows away from their proper categories — destructive, not corrective. Changeset `068` stays as shipped history; on a fresh install it is a no-op, because the save path no longer writes raw text.

## Tests

`TestCatalogEditorSampleResultsIntegrationTest` — 25 pass. New: a same-named active entry in another category must not be reused, and the resulting option must resolve into the Test Result category. The existing reuse fixture now seeds its entry **inside** that category, since matching there is the behaviour under test.

Inversion-verified: with the scoping line removed the new test fails, binding to the foreign entry (`952082`).

## Known trade-off

Typing a custom option whose text already exists in another category now creates a new entry under "Test Result" rather than adopting the foreign one. That is the intended strictness — the picker is the path for reusing an existing entry — but it does mean a duplicate name can exist across categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)