### PR TITLE
fix: change validation page link from "View Patient" to "Modify Order"

### DIFF
--- a/frontend/src/components/validation/Validation.jsx
+++ b/frontend/src/components/validation/Validation.jsx
@@ -258,9 +258,11 @@ const Validation = (props) => {
                 hasIconOnly
                 renderIcon={Launch}
                 iconDescription={intl.formatMessage({
-                  id: "label.validation.viewPatient",
+                  id: "order.label.modify",
                 })}
-                href={`/PatientManagement?labNumber=${encodeURIComponent(
+                tooltipPosition="right"
+                tooltipAlignment="center"
+                href={`/ModifyOrder?accessionNumber=${encodeURIComponent(
                   row.accessionNumber,
                 )}`}
                 target="_blank"

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -2649,7 +2649,6 @@
   "input.placeholder.selectTest": "Select Test Type",
   "input.placeholder.selectTestSection": "Select Unit Type",
   "instructions.copy.labnum": "Copy Lab Number",
-  "label.validation.viewPatient": "View Patient",
   "instructions.order.entry.eqa.enabled": "When enabled, a checkbox will appear on the Order Entry screen allowing staff to mark a sample as an EQA (External Quality Assurance) sample. Patient demographics will be auto-populated with N/A and locked.",
   "instructions.test.activation": "Active Tests: a checked box indicates an already active test. To activate a test, check the box; to deactivate, uncheck the box. Any sample types without an existing active test are deactivated and appear at the bottom, under 'Inactive Sample Types'. If one of the tests is activated, the sample type will be activated.",
   "instructions.test.activation.confirm": "Verify that these are the changes you want to make. If correct then save. If not correct use the back button to make the correct changes",


### PR DESCRIPTION
On the Ready For Validation page, the icon link next to each accession number now opens the Modify Order flow (/ModifyOrder?accessionNumber=...) instead of the Patient Management page. The tooltip uses the existing translatable key `order.label.modify` and is positioned to the right so it does not collide with the adjacent Copy Lab Number button.

- Reuse existing translation key `order.label.modify` (Transifex-managed)
- Remove now-unused `label.validation.viewPatient` from en.json

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.


